### PR TITLE
Replace `@Nonnull` annotation with `@NotNull`

### DIFF
--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/backup/BackupRoundTripAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/backup/BackupRoundTripAcceptanceTest.java
@@ -35,9 +35,9 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
-import javax.annotation.Nonnull;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import jakarta.validation.constraints.NotNull;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -155,7 +155,7 @@ public class BackupRoundTripAcceptanceTest extends AbstractPreexistingNodeTest {
     assertThat(rebackupManifest).isEqualTo(backupManifest);
   }
 
-  @Nonnull
+  @NotNull
   private UnaryOperator<BesuNodeConfigurationBuilder> configureNodeCommands(
       final Path dataPath, final String... commands) {
     return nodeBuilder -> super.configureNode(nodeBuilder).dataPath(dataPath).run(commands);

--- a/besu/src/main/java/org/hyperledger/besu/cli/custom/CorsAllowedOriginsProperty.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/custom/CorsAllowedOriginsProperty.java
@@ -23,10 +23,10 @@ import java.util.List;
 import java.util.StringJoiner;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
-import javax.annotation.Nonnull;
 
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
+import jakarta.validation.constraints.NotNull;
 
 /** The Cors allowed origins property used in CLI */
 public class CorsAllowedOriginsProperty extends AbstractList<String> {
@@ -37,7 +37,7 @@ public class CorsAllowedOriginsProperty extends AbstractList<String> {
   public CorsAllowedOriginsProperty() {}
 
   @Override
-  @Nonnull
+  @NotNull
   public Iterator<String> iterator() {
     if (domains.size() == 1 && domains.get(0).equals("none")) {
       return Collections.emptyIterator();

--- a/besu/src/main/java/org/hyperledger/besu/cli/custom/JsonRPCAllowlistHostsProperty.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/custom/JsonRPCAllowlistHostsProperty.java
@@ -20,10 +20,10 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import javax.annotation.Nonnull;
 
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
+import jakarta.validation.constraints.NotNull;
 
 /** The Json Rpc allowlist hosts list for CLI option. */
 public class JsonRPCAllowlistHostsProperty extends AbstractList<String> {
@@ -34,7 +34,7 @@ public class JsonRPCAllowlistHostsProperty extends AbstractList<String> {
   public JsonRPCAllowlistHostsProperty() {}
 
   @Override
-  @Nonnull
+  @NotNull
   public Iterator<String> iterator() {
     if (hostnamesAllowlist.size() == 1 && hostnamesAllowlist.get(0).equals("none")) {
       return Collections.emptyIterator();

--- a/build.gradle
+++ b/build.gradle
@@ -193,6 +193,9 @@ configure(allprojects - project(':platform')) {
 
     testAnnotationProcessor(platform(project(':platform')))
 
+    // for validation annotations like @NotNull
+    implementation 'jakarta.validation:jakarta.validation-api'
+
     components.all(BouncyCastleCapability)
     errorprone 'com.google.errorprone:error_prone_core'
     // https://github.com/hyperledger/besu-errorprone-checks/

--- a/datatypes/src/main/java/org/hyperledger/besu/datatypes/StorageSlotKey.java
+++ b/datatypes/src/main/java/org/hyperledger/besu/datatypes/StorageSlotKey.java
@@ -16,8 +16,8 @@ package org.hyperledger.besu.datatypes;
 
 import java.util.Objects;
 import java.util.Optional;
-import javax.annotation.Nonnull;
 
+import jakarta.validation.constraints.NotNull;
 import org.apache.tuweni.units.bigints.UInt256;
 
 /**
@@ -105,7 +105,7 @@ public class StorageSlotKey implements Comparable<StorageSlotKey> {
   }
 
   @Override
-  public int compareTo(@Nonnull final StorageSlotKey other) {
+  public int compareTo(@NotNull final StorageSlotKey other) {
     return this.slotHash.compareTo(other.slotHash);
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/TransactionAdapter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/TransactionAdapter.java
@@ -36,10 +36,10 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import graphql.schema.DataFetchingEnvironment;
+import jakarta.validation.constraints.NotNull;
 import org.apache.tuweni.bytes.Bytes;
 
 /**
@@ -64,7 +64,7 @@ public class TransactionAdapter extends AdapterBase {
    *
    * @param transactionWithMetadata the TransactionWithMetadata object to adapt.
    */
-  public TransactionAdapter(final @Nonnull TransactionWithMetadata transactionWithMetadata) {
+  public TransactionAdapter(final @NotNull TransactionWithMetadata transactionWithMetadata) {
     this.transactionWithMetadata = transactionWithMetadata;
   }
 
@@ -75,7 +75,7 @@ public class TransactionAdapter extends AdapterBase {
    * @param transactionReceiptWithMetadata the TransactionReceiptWithMetadata object to adapt.
    */
   public TransactionAdapter(
-      final @Nonnull TransactionWithMetadata transactionWithMetadata,
+      final @NotNull TransactionWithMetadata transactionWithMetadata,
       final @Nullable TransactionReceiptWithMetadata transactionReceiptWithMetadata) {
     this.transactionWithMetadata = transactionWithMetadata;
     this.transactionReceiptWithMetadata = Optional.ofNullable(transactionReceiptWithMetadata);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/EngineJsonRpcService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/EngineJsonRpcService.java
@@ -58,7 +58,6 @@ import java.util.Optional;
 import java.util.StringJoiner;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -95,6 +94,7 @@ import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.BodyHandler;
 import io.vertx.ext.web.handler.CorsHandler;
+import jakarta.validation.constraints.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -382,7 +382,7 @@ public class EngineJsonRpcService {
     };
   }
 
-  @Nonnull
+  @NotNull
   private Handler<Buffer> handlerForUser(
       final SocketAddress socketAddress,
       final ServerWebSocket websocket,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthSendRawTransaction.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthSendRawTransaction.java
@@ -36,9 +36,9 @@ import org.hyperledger.besu.ethereum.transaction.TransactionInvalidReason;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
-import javax.annotation.Nonnull;
 
 import com.google.common.base.Suppliers;
+import jakarta.validation.constraints.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -114,7 +114,7 @@ public class EthSendRawTransaction implements JsonRpcMethod {
         errorReason -> getJsonRpcResponse(requestContext, errorReason, validationResult));
   }
 
-  @Nonnull
+  @NotNull
   private JsonRpcResponse getJsonRpcResponse(
       final JsonRpcRequestContext requestContext,
       final TransactionInvalidReason errorReason,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceFilter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceFilter.java
@@ -57,9 +57,9 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 import java.util.stream.Stream;
-import javax.annotation.Nonnull;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.validation.constraints.NotNull;
 import org.apache.tuweni.bytes.Bytes32;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -207,7 +207,7 @@ public class TraceFilter extends TraceBlock {
     return new JsonRpcSuccessResponse(requestContext.getRequest().getId(), result.getArrayNode());
   }
 
-  @Nonnull
+  @NotNull
   private List<Block> getBlockList(
       final long fromBlock, final long toBlock, final Optional<Block> block) {
     List<Block> blockList = new ArrayList<>();

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV1.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV1.java
@@ -30,10 +30,10 @@ import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 
 import java.util.Arrays;
 import java.util.List;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import io.vertx.core.Vertx;
+import jakarta.validation.constraints.NotNull;
 
 /**
  * #### Specification
@@ -98,7 +98,7 @@ public class EngineGetBlobsV1 extends ExecutionEngineJsonRpcMethod {
     return new JsonRpcSuccessResponse(requestContext.getRequest().getId(), result);
   }
 
-  private @Nonnull List<BlobAndProofV1> getBlobV1Result(final VersionedHash[] versionedHashes) {
+  private @NotNull List<BlobAndProofV1> getBlobV1Result(final VersionedHash[] versionedHashes) {
     return Arrays.stream(versionedHashes)
         .map(transactionPool::getBlobQuad)
         .map(this::getBlobAndProofV1)

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/VersionMetadata.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/VersionMetadata.java
@@ -20,12 +20,12 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Path;
-import javax.annotation.Nonnull;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.validation.constraints.NotNull;
 import org.apache.maven.artifact.versioning.ComparableVersion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -164,7 +164,7 @@ public class VersionMetadata implements Comparable<VersionMetadata> {
   }
 
   @Override
-  public int compareTo(@Nonnull final VersionMetadata versionMetadata) {
+  public int compareTo(@NotNull final VersionMetadata versionMetadata) {
     final String thisVersion = this.getBesuVersion().split("-", 2)[0];
     final String metadataVersion = versionMetadata.getBesuVersion().split("-", 2)[0];
     return new ComparableVersion(thisVersion).compareTo(new ComparableVersion(metadataVersion));

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/TransactionSimulator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/TransactionSimulator.java
@@ -53,10 +53,10 @@ import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
-import javax.annotation.Nonnull;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Suppliers;
+import jakarta.validation.constraints.NotNull;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.slf4j.Logger;
@@ -350,7 +350,7 @@ public class TransactionSimulator {
                     "Public world state not available for block " + header.toLogString()));
   }
 
-  @Nonnull
+  @NotNull
   public Optional<TransactionSimulatorResult> processWithWorldUpdater(
       final CallParameter callParams,
       final Optional<StateOverrideMap> maybeStateOverrides,
@@ -398,7 +398,7 @@ public class TransactionSimulator {
         () -> FAKE_SIGNATURE);
   }
 
-  @Nonnull
+  @NotNull
   public Optional<TransactionSimulatorResult> processWithWorldUpdater(
       final CallParameter callParams,
       final Optional<StateOverrideMap> maybeStateOverrides,

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/worldview/BonsaiWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/worldview/BonsaiWorldState.java
@@ -52,9 +52,9 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
-import javax.annotation.Nonnull;
 
 import com.google.common.annotations.VisibleForTesting;
+import jakarta.validation.constraints.NotNull;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.rlp.RLP;
@@ -101,7 +101,7 @@ public class BonsaiWorldState extends PathBasedWorldState {
   }
 
   @Override
-  public Optional<Bytes> getCode(@Nonnull final Address address, final Hash codeHash) {
+  public Optional<Bytes> getCode(@NotNull final Address address, final Hash codeHash) {
     return getWorldStateStorage().getCode(codeHash, address.addressHash());
   }
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/worldview/PathBasedWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/worldview/PathBasedWorldState.java
@@ -41,8 +41,8 @@ import org.hyperledger.besu.plugin.services.storage.SegmentedKeyValueStorageTran
 
 import java.util.Optional;
 import java.util.stream.Stream;
-import javax.annotation.Nonnull;
 
+import jakarta.validation.constraints.NotNull;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
@@ -383,7 +383,7 @@ public abstract class PathBasedWorldState
       final Address address, final StorageSlotKey storageSlotKey);
 
   @Override
-  public abstract Optional<Bytes> getCode(@Nonnull final Address address, final Hash codeHash);
+  public abstract Optional<Bytes> getCode(@NotNull final Address address, final Hash codeHash);
 
   protected abstract Hash calculateRootHash(
       final Optional<PathBasedWorldStateKeyValueStorage.Updater> maybeStateUpdater,

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/worldview/accumulator/preload/AccountConsumingMap.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/worldview/accumulator/preload/AccountConsumingMap.java
@@ -18,9 +18,9 @@ import org.hyperledger.besu.datatypes.Address;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
-import javax.annotation.Nonnull;
 
 import com.google.common.collect.ForwardingMap;
+import jakarta.validation.constraints.NotNull;
 
 public class AccountConsumingMap<T> extends ForwardingMap<Address, T> {
 
@@ -33,7 +33,7 @@ public class AccountConsumingMap<T> extends ForwardingMap<Address, T> {
   }
 
   @Override
-  public T put(@Nonnull final Address address, @Nonnull final T value) {
+  public T put(@NotNull final Address address, @NotNull final T value) {
     consumer.process(address, value);
     return accounts.put(address, value);
   }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/worldview/accumulator/preload/StorageConsumingMap.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/worldview/accumulator/preload/StorageConsumingMap.java
@@ -18,9 +18,9 @@ import org.hyperledger.besu.datatypes.Address;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
-import javax.annotation.Nonnull;
 
 import com.google.common.collect.ForwardingMap;
+import jakarta.validation.constraints.NotNull;
 
 public class StorageConsumingMap<K, T> extends ForwardingMap<K, T> {
 
@@ -37,7 +37,7 @@ public class StorageConsumingMap<K, T> extends ForwardingMap<K, T> {
   }
 
   @Override
-  public T put(@Nonnull final K slotKey, @Nonnull final T value) {
+  public T put(@NotNull final K slotKey, @NotNull final T value) {
     consumer.process(address, slotKey);
     return storages.put(slotKey, value);
   }

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/chain/ChainDataPrunerTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/chain/ChainDataPrunerTest.java
@@ -29,8 +29,8 @@ import java.util.Optional;
 import java.util.concurrent.AbstractExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
-import javax.annotation.Nonnull;
 
+import jakarta.validation.constraints.NotNull;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -203,7 +203,7 @@ public class ChainDataPrunerTest {
     @Override
     public void shutdown() {}
 
-    @Nonnull
+    @NotNull
     @Override
     public List<Runnable> shutdownNow() {
       return List.of();
@@ -220,12 +220,12 @@ public class ChainDataPrunerTest {
     }
 
     @Override
-    public boolean awaitTermination(final long timeout, final @Nonnull TimeUnit unit) {
+    public boolean awaitTermination(final long timeout, final @NotNull TimeUnit unit) {
       return true;
     }
 
     @Override
-    public void execute(final @Nonnull Runnable command) {
+    public void execute(final @NotNull Runnable command) {
       command.run();
     }
   }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeer.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeer.java
@@ -53,9 +53,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
-import javax.annotation.Nonnull;
 
 import com.google.common.annotations.VisibleForTesting;
+import jakarta.validation.constraints.NotNull;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
@@ -647,14 +647,14 @@ public class EthPeer implements Comparable<EthPeer> {
         System.currentTimeMillis() - connection.getInitiatedAt());
   }
 
-  @Nonnull
+  @NotNull
   public String getLoggableId() {
     // 8 bytes plus the 0x prefix is 18 characters
     return nodeId().toString().substring(0, 18) + "...";
   }
 
   @Override
-  public int compareTo(final @Nonnull EthPeer ethPeer) {
+  public int compareTo(final @NotNull EthPeer ethPeer) {
     final int repCompare = this.reputation.compareTo(ethPeer.reputation);
     if (repCompare != 0) return repCompare;
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeers.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeers.java
@@ -58,12 +58,12 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import javax.annotation.Nonnull;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.RemovalNotification;
+import jakarta.validation.constraints.NotNull;
 import org.apache.tuweni.bytes.Bytes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -223,7 +223,7 @@ public class EthPeers implements PeerSelector {
     }
   }
 
-  @Nonnull
+  @NotNull
   private List<PeerConnection> getIncompleteConnections(final Bytes id) {
     return incompleteConnections.asMap().keySet().stream()
         .filter(nrc -> nrc.getPeer().getId().equals(id))

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/PeerReputation.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/PeerReputation.java
@@ -26,8 +26,8 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import javax.annotation.Nonnull;
 
+import jakarta.validation.constraints.NotNull;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -131,7 +131,7 @@ public class PeerReputation implements Comparable<PeerReputation> {
   }
 
   @Override
-  public int compareTo(final @Nonnull PeerReputation otherReputation) {
+  public int compareTo(final @NotNull PeerReputation otherReputation) {
     return Integer.compare(this.score, otherReputation.score);
   }
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/tasks/CompleteBlocksTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/tasks/CompleteBlocksTask.java
@@ -37,8 +37,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
 
+import jakarta.validation.constraints.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -84,7 +84,7 @@ public class CompleteBlocksTask extends AbstractRetryingPeerTask<List<Block>> {
                             createEmptyBodyBasedOnProtocolSchedule(protocolSchedule, header))));
   }
 
-  @Nonnull
+  @NotNull
   private BlockBody createEmptyBodyBasedOnProtocolSchedule(
       final ProtocolSchedule protocolSchedule, final BlockHeader header) {
     return new BlockBody(

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardSyncAlgSpec.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardSyncAlgSpec.java
@@ -35,8 +35,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.Nonnull;
 
+import jakarta.validation.constraints.NotNull;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -322,7 +322,7 @@ public class BackwardSyncAlgSpec {
     return backwardChain;
   }
 
-  @Nonnull
+  @NotNull
   private Block getBlockByNumber(final int number) {
     return remoteBlockchain.getBlockByNumber(number).orElseThrow();
   }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardSyncContextTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardSyncContextTest.java
@@ -61,8 +61,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import javax.annotation.Nonnull;
 
+import jakarta.validation.constraints.NotNull;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -294,7 +294,7 @@ public class BackwardSyncContextTest {
     peer.respondWhileOtherThreadsWork(responder, () -> !future.isDone());
   }
 
-  @Nonnull
+  @NotNull
   private Block getBlockByNumber(final int number) {
     return remoteBlockchain.getBlockByNumber(number).orElseThrow();
   }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardSyncStepTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardSyncStepTest.java
@@ -55,8 +55,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import javax.annotation.Nonnull;
 
+import jakarta.validation.constraints.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -390,7 +390,7 @@ public class BackwardSyncStepTest {
     return chain;
   }
 
-  @Nonnull
+  @NotNull
   private BackwardChain createBackwardChain(final int number) {
     final BackwardChain backwardChain =
         new BackwardChain(headersStorage, blocksStorage, chainStorage, sessionDataStorage);
@@ -398,7 +398,7 @@ public class BackwardSyncStepTest {
     return backwardChain;
   }
 
-  @Nonnull
+  @NotNull
   private Block getBlockByNumber(final int number) {
     return remoteBlockchain.getBlockByNumber(number).orElseThrow();
   }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/ChainForTestCreator.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/ChainForTestCreator.java
@@ -28,8 +28,8 @@ import org.hyperledger.besu.evm.log.LogsBloomFilter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import javax.annotation.Nonnull;
 
+import jakarta.validation.constraints.NotNull;
 import org.apache.tuweni.bytes.Bytes;
 
 public class ChainForTestCreator {
@@ -115,7 +115,7 @@ public class ChainForTestCreator {
     return prepareHeader(number, Optional.empty());
   }
 
-  @Nonnull
+  @NotNull
   private static BlockHeader prepareEmptyHeader(final BlockHeader parent) {
     return new BlockHeader(
         parent.getHash(),

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/ForwardSyncStepTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/ForwardSyncStepTest.java
@@ -53,8 +53,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
 
+import jakarta.validation.constraints.NotNull;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -267,7 +267,7 @@ public class ForwardSyncStepTest {
     return chain;
   }
 
-  @Nonnull
+  @NotNull
   private BackwardChain backwardChainFromBlock(final int number) {
     final BackwardChain backwardChain =
         new BackwardChain(headersStorage, blocksStorage, chainStorage, sessionDataStorage);
@@ -275,7 +275,7 @@ public class ForwardSyncStepTest {
     return backwardChain;
   }
 
-  @Nonnull
+  @NotNull
   private Block getBlockByNumber(final int number) {
     return remoteBlockchain.getBlockByNumber(number).orElseThrow();
   }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/InMemoryBackwardChainTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/InMemoryBackwardChainTest.java
@@ -29,8 +29,8 @@ import org.hyperledger.besu.services.kvstore.InMemoryKeyValueStorage;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
-import javax.annotation.Nonnull;
 
+import jakarta.validation.constraints.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -82,7 +82,7 @@ public class InMemoryBackwardChainTest {
     assertThat(firstHeader).isEqualTo(blocks.get(blocks.size() - 4).getHeader());
   }
 
-  @Nonnull
+  @NotNull
   private BackwardChain createChainFromBlock(final Block pivot) {
     final BackwardChain backwardChain =
         new BackwardChain(headersStorage, blocksStorage, chainStorage, sessionDataStorage);

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgent.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgent.java
@@ -48,11 +48,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import javax.annotation.Nonnull;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import jakarta.validation.constraints.NotNull;
 import org.apache.tuweni.bytes.Bytes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -233,7 +233,7 @@ public class RlpxAgent {
     return peerConnectionCompletableFuture;
   }
 
-  @Nonnull
+  @NotNull
   private CompletableFuture<PeerConnection> createPeerConnectionCompletableFuture(final Peer peer) {
     final CompletableFuture<PeerConnection> peerConnectionCompletableFuture =
         initiateOutboundConnection(peer);

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/netty/NettyConnectionInitializer.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/netty/NettyConnectionInitializer.java
@@ -42,7 +42,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.IntSupplier;
 import java.util.stream.StreamSupport;
-import javax.annotation.Nonnull;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
@@ -56,6 +55,7 @@ import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.util.concurrent.SingleThreadEventExecutor;
+import jakarta.validation.constraints.NotNull;
 
 public class NettyConnectionInitializer
     implements ConnectionInitializer, HandshakerProvider, FramerProvider {
@@ -195,7 +195,7 @@ public class NettyConnectionInitializer
   /**
    * @return a channel initializer for outbound connections
    */
-  @Nonnull
+  @NotNull
   private ChannelInitializer<SocketChannel> outboundChannelInitializer(
       final Peer peer, final CompletableFuture<PeerConnection> connectionFuture) {
     return new ChannelInitializer<SocketChannel>() {
@@ -232,7 +232,7 @@ public class NettyConnectionInitializer
     };
   }
 
-  @Nonnull
+  @NotNull
   private HandshakeHandlerInbound inboundHandler(
       final CompletableFuture<PeerConnection> connectionFuture) {
     return new HandshakeHandlerInbound(
@@ -247,7 +247,7 @@ public class NettyConnectionInitializer
         peerTable);
   }
 
-  @Nonnull
+  @NotNull
   private HandshakeHandlerOutbound outboundHandler(
       final Peer peer, final CompletableFuture<PeerConnection> connectionFuture) {
     return new HandshakeHandlerOutbound(
@@ -263,7 +263,7 @@ public class NettyConnectionInitializer
         peerTable);
   }
 
-  @Nonnull
+  @NotNull
   private TimeoutHandler<Channel> timeoutHandler(
       final CompletableFuture<PeerConnection> connectionFuture, final String s) {
     return new TimeoutHandler<>(

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/wire/PeerInfo.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/wire/PeerInfo.java
@@ -27,8 +27,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import javax.annotation.Nonnull;
 
+import jakarta.validation.constraints.NotNull;
 import org.apache.tuweni.bytes.Bytes;
 import org.owasp.encoder.Encode;
 
@@ -158,7 +158,7 @@ public class PeerInfo implements Comparable<PeerInfo> {
   }
 
   @Override
-  public int compareTo(final @Nonnull PeerInfo peerInfo) {
+  public int compareTo(final @NotNull PeerInfo peerInfo) {
     return this.nodeId.compareTo(peerInfo.nodeId);
   }
 

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PeerDiscoveryControllerTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PeerDiscoveryControllerTest.java
@@ -76,12 +76,12 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
 
 import com.google.common.base.Ticker;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.net.InetAddresses;
+import jakarta.validation.constraints.NotNull;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.bytes.MutableBytes;
@@ -1722,7 +1722,7 @@ public class PeerDiscoveryControllerTest {
     verify(controller, times(1)).connectOnRlpxLayer(eq(maybePeer.get()));
   }
 
-  @Nonnull
+  @NotNull
   private Packet prepareForForkIdCheck(
       final List<NodeKey> nodeKeys, final DiscoveryPeer sender, final boolean sendForkId) {
     final HashMap<PacketType, Bytes> packetTypeBytesHashMap = new HashMap<>();

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/NetworkingServiceLifecycleTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/NetworkingServiceLifecycleTest.java
@@ -39,9 +39,9 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.stream.Stream;
-import javax.annotation.Nonnull;
 
 import io.vertx.core.Vertx;
+import jakarta.validation.constraints.NotNull;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -74,7 +74,7 @@ public class NetworkingServiceLifecycleTest {
     }
   }
 
-  @Nonnull
+  @NotNull
   private DefaultP2PNetwork.Builder getP2PNetworkBuilder() {
     final DefaultP2PNetwork.Builder builder = builder();
     final MutableBlockchain blockchainMock = mock(MutableBlockchain.class);

--- a/evm/src/main/java/org/hyperledger/besu/collections/undo/UndoList.java
+++ b/evm/src/main/java/org/hyperledger/besu/collections/undo/UndoList.java
@@ -20,7 +20,8 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
-import javax.annotation.Nonnull;
+
+import jakarta.validation.constraints.NotNull;
 
 /**
  * A list that supports rolling back the list to a prior state.
@@ -164,7 +165,7 @@ public class UndoList<V> implements List<V>, Undoable {
   }
 
   @Override
-  public boolean containsAll(final @Nonnull Collection<?> c) {
+  public boolean containsAll(final @NotNull Collection<?> c) {
     return new HashSet<>(delegate).containsAll(c);
   }
 
@@ -186,7 +187,7 @@ public class UndoList<V> implements List<V>, Undoable {
   }
 
   @Override
-  public boolean removeAll(final @Nonnull Collection<?> c) {
+  public boolean removeAll(final @NotNull Collection<?> c) {
     HashSet<?> hs = new HashSet<>(c);
     ListIterator<V> iter = delegate.listIterator();
     boolean updated = false;
@@ -202,7 +203,7 @@ public class UndoList<V> implements List<V>, Undoable {
   }
 
   @Override
-  public boolean retainAll(final @Nonnull Collection<?> c) {
+  public boolean retainAll(final @NotNull Collection<?> c) {
     HashSet<?> hs = new HashSet<>(c);
     ListIterator<V> iter = delegate.listIterator();
     boolean updated = false;
@@ -270,7 +271,7 @@ public class UndoList<V> implements List<V>, Undoable {
   }
 
   @Override
-  public <T> T[] toArray(final @Nonnull T[] a) {
+  public <T> T[] toArray(final @NotNull T[] a) {
     return delegate.toArray(a);
   }
 

--- a/evm/src/main/java/org/hyperledger/besu/collections/undo/UndoMap.java
+++ b/evm/src/main/java/org/hyperledger/besu/collections/undo/UndoMap.java
@@ -21,7 +21,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import javax.annotation.Nonnull;
+
+import jakarta.validation.constraints.NotNull;
 
 /**
  * A map that supports rolling back the map to a prior state.
@@ -110,7 +111,7 @@ public class UndoMap<K, V> implements Map<K, V>, Undoable {
   }
 
   @Override
-  public V put(final @Nonnull K key, final @Nonnull V value) {
+  public V put(final @NotNull K key, final @NotNull V value) {
     Objects.requireNonNull(value);
     final V oldValue = delegate.put(key, value);
     if (!value.equals(oldValue)) {
@@ -130,7 +131,7 @@ public class UndoMap<K, V> implements Map<K, V>, Undoable {
   }
 
   @Override
-  public void putAll(@Nonnull final Map<? extends K, ? extends V> m) {
+  public void putAll(@NotNull final Map<? extends K, ? extends V> m) {
     m.forEach(this::put);
   }
 
@@ -140,19 +141,19 @@ public class UndoMap<K, V> implements Map<K, V>, Undoable {
     delegate.clear();
   }
 
-  @Nonnull
+  @NotNull
   @Override
   public Set<K> keySet() {
     return Collections.unmodifiableSet(delegate.keySet());
   }
 
-  @Nonnull
+  @NotNull
   @Override
   public Collection<V> values() {
     return Collections.unmodifiableCollection(delegate.values());
   }
 
-  @Nonnull
+  @NotNull
   @Override
   public Set<Entry<K, V>> entrySet() {
     return Collections.unmodifiableSet(delegate.entrySet());

--- a/evm/src/main/java/org/hyperledger/besu/collections/undo/UndoSet.java
+++ b/evm/src/main/java/org/hyperledger/besu/collections/undo/UndoSet.java
@@ -20,7 +20,8 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
-import javax.annotation.Nonnull;
+
+import jakarta.validation.constraints.NotNull;
 
 /**
  * A set that supports rolling back the set to a prior state.
@@ -118,7 +119,7 @@ public class UndoSet<V> implements Set<V>, Undoable {
   }
 
   @Override
-  public boolean addAll(@Nonnull final Collection<? extends V> m) {
+  public boolean addAll(@NotNull final Collection<? extends V> m) {
     boolean added = false;
     for (V v : m) {
       // don't use short circuit, we need to evaluate all entries
@@ -129,7 +130,7 @@ public class UndoSet<V> implements Set<V>, Undoable {
   }
 
   @Override
-  public boolean removeAll(@Nonnull final Collection<?> c) {
+  public boolean removeAll(@NotNull final Collection<?> c) {
     boolean removed = false;
     for (Object v : c) {
       // don't use short circuit, we need to evaluate all entries
@@ -140,7 +141,7 @@ public class UndoSet<V> implements Set<V>, Undoable {
   }
 
   @Override
-  public boolean retainAll(@Nonnull final Collection<?> c) {
+  public boolean retainAll(@NotNull final Collection<?> c) {
     boolean removed = false;
     HashSet<?> hashed = new HashSet<>(c);
     Iterator<V> iter = delegate.iterator();
@@ -161,26 +162,26 @@ public class UndoSet<V> implements Set<V>, Undoable {
     delegate.clear();
   }
 
-  @Nonnull
+  @NotNull
   @Override
   public Iterator<V> iterator() {
     return new ReadOnlyIterator<>(delegate.iterator());
   }
 
-  @Nonnull
+  @NotNull
   @Override
   public Object[] toArray() {
     return delegate.toArray();
   }
 
-  @Nonnull
+  @NotNull
   @Override
-  public <T> T[] toArray(@Nonnull final T[] a) {
+  public <T> T[] toArray(@NotNull final T[] a) {
     return delegate.toArray(a);
   }
 
   @Override
-  public boolean containsAll(@Nonnull final Collection<?> c) {
+  public boolean containsAll(@NotNull final Collection<?> c) {
     return delegate.containsAll(c);
   }
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/code/CodeFactory.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/code/CodeFactory.java
@@ -17,8 +17,7 @@ package org.hyperledger.besu.evm.code;
 import org.hyperledger.besu.evm.Code;
 import org.hyperledger.besu.evm.code.EOFLayout.EOFContainerMode;
 
-import javax.annotation.Nonnull;
-
+import jakarta.validation.constraints.NotNull;
 import org.apache.tuweni.bytes.Bytes;
 
 /** The Code factory. */
@@ -74,7 +73,7 @@ public class CodeFactory {
     };
   }
 
-  private @Nonnull Code createV1Code(final Bytes bytes, final boolean createTransaction) {
+  private @NotNull Code createV1Code(final Bytes bytes, final boolean createTransaction) {
     int codeSize = bytes.size();
     if (codeSize > 0 && bytes.get(0) == EOF_LEAD_BYTE) {
       if (codeSize < 3) {
@@ -104,7 +103,7 @@ public class CodeFactory {
     }
   }
 
-  @Nonnull
+  @NotNull
   Code createCode(final EOFLayout layout) {
     if (!layout.isValid()) {
       return new CodeInvalid(layout.container(), "Invalid EOF Layout: " + layout.invalidReason());

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/AbstractExtCallOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/AbstractExtCallOperation.java
@@ -26,8 +26,7 @@ import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.internal.Words;
 
-import javax.annotation.Nonnull;
-
+import jakarta.validation.constraints.NotNull;
 import org.apache.tuweni.bytes.Bytes;
 
 /**
@@ -204,7 +203,7 @@ public abstract class AbstractExtCallOperation extends AbstractCallOperation {
     return new OperationResult(clampedAdd(cost, childGas), null, 0);
   }
 
-  private @Nonnull OperationResult softFailure(final MessageFrame frame, final long cost) {
+  private @NotNull OperationResult softFailure(final MessageFrame frame, final long cost) {
     frame.popStackItems(getStackItemsConsumed());
     frame.pushStackItem(EOF1_EXCEPTION_STACK_ITEM);
     return new OperationResult(cost, null);

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/AbstractAltBnPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/AbstractAltBnPrecompiledContract.java
@@ -22,9 +22,9 @@ import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.nativelib.gnark.LibGnarkEIP196;
 
 import java.util.Optional;
-import javax.annotation.Nonnull;
 
 import com.sun.jna.ptr.IntByReference;
+import jakarta.validation.constraints.NotNull;
 import org.apache.tuweni.bytes.Bytes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -103,9 +103,9 @@ public abstract class AbstractAltBnPrecompiledContract extends AbstractPrecompil
    * @param messageFrame the message frame
    * @return the precompile contract result
    */
-  @Nonnull
+  @NotNull
   public PrecompileContractResult computeNative(
-      final @Nonnull Bytes input, final MessageFrame messageFrame) {
+      final @NotNull Bytes input, final MessageFrame messageFrame) {
     final byte[] result = new byte[LibGnarkEIP196.EIP196_PREALLOCATE_FOR_RESULT_BYTES];
     final byte[] error = new byte[LibGnarkEIP196.EIP196_PREALLOCATE_FOR_ERROR_BYTES];
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/AbstractBLS12PrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/AbstractBLS12PrecompiledContract.java
@@ -22,10 +22,10 @@ import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.nativelib.gnark.LibGnarkEIP2537;
 
 import java.util.Optional;
-import javax.annotation.Nonnull;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.sun.jna.ptr.IntByReference;
+import jakarta.validation.constraints.NotNull;
 import org.apache.tuweni.bytes.Bytes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -109,10 +109,10 @@ public abstract class AbstractBLS12PrecompiledContract implements PrecompiledCon
     return name;
   }
 
-  @Nonnull
+  @NotNull
   @Override
   public PrecompileContractResult computePrecompile(
-      final Bytes input, @Nonnull final MessageFrame messageFrame) {
+      final Bytes input, @NotNull final MessageFrame messageFrame) {
 
     PrecompileInputResultTuple res = null;
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/AltBN128AddPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/AltBN128AddPrecompiledContract.java
@@ -24,10 +24,10 @@ import org.hyperledger.besu.nativelib.gnark.LibGnarkEIP196;
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Optional;
-import javax.annotation.Nonnull;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import jakarta.validation.constraints.NotNull;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.MutableBytes;
 import org.slf4j.Logger;
@@ -77,10 +77,10 @@ public class AltBN128AddPrecompiledContract extends AbstractAltBnPrecompiledCont
     return gasCost;
   }
 
-  @Nonnull
+  @NotNull
   @Override
   public PrecompileContractResult computePrecompile(
-      final Bytes input, @Nonnull final MessageFrame messageFrame) {
+      final Bytes input, @NotNull final MessageFrame messageFrame) {
 
     PrecompileInputResultTuple res;
     Integer cacheKey = null;

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/AltBN128MulPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/AltBN128MulPrecompiledContract.java
@@ -24,10 +24,10 @@ import org.hyperledger.besu.nativelib.gnark.LibGnarkEIP196;
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Optional;
-import javax.annotation.Nonnull;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import jakarta.validation.constraints.NotNull;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.MutableBytes;
 import org.slf4j.Logger;
@@ -83,10 +83,10 @@ public class AltBN128MulPrecompiledContract extends AbstractAltBnPrecompiledCont
     return gasCost;
   }
 
-  @Nonnull
+  @NotNull
   @Override
   public PrecompileContractResult computePrecompile(
-      final Bytes input, @Nonnull final MessageFrame messageFrame) {
+      final Bytes input, @NotNull final MessageFrame messageFrame) {
 
     if (input.size() >= 64 && input.slice(0, 64).equals(POINT_AT_INFINITY)) {
       return new PrecompileContractResult(
@@ -132,7 +132,7 @@ public class AltBN128MulPrecompiledContract extends AbstractAltBnPrecompiledCont
     return res.cachedResult();
   }
 
-  @Nonnull
+  @NotNull
   private static PrecompileContractResult computeDefault(final Bytes input) {
     final BigInteger x = extractParameter(input, 0, 32);
     final BigInteger y = extractParameter(input, 32, 32);

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/AltBN128PairingPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/AltBN128PairingPrecompiledContract.java
@@ -31,10 +31,10 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.Nonnull;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import jakarta.validation.constraints.NotNull;
 import org.apache.tuweni.bytes.Bytes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -102,10 +102,10 @@ public class AltBN128PairingPrecompiledContract extends AbstractAltBnPrecompiled
     return (pairingGasCost * parameters) + baseGasCost;
   }
 
-  @Nonnull
+  @NotNull
   @Override
   public PrecompileContractResult computePrecompile(
-      final Bytes input, @Nonnull final MessageFrame messageFrame) {
+      final Bytes input, @NotNull final MessageFrame messageFrame) {
     if (input.isEmpty()) {
       return PrecompileContractResult.success(TRUE);
     }
@@ -151,7 +151,7 @@ public class AltBN128PairingPrecompiledContract extends AbstractAltBnPrecompiled
     return res.cachedResult();
   }
 
-  @Nonnull
+  @NotNull
   private static PrecompileContractResult computeDefault(final Bytes input) {
     final int parameters = input.size() / PARAMETER_LENGTH;
     final List<AltBn128Point> a = new ArrayList<>();

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLAKE2BFPrecompileContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLAKE2BFPrecompileContract.java
@@ -24,10 +24,10 @@ import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
 import java.math.BigInteger;
 import java.util.Optional;
-import javax.annotation.Nonnull;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import jakarta.validation.constraints.NotNull;
 import org.apache.tuweni.bytes.Bytes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -68,10 +68,10 @@ public class BLAKE2BFPrecompileContract extends AbstractPrecompiledContract {
     return rounds.longValueExact();
   }
 
-  @Nonnull
+  @NotNull
   @Override
   public PrecompileContractResult computePrecompile(
-      final Bytes input, @Nonnull final MessageFrame messageFrame) {
+      final Bytes input, @NotNull final MessageFrame messageFrame) {
     if (input.size() != MESSAGE_LENGTH_BYTES) {
       LOG.trace(
           "Incorrect input length.  Expected {} and got {}", MESSAGE_LENGTH_BYTES, input.size());

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/BigIntegerModularExponentiationPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/BigIntegerModularExponentiationPrecompiledContract.java
@@ -26,9 +26,9 @@ import org.hyperledger.besu.nativelib.arithmetic.LibArithmetic;
 
 import java.math.BigInteger;
 import java.util.Optional;
-import javax.annotation.Nonnull;
 
 import com.sun.jna.ptr.IntByReference;
+import jakarta.validation.constraints.NotNull;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.MutableBytes;
 import org.slf4j.Logger;
@@ -95,10 +95,10 @@ public class BigIntegerModularExponentiationPrecompiledContract
     return gasCalculator().modExpGasCost(input);
   }
 
-  @Nonnull
+  @NotNull
   @Override
   public PrecompileContractResult computePrecompile(
-      final Bytes input, @Nonnull final MessageFrame messageFrame) {
+      final Bytes input, @NotNull final MessageFrame messageFrame) {
     if (useNative) {
       return computeNative(input);
     } else {
@@ -112,7 +112,7 @@ public class BigIntegerModularExponentiationPrecompiledContract
    * @param input the input
    * @return the precompile contract result
    */
-  @Nonnull
+  @NotNull
   public PrecompileContractResult computeDefault(final Bytes input) {
     final int baseLength = clampedToInt(baseLength(input));
     final int exponentLength = clampedToInt(exponentLength(input));
@@ -247,7 +247,7 @@ public class BigIntegerModularExponentiationPrecompiledContract
    * @param input the input
    * @return the precompile contract result
    */
-  public PrecompileContractResult computeNative(final @Nonnull Bytes input) {
+  public PrecompileContractResult computeNative(final @NotNull Bytes input) {
     final int modulusLength = clampedToInt(modulusLength(input));
     final IntByReference o_len = new IntByReference(modulusLength);
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/ECRECPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/ECRECPrecompiledContract.java
@@ -24,10 +24,10 @@ import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
 import java.math.BigInteger;
 import java.util.Optional;
-import javax.annotation.Nonnull;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import jakarta.validation.constraints.NotNull;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.bytes.MutableBytes;
@@ -71,10 +71,10 @@ public class ECRECPrecompiledContract extends AbstractPrecompiledContract {
     return gasCalculator().getEcrecPrecompiledContractGasCost();
   }
 
-  @Nonnull
+  @NotNull
   @Override
   public PrecompileContractResult computePrecompile(
-      final Bytes input, @Nonnull final MessageFrame messageFrame) {
+      final Bytes input, @NotNull final MessageFrame messageFrame) {
     final int size = input.size();
     final Bytes d = size >= 128 ? input : Bytes.wrap(input, MutableBytes.create(128 - size));
     final Bytes32 h = Bytes32.wrap(d, 0);

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/IDPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/IDPrecompiledContract.java
@@ -17,8 +17,7 @@ package org.hyperledger.besu.evm.precompile;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
-import javax.annotation.Nonnull;
-
+import jakarta.validation.constraints.NotNull;
 import org.apache.tuweni.bytes.Bytes;
 
 /** The ID precompiled contract. */
@@ -38,10 +37,10 @@ public class IDPrecompiledContract extends AbstractPrecompiledContract {
     return gasCalculator().idPrecompiledContractGasCost(input);
   }
 
-  @Nonnull
+  @NotNull
   @Override
   public PrecompileContractResult computePrecompile(
-      final Bytes input, @Nonnull final MessageFrame messageFrame) {
+      final Bytes input, @NotNull final MessageFrame messageFrame) {
     return PrecompileContractResult.success(input.copy());
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/KZGPointEvalPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/KZGPointEvalPrecompiledContract.java
@@ -24,12 +24,12 @@ import org.hyperledger.besu.evm.internal.Words;
 import java.nio.file.Path;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
-import javax.annotation.Nonnull;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.annotations.VisibleForTesting;
 import ethereum.ckzg4844.CKZG4844JNI;
+import jakarta.validation.constraints.NotNull;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.slf4j.Logger;
@@ -123,10 +123,10 @@ public class KZGPointEvalPrecompiledContract implements PrecompiledContract {
     return 50000;
   }
 
-  @Nonnull
+  @NotNull
   @Override
   public PrecompileContractResult computePrecompile(
-      final Bytes input, @Nonnull final MessageFrame messageFrame) {
+      final Bytes input, @NotNull final MessageFrame messageFrame) {
 
     if (input.size() != 192) {
       return PrecompileContractResult.halt(

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/PrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/PrecompiledContract.java
@@ -18,8 +18,8 @@ import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 
 import java.util.Optional;
-import javax.annotation.Nonnull;
 
+import jakarta.validation.constraints.NotNull;
 import org.apache.tuweni.bytes.Bytes;
 
 /**
@@ -53,9 +53,9 @@ public interface PrecompiledContract {
    * @param messageFrame context for this message
    * @return the output of the pre-compiled contract.
    */
-  @Nonnull
+  @NotNull
   PrecompileContractResult computePrecompile(
-      final Bytes input, @Nonnull final MessageFrame messageFrame);
+      final Bytes input, @NotNull final MessageFrame messageFrame);
 
   /**
    * Encapsulated result of precompiled contract.

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/RIPEMD160PrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/RIPEMD160PrecompiledContract.java
@@ -18,8 +18,7 @@ import org.hyperledger.besu.crypto.Hash;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
-import javax.annotation.Nonnull;
-
+import jakarta.validation.constraints.NotNull;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 
@@ -40,10 +39,10 @@ public class RIPEMD160PrecompiledContract extends AbstractPrecompiledContract {
     return gasCalculator().ripemd160PrecompiledContractGasCost(input);
   }
 
-  @Nonnull
+  @NotNull
   @Override
   public PrecompileContractResult computePrecompile(
-      final Bytes input, @Nonnull final MessageFrame messageFrame) {
+      final Bytes input, @NotNull final MessageFrame messageFrame) {
     return PrecompileContractResult.success(Bytes32.leftPad(Hash.ripemd160(input)));
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/SHA256PrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/SHA256PrecompiledContract.java
@@ -18,8 +18,7 @@ import org.hyperledger.besu.crypto.Hash;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
-import javax.annotation.Nonnull;
-
+import jakarta.validation.constraints.NotNull;
 import org.apache.tuweni.bytes.Bytes;
 
 /** The Sha256 precompiled contract. */
@@ -39,10 +38,10 @@ public class SHA256PrecompiledContract extends AbstractPrecompiledContract {
     return gasCalculator().sha256PrecompiledContractGasCost(input);
   }
 
-  @Nonnull
+  @NotNull
   @Override
   public PrecompileContractResult computePrecompile(
-      final Bytes input, @Nonnull final MessageFrame messageFrame) {
+      final Bytes input, @NotNull final MessageFrame messageFrame) {
     return PrecompileContractResult.success(Hash.sha256(input));
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/processor/AbstractMessageProcessor.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/processor/AbstractMessageProcessor.java
@@ -27,8 +27,8 @@ import org.hyperledger.besu.evm.tracing.OperationTracer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
 
+import jakarta.validation.constraints.NotNull;
 import org.apache.tuweni.bytes.Bytes;
 
 /**
@@ -235,7 +235,7 @@ public abstract class AbstractMessageProcessor {
    * @param codeBytes the code bytes
    * @return the code from evm
    */
-  public Code getCodeFromEVM(@Nonnull final Hash codeHash, final Bytes codeBytes) {
+  public Code getCodeFromEVM(@NotNull final Hash codeHash, final Bytes codeBytes) {
     return evm.getCode(codeHash, codeBytes);
   }
 

--- a/evm/src/test/java/org/hyperledger/besu/evm/code/CodeV0Test.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/code/CodeV0Test.java
@@ -32,8 +32,7 @@ import org.hyperledger.besu.evm.operation.JumpOperation;
 import org.hyperledger.besu.evm.operation.Operation.OperationResult;
 import org.hyperledger.besu.evm.worldstate.WorldUpdater;
 
-import javax.annotation.Nonnull;
-
+import jakarta.validation.constraints.NotNull;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.junit.jupiter.api.BeforeEach;
@@ -70,7 +69,7 @@ class CodeV0Test {
     Mockito.verify(getsCached, times(1)).calculateJumpDests();
   }
 
-  @Nonnull
+  @NotNull
   private MessageFrame createJumpFrame(final CodeV0 getsCached) {
     final MessageFrame frame =
         MessageFrame.builder()

--- a/evm/src/test/java/org/hyperledger/besu/evm/fluent/EVMExecutorTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/fluent/EVMExecutorTest.java
@@ -35,9 +35,9 @@ import java.math.BigInteger;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import javax.annotation.Nonnull;
 
 import com.google.common.collect.MultimapBuilder;
+import jakarta.validation.constraints.NotNull;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
@@ -213,7 +213,7 @@ class EVMExecutorTest {
     assertThat(result).isNotNull();
   }
 
-  @Nonnull
+  @NotNull
   private static SimpleWorld createSimpleWorld() {
     SimpleWorld simpleWorld = new SimpleWorld();
 

--- a/evm/src/test/java/org/hyperledger/besu/evm/operation/Create2OperationTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/operation/Create2OperationTest.java
@@ -42,8 +42,8 @@ import org.hyperledger.besu.evm.worldstate.WorldUpdater;
 
 import java.util.Deque;
 import java.util.List;
-import javax.annotation.Nonnull;
 
+import jakarta.validation.constraints.NotNull;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.junit.jupiter.api.Test;
@@ -249,7 +249,7 @@ public class Create2OperationTest {
     assertThat(result.getHaltReason()).isEqualTo(CODE_TOO_LARGE);
   }
 
-  @Nonnull
+  @NotNull
   private MessageFrame testMemoryFrame(final UInt256 memoryOffset, final UInt256 memoryLength) {
     final MessageFrame messageFrame =
         MessageFrame.builder()

--- a/evm/src/test/java/org/hyperledger/besu/evm/operation/CreateOperationTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/operation/CreateOperationTest.java
@@ -40,8 +40,8 @@ import org.hyperledger.besu.evm.worldstate.WorldUpdater;
 
 import java.util.Deque;
 import java.util.List;
-import javax.annotation.Nonnull;
 
+import jakarta.validation.constraints.NotNull;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.junit.jupiter.api.Test;
@@ -241,7 +241,7 @@ class CreateOperationTest {
     assertThat(messageFrame.getStackItem(0).trimLeadingZeros()).isEqualTo(Bytes.EMPTY);
   }
 
-  @Nonnull
+  @NotNull
   private MessageFrame testMemoryFrame(
       final UInt256 memoryOffset,
       final UInt256 memoryLength,

--- a/metrics/core/src/main/java/org/hyperledger/besu/metrics/opentelemetry/DebugMetricReader.java
+++ b/metrics/core/src/main/java/org/hyperledger/besu/metrics/opentelemetry/DebugMetricReader.java
@@ -15,7 +15,6 @@
 package org.hyperledger.besu.metrics.opentelemetry;
 
 import java.util.Collection;
-import javax.annotation.Nonnull;
 
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.metrics.InstrumentType;
@@ -23,6 +22,7 @@ import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.export.CollectionRegistration;
 import io.opentelemetry.sdk.metrics.export.MetricReader;
+import jakarta.validation.constraints.NotNull;
 
 class DebugMetricReader implements MetricReader {
   private CollectionRegistration registration;
@@ -34,7 +34,7 @@ class DebugMetricReader implements MetricReader {
   }
 
   @Override
-  public void register(final @Nonnull CollectionRegistration registration) {
+  public void register(final @NotNull CollectionRegistration registration) {
     this.registration = registration;
   }
 
@@ -50,7 +50,7 @@ class DebugMetricReader implements MetricReader {
 
   @Override
   public AggregationTemporality getAggregationTemporality(
-      final @Nonnull InstrumentType instrumentType) {
+      final @NotNull InstrumentType instrumentType) {
     return AggregationTemporality.CUMULATIVE;
   }
 }

--- a/platform/build.gradle
+++ b/platform/build.gradle
@@ -117,6 +117,8 @@ dependencies {
     api 'io.consensys.tuweni:tuweni-toml:2.7.0'
     api 'io.consensys.tuweni:tuweni-units:2.7.0'
 
+    api 'jakarta.validation:jakarta.validation-api:3.0.2'
+
     api 'javax.inject:javax.inject:1'
 
     api 'net.java.dev.jna:jna:5.16.0'

--- a/services/tasks/src/main/java/org/hyperledger/besu/services/tasks/InMemoryTasksPriorityQueues.java
+++ b/services/tasks/src/main/java/org/hyperledger/besu/services/tasks/InMemoryTasksPriorityQueues.java
@@ -22,7 +22,8 @@ import java.util.PriorityQueue;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
-import javax.annotation.Nonnull;
+
+import jakarta.validation.constraints.NotNull;
 
 /**
  * The InMemory tasks priority queues.
@@ -48,7 +49,7 @@ public class InMemoryTasksPriorityQueues<T extends TasksPriorityProvider>
     }
   }
 
-  @Nonnull
+  @NotNull
   private PriorityQueue<T> newEmptyQueue() {
     return new PriorityQueue<>(Comparator.comparingLong(TasksPriorityProvider::getPriority));
   }


### PR DESCRIPTION
## PR description

`@Nonnull` annotation is part of JSR-305 specification, but the JSR-305 specification is no longer actively maintained, which may limit its adoption in modern projects.

The proposed PR replace it with '@NotNull` from Jakarta validation.

This change is also preliminary to following dependency updates.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

