### PR TITLE
fix(evmtool): implement --repeat option in state-test subcommand

### DIFF
--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/EvmToolCommand.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/EvmToolCommand.java
@@ -265,6 +265,10 @@ public class EvmToolCommand implements Runnable {
       description = "display version info")
   boolean versionInfoRequested;
 
+  public Integer getRepeatCount() {
+    return repeat;
+  }
+
   static final Joiner STORAGE_JOINER = Joiner.on(",\n");
   private final EvmToolCommandOptionsModule daggerOptions = new EvmToolCommandOptionsModule();
   PrintWriter out;

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/StateTestSubCommand.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/StateTestSubCommand.java
@@ -189,18 +189,22 @@ public class StateTestSubCommand implements Runnable {
   }
 
   private void executeStateTest(final Map<String, GeneralStateTestCaseSpec> generalStateTests) {
-    for (final Map.Entry<String, GeneralStateTestCaseSpec> generalStateTestEntry :
-        generalStateTests.entrySet()) {
-      if (testName == null || testName.equals(generalStateTestEntry.getKey())) {
-        generalStateTestEntry
-            .getValue()
-            .finalStateSpecs()
-            .forEach((__, specs) -> traceTestSpecs(generalStateTestEntry.getKey(), specs));
+    int repeatCount = Math.max(1, parentCommand.getRepeatCount());
+    for (int i = 0; i < repeatCount; i++) {
+      boolean isLastIteration = (i == repeatCount - 1);
+      for (final Map.Entry<String, GeneralStateTestCaseSpec> generalStateTestEntry :
+          generalStateTests.entrySet()) {
+        if (testName == null || testName.equals(generalStateTestEntry.getKey())) {
+          generalStateTestEntry
+              .getValue()
+              .finalStateSpecs()
+              .forEach((__, specs) -> traceTestSpecs(generalStateTestEntry.getKey(), specs, isLastIteration));
+        }
       }
     }
   }
 
-  private void traceTestSpecs(final String test, final List<GeneralStateTestCaseEipSpec> specs) {
+  private void traceTestSpecs(final String test, final List<GeneralStateTestCaseEipSpec> specs, final boolean isLastIteration) {
     final OperationTracer tracer = // You should have picked Mercy.
         parentCommand.showJsonResults
             ? new StandardJsonTracer(
@@ -332,12 +336,14 @@ public class StateTestSubCommand implements Runnable {
         if (!result.getValidationResult().isValid()) {
           summaryLine.put("error", result.getValidationResult().getErrorMessage());
         }
-        if (parentCommand.showJsonAlloc) {
+        if (parentCommand.showJsonAlloc && isLastIteration) {
           EvmToolCommand.dumpWorldState(worldState, parentCommand.out);
         }
       }
 
-      parentCommand.out.println(summaryLine);
+      if (isLastIteration) {
+        parentCommand.out.println(summaryLine);
+      }
     }
   }
 }


### PR DESCRIPTION
## PR description
The `--repeat` option was defined in EvmToolCommand but not used by StateTestSubCommand. This adds support for running state tests multiple times for warmup.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #8855 

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

