### PR TITLE
unstable options help - ensure no duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 - Estimate gas on pending block by default [#8627](https://github.com/hyperledger/besu/pull/8627)
 - Upgrade Gradle to 8.14 and related plugins [#8638](https://github.com/hyperledger/besu/pull/8638)
 
+### Bug fixes
+- Fix `besu -X` unstable options help [#8662](https://github.com/hyperledger/besu/pull/8662)
+
 ## 25.5.0
 ### Breaking Changes
 - Changes to gas estimation algorithm for `eth_estimateGas` and `eth_createAccessList` [#8478](https://github.com/hyperledger/besu/pull/8478) - if you require the previous behavior, specify `--estimate-gas-tolerance-ratio=0.0`

--- a/besu/src/main/java/org/hyperledger/besu/cli/UnstableOptionsSubCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/UnstableOptionsSubCommand.java
@@ -82,6 +82,7 @@ public class UnstableOptionsSubCommand implements Runnable, CommandLine.IHelpCom
     final CommandLine.Model.CommandSpec cs = CommandLine.Model.CommandSpec.create();
     commandSpec.options().stream()
         .filter(option -> option.hidden() && option.names()[0].startsWith("--X"))
+        .distinct()
         .forEach(option -> cs.addOption(option.toBuilder().hidden(false).build()));
 
     if (cs.options().size() > 0) {

--- a/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -256,6 +256,14 @@ public class BesuCommandTest extends CommandTestAbstract {
     assertThat(commandErrorOutput.toString(UTF_8)).isEmpty();
   }
 
+  @Test
+  public void callingUnstableSubCommandMustNotError() {
+    parseCommand("-X");
+    final String expectedOutputStart = "Unstable options";
+    assertThat(commandOutput.toString(UTF_8)).startsWith(expectedOutputStart);
+    assertThat(commandErrorOutput.toString(UTF_8)).isEmpty();
+  }
+
   // Testing default values
   @Test
   public void callingBesuCommandWithoutOptionsMustSyncWithDefaultValues() {

--- a/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -260,8 +260,8 @@ public class BesuCommandTest extends CommandTestAbstract {
   public void callingUnstableSubCommandMustNotError() {
     parseCommand("-X");
     final String expectedOutputStart = "Unstable options";
-    assertThat(commandOutput.toString(UTF_8)).startsWith(expectedOutputStart);
     assertThat(commandErrorOutput.toString(UTF_8)).isEmpty();
+    assertThat(commandOutput.toString(UTF_8)).startsWith(expectedOutputStart);
   }
 
   // Testing default values


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <macfarla.github@gmail.com>## PR description

## Fixed Issue(s)
fixes #8661
Also added a test for Unstable options subcommand


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

