### PR TITLE
[TESTING] deduplicate gradle tasks for ATs

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -45,9 +45,9 @@ jobs:
         with:
           cache-disabled: true
       - name: List all acceptance tests
-        run: ./gradlew acceptanceTestNotPrivacy --test-dry-run -Dorg.gradle.parallel=true -Dorg.gradle.caching=true
+        run: ./gradlew acceptanceTest --test-dry-run -Dorg.gradle.parallel=true -Dorg.gradle.caching=true
       - name: Extract current test list
-        run: mkdir tmp; find . -type f -name TEST-*.xml | xargs -I{} bash -c "xmlstarlet sel -t -v '/testsuite/@name' '{}'; echo ' acceptanceTestNotPrivacy'" | tee tmp/currentTests.list
+        run: mkdir tmp; find . -type f -name TEST-*.xml | xargs -I{} bash -c "xmlstarlet sel -t -v '/testsuite/@name' '{}'; echo ' acceptanceTest'" | tee tmp/currentTests.list
       - name: Get acceptance test reports
         uses: dawidd6/action-download-artifact@e7466d1a7587ed14867642c2ca74b5bcc1e19a2d
         continue-on-error: true
@@ -80,7 +80,7 @@ jobs:
           name: test-args-${{ matrix.runner_index }}.txt
           path: '*.txt'
       - name: run acceptance tests
-        run: ./gradlew acceptanceTestNotPrivacy `cat gradleArgs.txt` -Dorg.gradle.caching=true
+        run: ./gradlew acceptanceTest `cat gradleArgs.txt` -Dorg.gradle.caching=true
       - name: Remove downloaded test results
         run: rm -rf tmp/junit-xml-reports-downloaded
       - name: Upload Acceptance Test Results

--- a/acceptance-tests/tests/build.gradle
+++ b/acceptance-tests/tests/build.gradle
@@ -124,7 +124,6 @@ task acceptanceTest(type: Test) {
 
 task acceptanceTestNotPrivacy(type: Test) {
   inputs.property "integration.date", LocalTime.now() // so it runs at every invocation
-  exclude '**/permissioning/**'
   exclude '**/bftsoak/**'
   exclude '**/acceptanceqbft/**'
 
@@ -204,34 +203,6 @@ task acceptanceTestBftSoak(type: Test) {
     exceptionFormat = 'full'
     showStackTraces = true
     showStandardStreams = true
-    showExceptions = true
-    showCauses = true
-  }
-
-  doFirst { mkdir "${buildDir}/jvmErrorLogs" }
-}
-
-task acceptanceTestPermissioning(type: Test) {
-  inputs.property "integration.date", LocalTime.now() // so it runs at every invocation
-  include '**/permissioning/**'
-
-  useJUnitPlatform {}
-
-  dependsOn(rootProject.installDist)
-  setSystemProperties(test.getSystemProperties())
-  systemProperty 'acctests.runBesuAsProcess', 'true'
-  systemProperty 'java.security.properties', "${buildDir}/resources/test/acceptanceTesting.security"
-  def javaProjects = rootProject.subprojects - project(':platform')
-  mustRunAfter javaProjects.test
-  description = 'Runs Permissioning Besu acceptance tests.'
-  group = 'verification'
-
-  jvmArgs "-XX:ErrorFile=${buildDir}/jvmErrorLogs/java_err_pid%p.log"
-
-  testLogging {
-    exceptionFormat = 'full'
-    showStackTraces = true
-    showStandardStreams = Boolean.getBoolean('acctests.showStandardStreams')
     showExceptions = true
     showCauses = true
   }

--- a/acceptance-tests/tests/build.gradle
+++ b/acceptance-tests/tests/build.gradle
@@ -151,35 +151,6 @@ task acceptanceTestNotPrivacy(type: Test) {
   doFirst { mkdir "${buildDir}/jvmErrorLogs" }
 }
 
-task acceptanceTestCliqueBft(type: Test) {
-  inputs.property "integration.date", LocalTime.now() // so it runs at every invocation
-  include '**/bft/**'
-  include '**/clique/**'
-
-  useJUnitPlatform {}
-
-  dependsOn(rootProject.installDist)
-  setSystemProperties(test.getSystemProperties())
-  systemProperty 'acctests.runBesuAsProcess', 'true'
-  systemProperty 'java.security.properties', "${buildDir}/resources/test/acceptanceTesting.security"
-  def javaProjects = rootProject.subprojects - project(':platform')
-  mustRunAfter javaProjects.test
-  description = 'Runs Clique and BFT Besu acceptance tests.'
-  group = 'verification'
-
-  jvmArgs "-XX:ErrorFile=${buildDir}/jvmErrorLogs/java_err_pid%p.log"
-
-  testLogging {
-    exceptionFormat = 'full'
-    showStackTraces = true
-    showStandardStreams = Boolean.getBoolean('acctests.showStandardStreams')
-    showExceptions = true
-    showCauses = true
-  }
-
-  doFirst { mkdir "${buildDir}/jvmErrorLogs" }
-}
-
 task acceptanceTestBftSoak(type: Test) {
   inputs.property "integration.date", LocalTime.now() // so it runs at every invocation
   include '**/bftsoak/**'

--- a/acceptance-tests/tests/build.gradle
+++ b/acceptance-tests/tests/build.gradle
@@ -95,34 +95,8 @@ sourceSets {
 
 processTestResources.dependsOn(':acceptance-tests:test-plugins:testPluginsJar',':acceptance-tests:test-plugins:jar')
 
+// FKA acceptanceTestNotPrivacy
 task acceptanceTest(type: Test) {
-  inputs.property "integration.date", LocalTime.now() // so it runs at every invocation
-
-  useJUnitPlatform {}
-
-  dependsOn(rootProject.installDist)
-  setSystemProperties(test.getSystemProperties())
-  systemProperty 'acctests.runBesuAsProcess', 'true'
-  systemProperty 'java.security.properties', "${buildDir}/resources/test/acceptanceTesting.security"
-  def javaProjects = rootProject.subprojects - project(':platform')
-  mustRunAfter javaProjects.test
-  description = 'Runs ALL Besu acceptance tests (mainnet and non-mainnet).'
-  group = 'verification'
-
-  jvmArgs "-XX:ErrorFile=${buildDir}/jvmErrorLogs/java_err_pid%p.log"
-
-  testLogging {
-    exceptionFormat = 'full'
-    showStackTraces = true
-    showStandardStreams = Boolean.getBoolean('acctests.showStandardStreams')
-    showExceptions = true
-    showCauses = true
-  }
-
-  doFirst { mkdir "${buildDir}/jvmErrorLogs" }
-}
-
-task acceptanceTestNotPrivacy(type: Test) {
   inputs.property "integration.date", LocalTime.now() // so it runs at every invocation
   exclude '**/bftsoak/**'
   exclude '**/acceptanceqbft/**'
@@ -135,7 +109,7 @@ task acceptanceTestNotPrivacy(type: Test) {
   systemProperty 'java.security.properties', "${buildDir}/resources/test/acceptanceTesting.security"
   def javaProjects = rootProject.subprojects - project(':platform')
   mustRunAfter javaProjects.test
-  description = 'Runs MAINNET Besu acceptance tests (excluding specific non-mainnet suites).'
+  description = 'Runs ALL Besu acceptance tests (excluding bftsoak and acceptanceqbft).'
   group = 'verification'
 
   jvmArgs "-XX:ErrorFile=${buildDir}/jvmErrorLogs/java_err_pid%p.log"


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <macfarla.github@gmail.com>## PR description

## Fixed Issue(s)
`acceptanceTestNotPrivacy` is now `acceptanceTest` and GHA is accordingly updated. Removed separate gradle tasks which were essentially duplicated.


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [x] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

