### PR TITLE
Only for performance benchmarking : change ModExp pricing for Cancun

### DIFF
--- a/.github/workflows/acceptance-qbft-tests.yml
+++ b/.github/workflows/acceptance-qbft-tests.yml
@@ -7,7 +7,6 @@ on:
       - main
       - release-*
       - verkle
-      - performance
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -7,7 +7,6 @@ on:
       - main
       - release-*
       - verkle
-      - performance
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -7,7 +7,6 @@ on:
       - main
       - release-*
       - verkle
-      - performance
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/pre-review.yml
+++ b/.github/workflows/pre-review.yml
@@ -7,7 +7,6 @@ on:
       - main
       - release-*
       - verkle
-      - performance
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/reference-tests.yml
+++ b/.github/workflows/reference-tests.yml
@@ -7,7 +7,6 @@ on:
       - main
       - release-*
       - verkle
-      - performance
 
 env:
   GRADLE_OPTS: "-Xmx6g -Dorg.gradle.daemon=false -Dorg.gradle.parallel=true -Dorg.gradle.caching=true"

--- a/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/CancunGasCalculator.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/CancunGasCalculator.java
@@ -14,16 +14,17 @@
  */
 package org.hyperledger.besu.evm.gascalculator;
 
-import org.apache.tuweni.bytes.Bytes;
+import static org.hyperledger.besu.datatypes.Address.KZG_POINT_EVAL;
+import static org.hyperledger.besu.evm.internal.Words.clampedAdd;
+import static org.hyperledger.besu.evm.internal.Words.clampedMultiply;
+import static org.hyperledger.besu.evm.internal.Words.clampedToInt;
+
 import org.hyperledger.besu.evm.internal.Words;
 import org.hyperledger.besu.evm.precompile.BigIntegerModularExponentiationPrecompiledContract;
 
 import java.math.BigInteger;
 
-import static org.hyperledger.besu.datatypes.Address.KZG_POINT_EVAL;
-import static org.hyperledger.besu.evm.internal.Words.clampedAdd;
-import static org.hyperledger.besu.evm.internal.Words.clampedMultiply;
-import static org.hyperledger.besu.evm.internal.Words.clampedToInt;
+import org.apache.tuweni.bytes.Bytes;
 
 /**
  * Gas Calculator for Cancun
@@ -58,17 +59,16 @@ public class CancunGasCalculator extends ShanghaiGasCalculator {
    */
   private static final long BLOB_GAS_PER_BLOB = 1 << 17;
 
-
   // Only for performance testing purposes, this code should not be merged into main
   @Override
   public long modExpGasCost(final Bytes input) {
     final long baseLength = BigIntegerModularExponentiationPrecompiledContract.baseLength(input);
     final long exponentLength =
-            BigIntegerModularExponentiationPrecompiledContract.exponentLength(input);
+        BigIntegerModularExponentiationPrecompiledContract.exponentLength(input);
     final long modulusLength =
-            BigIntegerModularExponentiationPrecompiledContract.modulusLength(input);
+        BigIntegerModularExponentiationPrecompiledContract.modulusLength(input);
     final long exponentOffset =
-            clampedAdd(BigIntegerModularExponentiationPrecompiledContract.BASE_OFFSET, baseLength);
+        clampedAdd(BigIntegerModularExponentiationPrecompiledContract.BASE_OFFSET, baseLength);
 
     final long maxLength = Math.max(modulusLength, baseLength);
     if (maxLength <= 0) {
@@ -87,21 +87,20 @@ public class CancunGasCalculator extends ShanghaiGasCalculator {
     }
 
     final long firstExponentBytesCap =
-            Math.min(exponentLength, ByzantiumGasCalculator.MAX_FIRST_EXPONENT_BYTES);
+        Math.min(exponentLength, ByzantiumGasCalculator.MAX_FIRST_EXPONENT_BYTES);
     final BigInteger firstExpBytes =
-            BigIntegerModularExponentiationPrecompiledContract.extractParameter(
-                    input, clampedToInt(exponentOffset), clampedToInt(firstExponentBytesCap));
+        BigIntegerModularExponentiationPrecompiledContract.extractParameter(
+            input, clampedToInt(exponentOffset), clampedToInt(firstExponentBytesCap));
     final long adjustedExponentLength = adjustedExponentLength(exponentLength, firstExpBytes);
 
     long gasRequirement =
-            clampedMultiply(multiplicationComplexity, Math.max(adjustedExponentLength, 1L));
+        clampedMultiply(multiplicationComplexity, Math.max(adjustedExponentLength, 1L));
     if (gasRequirement != Long.MAX_VALUE) {
       gasRequirement /= 3;
     }
 
     return Math.max(gasRequirement, 500L);
   }
-
 
   // EIP-1153
   @Override


### PR DESCRIPTION
## PR description
This code should not be merged into main. This is the fast way we have to test ModExp new pricing. It is scheduler for Fusaka but we enable it for Cancun on the performance branch to be able to test it.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

