### PR TITLE
Add Block size when available

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/BlockResultFactory.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/BlockResultFactory.java
@@ -90,7 +90,7 @@ public class BlockResultFactory {
             .map(TextNode::new)
             .collect(Collectors.toList());
     return new BlockResult(
-        block.getHeader(), txs, ommers, block.getHeader().getDifficulty(), block.calculateSize());
+        block.getHeader(), txs, ommers, block.getHeader().getDifficulty(), block.getSize());
   }
 
   public EngineGetPayloadResultV1 payloadTransactionCompleteV1(final Block block) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/BlockStateCallResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/BlockStateCallResult.java
@@ -43,7 +43,7 @@ public class BlockStateCallResult extends BlockResult {
         transactions,
         List.of(),
         null,
-        block.calculateSize(),
+        block.getSize(),
         false,
         block.getBody().getWithdrawals());
     this.callProcessingResults = callProcessingResults;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/UncleBlockResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/UncleBlockResult.java
@@ -31,7 +31,7 @@ public class UncleBlockResult {
    */
   public static BlockResult build(final BlockHeader header) {
     final BlockBody body = new BlockBody(Collections.emptyList(), Collections.emptyList());
-    final int size = new Block(header, body).calculateSize();
+    final int size = new Block(header, body).getSize();
     return new BlockResult(
         header, Collections.emptyList(), Collections.emptyList(), Difficulty.ZERO, size);
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueries.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueries.java
@@ -452,7 +452,7 @@ public class BlockchainQueries {
                                           body.getOmmers().stream()
                                               .map(BlockHeader::getHash)
                                               .collect(Collectors.toList());
-                                      final int size = new Block(header, body).calculateSize();
+                                      final int size = new Block(header, body).getSize();
                                       return new BlockWithMetadata<>(
                                           header,
                                           formattedTxs,
@@ -512,7 +512,7 @@ public class BlockchainQueries {
                                           body.getOmmers().stream()
                                               .map(BlockHeader::getHash)
                                               .collect(Collectors.toList());
-                                      final int size = new Block(header, body).calculateSize();
+                                      final int size = new Block(header, body).getSize();
                                       return new BlockWithMetadata<>(
                                           header, txs, ommers, td, size, body.getWithdrawals());
                                     })));

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTest.java
@@ -1737,7 +1737,7 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
         .isEqualTo(header.getDifficulty());
     assertThat(Bytes.fromHexStringLenient(result.getString("extraData")))
         .isEqualTo(header.getExtraData());
-    assertThat(hexStringToInt(result.getString("size"))).isEqualTo(block.calculateSize());
+    assertThat(hexStringToInt(result.getString("size"))).isEqualTo(block.getSize());
     assertThat(Long.decode(result.getString("gasLimit"))).isEqualTo(header.getGasLimit());
     assertThat(Long.decode(result.getString("gasUsed"))).isEqualTo(header.getGasUsed());
     assertThat(Long.decode(result.getString("timestamp"))).isEqualTo(header.getTimestamp());
@@ -1827,7 +1827,7 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
 
   public BlockWithMetadata<TransactionWithMetadata, Hash> blockWithMetadata(final Block block) {
     final Difficulty td = block.getHeader().getDifficulty().add(10L);
-    final int size = block.calculateSize();
+    final int size = block.getSize();
 
     final List<Transaction> txs = block.getBody().getTransactions();
     final List<TransactionWithMetadata> formattedTxs = new ArrayList<>(txs.size());
@@ -1847,7 +1847,7 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
 
   public BlockWithMetadata<Hash, Hash> blockWithMetadataAndTxHashes(final Block block) {
     final Difficulty td = block.getHeader().getDifficulty().add(10L);
-    final int size = block.calculateSize();
+    final int size = block.getSize();
 
     final List<Hash> txs =
         block.getBody().getTransactions().stream()

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetUncleByBlockHashAndIndexTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetUncleByBlockHashAndIndexTest.java
@@ -148,11 +148,7 @@ public class EthGetUncleByBlockHashAndIndexTest {
     final Block block =
         new Block(header, new BlockBody(Collections.emptyList(), Collections.emptyList()));
     return new BlockResult(
-        header,
-        Collections.emptyList(),
-        Collections.emptyList(),
-        Difficulty.ZERO,
-        block.calculateSize());
+        header, Collections.emptyList(), Collections.emptyList(), Difficulty.ZERO, block.getSize());
   }
 
   private JsonRpcRequestContext getUncleByBlockHashAndIndex(final Object[] params) {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetUncleByBlockNumberAndIndexTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetUncleByBlockNumberAndIndexTest.java
@@ -125,11 +125,7 @@ public class EthGetUncleByBlockNumberAndIndexTest {
     final Block block =
         new Block(header, new BlockBody(Collections.emptyList(), Collections.emptyList()));
     return new BlockResult(
-        header,
-        Collections.emptyList(),
-        Collections.emptyList(),
-        Difficulty.ZERO,
-        block.calculateSize());
+        header, Collections.emptyList(), Collections.emptyList(), Difficulty.ZERO, block.getSize());
   }
 
   private JsonRpcRequestContext getUncleByBlockNumberAndIndex(final Object[] params) {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/Block.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/Block.java
@@ -29,10 +29,18 @@ public class Block {
 
   private final BlockHeader header;
   private final BlockBody body;
+  private int size;
+
+  public Block(final BlockHeader header, final BlockBody body, final int size) {
+    this.header = header;
+    this.body = body;
+    this.size = size;
+  }
 
   public Block(final BlockHeader header, final BlockBody body) {
     this.header = header;
     this.body = body;
+    this.size = -1; // Size will be calculated on demand
   }
 
   public BlockHeader getHeader() {
@@ -51,8 +59,11 @@ public class Block {
     return RLP.encode(this::writeTo);
   }
 
-  public int calculateSize() {
-    return toRlp().size();
+  public int getSize() {
+    if (size < 0) {
+      size = toRlp().size();
+    }
+    return size;
   }
 
   public void writeTo(final RLPOutput out) {
@@ -67,6 +78,7 @@ public class Block {
   }
 
   public static Block readFrom(final RLPInput in, final BlockHeaderFunctions hashFunction) {
+    int size = in.nextSize();
     in.enterList();
     final BlockHeader header = BlockHeader.readFrom(in, hashFunction);
     final List<Transaction> transactions = in.readList(Transaction::readFrom);
@@ -75,7 +87,7 @@ public class Block {
         in.isEndOfCurrentList() ? Optional.empty() : Optional.of(in.readList(Withdrawal::readFrom));
     in.leaveList();
 
-    return new Block(header, new BlockBody(transactions, ommers, withdrawals));
+    return new Block(header, new BlockBody(transactions, ommers, withdrawals), size);
   }
 
   @Override

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/util/RawBlockIterator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/util/RawBlockIterator.java
@@ -15,8 +15,6 @@
 package org.hyperledger.besu.ethereum.util;
 
 import org.hyperledger.besu.ethereum.core.Block;
-import org.hyperledger.besu.ethereum.core.BlockBody;
-import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderFunctions;
 import org.hyperledger.besu.ethereum.rlp.BytesValueRLPInput;
 import org.hyperledger.besu.ethereum.rlp.RLP;
@@ -95,10 +93,7 @@ public final class RawBlockIterator implements Iterator<Block>, Closeable {
 
       final Bytes rlpBytes = Bytes.wrap(Bytes.wrapByteBuffer(readBuffer, 0, length).toArray());
       final RLPInput rlp = new BytesValueRLPInput(rlpBytes, false);
-      rlp.enterList();
-      final BlockHeader header = BlockHeader.readFrom(rlp, blockHeaderFunctions);
-      final BlockBody body = BlockBody.readFrom(rlp, blockHeaderFunctions);
-      next = new Block(header, body);
+      next = Block.readFrom(rlp, blockHeaderFunctions);
       readBuffer.position(length);
       readBuffer.compact();
       readBuffer.position(initial - length);


### PR DESCRIPTION
## PR description
When creating a block from the RLP set the size of the Block. Previously the size of a Block was calculated by RLP encoding it, which is unnecessary now if we create the block from the RLP. 