### PR TITLE
Expose a method to get blob gas price from plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - Introduce the `TransactionValidatorService` to allow plugins to add custom validation rules [#8793](https://github.com/hyperledger/besu/pull/8793)
 - Enable parallel tx processing by default if Bonsai is used [#8668](https://github.com/hyperledger/besu/pull/8668)
 - Increase mainnet gas limit to 45M [#8824](https://github.com/hyperledger/besu/pull/8824)
-
+- Expose a method to get blob gas price from plugins [#8843](https://github.com/hyperledger/besu/pull/8843)
 
 #### Fusaka Devnet
 - EIP-7825 - Transaction gas limit cap [#8700](https://github.com/hyperledger/besu/pull/8700)

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/TransitionProtocolSchedule.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/TransitionProtocolSchedule.java
@@ -81,7 +81,8 @@ public class TransitionProtocolSchedule implements ProtocolSchedule {
    * @return the ProtocolSpec to be used by the provided block
    */
   @Override
-  public ProtocolSpec getByBlockHeader(final ProcessableBlockHeader blockHeader) {
+  public ProtocolSpec getByBlockHeader(
+      final org.hyperledger.besu.plugin.data.ProcessableBlockHeader blockHeader) {
     return this.transitionUtils.dispatchFunctionAccordingToMergeState(
         protocolSchedule -> protocolSchedule.getByBlockHeader(blockHeader));
   }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/DefaultProtocolSchedule.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/DefaultProtocolSchedule.java
@@ -19,9 +19,9 @@ import static com.google.common.base.Preconditions.checkArgument;
 import org.hyperledger.besu.datatypes.HardforkId;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.PermissionTransactionFilter;
-import org.hyperledger.besu.ethereum.core.ProcessableBlockHeader;
 import org.hyperledger.besu.ethereum.mainnet.ScheduledProtocolSpec.BlockNumberProtocolSpec;
 import org.hyperledger.besu.ethereum.mainnet.ScheduledProtocolSpec.TimestampProtocolSpec;
+import org.hyperledger.besu.plugin.data.ProcessableBlockHeader;
 import org.hyperledger.besu.plugin.services.txvalidator.TransactionValidationRule;
 
 import java.math.BigInteger;

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ProtocolSchedule.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ProtocolSchedule.java
@@ -18,7 +18,7 @@ import org.hyperledger.besu.datatypes.HardforkId;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderBuilder;
 import org.hyperledger.besu.ethereum.core.PermissionTransactionFilter;
-import org.hyperledger.besu.ethereum.core.ProcessableBlockHeader;
+import org.hyperledger.besu.plugin.data.ProcessableBlockHeader;
 import org.hyperledger.besu.plugin.services.txvalidator.TransactionValidationRule;
 
 import java.math.BigInteger;

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ScheduledProtocolSpec.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ScheduledProtocolSpec.java
@@ -14,16 +14,17 @@
  */
 package org.hyperledger.besu.ethereum.mainnet;
 
-import org.hyperledger.besu.ethereum.core.ProcessableBlockHeader;
+import org.hyperledger.besu.plugin.data.ProcessableBlockHeader;
 
 /**
  * Associates a {@link ProtocolSpec} with a given block number or timestamp level starting point
  * Knows how to query the timestamp or block number of a given block header
  */
 public interface ScheduledProtocolSpec {
-  boolean isOnOrAfterMilestoneBoundary(ProcessableBlockHeader header);
+  boolean isOnOrAfterMilestoneBoundary(
+      org.hyperledger.besu.plugin.data.ProcessableBlockHeader header);
 
-  boolean isOnMilestoneBoundary(ProcessableBlockHeader header);
+  boolean isOnMilestoneBoundary(org.hyperledger.besu.plugin.data.ProcessableBlockHeader header);
 
   Hardfork fork();
 
@@ -60,12 +61,14 @@ public interface ScheduledProtocolSpec {
     }
 
     @Override
-    public boolean isOnOrAfterMilestoneBoundary(final ProcessableBlockHeader header) {
+    public boolean isOnOrAfterMilestoneBoundary(
+        final org.hyperledger.besu.plugin.data.ProcessableBlockHeader header) {
       return Long.compareUnsigned(header.getTimestamp(), timestamp) >= 0;
     }
 
     @Override
-    public boolean isOnMilestoneBoundary(final ProcessableBlockHeader header) {
+    public boolean isOnMilestoneBoundary(
+        final org.hyperledger.besu.plugin.data.ProcessableBlockHeader header) {
       return header.getTimestamp() == timestamp;
     }
 
@@ -95,7 +98,8 @@ public interface ScheduledProtocolSpec {
     }
 
     @Override
-    public boolean isOnOrAfterMilestoneBoundary(final ProcessableBlockHeader header) {
+    public boolean isOnOrAfterMilestoneBoundary(
+        final org.hyperledger.besu.plugin.data.ProcessableBlockHeader header) {
       return header.getNumber() >= blockNumber;
     }
 

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -71,7 +71,7 @@ Calculated : ${currentHash}
 tasks.register('checkAPIChanges', FileStateChecker) {
   description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
   files = sourceSets.main.allJava.files
-  knownHash = '4lHVP5Gc91MkqyiTvU9HVlBZx0tOgodIdOmasEAGTtM='
+  knownHash = '2iFZ9OBdtl1VoQLGPdqolq8zlBIkwszjin8vO4TkTqk='
 }
 check.dependsOn('checkAPIChanges')
 

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/BlockchainService.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/BlockchainService.java
@@ -61,6 +61,14 @@ public interface BlockchainService extends BesuService {
   Hash getChainHeadHash();
 
   /**
+   * Return the blob gas price for the specified block
+   *
+   * @param blockHeader the block header
+   * @return the block gas price or Wei.ZERO if blobs are not yet supported for that block header
+   */
+  Wei getBlobGasPrice(BlockHeader blockHeader);
+
+  /**
    * Get the receipts for a block by block hash
    *
    * @param blockHash the block hash


### PR DESCRIPTION
## PR description

Added the method `Wei getBlobGasPrice(BlockHeader blockHeader);` to the `BlockchainService` so that plugins can get the blob gas price by block header.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

