### PR TITLE
Add `--Xhistory-expiry-prune` for enabling optimal RocksDB GC settings

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -2829,6 +2829,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
         .setTxPoolImplementation(buildTransactionPoolConfiguration().getTxPoolImplementation())
         .setWorldStateUpdateMode(unstableEvmOptions.toDomainObject().worldUpdaterMode())
         .setPluginContext(this.besuPluginContext)
+        .setHistoryExpiryPruneEnabled(getDataStorageConfiguration().getHistoryExpiryPruneEnabled())
         .setBlobDBSettings(rocksDBPlugin.getBlobDBSettings());
 
     return builder.build();

--- a/besu/src/main/java/org/hyperledger/besu/cli/ConfigurationOverviewBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/ConfigurationOverviewBuilder.java
@@ -62,6 +62,7 @@ public class ConfigurationOverviewBuilder {
   private EvmConfiguration.WorldUpdaterMode worldStateUpdateMode;
   private Map<String, String> environment;
   private BesuPluginContextImpl besuPluginContext;
+  private boolean isHistoryExpiryPruneEnabled = false;
   private RocksDBCLIOptions.BlobDBSettings blobDBSettings;
 
   /**
@@ -317,6 +318,18 @@ public class ConfigurationOverviewBuilder {
   }
 
   /**
+   * Sets the history expiry prune enabled.
+   *
+   * @param isHistoryExpiryPruneEnabled the history expiry prune enabled
+   * @return the builder
+   */
+  public ConfigurationOverviewBuilder setHistoryExpiryPruneEnabled(
+      final boolean isHistoryExpiryPruneEnabled) {
+    this.isHistoryExpiryPruneEnabled = isHistoryExpiryPruneEnabled;
+    return this;
+  }
+
+  /**
    * Sets the blob db settings.
    *
    * @param blobDBSettings the blob db settings
@@ -409,6 +422,10 @@ public class ConfigurationOverviewBuilder {
 
     if (isHighSpec) {
       lines.add("Experimental high spec configuration enabled");
+    }
+
+    if (isHistoryExpiryPruneEnabled) {
+      lines.add("History expiry prune enabled");
     }
 
     if (blobDBSettings != null && blobDBSettings.isBlockchainGarbageCollectionEnabled()) {

--- a/besu/src/main/java/org/hyperledger/besu/cli/options/storage/DataStorageOptions.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/storage/DataStorageOptions.java
@@ -49,6 +49,13 @@ public class DataStorageOptions implements CLIOptions<DataStorageConfiguration> 
       fallbackValue = "true")
   private Boolean receiptCompactionEnabled = DEFAULT_RECEIPT_COMPACTION_ENABLED;
 
+  @CommandLine.Option(
+      names = {"--Xhistory-expiry-prune"},
+      hidden = true,
+      description =
+          "Convenience option to configure BlobDB garbage collection settings following a history expiry prune")
+  private boolean historyExpiryPrune = false;
+
   /**
    * Options specific to path-based storage modes. Holds the necessary parameters to configure
    * path-based storage, such as the Bonsai mode or Verkle in the future.
@@ -91,6 +98,7 @@ public class DataStorageOptions implements CLIOptions<DataStorageConfiguration> 
     dataStorageOptions.pathBasedExtraStorageOptions =
         PathBasedExtraStorageOptions.fromConfig(
             domainObject.getPathBasedExtraStorageConfiguration());
+    dataStorageOptions.historyExpiryPrune = domainObject.getHistoryExpiryPruneEnabled();
     return dataStorageOptions;
   }
 
@@ -100,6 +108,7 @@ public class DataStorageOptions implements CLIOptions<DataStorageConfiguration> 
         ImmutableDataStorageConfiguration.builder()
             .dataStorageFormat(dataStorageFormat)
             .receiptCompactionEnabled(receiptCompactionEnabled)
+            .historyExpiryPruneEnabled(historyExpiryPrune)
             .pathBasedExtraStorageConfiguration(pathBasedExtraStorageOptions.toDomainObject());
     return builder.build();
   }

--- a/besu/src/main/java/org/hyperledger/besu/services/BesuConfigurationImpl.java
+++ b/besu/src/main/java/org/hyperledger/besu/services/BesuConfigurationImpl.java
@@ -154,5 +154,10 @@ public class BesuConfigurationImpl implements BesuConfiguration {
     public boolean getReceiptCompactionEnabled() {
       return dataStorageConfiguration.getReceiptCompactionEnabled();
     }
+
+    @Override
+    public boolean isHistoryExpiryPruneEnabled() {
+      return dataStorageConfiguration.getHistoryExpiryPruneEnabled();
+    }
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/worldstate/DataStorageConfiguration.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/worldstate/DataStorageConfiguration.java
@@ -24,6 +24,7 @@ import org.immutables.value.Value;
 public interface DataStorageConfiguration {
 
   boolean DEFAULT_RECEIPT_COMPACTION_ENABLED = true;
+  boolean DEFAULT_HISTORY_EXPIRY_PRUNE_ENABLED = false;
 
   DataStorageConfiguration DEFAULT_CONFIG =
       ImmutableDataStorageConfiguration.builder()
@@ -58,5 +59,10 @@ public interface DataStorageConfiguration {
   @Value.Default
   default boolean getReceiptCompactionEnabled() {
     return DEFAULT_RECEIPT_COMPACTION_ENABLED;
+  }
+
+  @Value.Default
+  default boolean getHistoryExpiryPruneEnabled() {
+    return DEFAULT_HISTORY_EXPIRY_PRUNE_ENABLED;
   }
 }

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -71,7 +71,7 @@ Calculated : ${currentHash}
 tasks.register('checkAPIChanges', FileStateChecker) {
   description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
   files = sourceSets.main.allJava.files
-  knownHash = '9U76qvaQoyALZDKM4rz4n8555e45WbAPGGwt7mzNF8A='
+  knownHash = 'aluchMXcxMIQQ3+rMQjCQGQyS797FGwzfYkzxITN4SE='
 }
 check.dependsOn('checkAPIChanges')
 

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/storage/DataStorageConfiguration.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/storage/DataStorageConfiguration.java
@@ -36,4 +36,16 @@ public interface DataStorageConfiguration {
    */
   @Unstable
   boolean getReceiptCompactionEnabled();
+
+  /**
+   * Whether block history expiry prune is enabled. When enabled this: - Enables online pruner if
+   * data is not already pruned - Enables RocksDB blob garbage collection settings to reclaim the
+   * space from the pruned blocks
+   *
+   * @return Whether history expiry is enabled
+   */
+  @Unstable
+  default boolean isHistoryExpiryPruneEnabled() {
+    return false;
+  }
 }

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBKeyValueStorageFactory.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBKeyValueStorageFactory.java
@@ -18,6 +18,9 @@ import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration
 import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.BaseVersionedStorageFormat.BONSAI_WITH_VARIABLES;
 import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.BaseVersionedStorageFormat.FOREST_WITH_RECEIPT_COMPACTION;
 import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.BaseVersionedStorageFormat.FOREST_WITH_VARIABLES;
+import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.BLOB_BLOCKCHAIN_GARBAGE_COLLECTION_ENABLED;
+import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.BLOB_GARBAGE_COLLECTION_AGE_CUTOFF;
+import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.BLOB_GARBAGE_COLLECTION_FORCE_THRESHOLD;
 
 import org.hyperledger.besu.plugin.services.BesuConfiguration;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
@@ -195,10 +198,31 @@ public class RocksDBKeyValueStorageFactory implements KeyValueStorageFactory {
               + " could not be found. You may not have the appropriate permission to access the item.";
       throw new StorageException(message, e);
     }
-    rocksDBConfiguration =
-        RocksDBConfigurationBuilder.from(configuration.get())
-            .databaseDir(storagePath(commonConfiguration))
-            .build();
+    final RocksDBFactoryConfiguration factoryConfig = configuration.get();
+    var configBuilder =
+        RocksDBConfigurationBuilder.from(factoryConfig)
+            .databaseDir(storagePath(commonConfiguration));
+
+    if (commonConfiguration.getDataStorageConfiguration().isHistoryExpiryPruneEnabled()) {
+      configBuilder.isBlockchainGarbageCollectionEnabled(true);
+      final double blobGarbageCollectionAgeCutoff =
+          factoryConfig.getBlobGarbageCollectionAgeCutoff().orElse(0.5);
+      final double blobGarbageCollectionForceThreshold =
+          factoryConfig.getBlobGarbageCollectionForceThreshold().orElse(0.1);
+      configBuilder.blobGarbageCollectionAgeCutoff(Optional.of(blobGarbageCollectionAgeCutoff));
+      configBuilder.blobGarbageCollectionForceThreshold(
+          Optional.of(blobGarbageCollectionForceThreshold));
+      LOG.atInfo()
+          .setMessage("History expiry prune is enabled so setting {}; {}={}; {}={}")
+          .addArgument(BLOB_BLOCKCHAIN_GARBAGE_COLLECTION_ENABLED)
+          .addArgument(BLOB_GARBAGE_COLLECTION_AGE_CUTOFF)
+          .addArgument(blobGarbageCollectionAgeCutoff)
+          .addArgument(BLOB_GARBAGE_COLLECTION_FORCE_THRESHOLD)
+          .addArgument(blobGarbageCollectionForceThreshold)
+          .log();
+    }
+
+    rocksDBConfiguration = configBuilder.build();
   }
 
   private boolean requiresInit() {


### PR DESCRIPTION
## PR description

`besu --Xhistory-expiry-prune`
will automatically set the following rocksdb GC options based on the testing conducted in https://github.com/hyperledger/besu/pull/8599:
```
--Xplugin-rocksdb-blockchain-blob-garbage-collection-enabled
--Xplugin-rocksdb-blob-garbage-collection-age-cutoff=0.5
--Xplugin-rocksdb-blob-garbage-collection-force-threshold=0.1
```

The config overview displays:
```
# History expiry prune enabled                                                                     #
```

and the full settings are shown in an INFO log:
`2025-05-23 09:39:40.179+10:00 | main | INFO  | RocksDBKeyValueStorageFactory | History expiry prune is enabled so setting --Xplugin-rocksdb-blockchain-blob-garbage-collection-enabled; --Xplugin-rocksdb-blob-garbage-collection-age-cutoff=0.5; --Xplugin-rocksdb-blob-garbage-collection-force-threshold=0.1`

It is still possible to set these options separately.
It is also possible to set these options along with `--Xhistory-expiry-prune` as a way to override the configured settings (though this isn't recommended).

For example, if I do  `--Xhistory-expiry-prune --Xplugin-rocksdb-blob-garbage-collection-age-cutoff=0.9` to make the age cutoff consider all files for GC, then the user will see this displayed:

```
# History expiry prune enabled                                                                     #
# Experimental BlobDB GC age cutoff: 0.9;                                                          #
```
`2025-05-23 09:44:45.810+10:00 | main | INFO  | RocksDBKeyValueStorageFactory | History expiry prune is enabled so setting --Xplugin-rocksdb-blockchain-blob-garbage-collection-enabled; --Xplugin-rocksdb-blob-garbage-collection-age-cutoff=0.9; --Xplugin-rocksdb-blob-garbage-collection-force-threshold=0.1`

Note,  `--Xplugin-rocksdb-blockchain-blob-garbage-collection-enabled` is always forced to true when `--Xhistory-expiry-prune` is set because the BLOCKCHAIN column family must have GC enabled in order to reclaim space.

As per the GC flags PR https://github.com/hyperledger/besu/pull/8599: 
 - age-cutoff and force-threshold setting will apply to all column families with BlobDB enabled (currently just TRIE_LOG_STORAGE) but the impact should be minimal since if you are enabling history expiry, you likely also only retain recent Trie Logs.
 - we will only display the settings in the configuration overview if the user has explicitly set the GC flags, we don't display them when the `--Xhistory-expiry-prune` flag sets them. The INFO logs will always show the full settings.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

Fixes https://github.com/hyperledger/besu/issues/8654

### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

