### PR TITLE
Swap precedence order while parsing enr records

### DIFF
--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/dns/KVReader.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/dns/KVReader.java
@@ -33,11 +33,11 @@ public class KVReader {
     return Arrays.stream(record.split("\\s+"))
         .map(
             it -> {
-              // if it contains an = or :, split into Map.entry from the first occurrence
-              if (it.contains("=")) {
-                return it.split("=", 2);
-              } else if (it.contains(":")) {
+              // First split on ':' since Base64 uses '=' as padding
+              if (it.contains(":")) {
                 return it.split(":", 2);
+              } else if (it.contains("=")) {
+                return it.split("=", 2);
               } else {
                 // this should not happen, as the record should be well-formed
                 return new String[] {it};


### PR DESCRIPTION
## PR description
I also noticed an edge case in ENR records where if its value, which is encoded in Base64, contains a `=` that is a perfectly legit character and means a padded value, then the parsing will fail. 

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #8697

### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

