### PR TITLE
ignore invalid ENR nodes in DNS daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Bug fixes
 - Fix `besu -X` unstable options help [#8662](https://github.com/hyperledger/besu/pull/8662)
+- Prevent parsing of invalid ENR records from crashing DNSDaemon [#8368](https://github.com/hyperledger/besu/issues/8368)
 
 ## 25.5.0
 ### Breaking Changes

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/dns/DNSEntry.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/dns/DNSEntry.java
@@ -65,7 +65,7 @@ public interface DNSEntry {
       try {
         return Bytes.wrap(Base64.getUrlDecoder().decode(enrValue));
       } catch (IllegalArgumentException iae) {
-        LOG.info("enr value `{}` is not properly base64url encoded", enrValue);
+        LOG.debug("enr value `{}` is not properly base64url encoded", enrValue);
         return null;
       }
     }

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/dns/DNSEntry.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/dns/DNSEntry.java
@@ -27,6 +27,8 @@ import org.apache.tuweni.crypto.SECP256K1;
 import org.apache.tuweni.io.Base32;
 import org.apache.tuweni.io.Base64URLSafe;
 import org.bouncycastle.math.ec.ECPoint;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 // Adapted from https://github.com/tmio/tuweni and licensed under Apache 2.0
 /** Intermediate format to write DNS entries */
@@ -34,24 +36,38 @@ public interface DNSEntry {
 
   /** Represents a node in the ENR record. */
   class ENRNode implements DNSEntry {
+    private static final Logger LOG = LoggerFactory.getLogger(ENRNode.class);
 
     private final EthereumNodeRecord nodeRecord;
 
+    private ENRNode(final EthereumNodeRecord nodeRecord) {
+      this.nodeRecord = nodeRecord;
+    }
+
     /**
-     * Constructs ENRNode with the given attributes.
+     * Create an ENRNode with the given attributes.
      *
      * @param attrs the attributes of the node
+     * @return created ENRNode
      */
-    public ENRNode(final Map<String, String> attrs) {
+    public static ENRNode fromAttrs(final Map<String, String> attrs) {
       if (attrs == null) {
         throw new IllegalArgumentException("ENRNode attributes cannot be null");
       }
-      nodeRecord =
-          Optional.ofNullable(attrs.get("enr"))
-              .map(Base64.getUrlDecoder()::decode)
-              .map(Bytes::wrap)
-              .map(EthereumNodeRecord::fromRLP)
-              .orElseThrow(() -> new IllegalArgumentException("Invalid ENR record"));
+      return Optional.ofNullable(attrs.get("enr"))
+          .map(ENRNode::decodeValue)
+          .map(EthereumNodeRecord::fromRLP)
+          .map(ENRNode::new)
+          .orElse(null);
+    }
+
+    private static Bytes decodeValue(final String enrValue) {
+      try {
+        return Bytes.wrap(Base64.getUrlDecoder().decode(enrValue));
+      } catch (IllegalArgumentException iae) {
+        LOG.info("enr value `{}` is not properly base64url encoded", enrValue);
+        return null;
+      }
     }
 
     /**

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/dns/DNSResolver.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/dns/DNSResolver.java
@@ -194,16 +194,15 @@ public class DNSResolver {
         case "enrtree-branch":
           return new DNSEntry.ENRTree(record.substring(prefix.length() + 1));
         case "enr":
-          return new ENRNode(readKV(record));
+          return ENRNode.fromAttrs(readKV(record));
         case "enrtree":
           return new ENRTreeLink(record);
       }
+      LOG.error("{} should contain enrtree-branch, enr, enrtree-root or enrtree", serialized);
     } catch (Throwable t) {
-      LOG.error("Failed to parse record: {}", record);
-      throw t;
+      LOG.warn("Failed to parse record: {}", record);
     }
-    throw new IllegalArgumentException(
-        serialized + " should contain enrtree-branch, enr, enrtree-root or enrtree");
+    return null;
   }
 
   private static String trimQuotes(final String str) {

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/dns/DNSDaemonTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/dns/DNSDaemonTest.java
@@ -28,7 +28,6 @@ import io.vertx.junit5.VertxTestContext;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -98,7 +97,59 @@ class DNSDaemonTest {
     vertx.deployVerticle(dnsDaemon, options);
   }
 
-  @Disabled("test is flaky see https://github.com/hyperledger/besu/issues/8373")
+  @Test
+  @DisplayName("Test DNS Daemon with a mock DNS server and add in am invalid ENR")
+  void invalidEnrShouldNotCrashDaemon(final Vertx vertx, final VertxTestContext testContext) {
+    final Checkpoint checkpoint = testContext.checkpoint();
+    dnsDaemon =
+        new DNSDaemon(
+            holeskyEnr,
+            (seq, records) -> {
+              if (seq != EXPECTED_SEQ) {
+                testContext.failNow(
+                    String.format(
+                        "Expecting sequence to be %d in first pass but got: %d",
+                        EXPECTED_SEQ, seq));
+              }
+              if (records.size() != 115) {
+                testContext.failNow(
+                    "Expecting 115 records in first pass but got: " + records.size());
+              }
+              records.forEach(
+                  enr -> {
+                    try {
+                      // make sure enode url can be built from record
+                      EnodeURLImpl.builder()
+                          .ipAddress(enr.ip())
+                          .nodeId(enr.publicKey())
+                          .discoveryPort(enr.udp())
+                          .listeningPort(enr.tcp())
+                          .build();
+                    } catch (final Exception e) {
+                      testContext.failNow(e);
+                    }
+                  });
+              checkpoint.flag();
+            },
+            0,
+            1L,
+            0,
+            "localhost:" + mockDnsServerVerticle.port());
+
+    mockDnsServerVerticle.addTxtRecord(
+        "FDXN3SN67NA5DKA4J2GOK7BVQI.all.holesky.ethdisco.net",
+        "enrtree-branch:I56MJAJBMXTZZEPBQR6HWNAH7A");
+    mockDnsServerVerticle.addTxtRecord(
+        "I56MJAJBMXTZZEPBQR6HWNAH7A.all.holesky.ethdisco.net", "enr:-Lu4QMFaK");
+
+    final DeploymentOptions options =
+        new DeploymentOptions()
+            .setThreadingModel(ThreadingModel.VIRTUAL_THREAD)
+            .setWorkerPoolSize(1);
+    vertx.deployVerticle(dnsDaemon, options);
+  }
+
+  //  @Disabled("test is flaky see https://github.com/hyperledger/besu/issues/8373")
   @Test
   @DisplayName("Test DNS Daemon with periodic lookup to a mock DNS server")
   void testDNSDaemonPeriodic(final Vertx vertx, final VertxTestContext testContext)

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/dns/DNSDaemonTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/dns/DNSDaemonTest.java
@@ -98,7 +98,7 @@ class DNSDaemonTest {
   }
 
   @Test
-  @DisplayName("Test DNS Daemon with a mock DNS server and add in am invalid ENR")
+  @DisplayName("Test DNS Daemon with a mock DNS server with invalid ENR records")
   void invalidEnrShouldNotCrashDaemon(final Vertx vertx, final VertxTestContext testContext) {
     final Checkpoint checkpoint = testContext.checkpoint();
     dnsDaemon =
@@ -138,9 +138,22 @@ class DNSDaemonTest {
 
     mockDnsServerVerticle.addTxtRecord(
         "FDXN3SN67NA5DKA4J2GOK7BVQI.all.holesky.ethdisco.net",
-        "enrtree-branch:I56MJAJBMXTZZEPBQR6HWNAH7A");
+        "enrtree-branch:I56MJAJBMXTZZEPBQR6HWNAH7A,I56GAAJBMXTZZEPBQR6HWNAH7A,I56HGDJBMXTZZEPBQR6HWNAH7A");
+
+    // ENR value - invalid encoding
     mockDnsServerVerticle.addTxtRecord(
         "I56MJAJBMXTZZEPBQR6HWNAH7A.all.holesky.ethdisco.net", "enr:-Lu4QMFaK");
+
+    // empty ENR record
+    mockDnsServerVerticle.addTxtRecord(
+        "I56GAAJBMXTZZEPBQR6HWNAH7A.all.holesky.ethdisco.net", "enr:");
+
+    // invalid IP field in ENR record
+    mockDnsServerVerticle.addTxtRecord(
+        "I56HGDJBMXTZZEPBQR6HWNAH7A.all.holesky.ethdisco.net",
+        "enr:-KS4QK1ecw-CGrDDZ4YwFrhgqctD0tWMHKJhUVxsS4um3aUFe3yBHRtVL9uYKk16DurN1IdSKTOB1zNCvjBybjZ_KAqGAYtJ5U8wg2V0a"
+            + "MfGhJsZKtCAgmlkgnY0gmlwhQ_MtDn_iXNlY3AyNTZrMaEDVw-3497LHMjigYh2MteIoI9byWFnSmGR-590_KkaSHGEc25hcMCDdGNwgnZf"
+            + "g3VkcIJ2Xw");
 
     final DeploymentOptions options =
         new DeploymentOptions()

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/dns/DNSResolverTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/dns/DNSResolverTest.java
@@ -16,8 +16,11 @@ package org.hyperledger.besu.ethereum.p2p.discovery.dns;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.net.InetAddress;
 import java.security.Security;
+import java.util.Optional;
 
+import org.apache.tuweni.bytes.Bytes;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -67,5 +70,44 @@ class DNSResolverTest {
             "EYBOZ2NZSHDWDSNHV66XASXOHM",
             "FUVRJMMMKJMCL4L4EBEOWCSOFA")
         .doesNotContain("EC6Q");
+  }
+
+  @Test
+  void enrNodeIsParsed() throws Exception {
+    final String txtRecord =
+        "\"enr:-KO4QK1ecw-CGrDDZ4YwFrhgqctD0tWMHKJhUVxsS4um3aUFe3yBHRtVL9uYKk16DurN1IdSKTOB1zNCvjBybjZ_KAqGAYt"
+            + "J5U8wg2V0aMfGhJsZKtCAgmlkgnY0gmlwhA_MtDmJc2VjcDI1NmsxoQNXD7fj3sscyOKBiHYy14igj1vJYWdKYZH7n3T8qRpIcY"
+            + "RzbmFwwIN0Y3CCdl-DdWRwgnZf\"";
+    final DNSEntry entry = DNSResolver.readDNSEntry(txtRecord);
+
+    assertThat(entry).isInstanceOf(DNSEntry.ENRNode.class);
+    final EthereumNodeRecord record = ((DNSEntry.ENRNode) entry).nodeRecord();
+    assertThat(record.rlp())
+        .isEqualTo(
+            Bytes.fromHexString(
+                "0xf8a3b840ad5e730f821ab0c367863016b860a9cb43d2d58"
+                    + "c1ca261515c6c4b8ba6dda5057b7c811d1b552fdb982a4d7a0eeacdd48752293381d73342be30726e367f280a86018b49e54f3"
+                    + "083657468c7c6849b192ad080826964827634826970840fccb43989736563703235366b31a103570fb7e3decb1cc8e28188763"
+                    + "2d788a08f5bc961674a6191fb9f74fca91a487184736e6170c08374637082765f8375647082765f"));
+    assertThat(record.publicKey())
+        .isEqualTo(
+            Bytes.fromHexString(
+                "0x570fb7e3decb1cc8e281887632d788a08f5bc9616"
+                    + "74a6191fb9f74fca91a4871957e3775d4bdfd4fdeff9bff92ad2f5965234d0e3c04ab4b85ab3eabd3193c35"));
+    assertThat(record.ip())
+        .isEqualTo(InetAddress.getByAddress(new byte[] {15, (byte) 204, (byte) 180, 57}));
+    assertThat(record.tcp()).isEqualTo(Optional.of(30303));
+    assertThat(record.udp()).isEqualTo(Optional.of(30303));
+  }
+
+  @Test
+  void invalidEnrNodeIsIgnored() {
+    final String txtRecord =
+        "\"enr:-Lu4QMFaKrYJyYO06WxKfW8njcWATSuGJZV72zCIv6dTsihJJ4QM48Sxpi1xN--CI3MX4MTy-qhknkn9ESZF3_AOvhuGAZS-"
+            + "S2T2g2V0aMrJhPxk7ASDEYwwgmlkgnY0gmlwhLkcZFKDaXA2kCABFegBEChSAAAAAAAAAAGJc2VjcDI1NmsxoQM9Tj7Od8vEHMK8"
+            + "qCD8T0RHeN_LeLbbETpKFlfhx4UVzIRzbmFwwIN0Y3CCdl-DdWRwg\"";
+    final DNSEntry entry = DNSResolver.readDNSEntry(txtRecord);
+
+    assertThat(entry).isNull();
   }
 }

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/dns/MockDnsServerVerticle.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/dns/MockDnsServerVerticle.java
@@ -71,6 +71,10 @@ public class MockDnsServerVerticle extends AbstractVerticle {
             });
   }
 
+  public void addTxtRecord(final String key, final String value) {
+    txtRecords.put(key, value);
+  }
+
   @Override
   public void stop() {
     LOG.info("Stopping Mock DNS Server");


### PR DESCRIPTION
## PR description
Badly encoded ENR nodes should be ignored instead of crashing the daemon. Example of a badly encoded ENR node seen in the wild:
```
{"@timestamp":"2025-05-23T02:26:27,631","level":"ERROR","thread":"vert.x-virtual-thread-3681","class":"DNSResolver","message":"Failed to parse record: enr:-Lu4QMFaKrYJyYO06WxKfW8njcWATSuGJZV72zCIv6dTsihJJ4QM48Sxpi1xN--CI3MX4MTy-qhknkn9ESZF3_AOvhuGAZS-S2T2g2V0aMrJhPxk7ASDEYwwgmlkgnY0gmlwhLkcZFKDaXA2kCABFegBEChSAAAAAAAAAAGJc2VjcDI1NmsxoQM9Tj7Od8vEHMK8qCD8T0RHeN_LeLbbETpKFlfhx4UVzIRzbmFwwIN0Y3CCdl-DdWRwg","throwable":""}
```

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
#fixes 8368

### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

