### PR TITLE
Improve transaction simulation when no gas pricing is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,12 @@
 ## Unreleased
 
 ### Breaking Changes
+- Change in behavior for `eth_estimateGas`, to improve accuracy, when used on a network with a base fee market, the internal transaction simulation does not anymore underprice transactions, so if there are no gas pricing related fields specified in the request, then gas price for the transaction is set to the base fee value [#8888](https://github.com/hyperledger/besu/pull/8888)  
 
 ### Upcoming Breaking Changes
 
 ### Additions and Improvements
-
+- Improve transaction simulation and gas estimation when no gas pricing is present [#8888](https://github.com/hyperledger/besu/pull/8888)
 #### Fusaka
 
 ### Bug fixes

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/transaction/eth/EthEstimateGasTransaction.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/transaction/eth/EthEstimateGasTransaction.java
@@ -27,7 +27,7 @@ import org.web3j.protocol.core.methods.response.EthEstimateGas;
 public class EthEstimateGasTransaction implements Transaction<EthEstimateGas> {
   private final String contractAddress;
   private final String functionCall;
-  private final String from = "";
+  private final String from = "0xfe3b557e8fb62b89f4916b721be55ceb828dbd73";
 
   public EthEstimateGasTransaction(final String contractAddress, final String functionCall) {
     this.contractAddress = contractAddress;
@@ -45,7 +45,7 @@ public class EthEstimateGasTransaction implements Transaction<EthEstimateGas> {
               new org.web3j.protocol.core.methods.request.Transaction(
                   from,
                   nonce,
-                  BigInteger.ZERO,
+                  null,
                   BigInteger.ZERO,
                   contractAddress,
                   BigInteger.ZERO,

--- a/datatypes/src/main/java/org/hyperledger/besu/datatypes/CallParameter.java
+++ b/datatypes/src/main/java/org/hyperledger/besu/datatypes/CallParameter.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.datatypes;
+
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalLong;
+
+import org.apache.tuweni.bytes.Bytes;
+
+/**
+ * Interface defining parameters for Ethereum transaction calls and simulations.
+ *
+ * <p>This interface provides access to all the parameters that can be specified when making calls
+ * to the Ethereum network, including both legacy and EIP-1559 transaction parameters, as well as
+ * EIP-4844 blob transaction parameters.
+ *
+ * <p>All parameters are optional to support various call scenarios where only a subset of
+ * parameters may be specified.
+ */
+public interface CallParameter {
+
+  /**
+   * Returns the chain ID for the transaction.
+   *
+   * @return an {@link Optional} containing the chain ID, or empty if not specified
+   */
+  Optional<BigInteger> getChainId();
+
+  /**
+   * Returns the sender address of the transaction.
+   *
+   * @return an {@link Optional} containing the sender address, or empty if not specified
+   */
+  Optional<Address> getSender();
+
+  /**
+   * Returns the recipient address of the transaction.
+   *
+   * @return an {@link Optional} containing the recipient address, or empty if not specified
+   */
+  Optional<Address> getTo();
+
+  /**
+   * Returns the gas limit for the transaction.
+   *
+   * @return an {@link OptionalLong} containing the gas limit, or empty if not specified
+   */
+  OptionalLong getGas();
+
+  /**
+   * Returns the maximum priority fee per gas (EIP-1559).
+   *
+   * <p>This represents the maximum fee per gas that the sender is willing to pay as a tip to the
+   * block producer.
+   *
+   * @return an {@link Optional} containing the maximum priority fee per gas, or empty if not
+   *     specified
+   */
+  Optional<Wei> getMaxPriorityFeePerGas();
+
+  /**
+   * Returns the maximum fee per gas (EIP-1559).
+   *
+   * <p>This represents the maximum total fee per gas that the sender is willing to pay, including
+   * both the base fee and the priority fee.
+   *
+   * @return an {@link Optional} containing the maximum fee per gas, or empty if not specified
+   */
+  Optional<Wei> getMaxFeePerGas();
+
+  /**
+   * Returns the maximum fee per blob gas (EIP-4844).
+   *
+   * <p>This parameter is used for blob transactions to specify the maximum fee the sender is
+   * willing to pay per unit of blob gas.
+   *
+   * @return an {@link Optional} containing the maximum fee per blob gas, or empty if not specified
+   */
+  Optional<Wei> getMaxFeePerBlobGas();
+
+  /**
+   * Returns the gas price for legacy transactions.
+   *
+   * <p>This parameter is used in pre-EIP-1559 transactions to specify the price per unit of gas.
+   *
+   * @return an {@link Optional} containing the gas price, or empty if not specified
+   */
+  Optional<Wei> getGasPrice();
+
+  /**
+   * Returns the value (amount of Ether) to be transferred with the transaction.
+   *
+   * @return an {@link Optional} containing the transaction value, or empty if not specified
+   */
+  Optional<Wei> getValue();
+
+  /**
+   * Returns the access list for the transaction (EIP-2930).
+   *
+   * <p>The access list specifies addresses and storage keys that the transaction plans to access,
+   * potentially reducing gas costs.
+   *
+   * @return an {@link Optional} containing the access list, or empty if not specified
+   */
+  Optional<List<AccessListEntry>> getAccessList();
+
+  /**
+   * Returns the blob versioned hashes for blob transactions (EIP-4844).
+   *
+   * <p>These hashes represent the blob data associated with the transaction and are used for blob
+   * transaction validation.
+   *
+   * @return an {@link Optional} containing the list of blob versioned hashes, or empty if not
+   *     specified
+   */
+  Optional<List<VersionedHash>> getBlobVersionedHashes();
+
+  /**
+   * Returns the nonce of the transaction.
+   *
+   * <p>The nonce is a sequence number that prevents replay attacks and ensures transaction ordering
+   * for a given sender.
+   *
+   * @return an {@link OptionalLong} containing the nonce, or empty if not specified
+   */
+  OptionalLong getNonce();
+
+  /**
+   * Returns whether strict validation should be applied.
+   *
+   * <p>When strict mode is enabled, additional validation rules may be applied during transaction
+   * processing or simulation.
+   *
+   * @return an {@link Optional} containing the strict flag, or empty if not specified
+   */
+  Optional<Boolean> getStrict();
+
+  /**
+   * Returns the transaction payload (input data).
+   *
+   * <p>This contains the data sent along with the transaction, which may include contract method
+   * calls, constructor parameters, or arbitrary data.
+   *
+   * @return an {@link Optional} containing the payload bytes, or empty if not specified
+   */
+  Optional<Bytes> getPayload();
+}

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/frontier/EthCreateAccessListIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/frontier/EthCreateAccessListIntegrationTest.java
@@ -158,7 +158,7 @@ public class EthCreateAccessListIntegrationTest {
   public void shouldReturnExpectedValueForTransfer() {
     final CallParameter callParameter =
         ImmutableCallParameter.builder()
-            .sender(Address.fromHexString("0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"))
+            .sender(Address.fromHexString("0x658bdf435d810c91414ec09147daa6db62406379"))
             .to(Address.fromHexString("0x8888f1f195afa192cfee860698584c030f4c9db1"))
             .value(Wei.ZERO)
             .build();
@@ -176,7 +176,7 @@ public class EthCreateAccessListIntegrationTest {
   public void shouldReturnExpectedValueForContractDeploy() {
     final CallParameter callParameter =
         ImmutableCallParameter.builder()
-            .sender(Address.fromHexString("0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"))
+            .sender(Address.fromHexString("0x658bdf435d810c91414ec09147daa6db62406379"))
             .input(
                 Bytes.fromHexString(
                     "0x608060405234801561001057600080fd5b50610157806100206000396000f30060806040526004361061004c576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680633bdab8bf146100515780639ae97baa14610068575b600080fd5b34801561005d57600080fd5b5061006661007f565b005b34801561007457600080fd5b5061007d6100b9565b005b7fa53887c1eed04528e23301f55ad49a91634ef5021aa83a97d07fd16ed71c039a60016040518082815260200191505060405180910390a1565b7fa53887c1eed04528e23301f55ad49a91634ef5021aa83a97d07fd16ed71c039a60026040518082815260200191505060405180910390a17fa53887c1eed04528e23301f55ad49a91634ef5021aa83a97d07fd16ed71c039a60036040518082815260200191505060405180910390a15600a165627a7a7230582010ddaa52e73a98c06dbcd22b234b97206c1d7ed64a7c048e10c2043a3d2309cb0029"))

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AbstractEstimateGas.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AbstractEstimateGas.java
@@ -199,7 +199,7 @@ public abstract class AbstractEstimateGas extends AbstractBlockParameterMethod {
 
     return isAllowExceedingBalance
         ? TransactionValidationParams.transactionSimulatorAllowExceedingBalanceAndFutureNonce()
-        : TransactionValidationParams.transactionSimulatorAllowUnderpricedAndFutureNonce();
+        : TransactionValidationParams.transactionSimulatorAllowFutureNonce();
   }
 
   @VisibleForTesting

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthEstimateGasTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthEstimateGasTest.java
@@ -440,7 +440,7 @@ public class EthEstimateGasTest {
                 modifiedLegacyTransactionCallParameter(
                     BLOCK_GAS_LIMIT, Wei.ZERO, OptionalLong.empty(), Optional.empty())),
             eq(Optional.empty()), // no account overrides
-            eq(TransactionValidationParams.transactionSimulatorAllowUnderpricedAndFutureNonce()),
+            eq(TransactionValidationParams.transactionSimulatorAllowFutureNonce()),
             any(OperationTracer.class),
             eq(pendingBlockHeader));
   }
@@ -510,7 +510,7 @@ public class EthEstimateGasTest {
         .processOnPending(
             eq(modifiedEip1559TransactionCallParameter(TX_GAS_LIMIT_CAP, OptionalLong.empty())),
             eq(Optional.empty()), // no account overrides
-            eq(TransactionValidationParams.transactionSimulatorAllowUnderpricedAndFutureNonce()),
+            eq(TransactionValidationParams.transactionSimulatorAllowFutureNonce()),
             any(OperationTracer.class),
             eq(pendingBlockHeader));
   }

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_estimateGas_from_contract.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_estimateGas_from_contract.json
@@ -14,7 +14,9 @@
   "response": {
     "jsonrpc": "2.0",
     "id": 3,
-    "result": "0x52dd"
+    "error":{
+      "code":-32004,
+      "message":"Upfront cost exceeds account balance (transaction up-front cost 0x1120ed6c5d23b0 exceeds transaction sender account balance 0x140)"}
   },
   "statusCode": 200
 }

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_estimateGas_from_contract_withBlockTag.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_estimateGas_from_contract_withBlockTag.json
@@ -6,7 +6,7 @@
     "params": [
       {
         "to": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
-        "from": "0x6295ee1b4f6dd65047762f924ecd367c17eabf8f",
+        "from": "0x8888f1f195afa192cfee860698584c030f4c9db1",
         "data": "0x123456"
       },
       "latest"

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_estimateGas_insufficientGas.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_estimateGas_insufficientGas.json
@@ -6,7 +6,7 @@
     "params": [
       {
         "to": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
-        "from": "0x6295ee1b4f6dd65047762f924ecd367c17eabf8f",
+        "from": "0x8888f1f195afa192cfee860698584c030f4c9db1",
         "gas": "0x1"
       }
     ]

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_estimateGas_noParams.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_estimateGas_noParams.json
@@ -10,7 +10,9 @@
   "response": {
     "jsonrpc": "2.0",
     "id": 3,
-    "result": "0xd221"
-  },
-  "statusCode": 200
+    "error" : {
+      "code" : -32004,
+      "message" : "Upfront cost exceeds account balance (transaction up-front cost 0x1120ed6c5d23b0 exceeds transaction sender account balance 0x2c8763688000)"
+    }
+  },  "statusCode": 200
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/CallParameter.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/CallParameter.java
@@ -38,35 +38,48 @@ import org.immutables.value.Value;
 @Value.Immutable
 @JsonDeserialize(as = ImmutableCallParameter.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
-public abstract class CallParameter {
+public abstract class CallParameter implements org.hyperledger.besu.datatypes.CallParameter {
+  @Override
   @JsonDeserialize(contentUsing = ChainIdDeserializer.class)
   public abstract Optional<BigInteger> getChainId();
 
+  @Override
   @JsonProperty("from")
   public abstract Optional<Address> getSender();
 
+  @Override
   public abstract Optional<Address> getTo();
 
+  @Override
   @JsonDeserialize(using = OptionalUnsignedLongDeserializer.class)
   public abstract OptionalLong getGas();
 
+  @Override
   public abstract Optional<Wei> getMaxPriorityFeePerGas();
 
+  @Override
   public abstract Optional<Wei> getMaxFeePerGas();
 
+  @Override
   public abstract Optional<Wei> getMaxFeePerBlobGas();
 
+  @Override
   public abstract Optional<Wei> getGasPrice();
 
+  @Override
   public abstract Optional<Wei> getValue();
 
+  @Override
   public abstract Optional<List<AccessListEntry>> getAccessList();
 
+  @Override
   public abstract Optional<List<VersionedHash>> getBlobVersionedHashes();
 
+  @Override
   @JsonDeserialize(using = OptionalUnsignedLongDeserializer.class)
   public abstract OptionalLong getNonce();
 
+  @Override
   public abstract Optional<Boolean> getStrict();
 
   /**
@@ -96,6 +109,7 @@ public abstract class CallParameter {
    *
    * @return the payload, or empty if none is present.
    */
+  @Override
   @Value.Derived
   public Optional<Bytes> getPayload() {
     return getInput().or(this::getData);

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/TransactionSimulator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/TransactionSimulator.java
@@ -23,6 +23,7 @@ import org.hyperledger.besu.crypto.SignatureAlgorithm;
 import org.hyperledger.besu.crypto.SignatureAlgorithmFactory;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.BlobGas;
+import org.hyperledger.besu.datatypes.CallParameter;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.StateOverride;
 import org.hyperledger.besu.datatypes.StateOverrideMap;
@@ -577,6 +578,8 @@ public class TransactionSimulator {
     // Set versioned hashes if present
     callParams.getBlobVersionedHashes().ifPresent(transactionBuilder::versionedHashes);
 
+    final boolean noPricingParametersPresent = noGasPriceParametersPresent(callParams);
+
     final Wei gasPrice;
     final Wei maxFeePerGas;
     final Wei maxPriorityFeePerGas;
@@ -587,7 +590,13 @@ public class TransactionSimulator {
       maxPriorityFeePerGas = Wei.ZERO;
       maxFeePerBlobGas = Wei.ZERO;
     } else {
-      gasPrice = callParams.getGasPrice().orElse(Wei.ZERO);
+      if (noPricingParametersPresent && !transactionValidationParams.allowUnderpriced()) {
+        // in case there are gas price parameters and underpriced txs are not allowed,
+        // then set the gas price to the min necessary to process the tx.
+        gasPrice = processableHeader.getBaseFee().orElse(Wei.ZERO);
+      } else {
+        gasPrice = callParams.getGasPrice().orElse(Wei.ZERO);
+      }
       maxFeePerGas = callParams.getMaxFeePerGas().orElse(gasPrice);
       maxPriorityFeePerGas = callParams.getMaxPriorityFeePerGas().orElse(gasPrice);
       maxFeePerBlobGas = callParams.getMaxFeePerBlobGas().orElse(blobGasPrice);
@@ -597,7 +606,7 @@ public class TransactionSimulator {
       transactionBuilder.gasPrice(gasPrice);
     }
 
-    if (shouldSetMaxFeePerGas(callParams, processableHeader)) {
+    if (shouldSetMaxFeePerGas(callParams, processableHeader, noPricingParametersPresent)) {
       transactionBuilder.maxFeePerGas(maxFeePerGas).maxPriorityFeePerGas(maxPriorityFeePerGas);
     }
 
@@ -658,7 +667,9 @@ public class TransactionSimulator {
   }
 
   private boolean shouldSetMaxFeePerGas(
-      final CallParameter callParams, final ProcessableBlockHeader header) {
+      final CallParameter callParams,
+      final ProcessableBlockHeader header,
+      final boolean noGasPriceParametersPresent) {
 
     // Return false if chain ID is not present
     if (protocolSchedule.getChainId().isEmpty()) {
@@ -676,16 +687,21 @@ public class TransactionSimulator {
     }
 
     // Return true if all gas price parameters are empty
-    if (callParams.getMaxPriorityFeePerGas().isEmpty()
-        && callParams.getMaxFeePerGas().isEmpty()
-        && callParams.getGasPrice().isEmpty()) {
+    if (noGasPriceParametersPresent) {
       return true;
     }
 
-    // Return true if either maxPriorityFeePerGas or maxFeePerGas is present
+    // Return true if either maxPriorityFeePerGas or maxFeePerGas is present.
     // This ensures the transaction is considered EIP-1559 only if these parameters are present
     return callParams.getMaxPriorityFeePerGas().isPresent()
         || callParams.getMaxFeePerGas().isPresent();
+  }
+
+  private boolean noGasPriceParametersPresent(final CallParameter callParams) {
+    // Return true if all gas price parameters are empty
+    return callParams.getMaxPriorityFeePerGas().isEmpty()
+        && callParams.getMaxFeePerGas().isEmpty()
+        && callParams.getGasPrice().isEmpty();
   }
 
   private boolean shouldSetBlobGasPrice(final CallParameter callParams) {

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -71,7 +71,7 @@ Calculated : ${currentHash}
 tasks.register('checkAPIChanges', FileStateChecker) {
   description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
   files = sourceSets.main.allJava.files
-  knownHash = '2iFZ9OBdtl1VoQLGPdqolq8zlBIkwszjin8vO4TkTqk='
+  knownHash = 'lIxtWb7w8OQAqxaSQIva/H4fC6GxlkCbGVri0ibMYIc='
 }
 check.dependsOn('checkAPIChanges')
 

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/TransactionSimulationService.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/TransactionSimulationService.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.plugin.services;
 
+import org.hyperledger.besu.datatypes.CallParameter;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.StateOverrideMap;
 import org.hyperledger.besu.datatypes.Transaction;
@@ -22,11 +23,49 @@ import org.hyperledger.besu.plugin.Unstable;
 import org.hyperledger.besu.plugin.data.ProcessableBlockHeader;
 import org.hyperledger.besu.plugin.data.TransactionSimulationResult;
 
+import java.util.EnumSet;
 import java.util.Optional;
 
 /** Transaction simulation service interface */
 @Unstable
 public interface TransactionSimulationService extends BesuService {
+  /**
+   * Enumeration of simulation parameters that control validation behavior during transaction
+   * simulation.
+   *
+   * <p>These parameters allow relaxing certain validation rules that would normally cause a
+   * transaction to fail, enabling more flexible simulation scenarios for testing, debugging, or
+   * analysis purposes.
+   */
+  enum SimulationParameters {
+
+    /**
+     * Allows the transaction to proceed even if the sender's account balance is insufficient to
+     * cover the transaction value and gas costs.
+     *
+     * <p>When this parameter is enabled, balance validation is bypassed, allowing simulation of
+     * transactions that would normally fail due to insufficient funds.
+     */
+    ALLOW_EXCEEDING_BALANCE,
+
+    /**
+     * Allows the transaction to proceed even if the nonce is higher than the sender's current
+     * account nonce.
+     *
+     * <p>When this parameter is enabled, nonce validation is relaxed, allowing simulation of future
+     * transactions without requiring all intermediate transactions to be processed first.
+     */
+    ALLOW_FUTURE_NONCE,
+
+    /**
+     * Allows the transaction to proceed even if the gas price is below the network's minimum gas
+     * price requirements.
+     *
+     * <p>When this parameter is enabled, gas price validation is bypassed, allowing simulation of
+     * transactions with artificially low gas prices that would normally be rejected by the network.
+     */
+    ALLOW_UNDERPRICED
+  }
 
   /**
    * Return a simulation of what could be current pending block, it can also be passed to {@link
@@ -37,8 +76,8 @@ public interface TransactionSimulationService extends BesuService {
   ProcessableBlockHeader simulatePendingBlockHeader();
 
   /**
-   * Simulate transaction execution at the block identified by the hash if present, otherwise on the
-   * pending block, with optional state overrides that can be applied before the simulation.
+   * Simulate transaction execution at the block identified by the hash, with optional state
+   * overrides that can be applied before the simulation.
    *
    * @param transaction tx
    * @param stateOverrides state overrides to apply to this simulation
@@ -47,16 +86,43 @@ public interface TransactionSimulationService extends BesuService {
    * @param isAllowExceedingBalance should ignore the sender balance during the simulation?
    * @return the result of the simulation
    */
+  @Deprecated(forRemoval = true)
+  default Optional<TransactionSimulationResult> simulate(
+      final Transaction transaction,
+      final Optional<StateOverrideMap> stateOverrides,
+      final Hash blockHash,
+      final OperationTracer operationTracer,
+      final boolean isAllowExceedingBalance) {
+    final var simulationParameters =
+        isAllowExceedingBalance
+            ? EnumSet.of(SimulationParameters.ALLOW_EXCEEDING_BALANCE)
+            : EnumSet.noneOf(SimulationParameters.class);
+
+    return simulate(transaction, stateOverrides, blockHash, operationTracer, simulationParameters);
+  }
+
+  /**
+   * Simulate transaction execution at the block identified by the hash, with optional state
+   * overrides that can be applied before the simulation.
+   *
+   * @param transaction tx
+   * @param stateOverrides state overrides to apply to this simulation
+   * @param blockHash hash of the block
+   * @param operationTracer the tracer
+   * @param simulationParameters optional set of parameters that affected the behavior of the
+   *     simulation
+   * @return the result of the simulation
+   */
   Optional<TransactionSimulationResult> simulate(
       Transaction transaction,
       Optional<StateOverrideMap> stateOverrides,
       Hash blockHash,
       OperationTracer operationTracer,
-      boolean isAllowExceedingBalance);
+      EnumSet<SimulationParameters> simulationParameters);
 
   /**
-   * Simulate transaction execution at the block identified by the hash if present, otherwise on the
-   * pending block, with optional state overrides that can be applied before the simulation.
+   * Simulate transaction execution at the block identified by the block header, with optional state
+   * overrides that can be applied before the simulation.
    *
    * @param transaction tx
    * @param stateOverrides state overrides to apply to this simulation
@@ -66,11 +132,60 @@ public interface TransactionSimulationService extends BesuService {
    * @param isAllowFutureNonce should skip strict check on sequential nonce?
    * @return the result of the simulation
    */
+  @Deprecated(forRemoval = true)
+  default Optional<TransactionSimulationResult> simulate(
+      final Transaction transaction,
+      final Optional<StateOverrideMap> stateOverrides,
+      final ProcessableBlockHeader processableBlockHeader,
+      final OperationTracer operationTracer,
+      final boolean isAllowExceedingBalance,
+      final boolean isAllowFutureNonce) {
+    final var simulationParameters = EnumSet.noneOf(SimulationParameters.class);
+    if (isAllowExceedingBalance) {
+      simulationParameters.add(SimulationParameters.ALLOW_EXCEEDING_BALANCE);
+    }
+    if (isAllowFutureNonce) {
+      simulationParameters.add(SimulationParameters.ALLOW_FUTURE_NONCE);
+    }
+    return simulate(
+        transaction, stateOverrides, processableBlockHeader, operationTracer, simulationParameters);
+  }
+
+  /**
+   * Simulate transaction execution at the block identified by the block header, with optional state
+   * overrides that can be applied before the simulation.
+   *
+   * @param transaction tx
+   * @param stateOverrides state overrides to apply to this simulation
+   * @param processableBlockHeader block header to simulate on pending block
+   * @param operationTracer the tracer
+   * @param simulationParameters optional set of parameters that affected the behavior of the
+   *     simulation
+   * @return the result of the simulation
+   */
   Optional<TransactionSimulationResult> simulate(
       Transaction transaction,
       Optional<StateOverrideMap> stateOverrides,
       ProcessableBlockHeader processableBlockHeader,
       OperationTracer operationTracer,
-      boolean isAllowExceedingBalance,
-      boolean isAllowFutureNonce);
+      EnumSet<SimulationParameters> simulationParameters);
+
+  /**
+   * Simulate transaction (specified by call parameters) execution at the block identified by the
+   * block header, with optional state overrides that can be applied before the simulation.
+   *
+   * @param callParameters call parameters
+   * @param stateOverrides state overrides to apply to this simulation
+   * @param processableBlockHeader block header to simulate
+   * @param operationTracer the tracer
+   * @param simulationParameters optional set of parameters that affected the behavior of the
+   *     simulation
+   * @return the result of the simulation
+   */
+  Optional<TransactionSimulationResult> simulate(
+      CallParameter callParameters,
+      Optional<StateOverrideMap> stateOverrides,
+      ProcessableBlockHeader processableBlockHeader,
+      OperationTracer operationTracer,
+      EnumSet<SimulationParameters> simulationParameters);
 }


### PR DESCRIPTION
## PR description

Follow up to https://github.com/hyperledger/besu/pull/8629

This PR helps getting more accurate simulations of transactions in case there is no gas pricing defined in call parameters.

Before when no gas pricing was defined, and the fee market requires a base fee, the only way to simulate a transaction was to force the tx validation parameters to _allow_exceeding_balance_ or _allow_underpriced_ , since all the gas pricing field of the tx were set to 0. That in some cases could result in less accurate simulations and gas estimations.

With this PR, if there is no gas pricing defined in call parameters and a base fee is required, then at the moment of creating the transaction for the simulation, the gas pricing fields are set to the base fee value of the block header used for the simulation. This way there is no more need to force tx validation parameters to force the simulation, other than the _allow_future_nonce_, increasing the accuracy.

If gas pricing parameters are present in the call parameters, then no adjustment is done, and if they are not enough for the current base fee market, or the sender has not enough balance, the simulation will fails, that is in line with Geth's behavior.

Moreover a new transaction simulation method is exposed, in the Plugin API, to allow plugin to directly simulate using call parameters, to avoid forcing plugins to build a transaction on their own and having to implement gas pricing setting rules that could be not aligned with Besu defaults.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

