### PR TITLE
Add vertx and vertx-web-client to plugin-api

### DIFF
--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -35,7 +35,9 @@ dependencies {
   api 'io.consensys.tuweni:tuweni-units'
   implementation 'com.google.guava:guava'
   implementation project(':evm')
-  compileOnly 'io.vertx:vertx-core'
+  // included so plugins do not need to depend on a specific vertx version
+  implementation 'io.vertx:vertx-core'
+  implementation 'io.vertx:vertx-web-client'
 }
 
 configurations { testArtifacts }


### PR DESCRIPTION
## PR description
besu plugins such as fleet-mode and besu-shomei use vertx-web-client for RPC.  

Plugins *can* include their own vertx version and reference, hoping that it does not conflict with besu, but it seems wiser to include vertx dependencies in the plugin-api (or potentially a separate besu-support library)

Open to suggestions here, but this was what I needed to do to get the besu-shomei-plugin working (include it in a besu dep)


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

