### PR TITLE
Make gas estimation strict by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Breaking Changes
 - Remove `MetricSystem::createLabelledGauge` deprecated since `24.12.0`, replace it with `MetricSystem::createLabelledSuppliedGauge` [#8299](https://github.com/hyperledger/besu/pull/8299)
 - Remove the deprecated `--tx-pool-disable-locals` option, use `--tx-pool-no-local-priority`, instead. [#8614](https://github.com/hyperledger/besu/pull/8614)
+- Change in behavior, the non standard `strict` parameter of the `eth_estimateGas` method changed its default from `false` to `true`, for more accurate estimations. It is still possible to force the previous behavior, explicitly passing the `strict` parameter in the request, set to `false` [#8629](https://github.com/hyperledger/besu/pull/8629)
 
 ### Upcoming Breaking Changes
 ### Additions and Improvements
@@ -13,6 +14,7 @@
 - Increase default target-gas-limit to 60M for Ephemery [#8622](https://github.com/hyperledger/besu/pull/8622)
 - Estimate gas on pending block by default [#8627](https://github.com/hyperledger/besu/pull/8627)
 - Upgrade Gradle to 8.14 and related plugins [#8638](https://github.com/hyperledger/besu/pull/8638)
+- Make gas estimation strict by default [#8629](https://github.com/hyperledger/besu/pull/8629)
 
 ### Bug fixes
 - Fix `besu -X` unstable options help [#8662](https://github.com/hyperledger/besu/pull/8662)

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/transaction/CallSmartContractFunction.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/transaction/CallSmartContractFunction.java
@@ -33,6 +33,7 @@ public class CallSmartContractFunction implements Transaction<EthSendTransaction
   private static final Credentials BENEFACTOR_ONE =
       Credentials.create(Accounts.GENESIS_ACCOUNT_ONE_PRIVATE_KEY);
 
+  private BigInteger gasPrice = GAS_PRICE;
   private BigInteger gasLimit = BigInteger.valueOf(3000000);
   private final String functionCall;
   private final String contractAddress;
@@ -46,10 +47,14 @@ public class CallSmartContractFunction implements Transaction<EthSendTransaction
   }
 
   public CallSmartContractFunction(
-      final String contractAddress, final String functionCall, final BigInteger gasLimit) {
+      final String contractAddress,
+      final String functionCall,
+      final BigInteger gasLimit,
+      final BigInteger gasPrice) {
     this.contractAddress = contractAddress;
     this.functionCall = functionCall;
     this.gasLimit = gasLimit;
+    this.gasPrice = gasPrice;
   }
 
   @Override
@@ -58,7 +63,7 @@ public class CallSmartContractFunction implements Transaction<EthSendTransaction
         new RawTransactionManager(node.eth(), BENEFACTOR_ONE);
     try {
       return transactionManager.sendTransaction(
-          GAS_PRICE, gasLimit, contractAddress, functionCall, BigInteger.ZERO);
+          gasPrice, gasLimit, contractAddress, functionCall, BigInteger.ZERO);
     } catch (IOException e) {
       throw new IllegalStateException(e);
     }

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/transaction/DeploySmartContractTransaction.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/transaction/DeploySmartContractTransaction.java
@@ -38,10 +38,20 @@ public class DeploySmartContractTransaction<T extends Contract> implements Trans
 
   private final Class<T> clazz;
   private final Object[] args;
+  private BigInteger gasPrice = DEFAULT_GAS_PRICE;
+  private BigInteger gasLimit = DEFAULT_GAS_LIMIT;
 
   public DeploySmartContractTransaction(final Class<T> clazz, final Object... args) {
     this.clazz = clazz;
     this.args = args;
+  }
+
+  public void setGasPrice(final BigInteger gasPrice) {
+    this.gasPrice = gasPrice;
+  }
+
+  public void setGasLimit(final BigInteger gasLimit) {
+    this.gasLimit = gasLimit;
   }
 
   @Override
@@ -49,8 +59,7 @@ public class DeploySmartContractTransaction<T extends Contract> implements Trans
     try {
       if (args != null && args.length != 0) {
         final ArrayList<Object> parameterObjects = new ArrayList<>();
-        parameterObjects.addAll(
-            Arrays.asList(node.eth(), BENEFACTOR_ONE, DEFAULT_GAS_PRICE, DEFAULT_GAS_LIMIT));
+        parameterObjects.addAll(Arrays.asList(node.eth(), BENEFACTOR_ONE, gasPrice, gasLimit));
         parameterObjects.addAll(Arrays.asList(args));
 
         final Method method =
@@ -71,8 +80,7 @@ public class DeploySmartContractTransaction<T extends Contract> implements Trans
                 "deploy", Web3j.class, Credentials.class, BigInteger.class, BigInteger.class);
 
         final Object invoked =
-            method.invoke(
-                METHOD_IS_STATIC, node.eth(), BENEFACTOR_ONE, DEFAULT_GAS_PRICE, DEFAULT_GAS_LIMIT);
+            method.invoke(METHOD_IS_STATIC, node.eth(), BENEFACTOR_ONE, gasPrice, gasLimit);
 
         return cast(invoked).send();
       }

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/transaction/contract/ContractTransactions.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/transaction/contract/ContractTransactions.java
@@ -39,7 +39,10 @@ public class ContractTransactions {
   }
 
   public CallSmartContractFunction callSmartContract(
-      final String contractAddress, final String functionCall, final BigInteger gasLimit) {
-    return new CallSmartContractFunction(contractAddress, functionCall, gasLimit);
+      final String contractAddress,
+      final String functionCall,
+      final BigInteger gasLimit,
+      final BigInteger gasPrice) {
+    return new CallSmartContractFunction(contractAddress, functionCall, gasLimit, gasPrice);
   }
 }

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/jsonrpc/EthEstimateGasAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/jsonrpc/EthEstimateGasAcceptanceTest.java
@@ -31,7 +31,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class EthEstimateGasAcceptanceTest extends AcceptanceTestBase {
-
+  private static final BigInteger GAS_PRICE = BigInteger.valueOf(10000000000L);
   final List<SimpleEntry<Integer, Long>> testCase = new ArrayList<>();
 
   @Test
@@ -44,8 +44,9 @@ public class EthEstimateGasAcceptanceTest extends AcceptanceTestBase {
                 b.genesisConfigProvider(GenesisConfigurationFactory::createDevLondonGenesisConfig)
                     .devMode(false));
     cluster.start(node);
-    final TestDepth testDepth =
-        node.execute(contractTransactions.createSmartContract(TestDepth.class));
+    final var deployContract = contractTransactions.createSmartContract(TestDepth.class);
+    deployContract.setGasPrice(GAS_PRICE);
+    final TestDepth testDepth = node.execute(deployContract);
 
     // taken from geth
     testCase.add(new SimpleEntry<>(1, 45554L));
@@ -86,7 +87,7 @@ public class EthEstimateGasAcceptanceTest extends AcceptanceTestBase {
       var transactionTooLow =
           node.execute(
               contractTransactions.callSmartContract(
-                  testDepth.getContractAddress(), functionCall, gasTooLow));
+                  testDepth.getContractAddress(), functionCall, gasTooLow, GAS_PRICE));
 
       node.verify(eth.expectSuccessfulTransactionReceipt(transactionTooLow.getTransactionHash()));
 
@@ -102,7 +103,10 @@ public class EthEstimateGasAcceptanceTest extends AcceptanceTestBase {
       var transaction =
           node.execute(
               contractTransactions.callSmartContract(
-                  testDepth.getContractAddress(), functionCall, estimateGas.getAmountUsed()));
+                  testDepth.getContractAddress(),
+                  functionCall,
+                  estimateGas.getAmountUsed(),
+                  GAS_PRICE));
 
       node.verify(eth.expectSuccessfulTransactionReceipt(transaction.getTransactionHash()));
 

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/jsonrpc/EthEstimateGasZeroToleranceAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/jsonrpc/EthEstimateGasZeroToleranceAcceptanceTest.java
@@ -31,7 +31,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class EthEstimateGasZeroToleranceAcceptanceTest extends AcceptanceTestBase {
-
+  private static final BigInteger GAS_PRICE = BigInteger.valueOf(1000000000000L);
   final List<SimpleEntry<Integer, Long>> testCase = new ArrayList<>();
 
   @Test
@@ -46,8 +46,9 @@ public class EthEstimateGasZeroToleranceAcceptanceTest extends AcceptanceTestBas
             List.of("--estimate-gas-tolerance-ratio=0.0"));
 
     cluster.start(node);
-    final TestDepth testDepth =
-        node.execute(contractTransactions.createSmartContract(TestDepth.class));
+    final var deployContract = contractTransactions.createSmartContract(TestDepth.class);
+    deployContract.setGasPrice(GAS_PRICE);
+    final TestDepth testDepth = node.execute(deployContract);
 
     // taken from geth
     testCase.add(new SimpleEntry<>(1, 45554L));
@@ -88,7 +89,8 @@ public class EthEstimateGasZeroToleranceAcceptanceTest extends AcceptanceTestBas
               contractTransactions.callSmartContract(
                   testDepth.getContractAddress(),
                   functionCall,
-                  estimateGas.getAmountUsed().subtract(BigInteger.ONE)));
+                  estimateGas.getAmountUsed().subtract(BigInteger.ONE),
+                  GAS_PRICE));
 
       node.verify(eth.expectSuccessfulTransactionReceipt(transactionTooLow.getTransactionHash()));
 
@@ -104,7 +106,10 @@ public class EthEstimateGasZeroToleranceAcceptanceTest extends AcceptanceTestBas
       var transaction =
           node.execute(
               contractTransactions.callSmartContract(
-                  testDepth.getContractAddress(), functionCall, estimateGas.getAmountUsed()));
+                  testDepth.getContractAddress(),
+                  functionCall,
+                  estimateGas.getAmountUsed(),
+                  GAS_PRICE));
 
       node.verify(eth.expectSuccessfulTransactionReceipt(transaction.getTransactionHash()));
 

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptanceqbft/jsonrpc/EthEstimateGasAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptanceqbft/jsonrpc/EthEstimateGasAcceptanceTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class EthEstimateGasAcceptanceTest extends AcceptanceTestBase {
-
+  private static final BigInteger GAS_PRICE = BigInteger.valueOf(10000000000L);
   private BesuNode node;
   private TestDepth testDepth;
 
@@ -87,7 +87,8 @@ public class EthEstimateGasAcceptanceTest extends AcceptanceTestBase {
               contractTransactions.callSmartContract(
                   testDepth.getContractAddress(),
                   functionCall,
-                  estimateGas.getAmountUsed().subtract(BigInteger.ONE)));
+                  estimateGas.getAmountUsed().subtract(BigInteger.ONE),
+                  GAS_PRICE));
 
       node.verify(eth.expectSuccessfulTransactionReceipt(transactionTooLow.getTransactionHash()));
 
@@ -103,7 +104,10 @@ public class EthEstimateGasAcceptanceTest extends AcceptanceTestBase {
       var transaction =
           node.execute(
               contractTransactions.callSmartContract(
-                  testDepth.getContractAddress(), functionCall, estimateGas.getAmountUsed()));
+                  testDepth.getContractAddress(),
+                  functionCall,
+                  estimateGas.getAmountUsed(),
+                  GAS_PRICE));
 
       node.verify(eth.expectSuccessfulTransactionReceipt(transaction.getTransactionHash()));
 

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/frontier/EthEstimateGasIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/frontier/EthEstimateGasIntegrationTest.java
@@ -31,6 +31,7 @@ import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
 import org.hyperledger.besu.ethereum.transaction.CallParameter;
 import org.hyperledger.besu.ethereum.transaction.ImmutableCallParameter;
 import org.hyperledger.besu.ethereum.transaction.TransactionInvalidReason;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.testutil.BlockTestUtil;
 
 import java.nio.charset.StandardCharsets;
@@ -132,7 +133,7 @@ public class EthEstimateGasIntegrationTest {
   }
 
   @Test
-  public void shouldNotIgnoreSenderBalanceAccountWhenStrictModeDisabledAndThrowError() {
+  public void shouldNotIgnoreSenderBalanceAccountAndThrowError() {
     final CallParameter callParameter =
         ImmutableCallParameter.builder()
             .sender(Address.fromHexString("0x6295ee1b4f6dd65047762f924ecd367c17eabf8f"))
@@ -141,16 +142,11 @@ public class EthEstimateGasIntegrationTest {
             .input(
                 Bytes.fromHexString(
                     "0x608060405234801561001057600080fd5b50610157806100206000396000f30060806040526004361061004c576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680633bdab8bf146100515780639ae97baa14610068575b600080fd5b34801561005d57600080fd5b5061006661007f565b005b34801561007457600080fd5b5061007d6100b9565b005b7fa53887c1eed04528e23301f55ad49a91634ef5021aa83a97d07fd16ed71c039a60016040518082815260200191505060405180910390a1565b7fa53887c1eed04528e23301f55ad49a91634ef5021aa83a97d07fd16ed71c039a60026040518082815260200191505060405180910390a17fa53887c1eed04528e23301f55ad49a91634ef5021aa83a97d07fd16ed71c039a60036040518082815260200191505060405180910390a15600a165627a7a7230582010ddaa52e73a98c06dbcd22b234b97206c1d7ed64a7c048e10c2043a3d2309cb0029"))
-            .strict(true)
             .build();
 
     final JsonRpcRequestContext request = requestWithParams(callParameter);
-    final ValidationResult<TransactionInvalidReason> validationResult =
-        ValidationResult.invalid(
-            TransactionInvalidReason.UPFRONT_COST_EXCEEDS_BALANCE,
-            "transaction up-front cost 0x1cc31b3333167018 exceeds transaction sender account balance 0x140");
-    final JsonRpcError rpcError = JsonRpcError.from(validationResult);
-    final JsonRpcResponse expectedResponse = new JsonRpcErrorResponse(null, rpcError);
+    final JsonRpcResponse expectedResponse =
+        new JsonRpcErrorResponse(null, RpcErrorType.TRANSACTION_UPFRONT_COST_EXCEEDS_BALANCE);
 
     final JsonRpcResponse response = method.response(request);
     assertThat(response).usingRecursiveComparison().isEqualTo(expectedResponse);

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/frontier/EthEstimateGasIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/frontier/EthEstimateGasIntegrationTest.java
@@ -23,15 +23,12 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.JsonRpcTestMethodsFactory;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
-import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.ethereum.transaction.CallParameter;
 import org.hyperledger.besu.ethereum.transaction.ImmutableCallParameter;
-import org.hyperledger.besu.ethereum.transaction.TransactionInvalidReason;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.testutil.BlockTestUtil;
 
 import java.nio.charset.StandardCharsets;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AbstractEstimateGas.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AbstractEstimateGas.java
@@ -204,7 +204,7 @@ public abstract class AbstractEstimateGas extends AbstractBlockParameterMethod {
 
     return isAllowExceedingBalance
         ? TransactionValidationParams.transactionSimulatorAllowExceedingBalanceAndFutureNonce()
-        : TransactionValidationParams.transactionSimulatorEstimateGasParams();
+        : TransactionValidationParams.transactionSimulatorAllowUnderpricedAndFutureNonce();
   }
 
   @VisibleForTesting

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AbstractEstimateGas.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AbstractEstimateGas.java
@@ -171,7 +171,7 @@ public abstract class AbstractEstimateGas extends AbstractBlockParameterMethod {
 
   protected static TransactionValidationParams getTransactionValidationParams(
       final CallParameter callParams) {
-    final boolean isAllowExceedingBalance = !callParams.getStrict().orElse(Boolean.FALSE);
+    final boolean isAllowExceedingBalance = !callParams.getStrict().orElse(Boolean.TRUE);
 
     return isAllowExceedingBalance
         ? TransactionValidationParams.transactionSimulatorAllowExceedingBalanceAndFutureNonce()

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AbstractEstimateGas.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AbstractEstimateGas.java
@@ -175,7 +175,7 @@ public abstract class AbstractEstimateGas extends AbstractBlockParameterMethod {
 
     return isAllowExceedingBalance
         ? TransactionValidationParams.transactionSimulatorAllowExceedingBalanceAndFutureNonce()
-        : TransactionValidationParams.transactionSimulatorAllowFutureNonce();
+        : TransactionValidationParams.transactionSimulatorEstimateGasParams();
   }
 
   @VisibleForTesting

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthCreateAccessList.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthCreateAccessList.java
@@ -49,25 +49,24 @@ public class EthCreateAccessList extends AbstractEstimateGas {
       final JsonRpcRequestContext requestContext,
       final CallParameter callParams,
       final ProcessableBlockHeader blockHeader,
-      final TransactionSimulationFunction simulationFunction) {
+      final TransactionSimulationFunction simulationFunction,
+      final long gasLimitUpperBound,
+      final long minTxCost) {
 
     final AccessListOperationTracer tracer = AccessListOperationTracer.create();
-    // if it's a value transfer, try optimistic simulation - get gas min from GasCalculator
-    final long minTxCost = this.getBlockchainQueries().getMinimumTransactionCost(blockHeader);
     if (attemptOptimisticSimulationWithMinimumBlockGasUsed(
-        blockHeader, callParams, simulationFunction, tracer)) {
+        minTxCost, callParams, simulationFunction, tracer)) {
       return new CreateAccessListResult(tracer.getAccessList(), minTxCost);
     }
     // Otherwise, do the calculation with the provided gasLimit
     final Optional<TransactionSimulatorResult> firstResult =
-        simulationFunction.simulate(
-            overrideGasLimit(callParams, blockHeader.getGasLimit()), tracer);
+        simulationFunction.simulate(overrideGasLimit(callParams, gasLimitUpperBound), tracer);
 
     // if the call accessList is different from the simulation result, calculate gas and return
     if (shouldProcessWithAccessListOverride(callParams, tracer)) {
       final AccessListSimulatorResult result =
           processTransactionWithAccessListOverride(
-              callParams, blockHeader.getGasLimit(), tracer.getAccessList(), simulationFunction);
+              callParams, gasLimitUpperBound, tracer.getAccessList(), simulationFunction);
       return createResponse(requestContext, result);
     } else {
       return createResponse(requestContext, new AccessListSimulatorResult(firstResult, tracer));

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthCreateAccessListTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthCreateAccessListTest.java
@@ -398,7 +398,7 @@ public class EthCreateAccessListTest {
         .gasPrice(gasPrice)
         .value(Wei.ZERO)
         .input(Bytes.EMPTY)
-        .strict(false)
+        .strict(true)
         .build();
   }
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthCreateAccessListTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthCreateAccessListTest.java
@@ -87,6 +87,7 @@ public class EthCreateAccessListTest {
     when(blockchainQueries.getBlockHeaderByNumber(1L))
         .thenReturn(Optional.of(finalizedBlockHeader));
     when(blockchainQueries.getMinimumTransactionCost(any())).thenReturn(MIN_TX_GAS_COST);
+    when(blockchainQueries.accountBalance(any(), any())).thenReturn(Optional.of(Wei.MAX_WEI));
     when(genesisBlockHeader.getGasLimit()).thenReturn(Long.MAX_VALUE);
     when(genesisBlockHeader.getNumber()).thenReturn(0L);
     when(finalizedBlockHeader.getGasLimit()).thenReturn(Long.MAX_VALUE);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthEstimateGasTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthEstimateGasTest.java
@@ -441,7 +441,7 @@ public class EthEstimateGasTest {
         .processOnPending(
             eq(
                 modifiedLegacyTransactionCallParameter(
-                    Long.MAX_VALUE, Wei.ZERO, OptionalLong.empty(), Optional.of(true))),
+                    Long.MAX_VALUE, Wei.ZERO)),
             eq(Optional.empty()), // no account overrides
             eq(TransactionValidationParams.transactionSimulatorAllowFutureNonce()),
             any(OperationTracer.class),
@@ -627,17 +627,20 @@ public class EthEstimateGasTest {
     return mockTxSimResult;
   }
 
-  private CallParameter defaultLegacyTransactionCallParameter(final Wei gasPrice) {
-    return legacyTransactionCallParameter(gasPrice, Optional.empty());
+  private JsonCallParameter defaultLegacyTransactionCallParameter(final Wei gasPrice) {
+    return legacyTransactionCallParameter(gasPrice, false);
   }
 
-  private CallParameter legacyTransactionCallParameter(
-      final Wei gasPrice, final Optional<Boolean> maybeStrict) {
-    return ImmutableCallParameter.builder()
-        .sender(Address.fromHexString("0x0"))
-        .to(Address.fromHexString("0x0"))
-        .gasPrice(gasPrice)
-        .strict(maybeStrict)
+  private JsonCallParameter legacyTransactionCallParameter(
+      final Wei gasPrice, final boolean isStrict) {
+    return new JsonCallParameter.JsonCallParameterBuilder()
+        .withFrom(Address.fromHexString("0x0"))
+        .withTo(Address.fromHexString("0x0"))
+        .withGas(0L)
+        .withGasPrice(gasPrice)
+        .withValue(Wei.ZERO)
+        .withInput(Bytes.EMPTY)
+        .withStrict(isStrict)
         .build();
   }
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthEstimateGasTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthEstimateGasTest.java
@@ -444,7 +444,7 @@ public class EthEstimateGasTest {
                 modifiedLegacyTransactionCallParameter(
                     Long.MAX_VALUE, Wei.ZERO, OptionalLong.empty(), Optional.empty())),
             eq(Optional.empty()), // no account overrides
-            eq(TransactionValidationParams.transactionSimulatorEstimateGasParams()),
+            eq(TransactionValidationParams.transactionSimulatorAllowUnderpricedAndFutureNonce()),
             any(OperationTracer.class),
             eq(pendingBlockHeader));
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthEstimateGasTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthEstimateGasTest.java
@@ -443,7 +443,7 @@ public class EthEstimateGasTest {
                 modifiedLegacyTransactionCallParameter(
                     Long.MAX_VALUE, Wei.ZERO)),
             eq(Optional.empty()), // no account overrides
-            eq(TransactionValidationParams.transactionSimulatorAllowFutureNonce()),
+            eq(TransactionValidationParams.transactionSimulatorEstimateGasParams()),
             any(OperationTracer.class),
             eq(pendingBlockHeader));
   }
@@ -628,7 +628,7 @@ public class EthEstimateGasTest {
   }
 
   private JsonCallParameter defaultLegacyTransactionCallParameter(final Wei gasPrice) {
-    return legacyTransactionCallParameter(gasPrice, false);
+    return legacyTransactionCallParameter(gasPrice, true);
   }
 
   private JsonCallParameter legacyTransactionCallParameter(
@@ -674,7 +674,6 @@ public class EthEstimateGasTest {
         .to(Address.fromHexString("0x0"))
         .maxPriorityFeePerGas(Wei.fromHexString("0x10"))
         .maxFeePerGas(Wei.fromHexString("0x10"))
-        .strict(false)
         .nonce(maybeNonce)
         .build();
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthEstimateGasTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthEstimateGasTest.java
@@ -87,6 +87,7 @@ public class EthEstimateGasTest {
     when(blockchainQueries.getBlockHeaderByNumber(1L))
         .thenReturn(Optional.of(finalizedBlockHeader));
     when(blockchainQueries.getMinimumTransactionCost(any())).thenReturn(MIN_TX_GAS_COST);
+    when(blockchainQueries.accountBalance(any(), any())).thenReturn(Optional.of(Wei.MAX_WEI));
     when(genesisBlockHeader.getGasLimit()).thenReturn(Long.MAX_VALUE);
     when(genesisBlockHeader.getNumber()).thenReturn(0L);
     when(finalizedBlockHeader.getGasLimit()).thenReturn(Long.MAX_VALUE);
@@ -423,9 +424,9 @@ public class EthEstimateGasTest {
   }
 
   @Test
-  public void shouldNotIgnoreSenderBalanceAccountWhenStrictModeEnabled() {
+  public void shouldNotIgnoreSenderBalanceByDefault() {
     final JsonRpcRequestContext request =
-        ethEstimateGasRequest(legacyTransactionCallParameter(Wei.ZERO, Optional.of(true)));
+        ethEstimateGasRequest(defaultLegacyTransactionCallParameter(Wei.ZERO));
     getMockTransactionSimulatorResult(
         false,
         MIN_TX_GAS_COST,
@@ -433,7 +434,7 @@ public class EthEstimateGasTest {
         Optional.empty(),
         pendingBlockHeader,
         OptionalLong.empty(),
-        Optional.of(true));
+        Optional.empty());
 
     method.response(request);
 
@@ -441,7 +442,7 @@ public class EthEstimateGasTest {
         .processOnPending(
             eq(
                 modifiedLegacyTransactionCallParameter(
-                    Long.MAX_VALUE, Wei.ZERO)),
+                    Long.MAX_VALUE, Wei.ZERO, OptionalLong.empty(), Optional.empty())),
             eq(Optional.empty()), // no account overrides
             eq(TransactionValidationParams.transactionSimulatorEstimateGasParams()),
             any(OperationTracer.class),
@@ -587,14 +588,6 @@ public class EthEstimateGasTest {
               eq(blockHeader)))
           .thenReturn(Optional.of(mockTxSimResult));
       when(transactionSimulator.processOnPending(
-              eq(modifiedEip1559TransactionCallParameter()),
-              eq(Optional.empty()), // no account overrides
-              any(TransactionValidationParams.class),
-              any(OperationTracer.class),
-              eq(blockHeader)))
-          .thenReturn(Optional.of(mockTxSimResult));
-      // for testing different combination of gasPrice params
-      when(transactionSimulator.processOnPending(
               eq(modifiedEip1559TransactionCallParameter(MIN_TX_GAS_COST, maybeNonce)),
               eq(Optional.empty()), // no account overrides
               any(TransactionValidationParams.class),
@@ -627,20 +620,17 @@ public class EthEstimateGasTest {
     return mockTxSimResult;
   }
 
-  private JsonCallParameter defaultLegacyTransactionCallParameter(final Wei gasPrice) {
-    return legacyTransactionCallParameter(gasPrice, true);
+  private CallParameter defaultLegacyTransactionCallParameter(final Wei gasPrice) {
+    return legacyTransactionCallParameter(gasPrice, Optional.empty());
   }
 
-  private JsonCallParameter legacyTransactionCallParameter(
-      final Wei gasPrice, final boolean isStrict) {
-    return new JsonCallParameter.JsonCallParameterBuilder()
-        .withFrom(Address.fromHexString("0x0"))
-        .withTo(Address.fromHexString("0x0"))
-        .withGas(0L)
-        .withGasPrice(gasPrice)
-        .withValue(Wei.ZERO)
-        .withInput(Bytes.EMPTY)
-        .withStrict(isStrict)
+  private CallParameter legacyTransactionCallParameter(
+      final Wei gasPrice, final Optional<Boolean> maybeStrict) {
+    return ImmutableCallParameter.builder()
+        .sender(Address.fromHexString("0x0"))
+        .to(Address.fromHexString("0x0"))
+        .gasPrice(gasPrice)
+        .strict(maybeStrict)
         .build();
   }
 
@@ -690,7 +680,6 @@ public class EthEstimateGasTest {
         .gas(gasLimit)
         .maxPriorityFeePerGas(Wei.fromHexString("0x10"))
         .maxFeePerGas(Wei.fromHexString("0x10"))
-        .strict(false)
         .nonce(maybeNonce)
         .build();
   }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/TransactionValidationParams.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/TransactionValidationParams.java
@@ -38,6 +38,9 @@ public interface TransactionValidationParams {
   TransactionValidationParams transactionSimulatorParamsAllowFutureNonce =
       ImmutableTransactionValidationParams.of(true, false, false, false, false, true);
 
+  TransactionValidationParams transactionSimulatorEstimateGasParams =
+      ImmutableTransactionValidationParams.of(true, false, true, false, false, true);
+
   TransactionValidationParams transactionSimulatorAllowExceedingBalanceParams =
       ImmutableTransactionValidationParams.of(false, true, false, false, false, true);
 
@@ -80,6 +83,10 @@ public interface TransactionValidationParams {
 
   static TransactionValidationParams transactionSimulatorAllowFutureNonce() {
     return transactionSimulatorParamsAllowFutureNonce;
+  }
+
+  static TransactionValidationParams transactionSimulatorEstimateGasParams() {
+    return transactionSimulatorEstimateGasParams;
   }
 
   static TransactionValidationParams transactionSimulatorAllowExceedingBalance() {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/TransactionValidationParams.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/TransactionValidationParams.java
@@ -38,7 +38,7 @@ public interface TransactionValidationParams {
   TransactionValidationParams transactionSimulatorParamsAllowFutureNonce =
       ImmutableTransactionValidationParams.of(true, false, false, false, false, true);
 
-  TransactionValidationParams transactionSimulatorEstimateGasParams =
+  TransactionValidationParams transactionSimulatorAllowUnderpricedAndFutureNonceParams =
       ImmutableTransactionValidationParams.of(true, false, true, false, false, true);
 
   TransactionValidationParams transactionSimulatorAllowExceedingBalanceParams =
@@ -85,8 +85,8 @@ public interface TransactionValidationParams {
     return transactionSimulatorParamsAllowFutureNonce;
   }
 
-  static TransactionValidationParams transactionSimulatorEstimateGasParams() {
-    return transactionSimulatorEstimateGasParams;
+  static TransactionValidationParams transactionSimulatorAllowUnderpricedAndFutureNonce() {
+    return transactionSimulatorAllowUnderpricedAndFutureNonceParams;
   }
 
   static TransactionValidationParams transactionSimulatorAllowExceedingBalance() {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/TransactionSimulator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/TransactionSimulator.java
@@ -414,8 +414,7 @@ public class TransactionSimulator {
     final Address senderAddress = callParams.getSender().orElse(DEFAULT_FROM);
 
     final ProcessableBlockHeader blockHeaderToProcess;
-    if ((transactionValidationParams.isAllowExceedingBalance()
-            || transactionValidationParams.allowUnderpriced())
+    if (transactionValidationParams.isAllowExceedingBalance()
         && processableHeader.getBaseFee().isPresent()) {
       blockHeaderToProcess =
           new BlockHeaderBuilder()

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/TransactionSimulator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/TransactionSimulator.java
@@ -414,7 +414,8 @@ public class TransactionSimulator {
     final Address senderAddress = callParams.getSender().orElse(DEFAULT_FROM);
 
     final ProcessableBlockHeader blockHeaderToProcess;
-    if (transactionValidationParams.isAllowExceedingBalance()
+    if ((transactionValidationParams.isAllowExceedingBalance()
+            || transactionValidationParams.allowUnderpriced())
         && processableHeader.getBaseFee().isPresent()) {
       blockHeaderToProcess =
           new BlockHeaderBuilder()


### PR DESCRIPTION
## PR description

Second PR of the series that improves gas estimation.

Besu implementation of `eth_gasEstimation` accepts the non standard parameters `strict`, that by default is `false`.
This parameters tells Besu that when processing the tx to estimate the gas used, the sender is allowed to exceeds his balance, and this is achieved setting to `0` all the gas price related field in the tx and in the block header.
This approach is not the standard, and could cause wrong gas estimations for some txs, so this PR set the default value of the `strict` parameter to `true`.

It is still possible to force the previous behavior, explicitly passing the `strict` parameter in the request, set to `false`.

Since `strict` mode does not alter gas pricing parameters, there is the need to calculate the gas limit upper bound that the sender is able to afford according to his balance, and use that upper bound in case it is lower than the block gas limit, when starting the binary search, to avoid tx upfront cost exceed balance errors.

Always in `strict` mode, since the gas pricing parameters are absent, then we need to permit underpriced tx, to skip checks on baseFee and blobBaseFee.

Comparing this PR with current main branch, using https://github.com/Consensys/compate-estimate-gas-plugin, there are less under estimations:

BesuPR8629 3399
BesuNightly 3426


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

