### PR TITLE
Change stack size growth strategy to 0.5 rate

### DIFF
--- a/evm/src/main/java/org/hyperledger/besu/evm/internal/FlexStack.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/internal/FlexStack.java
@@ -31,10 +31,10 @@ import java.util.Objects;
  */
 public class FlexStack<T> {
   /**
-   * Formula `x = round( y / ( (1 + 0,5)^n ) ) + 1`, computes the initial stack size, `x` that one has to start with
-   * to reach a maximum stack size, `y`, in `n` number of array resizes at a growth rate of 50%.
-   * Currently, for mainnet y=1024 and, if considering n=6 in the worst case, the start size is 91 which is reasonable
-   * for mainnet.
+   * Formula `x = round( y / ( (1 + 0,5)^n ) ) + 1`, computes the initial stack size, `x` that one
+   * has to start with to reach a maximum stack size, `y`, in `n` number of array resizes at a
+   * growth rate of 50%. Currently, for mainnet y=1024 and, if considering n=6 in the worst case,
+   * the start size is 91 which is reasonable for mainnet.
    */
   private static final double INITIAL_SIZE_COEFICIENT = 1 / Math.pow(1.5D, 6D);
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/internal/FlexStack.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/internal/FlexStack.java
@@ -55,7 +55,7 @@ public class FlexStack<T> {
   public FlexStack(final int maxSize, final Class<T> klass) {
     checkArgument(maxSize > 0, "max size must be positive");
 
-    final int initialSize = (int) Math.round(maxSize * INITIAL_SIZE_COEFICIENT) + 1;
+    int initialSize = (int) Math.round(maxSize * INITIAL_SIZE_COEFICIENT) + 1;
     this.currentCapacity = Math.min(initialSize, maxSize);
     this.entries = (T[]) Array.newInstance(klass, currentCapacity);
     this.maxSize = maxSize;
@@ -169,11 +169,15 @@ public class FlexStack<T> {
       throw new OverflowException();
     }
     if (nextTop >= currentCapacity) {
-      final int newCapacity = currentCapacity + (currentCapacity >> 1);
+      final int newCapacity = newLength(currentCapacity, currentCapacity + 1, currentCapacity >> 1);
       expandEntries(Math.min(newCapacity, maxSize));
     }
     entries[nextTop] = operand;
     top = nextTop;
+  }
+
+  private static int newLength(final int oldCapacity, final int minGrowth, final int prefGrowth) {
+    return oldCapacity + Math.max(minGrowth, prefGrowth);
   }
 
   /**

--- a/evm/src/main/java/org/hyperledger/besu/evm/internal/FlexStack.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/internal/FlexStack.java
@@ -30,8 +30,13 @@ import java.util.Objects;
  * @param <T> the type parameter
  */
 public class FlexStack<T> {
-
-  private static final int INCREMENT = 32;
+  /**
+   * Formula `x = round( y / ( (1 + 0,5)^n ) ) + 1`, computes the initial stack size, `x` that one has to start with
+   * to reach a maximum stack size, `y`, in `n` number of array resizes at a growth rate of 50%.
+   * Currently, for mainnet y=1024 and, if considering n=6 in the worst case, the start size is 91 which is reasonable
+   * for mainnet.
+   */
+  private static final double INITIAL_SIZE_COEFICIENT = 1 / Math.pow(1.5D, 6D);
 
   private T[] entries;
 
@@ -50,7 +55,8 @@ public class FlexStack<T> {
   public FlexStack(final int maxSize, final Class<T> klass) {
     checkArgument(maxSize > 0, "max size must be positive");
 
-    this.currentCapacity = Math.min(INCREMENT, maxSize);
+    final int initialSize = (int) Math.round(maxSize * INITIAL_SIZE_COEFICIENT) + 1;
+    this.currentCapacity = Math.min(initialSize, maxSize);
     this.entries = (T[]) Array.newInstance(klass, currentCapacity);
     this.maxSize = maxSize;
     this.top = -1;
@@ -163,7 +169,8 @@ public class FlexStack<T> {
       throw new OverflowException();
     }
     if (nextTop >= currentCapacity) {
-      expandEntries(Math.min(currentCapacity + INCREMENT, maxSize));
+      final int newCapacity = currentCapacity + (currentCapacity >> 1);
+      expandEntries(Math.min(newCapacity, maxSize));
     }
     entries[nextTop] = operand;
     top = nextTop;


### PR DESCRIPTION
This PR changes the stack rate growth strategy of `FlexStack` to grow at a 50% rate instead of constantly growing by 32 slots as is currently. The former is the approach adopted by the JDK for `ArrayList`.

With a 50% allocation rate and considering a max stack size of 1024, setting the initial size to 91 one can reach the worse case (1024) in just 6 resizes compared to 32 required with the current approach.
Also the current usage on mainnet has shown that CALLs never go above 150 deep during execution.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

