### PR TITLE
Enable decoding for large newPayloads

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/handlers/JsonRpcParserHandler.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/handlers/JsonRpcParserHandler.java
@@ -25,8 +25,12 @@ import io.vertx.core.json.DecodeException;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.ext.web.RoutingContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class JsonRpcParserHandler {
+
+  private static final Logger LOG = LoggerFactory.getLogger(JsonRpcParserHandler.class);
 
   private JsonRpcParserHandler() {}
 
@@ -39,6 +43,10 @@ public class JsonRpcParserHandler {
         try {
           ctx.put(ContextKey.REQUEST_BODY_AS_JSON_OBJECT.name(), ctx.getBodyAsJson());
         } catch (DecodeException | ClassCastException jsonObjectDecodeException) {
+          LOG.atDebug()
+              .setMessage("Attempted getBodyAsJson, but error parsing JSON object: {}")
+              .addArgument(jsonObjectDecodeException.getMessage())
+              .log();
           try {
             final JsonArray batchRequest = ctx.getBodyAsJsonArray();
             if (batchRequest.isEmpty()) {
@@ -48,6 +56,11 @@ public class JsonRpcParserHandler {
               ctx.put(ContextKey.REQUEST_BODY_AS_JSON_ARRAY.name(), batchRequest);
             }
           } catch (DecodeException | ClassCastException jsonArrayDecodeException) {
+            LOG.atDebug()
+                .setMessage(
+                    "Attempted getBodyAsJsonArray, but error parsing JSON object: "
+                        + jsonObjectDecodeException.getMessage())
+                .log();
             errorResponse(response, RpcErrorType.PARSE_ERROR);
             return;
           }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/EngineJsonRpcService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/EngineJsonRpcService.java
@@ -60,6 +60,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nullable;
 
+import com.fasterxml.jackson.core.StreamReadConstraints;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.baggage.propagation.W3CBaggagePropagator;
@@ -85,6 +87,7 @@ import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.http.ServerWebSocket;
+import io.vertx.core.json.jackson.DatabindCodec;
 import io.vertx.core.net.HostAndPort;
 import io.vertx.core.net.PfxOptions;
 import io.vertx.core.net.SocketAddress;
@@ -229,6 +232,13 @@ public class EngineJsonRpcService {
     }
     final CompletableFuture<Void> resultFuture = new CompletableFuture<>();
     try {
+
+      // TODO SLD: Enables very large transaction decoding for perfnet testing
+      ObjectMapper om = DatabindCodec.mapper();
+      StreamReadConstraints src =
+          StreamReadConstraints.builder().maxStringLength(Integer.MAX_VALUE).build();
+      om.getFactory().setStreamReadConstraints(src); // registers globally in vert.x
+
       // Create the HTTP server and a router object.
       httpServer = vertx.createHttpServer(getHttpServerOptions());
       httpServer.webSocketHandler(webSocketHandler());

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/JsonRpcParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/JsonRpcParameter.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Optional;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
@@ -27,6 +28,13 @@ public class JsonRpcParameter {
   private static final ObjectMapper mapper =
       new ObjectMapper()
           .registerModule(new Jdk8Module()); // Handle JDK8 Optionals (de)serialization
+
+  static {
+    mapper
+        .getFactory()
+        .setStreamReadConstraints(
+            StreamReadConstraints.builder().maxStringLength(Integer.MAX_VALUE).build());
+  }
 
   /**
    * Retrieves a required parameter at the given index interpreted as the given class. Throws


### PR DESCRIPTION
First pass maxes out StreamReadConstraints.maxStringLength for jackson decoding

TODO
We might want a more reasonable max value, and to only apply it to newPayload/engine API requests
