### PR TITLE
Remove RPC categories for removed RPCs: PRIV and EEA

### DIFF
--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/configuration/BesuNodeConfigurationBuilder.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/configuration/BesuNodeConfigurationBuilder.java
@@ -178,12 +178,6 @@ public class BesuNodeConfigurationBuilder {
     return this;
   }
 
-  public BesuNodeConfigurationBuilder enablePrivateTransactions() {
-    this.jsonRpcConfiguration.addRpcApi(RpcApis.EEA.name());
-    this.jsonRpcConfiguration.addRpcApi(RpcApis.PRIV.name());
-    return this;
-  }
-
   public BesuNodeConfigurationBuilder jsonRpcTxPool() {
     this.jsonRpcConfiguration.addRpcApi(RpcApis.TXPOOL.name());
     return this;

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcTestMethodsFactory.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcTestMethodsFactory.java
@@ -189,7 +189,6 @@ public class JsonRpcTestMethodsFactory {
     apis.add(RpcApis.ETH.name());
     apis.add(RpcApis.NET.name());
     apis.add(RpcApis.WEB3.name());
-    apis.add(RpcApis.PRIV.name());
     apis.add(RpcApis.DEBUG.name());
 
     final Path dataDir = mock(Path.class);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/RpcApis.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/RpcApis.java
@@ -27,8 +27,6 @@ public enum RpcApis {
   PERM,
   WEB3,
   ADMIN,
-  EEA,
-  PRIV,
   TXPOOL,
   TRACE,
   PLUGINS,
@@ -41,7 +39,7 @@ public enum RpcApis {
 
   @SuppressWarnings("unused")
   public static final List<RpcApis> ALL_JSON_RPC_APIS =
-      Arrays.asList(ETH, DEBUG, MINER, NET, PERM, WEB3, ADMIN, EEA, PRIV, TXPOOL, TRACE, PLUGINS);
+      Arrays.asList(ETH, DEBUG, MINER, NET, PERM, WEB3, ADMIN, TXPOOL, TRACE, PLUGINS);
 
   public static final List<String> VALID_APIS =
       Stream.of(RpcApis.values()).map(RpcApis::name).collect(Collectors.toList());


### PR DESCRIPTION
## PR description

## Fixed Issue(s)
Privacy removal means these RPCs have been removed. 


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

