### PR TITLE
refactor(testing): remove trusted setup initialisation from BlobTestFixture

### DIFF
--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV1Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV1Test.java
@@ -42,6 +42,7 @@ import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.core.TransactionTestFixture;
 import org.hyperledger.besu.ethereum.core.kzg.BlobsWithCommitments;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
+import org.hyperledger.besu.ethereum.util.TrustedSetupClassLoaderExtension;
 import org.hyperledger.besu.plugin.services.rpc.RpcResponseType;
 
 import java.math.BigInteger;
@@ -63,7 +64,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
-@ExtendWith(MockitoExtension.class)
+@ExtendWith({MockitoExtension.class, TrustedSetupClassLoaderExtension.class})
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class EngineGetBlobsV1Test {
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadV3Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadV3Test.java
@@ -48,6 +48,7 @@ import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.core.TransactionReceipt;
 import org.hyperledger.besu.ethereum.core.TransactionTestFixture;
 import org.hyperledger.besu.ethereum.core.kzg.BlobsWithCommitments;
+import org.hyperledger.besu.ethereum.util.TrustedSetupClassLoaderExtension;
 
 import java.math.BigInteger;
 import java.util.Collections;
@@ -62,8 +63,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(
-    MockitoExtension.class) // mocks in parent class may not be used, throwing unnecessary stubbing
+@ExtendWith({MockitoExtension.class, TrustedSetupClassLoaderExtension.class})
 public class EngineGetPayloadV3Test extends AbstractEngineGetPayloadTest {
 
   public EngineGetPayloadV3Test() {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadV4Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadV4Test.java
@@ -47,6 +47,7 @@ import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.core.TransactionReceipt;
 import org.hyperledger.besu.ethereum.core.TransactionTestFixture;
 import org.hyperledger.besu.ethereum.core.kzg.BlobsWithCommitments;
+import org.hyperledger.besu.ethereum.util.TrustedSetupClassLoaderExtension;
 
 import java.math.BigInteger;
 import java.util.Comparator;
@@ -61,8 +62,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(
-    MockitoExtension.class) // mocks in parent class may not be used, throwing unnecessary stubbing
+@ExtendWith({MockitoExtension.class, TrustedSetupClassLoaderExtension.class})
 public class EngineGetPayloadV4Test extends AbstractEngineGetPayloadTest {
 
   public EngineGetPayloadV4Test() {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV3Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV3Test.java
@@ -56,6 +56,7 @@ import org.hyperledger.besu.ethereum.mainnet.BodyValidation;
 import org.hyperledger.besu.ethereum.mainnet.CancunTargetingGasLimitCalculator;
 import org.hyperledger.besu.ethereum.mainnet.ScheduledProtocolSpec;
 import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
+import org.hyperledger.besu.ethereum.util.TrustedSetupClassLoaderExtension;
 import org.hyperledger.besu.evm.gascalculator.CancunGasCalculator;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 
@@ -74,7 +75,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
+@ExtendWith({MockitoExtension.class, TrustedSetupClassLoaderExtension.class})
 public class EngineNewPayloadV3Test extends EngineNewPayloadV2Test {
   private static final Supplier<SignatureAlgorithm> SIGNATURE_ALGORITHM =
       Suppliers.memoize(SignatureAlgorithmFactory::getInstance);

--- a/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreatorTest.java
+++ b/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreatorTest.java
@@ -79,6 +79,7 @@ import org.hyperledger.besu.ethereum.mainnet.requests.DepositRequestProcessor;
 import org.hyperledger.besu.ethereum.mainnet.requests.RequestProcessingContext;
 import org.hyperledger.besu.ethereum.mainnet.systemcall.BlockProcessingContext;
 import org.hyperledger.besu.ethereum.transaction.TransactionInvalidReason;
+import org.hyperledger.besu.ethereum.util.TrustedSetupClassLoaderExtension;
 import org.hyperledger.besu.evm.account.Account;
 import org.hyperledger.besu.evm.internal.EvmConfiguration;
 import org.hyperledger.besu.evm.log.Log;
@@ -101,7 +102,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
+@ExtendWith({MockitoExtension.class, TrustedSetupClassLoaderExtension.class})
 abstract class AbstractBlockCreatorTest {
   private static final Supplier<SignatureAlgorithm> SIGNATURE_ALGORITHM =
       Suppliers.memoize(SignatureAlgorithmFactory::getInstance);

--- a/ethereum/core/src/test-support/java/org/hyperledger/besu/ethereum/core/BlobTestFixture.java
+++ b/ethereum/core/src/test-support/java/org/hyperledger/besu/ethereum/core/BlobTestFixture.java
@@ -14,14 +14,11 @@
  */
 package org.hyperledger.besu.ethereum.core;
 
-import static org.assertj.core.api.Assertions.fail;
-
 import org.hyperledger.besu.datatypes.VersionedHash;
 import org.hyperledger.besu.ethereum.core.kzg.Blob;
 import org.hyperledger.besu.ethereum.core.kzg.BlobsWithCommitments;
 import org.hyperledger.besu.ethereum.core.kzg.KZGCommitment;
 import org.hyperledger.besu.ethereum.core.kzg.KZGProof;
-import org.hyperledger.besu.evm.precompile.KZGPointEvalPrecompiledContract;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,30 +29,25 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.bytes.Bytes48;
 import org.bouncycastle.crypto.digests.SHA256Digest;
 
+/**
+ * A utility class for creating blobs and their associated cryptographic artifacts (KZG commitments,
+ * proofs, and versioned hashes) for testing purposes.
+ *
+ * <p>This class facilitates testing scenarios involving Ethereum's blob and KZG cryptographic
+ * primitives. It uses the CKZG4844JNI library to compute KZG commitments and proofs and provides
+ * methods to generate blobs and their associated data.
+ *
+ * <p>To ensure the required trusted setup is loaded, use the {@link
+ * org.hyperledger.besu.ethereum.util.TrustedSetupClassLoaderExtension} in your test classes. This
+ * extension handles loading the native library and trusted setup automatically.
+ *
+ * @see org.hyperledger.besu.ethereum.util.TrustedSetupClassLoaderExtension
+ */
 public class BlobTestFixture {
-
   private byte byteValue = 0x00;
-
-  public BlobTestFixture() {
-    try {
-      // optimistically tear down a potential previous loaded trusted setup
-      KZGPointEvalPrecompiledContract.tearDown();
-    } catch (Throwable ignore) {
-      // and ignore errors in case no trusted setup was already loaded
-    }
-    try {
-      CKZG4844JNI.loadNativeLibrary();
-      CKZG4844JNI.loadTrustedSetupFromResource(
-          "/kzg-trusted-setups/mainnet.txt", BlobTestFixture.class, 0);
-
-    } catch (Exception e) {
-      fail("Failed to compute commitment", e);
-    }
-  }
 
   record BlobTriplet(
       Blob blob, KZGCommitment kzgCommitment, KZGProof kzgProof, VersionedHash versionedHash) {}
-  ;
 
   public BlobTriplet createBlobTriplet() {
     byte[] rawMaterial = new byte[131072];

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionValidatorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionValidatorTest.java
@@ -46,6 +46,7 @@ import org.hyperledger.besu.ethereum.core.kzg.KZGCommitment;
 import org.hyperledger.besu.ethereum.core.kzg.KZGProof;
 import org.hyperledger.besu.ethereum.mainnet.feemarket.FeeMarket;
 import org.hyperledger.besu.ethereum.transaction.TransactionInvalidReason;
+import org.hyperledger.besu.ethereum.util.TrustedSetupClassLoaderExtension;
 import org.hyperledger.besu.evm.account.Account;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
@@ -65,7 +66,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
-@ExtendWith(MockitoExtension.class)
+@ExtendWith({MockitoExtension.class, TrustedSetupClassLoaderExtension.class})
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class MainnetTransactionValidatorTest {
 

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/transaction/TransactionSimulatorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/transaction/TransactionSimulatorTest.java
@@ -55,6 +55,7 @@ import org.hyperledger.besu.ethereum.mainnet.blockhash.BlockHashProcessor;
 import org.hyperledger.besu.ethereum.mainnet.feemarket.FeeMarket;
 import org.hyperledger.besu.ethereum.processing.TransactionProcessingResult;
 import org.hyperledger.besu.ethereum.processing.TransactionProcessingResult.Status;
+import org.hyperledger.besu.ethereum.util.TrustedSetupClassLoaderExtension;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
 import org.hyperledger.besu.evm.account.Account;
 import org.hyperledger.besu.evm.account.MutableAccount;
@@ -78,7 +79,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
-@ExtendWith(MockitoExtension.class)
+@ExtendWith({MockitoExtension.class, TrustedSetupClassLoaderExtension.class})
 @MockitoSettings(strictness = Strictness.LENIENT)
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class TransactionSimulatorTest {

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/util/TrustedSetupClassLoaderExtension.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/util/TrustedSetupClassLoaderExtension.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.util;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.hyperledger.besu.evm.precompile.KZGPointEvalPrecompiledContract;
+
+import ethereum.ckzg4844.CKZG4844JNI;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/** JUnit extension to load the native library and trusted setup for the entire test class. */
+public class TrustedSetupClassLoaderExtension implements BeforeAllCallback {
+  private static final String TRUSTED_SETUP_RESOURCE = "/kzg-trusted-setups/mainnet.txt";
+
+  @Override
+  public void beforeAll(final ExtensionContext context) {
+    try {
+      // Optimistically tear down any previously loaded trusted setup.
+      try {
+        KZGPointEvalPrecompiledContract.tearDown();
+      } catch (Throwable ignore) {
+        // Ignore errors if no trusted setup was already loaded.
+      }
+      CKZG4844JNI.loadNativeLibrary();
+      CKZG4844JNI.loadTrustedSetupFromResource(
+          TRUSTED_SETUP_RESOURCE, context.getTestClass().orElseThrow(), 0);
+    } catch (Exception e) {
+      fail("Failed to load trusted setup or native library", e);
+    }
+  }
+}

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/AbstractTransactionPoolTestBase.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/AbstractTransactionPoolTestBase.java
@@ -70,6 +70,7 @@ import org.hyperledger.besu.ethereum.mainnet.TransactionValidatorFactory;
 import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
 import org.hyperledger.besu.ethereum.mainnet.feemarket.FeeMarket;
 import org.hyperledger.besu.ethereum.transaction.TransactionInvalidReason;
+import org.hyperledger.besu.ethereum.util.TrustedSetupClassLoaderExtension;
 import org.hyperledger.besu.evm.account.Account;
 import org.hyperledger.besu.evm.internal.EvmConfiguration;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
@@ -98,7 +99,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 
 @SuppressWarnings("unchecked")
-@ExtendWith(MockitoExtension.class)
+@ExtendWith({MockitoExtension.class, TrustedSetupClassLoaderExtension.class})
 @MockitoSettings(strictness = LENIENT)
 public abstract class AbstractTransactionPoolTestBase {
 


### PR DESCRIPTION
## PR description

This PR refactors BlobTestFixture by removing the trusted setup initialisation logic and introducing a reusable JUnit extension (`TrustedSetupClassLoaderExtension`). The extension ensures the trusted setup is loaded once per test class.
