### PR TITLE
fix(testing): wait for trusted setup to finish loading before running tests

### DIFF
--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/util/TrustedSetupClassLoaderExtension.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/util/TrustedSetupClassLoaderExtension.java
@@ -18,28 +18,80 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import org.hyperledger.besu.evm.precompile.KZGPointEvalPrecompiledContract;
 
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import ethereum.ckzg4844.CKZG4844JNI;
+import ethereum.ckzg4844.CKZGException;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-/** JUnit extension to load the native library and trusted setup for the entire test class. */
 public class TrustedSetupClassLoaderExtension implements BeforeAllCallback {
+  private static final Logger LOG = LoggerFactory.getLogger(TrustedSetupClassLoaderExtension.class);
   private static final String TRUSTED_SETUP_RESOURCE = "/kzg-trusted-setups/mainnet.txt";
 
   @Override
   public void beforeAll(final ExtensionContext context) {
     try {
-      // Optimistically tear down any previously loaded trusted setup.
-      try {
-        KZGPointEvalPrecompiledContract.tearDown();
-      } catch (Throwable ignore) {
-        // Ignore errors if no trusted setup was already loaded.
-      }
-      CKZG4844JNI.loadNativeLibrary();
-      CKZG4844JNI.loadTrustedSetupFromResource(
-          TRUSTED_SETUP_RESOURCE, context.getTestClass().orElseThrow(), 0);
+      tearDownExistingSetup();
+      loadTrustedSetup(context);
+      awaitTrustedSetupLoad();
     } catch (Exception e) {
       fail("Failed to load trusted setup or native library", e);
+    }
+  }
+
+  // Tear down any existing setup to ensure a clean state before loading the trusted setup.
+  private void tearDownExistingSetup() {
+    try {
+      KZGPointEvalPrecompiledContract.tearDown();
+    } catch (Throwable ignore) {
+      // Ignore errors if no trusted setup was already loaded.
+    }
+  }
+
+  // Load the trusted setup from the specified resource.
+  private void loadTrustedSetup(final ExtensionContext context) {
+    CKZG4844JNI.loadNativeLibrary();
+    CKZG4844JNI.loadTrustedSetupFromResource(
+        TRUSTED_SETUP_RESOURCE, context.getTestClass().orElseThrow(), 0);
+  }
+
+  // Wait for the trusted setup to be loaded by checking if we can create a KZG commitment.
+  private void awaitTrustedSetupLoad() {
+    AtomicBoolean trustedSetupLoaded = new AtomicBoolean(false);
+
+    Awaitility.await()
+        .atMost(5, TimeUnit.SECONDS)
+        .pollDelay(100, TimeUnit.MILLISECONDS)
+        .pollInterval(100, TimeUnit.MILLISECONDS)
+        .until(() -> isTrustedSetupLoaded(trustedSetupLoaded));
+
+    if (!trustedSetupLoaded.get()) {
+      fail("Trusted setup not loaded");
+    } else {
+      LOG.info("Trusted setup loaded successfully from {}", TRUSTED_SETUP_RESOURCE);
+    }
+  }
+
+  // Check if the trusted setup is loaded by attempting to create a KZG commitment.
+  private boolean isTrustedSetupLoaded(final AtomicBoolean trustedSetupLoaded) {
+    try {
+      // Attempt to create a KZG commitment with an empty blob.
+      // If the trusted setup is loaded, this should throw a C_KZG_BADARGS exception.
+      CKZG4844JNI.blobToKzgCommitment(new byte[0]);
+      return false;
+    } catch (CKZGException e) {
+      // Check if the exception indicates invalid arguments (C_KZG_BADARGS),
+      // which confirms the trusted setup is loaded.
+      if (e.getError() == CKZGException.CKZGError.C_KZG_BADARGS) {
+        trustedSetupLoaded.set(true);
+        return true;
+      }
+      return false;
     }
   }
 }


### PR DESCRIPTION
## PR description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

