### PR TITLE
Add try/catch to log issues with ENR records

### DIFF
--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/dns/DNSResolver.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/dns/DNSResolver.java
@@ -14,6 +14,8 @@
  */
 package org.hyperledger.besu.ethereum.p2p.discovery.dns;
 
+import static org.hyperledger.besu.ethereum.p2p.discovery.dns.KVReader.readKV;
+
 import org.hyperledger.besu.crypto.Hash;
 import org.hyperledger.besu.ethereum.p2p.discovery.dns.DNSEntry.ENRNode;
 import org.hyperledger.besu.ethereum.p2p.discovery.dns.DNSEntry.ENRTreeLink;
@@ -25,6 +27,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
@@ -170,7 +173,49 @@ public class DNSResolver {
    * @return the DNS entry read from the domain. Empty if no record is found.
    */
   Optional<DNSEntry> resolveRecord(final String domainName) {
-    return resolveRawRecord(domainName).map(DNSEntry::readDNSEntry);
+    return resolveRawRecord(domainName).map(DNSResolver::readDNSEntry);
+  }
+
+  /**
+   * Read a DNS entry from a String.
+   *
+   * @param serialized the serialized form of a DNS entry
+   * @return DNS entry if found
+   * @throws IllegalArgumentException if the record cannot be read
+   */
+  @VisibleForTesting
+  static DNSEntry readDNSEntry(final String serialized) {
+    final String record = trimQuotes(serialized);
+    final String prefix = getPrefix(record);
+    try {
+      switch (prefix) {
+        case "enrtree-root":
+          return new ENRTreeRoot(readKV(record));
+        case "enrtree-branch":
+          return new DNSEntry.ENRTree(record.substring(prefix.length() + 1));
+        case "enr":
+          return new ENRNode(readKV(record));
+        case "enrtree":
+          return new ENRTreeLink(record);
+      }
+    } catch (Throwable t) {
+      LOG.error("Failed to parse record: {}", record);
+      throw t;
+    }
+    throw new IllegalArgumentException(
+        serialized + " should contain enrtree-branch, enr, enrtree-root or enrtree");
+  }
+
+  private static String trimQuotes(final String str) {
+    if (str.startsWith("\"") && str.endsWith("\"")) {
+      return str.substring(1, str.length() - 1);
+    }
+    return str;
+  }
+
+  private static String getPrefix(final String input) {
+    final String[] parts = input.split(":", 2);
+    return parts.length > 0 ? parts[0] : "";
   }
 
   /**

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/dns/DNSResolverTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/dns/DNSResolverTest.java
@@ -22,7 +22,7 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-class DNSEntryTest {
+class DNSResolverTest {
   @BeforeAll
   static void setup() {
     Security.addProvider(new BouncyCastleProvider());
@@ -32,7 +32,7 @@ class DNSEntryTest {
   void enrTreeRootIsParsed() {
     final String txtRecord =
         "\"enrtree-root:v1 e=KVKZLGARGADDZSMCF65QQMEWLE l=FDXN3SN67NA5DKA4J2GOK7BVQI seq=919 sig=braPmdwMk-g65lQxums6hEy553s3bWMoecW0QQ0IdykIoM9i3We0bxFT0IDONPaFcRePcN-yaOpt8GBfeQ4qDAE\"";
-    final DNSEntry entry = DNSEntry.readDNSEntry(txtRecord);
+    final DNSEntry entry = DNSResolver.readDNSEntry(txtRecord);
     assertThat(entry).isInstanceOf(DNSEntry.ENRTreeRoot.class);
     final DNSEntry.ENRTreeRoot enrTreeRoot = (DNSEntry.ENRTreeRoot) entry;
     assertThat(enrTreeRoot.enrRoot()).isEqualTo("KVKZLGARGADDZSMCF65QQMEWLE");
@@ -48,7 +48,7 @@ class DNSEntryTest {
             + "SZCFDMTYOERMIVOUXEWXSGDVEY,FZ26UT4LSG7D2NRX7SV6P3S6BI,7TWNYLCOQ7FEM4IG65WOTL4MVE,"
             + "6OJXGI7NJUESOLL2OZPS4B\" \"EC6Q,437FN4NSGMGFQLAXYWPX5JNACI,FCA7LN6NCO5IAWPG5FH7LX6XJA,"
             + "EYBOZ2NZSHDWDSNHV66XASXOHM,FUVRJMMMKJMCL4L4EBEOWCSOFA\"";
-    final DNSEntry entry = DNSEntry.readDNSEntry(txtRecord);
+    final DNSEntry entry = DNSResolver.readDNSEntry(txtRecord);
 
     assertThat(entry).isInstanceOf(DNSEntry.ENRTree.class);
     assertThat(((DNSEntry.ENRTree) entry).entries())


### PR DESCRIPTION
## PR description
Add in a way to log what are these ENR records that are causing issues in node discovery - by looking at the issue it is impossible to tell but likely a wrong format in the Base64 encoding of a record's value. If we see that there's no control over the format we can possibly silently drop this record and avoid exception propagation.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #8368

### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

