### PR TITLE
remove deprecated Xsnapsync-bft-enabled option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Remove the deprecated `--Xbonsai-trie-logs-pruning-window-size`, use `--bonsai-trie-logs-pruning-window-size` instead. [#8823](https://github.com/hyperledger/besu/pull/8823)
 - Remove the deprecated `--Xbonsai-limit-trie-logs-enabled`, use `--bonsai-limit-trie-logs-enabled` instead. [#8704](https://github.com/hyperledger/besu/issues/8704)
 - Remove the deprecated `--Xbonsai-trie-log-pruning-enabled`, use `--bonsai-limit-trie-logs-enabled` instead. [#8704](https://github.com/hyperledger/besu/issues/8704)
+- Remove the deprecated `--Xsnapsync-bft-enabled`. SNAP sync is now supported for BFT networks.
 - Remove methods from gas calculator deprecated since 24.4 `create2OperationGasCost`, `callOperationGasCost`, `createOperationGasCost`, and `cost` [#8817](https://github.com/hyperledger/besu/pull/8817)
 - Sunsetting features - for more context on the reasoning behind the deprecation of these features, including alternative options, read [this blog post](https://www.lfdecentralizedtrust.org/blog/sunsetting-tessera-and-simplifying-hyperledger-besu)
   - Stratum mining has been removed (part of PoW) [#8802](https://github.com/hyperledger/besu/pull/8802)
@@ -13,7 +14,6 @@
 
 ### Upcoming Breaking Changes
 - `--Xbonsai-parallel-tx-processing-enabled` is deprecated, use `--bonsai-parallel-tx-processing-enabled` instead.
-- `--Xsnapsync-bft-enabled` is deprecated and will be removed in a future release. SNAP sync is supported for BFT networks.
 - Sunsetting features - for more context on the reasoning behind the deprecation of these features, including alternative options, read [this blog post](https://www.lfdecentralizedtrust.org/blog/sunsetting-tessera-and-simplifying-hyperledger-besu)
   - Proof of Work consensus (PoW)
   - Fast Sync

--- a/app/src/main/java/org/hyperledger/besu/cli/options/SynchronizerOptions.java
+++ b/app/src/main/java/org/hyperledger/besu/cli/options/SynchronizerOptions.java
@@ -87,8 +87,6 @@ public class SynchronizerOptions implements CLIOptions<SynchronizerConfiguration
 
   private static final String CHECKPOINT_POST_MERGE_FLAG = "--Xcheckpoint-post-merge-enabled";
 
-  private static final String SNAP_SYNC_BFT_ENABLED_FLAG = "--Xsnapsync-bft-enabled";
-
   private static final String SNAP_SYNC_SAVE_PRE_MERGE_HEADERS_ONLY_FLAG =
       "--Xsnapsync-synchronizer-pre-merge-headers-only-enabled";
 
@@ -311,17 +309,6 @@ public class SynchronizerOptions implements CLIOptions<SynchronizerConfiguration
   private Boolean checkpointPostMergeSyncEnabled =
       SynchronizerConfiguration.DEFAULT_CHECKPOINT_POST_MERGE_ENABLED;
 
-  // TODO --Xsnapsync-bft-enabled is deprecated,
-  // remove in a future release
-  @CommandLine.Option(
-      names = SNAP_SYNC_BFT_ENABLED_FLAG, // deprecated
-      hidden = true,
-      paramLabel = "<Boolean>",
-      arity = "0..1",
-      description =
-          "This option is now deprecated and ignored, and will be removed in future release. Snap sync for BFT is supported by default.")
-  private Boolean snapsyncBftEnabled = SnapSyncConfiguration.DEFAULT_SNAP_SYNC_BFT_ENABLED;
-
   @CommandLine.Option(
       names = {"--Xpeertask-system-enabled"},
       hidden = true,
@@ -357,15 +344,6 @@ public class SynchronizerOptions implements CLIOptions<SynchronizerConfiguration
    */
   public boolean isSnapsyncServerEnabled() {
     return snapsyncServerEnabled;
-  }
-
-  /**
-   * Flag to know whether the Snap sync should be enabled for a BFT chain
-   *
-   * @return true if snap sync for BFT is enabled
-   */
-  public boolean isSnapSyncBftEnabled() {
-    return snapsyncBftEnabled;
   }
 
   /**

--- a/app/src/test/java/org/hyperledger/besu/cli/options/SynchronizerOptionsTest.java
+++ b/app/src/test/java/org/hyperledger/besu/cli/options/SynchronizerOptionsTest.java
@@ -18,7 +18,6 @@ import org.hyperledger.besu.ethereum.eth.sync.SynchronizerConfiguration;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.ImmutableSnapSyncConfiguration;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.SnapSyncConfiguration;
 
-import java.util.Arrays;
 import java.util.List;
 
 import com.google.common.collect.Range;
@@ -96,7 +95,7 @@ public class SynchronizerOptionsTest
 
   @Override
   protected List<String> getFieldsToIgnore() {
-    return Arrays.asList("syncMinimumPeerCount");
+    return List.of("syncMinimumPeerCount");
   }
 
   @Override


### PR DESCRIPTION
## PR description
deprecated since 25.3 per #7930 

## Fixed Issue(s)
fixes #7924 


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

