### PR TITLE
Expose methods to query the hardfork in the Plugin API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Additions and Improvements
 - Improve transaction simulation and gas estimation when no gas pricing is present [#8888](https://github.com/hyperledger/besu/pull/8888)
 - Add option to trace reference tests during execution [#8878](https://github.com/hyperledger/besu/pull/8878)
+- Expose methods to query hardfork by block header or for the next block in the Plugin API [#8909](https://github.com/hyperledger/besu/pull/8909)
 
 #### Fusaka devnets
 - EIP-7910 - `eth_config` JSON-RPC Method [#8417](https://github.com/hyperledger/besu/pull/8417)

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/AcceptanceTestBase.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/AcceptanceTestBase.java
@@ -48,13 +48,19 @@ import org.hyperledger.besu.tests.acceptance.dsl.transaction.txpool.TxPoolTransa
 import org.hyperledger.besu.tests.acceptance.dsl.transaction.web3.Web3Transactions;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.math.BigInteger;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 import org.apache.logging.log4j.ThreadContext;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -191,6 +197,21 @@ public class AcceptanceTestBase {
         () ->
             assertThat(node.execute(ethTransactions.blockNumber()))
                 .isGreaterThanOrEqualTo(BigInteger.valueOf(blockchainHeight)));
+  }
+
+  protected void waitForFile(final Path path) {
+    final File file = path.toFile();
+    Awaitility.waitAtMost(30, TimeUnit.SECONDS)
+        .until(
+            () -> {
+              if (file.exists()) {
+                try (final Stream<String> s = Files.lines(path)) {
+                  return s.count() > 0;
+                }
+              } else {
+                return false;
+              }
+            });
   }
 
   @Test

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/configuration/BesuNodeFactory.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/configuration/BesuNodeFactory.java
@@ -310,6 +310,21 @@ public class BesuNodeFactory {
             .build());
   }
 
+  public BesuNode createPluginsNode(
+      final String name,
+      final List<String> plugins,
+      final UnaryOperator<BesuNodeConfigurationBuilder> configBuilder)
+      throws IOException {
+
+    BesuNodeConfigurationBuilder builder =
+        new BesuNodeConfigurationBuilder()
+            .name(name)
+            .webSocketConfiguration(node.createWebSocketEnabledConfig())
+            .plugins(plugins);
+
+    return create(configBuilder.apply(builder).build());
+  }
+
   public BesuNode createArchiveNodeWithRpcApis(final String name, final String... enabledRpcApis)
       throws IOException {
     final JsonRpcConfiguration jsonRpcConfig = node.createJsonRpcEnabledConfig();

--- a/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/tests/acceptance/plugins/TestBlockchainServicePlugin.java
+++ b/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/tests/acceptance/plugins/TestBlockchainServicePlugin.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.tests.acceptance.plugins;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import org.hyperledger.besu.datatypes.HardforkId;
+import org.hyperledger.besu.plugin.BesuPlugin;
+import org.hyperledger.besu.plugin.ServiceManager;
+import org.hyperledger.besu.plugin.data.BlockHeader;
+import org.hyperledger.besu.plugin.services.BesuEvents;
+import org.hyperledger.besu.plugin.services.BlockchainService;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.google.auto.service.AutoService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@AutoService(BesuPlugin.class)
+public class TestBlockchainServicePlugin implements BesuPlugin {
+  private static final Logger LOG = LoggerFactory.getLogger(TestBlockchainServicePlugin.class);
+  private final List<HardforkSeen> seenHardforks = new ArrayList<>();
+  private ServiceManager serviceManager;
+  private File callbackDir;
+
+  @Override
+  public void register(final ServiceManager serviceManager) {
+    LOG.info("Registering TestBlockchainServicePlugin");
+    this.serviceManager = serviceManager;
+    callbackDir = new File(System.getProperty("besu.plugins.dir", "plugins"));
+  }
+
+  @Override
+  public void start() {
+    LOG.info("Starting TestBlockchainServicePlugin");
+    final var blockchainService = serviceManager.getService(BlockchainService.class).orElseThrow();
+
+    serviceManager
+        .getService(BesuEvents.class)
+        .orElseThrow()
+        .addBlockAddedListener(
+            addedBlockContext -> {
+              LOG.info("Block added: {}", addedBlockContext);
+              final var hardforkSeen =
+                  queryHardfork(blockchainService, addedBlockContext.getBlockHeader());
+              seenHardforks.add(
+                  queryHardfork(blockchainService, addedBlockContext.getBlockHeader()));
+              if (hardforkSeen.current.equals(HardforkId.MainnetHardforkId.LONDON)) {
+                LOG.info("Writing seen hardforks: {}", seenHardforks);
+                writeSeenHardforks();
+              }
+            });
+
+    seenHardforks.add(queryHardfork(blockchainService, blockchainService.getChainHeadHeader()));
+  }
+
+  private HardforkSeen queryHardfork(
+      final BlockchainService blockchainService, final BlockHeader header) {
+    final var currentHardfork = blockchainService.getHardforkId(header);
+    final var nextHardfork =
+        blockchainService.getNextBlockHardforkId(header, header.getTimestamp() + 1);
+
+    return new HardforkSeen(header.getNumber(), currentHardfork, nextHardfork);
+  }
+
+  @Override
+  public void stop() {}
+
+  private void writeSeenHardforks() {
+    try {
+      final File callbackFile = new File(callbackDir, "hardfork.list");
+      if (!callbackFile.getParentFile().exists()) {
+        callbackFile.getParentFile().mkdirs();
+        callbackFile.getParentFile().deleteOnExit();
+      }
+
+      final var content =
+          seenHardforks.stream()
+              .map(
+                  r ->
+                      String.join(
+                          ",", String.valueOf(r.blockNumber), r.current.name(), r.next.name()))
+              .collect(Collectors.joining("\n"));
+
+      Files.write(callbackFile.toPath(), content.getBytes(UTF_8));
+      callbackFile.deleteOnExit();
+    } catch (final IOException ioe) {
+      throw new RuntimeException(ioe);
+    }
+  }
+
+  private record HardforkSeen(long blockNumber, HardforkId current, HardforkId next) {}
+}

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/plugins/BadCLIOptionsPluginTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/plugins/BadCLIOptionsPluginTest.java
@@ -19,14 +19,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.hyperledger.besu.tests.acceptance.dsl.AcceptanceTestBase;
 import org.hyperledger.besu.tests.acceptance.dsl.node.BesuNode;
 
-import java.io.File;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Stream;
 
-import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -77,20 +72,5 @@ public class BadCLIOptionsPluginTest extends AcceptanceTestBase {
     waitForFile(node.homeDirectory().resolve("plugins/pluginLifecycle.stopped"));
     assertThat(node.homeDirectory().resolve("plugins/badCliOptions.start")).doesNotExist();
     assertThat(node.homeDirectory().resolve("plugins/badCliOptions.stop")).doesNotExist();
-  }
-
-  private void waitForFile(final Path path) {
-    final File file = path.toFile();
-    Awaitility.waitAtMost(30, TimeUnit.SECONDS)
-        .until(
-            () -> {
-              if (file.exists()) {
-                try (final Stream<String> s = Files.lines(path)) {
-                  return s.count() > 0;
-                }
-              } else {
-                return false;
-              }
-            });
   }
 }

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/plugins/BesuEventsPluginTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/plugins/BesuEventsPluginTest.java
@@ -17,14 +17,8 @@ package org.hyperledger.besu.tests.acceptance.plugins;
 import org.hyperledger.besu.tests.acceptance.dsl.AcceptanceTestBase;
 import org.hyperledger.besu.tests.acceptance.dsl.node.BesuNode;
 
-import java.io.File;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Collections;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Stream;
 
-import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -44,20 +38,5 @@ public class BesuEventsPluginTest extends AcceptanceTestBase {
   @Test
   public void blockIsAnnounced() {
     waitForFile(pluginNode.homeDirectory().resolve("plugins/newBlock.2"));
-  }
-
-  private void waitForFile(final Path path) {
-    final File file = path.toFile();
-    Awaitility.waitAtMost(30, TimeUnit.SECONDS)
-        .until(
-            () -> {
-              if (file.exists()) {
-                try (final Stream<String> s = Files.lines(path)) {
-                  return s.count() > 0;
-                }
-              } else {
-                return false;
-              }
-            });
   }
 }

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/plugins/BlockchainServicePluginTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/plugins/BlockchainServicePluginTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.tests.acceptance.plugins;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import org.hyperledger.besu.tests.acceptance.dsl.AcceptanceTestBase;
+import org.hyperledger.besu.tests.acceptance.dsl.node.BesuNode;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class BlockchainServicePluginTest extends AcceptanceTestBase {
+  private BesuNode minerNode;
+  private BesuNode pluginNode;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    minerNode =
+        besu.createMinerNode(
+            "minerNode",
+            besuNodeConfigurationBuilder -> besuNodeConfigurationBuilder.devMode(false));
+    minerNode.setGenesisConfig(GENESIS_CONFIG);
+    pluginNode =
+        besu.createPluginsNode(
+            "pluginNode",
+            Collections.singletonList("testPlugins"),
+            besuNodeConfigurationBuilder -> besuNodeConfigurationBuilder.devMode(false));
+    pluginNode.setGenesisConfig(GENESIS_CONFIG);
+
+    cluster.start(pluginNode, minerNode);
+  }
+
+  @Test
+  public void hardforkListIsCorrect() throws IOException {
+    final Path hardforkListFile = pluginNode.homeDirectory().resolve("plugins/hardfork.list");
+    waitForFile(hardforkListFile);
+    final var fileContents = Files.readAllLines(hardforkListFile);
+
+    final var expectedLines = List.of("0,BERLIN,BERLIN", "1,BERLIN,LONDON", "2,LONDON,LONDON");
+
+    for (int i = 0; i < expectedLines.size(); i++) {
+      assertThat(fileContents.get(i)).isEqualTo(expectedLines.get(i));
+    }
+  }
+
+  private static final String GENESIS_CONFIG =
+      """
+        {
+          "config": {
+            "chainId": 1337,
+            "berlinBlock": 0,
+            "londonBlock": 2,
+            "contractSizeLimit": 2147483647,
+            "ethash": {
+              "fixeddifficulty": 100
+            }
+          },
+          "nonce": "0x42",
+          "baseFeePerGas":"0x0",
+          "timestamp": "0x0",
+          "extraData": "0x11bbe8db4e347b4e8c937c1c8370e4b5ed33adb3db69cbdb7a38e1e50b1b82fa",
+          "gasLimit": "0x1fffffffffffff",
+          "difficulty": "0x10000",
+          "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "coinbase": "0x0000000000000000000000000000000000000000",
+          "alloc": {
+            "fe3b557e8fb62b89f4916b721be55ceb828dbd73": {
+              "privateKey": "8f2a55949038a9610f50fb23b5883af3b4ecb3c3bb792cbcefbd1542c692be63",
+              "comment": "private key and this comment are ignored.  In a real chain, the private key should NOT be stored",
+              "balance": "0xad78ebc5ac6200000"
+            },
+            "627306090abaB3A6e1400e9345bC60c78a8BEf57": {
+              "privateKey": "c87509a1c067bbde78beb793e6fa76530b6382a4c0241e5e4a9ec0a0f44dc0d3",
+              "comment": "private key and this comment are ignored.  In a real chain, the private key should NOT be stored",
+              "balance": "90000000000000000000000"
+            },
+            "f17f52151EbEF6C7334FAD080c5704D77216b732": {
+              "privateKey": "ae6ae8e5ccbfb04590405997ee2d52d2b330726137b875053c36d94e974d162f",
+              "comment": "private key and this comment are ignored.  In a real chain, the private key should NOT be stored",
+              "balance": "90000000000000000000000"
+            }
+          }
+        }
+        """;
+}

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/plugins/PicoCLIOptionsPluginTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/plugins/PicoCLIOptionsPluginTest.java
@@ -19,15 +19,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.hyperledger.besu.tests.acceptance.dsl.AcceptanceTestBase;
 import org.hyperledger.besu.tests.acceptance.dsl.node.BesuNode;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Stream;
 
-import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -74,20 +70,5 @@ public class PicoCLIOptionsPluginTest extends AcceptanceTestBase {
   public void shouldStop() {
     cluster.stopNode(node);
     waitForFile(node.homeDirectory().resolve("plugins/pluginLifecycle.stopped"));
-  }
-
-  private void waitForFile(final Path path) {
-    final File file = path.toFile();
-    Awaitility.waitAtMost(30, TimeUnit.SECONDS)
-        .until(
-            () -> {
-              if (file.exists()) {
-                try (final Stream<String> s = Files.lines(path)) {
-                  return s.count() > 0;
-                }
-              } else {
-                return false;
-              }
-            });
   }
 }

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptanceqbft/plugins/BesuEventsPluginTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptanceqbft/plugins/BesuEventsPluginTest.java
@@ -17,14 +17,8 @@ package org.hyperledger.besu.tests.acceptanceqbft.plugins;
 import org.hyperledger.besu.tests.acceptance.dsl.AcceptanceTestBase;
 import org.hyperledger.besu.tests.acceptance.dsl.node.BesuNode;
 
-import java.io.File;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Collections;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Stream;
 
-import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -44,20 +38,5 @@ public class BesuEventsPluginTest extends AcceptanceTestBase {
   @Test
   public void blockIsAnnounced() {
     waitForFile(pluginNode.homeDirectory().resolve("plugins/newBlock.2"));
-  }
-
-  private void waitForFile(final Path path) {
-    final File file = path.toFile();
-    Awaitility.waitAtMost(30, TimeUnit.SECONDS)
-        .until(
-            () -> {
-              if (file.exists()) {
-                try (final Stream<String> s = Files.lines(path)) {
-                  return s.count() > 0;
-                }
-              } else {
-                return false;
-              }
-            });
   }
 }

--- a/app/src/main/java/org/hyperledger/besu/services/BlockchainServiceImpl.java
+++ b/app/src/main/java/org/hyperledger/besu/services/BlockchainServiceImpl.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.services;
 import static org.hyperledger.besu.ethereum.mainnet.feemarket.ExcessBlobGasCalculator.calculateExcessBlobGasForParent;
 
 import org.hyperledger.besu.datatypes.BlobGas;
+import org.hyperledger.besu.datatypes.HardforkId;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
@@ -225,5 +226,18 @@ public class BlockchainServiceImpl implements BlockchainService {
       return Optional.empty();
     }
     return protocolSchedule.getChainId();
+  }
+
+  @Override
+  public HardforkId getHardforkId(final BlockHeader blockHeader) {
+    return protocolSchedule.getByBlockHeader(blockHeader).getHardforkId();
+  }
+
+  @Override
+  public HardforkId getNextBlockHardforkId(
+      final BlockHeader parentBlockHeader, final long timestampForNextBlock) {
+    return protocolSchedule
+        .getForNextBlockHeader(parentBlockHeader, timestampForNextBlock)
+        .getHardforkId();
   }
 }

--- a/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/CliqueProtocolScheduleTest.java
+++ b/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/CliqueProtocolScheduleTest.java
@@ -16,6 +16,7 @@ package org.hyperledger.besu.consensus.clique;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.FRONTIER;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -100,7 +101,7 @@ public class CliqueProtocolScheduleTest {
                 new NoOpMetricsSystem())
             .getByBlockHeader(blockHeader(0));
 
-    assertThat(homestead.getName()).isEqualTo("Frontier");
+    assertThat(homestead.getHardforkId()).isEqualTo(FRONTIER);
     assertThat(homestead.getBlockReward()).isEqualTo(Wei.ZERO);
     assertThat(homestead.isSkipZeroBlockRewards()).isEqualTo(true);
     assertThat(homestead.getDifficultyCalculator()).isInstanceOf(CliqueDifficultyCalculator.class);

--- a/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/blockcreation/CliqueBlockMinerTest.java
+++ b/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/blockcreation/CliqueBlockMinerTest.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.consensus.clique.blockcreation;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.FRONTIER;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
@@ -97,7 +98,7 @@ class CliqueBlockMinerTest {
 
     final BlockImporter blockImporter = mock(BlockImporter.class);
     final ProtocolSpec protocolSpec = mock(ProtocolSpec.class);
-
+    when(protocolSpec.getHardforkId()).thenReturn(FRONTIER);
     final ProtocolSchedule protocolSchedule = singleSpecSchedule(protocolSpec);
 
     when(protocolSpec.getBlockImporter()).thenReturn(blockImporter);
@@ -153,7 +154,7 @@ class CliqueBlockMinerTest {
 
     final BlockImporter blockImporter = mock(BlockImporter.class);
     final ProtocolSpec protocolSpec = mock(ProtocolSpec.class);
-
+    when(protocolSpec.getHardforkId()).thenReturn(FRONTIER);
     final ProtocolSchedule protocolSchedule = singleSpecSchedule(protocolSpec);
 
     when(protocolSpec.getBlockImporter()).thenReturn(blockImporter);

--- a/consensus/common/src/test/java/org/hyperledger/besu/consensus/common/CombinedProtocolScheduleFactoryTest.java
+++ b/consensus/common/src/test/java/org/hyperledger/besu/consensus/common/CombinedProtocolScheduleFactoryTest.java
@@ -15,6 +15,13 @@
 package org.hyperledger.besu.consensus.common;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.BERLIN;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.BYZANTIUM;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.CONSTANTINOPLE;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.FRONTIER;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.HOMESTEAD;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.LONDON;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.SHANGHAI;
 
 import org.hyperledger.besu.config.GenesisConfigOptions;
 import org.hyperledger.besu.config.StubGenesisConfigOptions;
@@ -62,18 +69,18 @@ public class CombinedProtocolScheduleFactoryTest {
     final BftProtocolSchedule combinedProtocolSchedule =
         combinedProtocolScheduleFactory.create(consensusSchedule, Optional.of(BigInteger.TEN));
 
-    assertThat(combinedProtocolSchedule.getByBlockNumberOrTimestamp(0L, 0L).getName())
-        .isEqualTo("Frontier");
+    assertThat(combinedProtocolSchedule.getByBlockNumberOrTimestamp(0L, 0L).getHardforkId())
+        .isEqualTo(FRONTIER);
     assertThat(combinedProtocolSchedule.getByBlockNumberOrTimestamp(0L, 0L))
         .isSameAs(protocolSchedule.getByBlockNumberOrTimestamp(0L, 0L));
 
-    assertThat(combinedProtocolSchedule.getByBlockNumberOrTimestamp(5L, 0L).getName())
-        .isEqualTo("Homestead");
+    assertThat(combinedProtocolSchedule.getByBlockNumberOrTimestamp(5L, 0L).getHardforkId())
+        .isEqualTo(HOMESTEAD);
     assertThat(combinedProtocolSchedule.getByBlockNumberOrTimestamp(5L, 0L))
         .isSameAs(protocolSchedule.getByBlockNumberOrTimestamp(5L, 0L));
 
-    assertThat(combinedProtocolSchedule.getByBlockNumberOrTimestamp(10L, 0L).getName())
-        .isEqualTo("Constantinople");
+    assertThat(combinedProtocolSchedule.getByBlockNumberOrTimestamp(10L, 0L).getHardforkId())
+        .isEqualTo(CONSTANTINOPLE);
     assertThat(combinedProtocolSchedule.getByBlockNumberOrTimestamp(10L, 0L))
         .isSameAs(protocolSchedule.getByBlockNumberOrTimestamp(10L, 0L));
 
@@ -111,51 +118,52 @@ public class CombinedProtocolScheduleFactoryTest {
         combinedProtocolScheduleFactory.create(consensusSchedule, Optional.of(BigInteger.TEN));
 
     // consensus schedule 1
-    assertThat(combinedProtocolSchedule.getByBlockNumberOrTimestamp(0L, 0L).getName())
-        .isEqualTo("Frontier");
+    assertThat(combinedProtocolSchedule.getByBlockNumberOrTimestamp(0L, 0L).getHardforkId())
+        .isEqualTo(FRONTIER);
     assertThat(combinedProtocolSchedule.getByBlockNumberOrTimestamp(0L, 0L))
         .isSameAs(protocolSchedule1.getByBlockNumberOrTimestamp(0L, 0L));
 
-    assertThat(combinedProtocolSchedule.getByBlockNumberOrTimestamp(5L, 0L).getName())
-        .isEqualTo("Homestead");
+    assertThat(combinedProtocolSchedule.getByBlockNumberOrTimestamp(5L, 0L).getHardforkId())
+        .isEqualTo(HOMESTEAD);
     assertThat(combinedProtocolSchedule.getByBlockNumberOrTimestamp(5L, 0L))
         .isSameAs(protocolSchedule1.getByBlockNumberOrTimestamp(5L, 0L));
-    assertThat(combinedProtocolSchedule.getByBlockNumberOrTimestamp(10L, 0L).getName())
-        .isEqualTo("Byzantium");
+    assertThat(combinedProtocolSchedule.getByBlockNumberOrTimestamp(10L, 0L).getHardforkId())
+        .isEqualTo(BYZANTIUM);
     assertThat(combinedProtocolSchedule.getByBlockNumberOrTimestamp(10L, 0L))
         .isSameAs(protocolSchedule1.getByBlockNumberOrTimestamp(10L, 0L));
 
     // consensus schedule 2 migration block
-    assertThat(combinedProtocolSchedule.getByBlockNumberOrTimestamp(100L, 0L).getName())
-        .isEqualTo("Byzantium");
+    assertThat(combinedProtocolSchedule.getByBlockNumberOrTimestamp(100L, 0L).getHardforkId())
+        .isEqualTo(BYZANTIUM);
     assertThat(combinedProtocolSchedule.getByBlockNumberOrTimestamp(100L, 0L))
         .isSameAs(protocolSchedule2.getByBlockNumberOrTimestamp(10L, 0L));
 
     // consensus schedule 2
-    assertThat(combinedProtocolSchedule.getByBlockNumberOrTimestamp(105L, 0L).getName())
-        .isEqualTo("Constantinople");
+    assertThat(combinedProtocolSchedule.getByBlockNumberOrTimestamp(105L, 0L).getHardforkId())
+        .isEqualTo(CONSTANTINOPLE);
     assertThat(combinedProtocolSchedule.getByBlockNumberOrTimestamp(105L, 0L))
         .isSameAs(protocolSchedule2.getByBlockNumberOrTimestamp(105L, 0L));
-    assertThat(combinedProtocolSchedule.getByBlockNumberOrTimestamp(110L, 0L).getName())
-        .isEqualTo("Berlin");
+    assertThat(combinedProtocolSchedule.getByBlockNumberOrTimestamp(110L, 0L).getHardforkId())
+        .isEqualTo(BERLIN);
     assertThat(combinedProtocolSchedule.getByBlockNumberOrTimestamp(110L, 0L))
         .isSameAs(protocolSchedule2.getByBlockNumberOrTimestamp(110L, 0L));
 
     // consensus schedule 3 migration block
-    assertThat(combinedProtocolSchedule.getByBlockNumberOrTimestamp(200L, 0L).getName())
-        .isEqualTo("Berlin");
+    assertThat(combinedProtocolSchedule.getByBlockNumberOrTimestamp(200L, 0L).getHardforkId())
+        .isEqualTo(BERLIN);
     assertThat(combinedProtocolSchedule.getByBlockNumberOrTimestamp(200L, 0L))
         .isSameAs(protocolSchedule3.getByBlockNumberOrTimestamp(110L, 0L));
 
     // consensus schedule 3
-    assertThat(combinedProtocolSchedule.getByBlockNumberOrTimestamp(220L, 0L).getName())
-        .isEqualTo("London");
+    assertThat(combinedProtocolSchedule.getByBlockNumberOrTimestamp(220L, 0L).getHardforkId())
+        .isEqualTo(LONDON);
     assertThat(combinedProtocolSchedule.getByBlockNumberOrTimestamp(220L, 0L))
         .isSameAs(protocolSchedule3.getByBlockNumberOrTimestamp(220L, 0L));
 
     // consensus schedule 4
-    assertThat(combinedProtocolSchedule.getByBlockNumberOrTimestamp(0L, 1000000050L).getName())
-        .isEqualTo("Shanghai");
+    assertThat(
+            combinedProtocolSchedule.getByBlockNumberOrTimestamp(0L, 1000000050L).getHardforkId())
+        .isEqualTo(SHANGHAI);
     assertThat(combinedProtocolSchedule.getByBlockNumberOrTimestamp(220L, 1000000050L))
         .isSameAs(protocolSchedule4.getByBlockNumberOrTimestamp(220L, 1000000050L));
 

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/MergeProtocolSchedule.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/MergeProtocolSchedule.java
@@ -14,6 +14,8 @@
  */
 package org.hyperledger.besu.consensus.merge;
 
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.PARIS;
+
 import org.hyperledger.besu.config.GenesisConfigOptions;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.GasLimitCalculator;
@@ -103,7 +105,7 @@ public class MergeProtocolSchedule {
         .difficultyCalculator((a, b) -> BigInteger.ZERO)
         .skipZeroBlockRewards(true)
         .isPoS(true)
-        .name("Paris");
+        .hardforkId(PARIS);
   }
 
   private static BlockHeaderValidator.Builder getBlockHeaderValidator(

--- a/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/MergeProtocolScheduleTest.java
+++ b/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/MergeProtocolScheduleTest.java
@@ -15,6 +15,9 @@
 package org.hyperledger.besu.consensus.merge;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.CANCUN;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.PARIS;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.SHANGHAI;
 
 import org.hyperledger.besu.config.GenesisConfig;
 import org.hyperledger.besu.config.GenesisConfigOptions;
@@ -84,8 +87,8 @@ public class MergeProtocolScheduleTest {
         protocolSchedule.getByBlockHeader(
             new BlockHeaderTestFixture().timestamp(1681338455).buildHeader());
 
-    assertThat(parisSpec.getName()).isEqualTo("Paris");
-    assertThat(shanghaiSpec.getName()).isEqualTo("Shanghai");
+    assertThat(parisSpec.getHardforkId()).isEqualTo(PARIS);
+    assertThat(shanghaiSpec.getHardforkId()).isEqualTo(SHANGHAI);
 
     // ensure PUSH0 is enabled in Shanghai
     final int PUSH0 = 0x5f;
@@ -125,8 +128,8 @@ public class MergeProtocolScheduleTest {
         protocolSchedule.getByBlockHeader(
             new BlockHeaderTestFixture().number(10).timestamp(1000).buildHeader());
 
-    assertThat(parisSpec.getName()).isEqualTo("Paris");
-    assertThat(cancunSpec.getName()).isEqualTo("Cancun");
+    assertThat(parisSpec.getHardforkId()).isEqualTo(PARIS);
+    assertThat(cancunSpec.getHardforkId()).isEqualTo(CANCUN);
 
     // ensure PUSH0 is enabled in Cancun (i.e. it has picked up the Shanghai change rather than been
     // reverted to Paris)
@@ -154,14 +157,14 @@ public class MergeProtocolScheduleTest {
     final long lastParisBlockNumber = 17034869L;
     final ProtocolSpec parisSpec =
         protocolSchedule.getByBlockHeader(blockHeader(lastParisBlockNumber));
-    assertThat(parisSpec.getName()).isEqualTo("Paris");
+    assertThat(parisSpec.getHardforkId()).isEqualTo(PARIS);
 
     for (long forkTimestamp : config.getForkBlockTimestamps()) {
       final ProtocolSpec postParisSpec =
           protocolSchedule.getByBlockHeader(
               new BlockHeaderTestFixture().timestamp(forkTimestamp).buildHeader());
 
-      assertThat(postParisSpec.getName()).isNotEqualTo("Paris");
+      assertThat(postParisSpec.getHardforkId()).isNotEqualTo(PARIS);
       // ensure PUSH0 is enabled from Shanghai onwards
       final int PUSH0 = 0x5f;
       assertThat(parisSpec.getEvm().getOperationsUnsafe()[PUSH0])
@@ -186,7 +189,7 @@ public class MergeProtocolScheduleTest {
                 new NoOpMetricsSystem())
             .getByBlockHeader(blockHeader(0));
 
-    assertThat(london.getName()).isEqualTo("Paris");
+    assertThat(london.getHardforkId()).isEqualTo(PARIS);
     assertProofOfStakeConfigIsEnabled(london);
   }
 

--- a/datatypes/src/main/java/org/hyperledger/besu/datatypes/HardforkId.java
+++ b/datatypes/src/main/java/org/hyperledger/besu/datatypes/HardforkId.java
@@ -47,8 +47,10 @@ public interface HardforkId {
     FRONTIER(true, "Frontier"),
     /** Homestead fork. */
     HOMESTEAD(true, "Homestead"),
-    /** DAO Fork fork. */
-    DAO_FORK(true, "DAO Fork"),
+    /** DAO Recovery Init fork. */
+    DAO_RECOVERY_INIT(true, "DAO Recovery Init"),
+    /** DAO Recovery Transition fork. */
+    DAO_RECOVERY_TRANSITION(true, "DAO Recovery Transition"),
     /** Tangerine Whistle fork. */
     TANGERINE_WHISTLE(true, "Tangerine Whistle"),
     /** Spurious Dragon fork. */
@@ -102,9 +104,9 @@ public interface HardforkId {
     /** Bangkok fork. */
     BANGKOK(false, "Bangkok"),
     /** Development fork, for accepted and unscheduled EIPs. */
-    FUTURE_EIPS(false, "Development, for accepted and unscheduled EIPs"),
+    FUTURE_EIPS(false, "FutureEips"),
     /** Developmental fork, for experimental EIPs. */
-    EXPERIMENTAL_EIPS(false, "Developmental, for experimental EIPs");
+    EXPERIMENTAL_EIPS(false, "ExperimentalEips");
 
     final boolean finalized;
     final String description;
@@ -144,6 +146,8 @@ public interface HardforkId {
     FRONTIER(true, "Frontier"),
     /** Homestead fork. */
     HOMESTEAD(true, "Homestead"),
+    /** Classic Recovery Init fork. */
+    CLASSIC_RECOVERY_INIT(true, "Classic Recovery Init"),
     /** Classic Tangerine Whistle fork. */
     CLASSIC_TANGERINE_WHISTLE(true, "Classic Tangerine Whistle"),
     /** Die Hard fork. */

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminNodeInfo.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminNodeInfo.java
@@ -131,7 +131,11 @@ public class AdminNodeInfo implements JsonRpcMethod {
                 networkId)));
 
     response.put(
-        "activeFork", protocolSchedule.getByBlockHeader(chainHead.getBlockHeader()).getName());
+        "activeFork",
+        protocolSchedule
+            .getByBlockHeader(chainHead.getBlockHeader())
+            .getHardforkId()
+            .description());
 
     return new JsonRpcSuccessResponse(requestContext.getRequest().getId(), response);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminNodeInfoTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminNodeInfoTest.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.LONDON;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -98,7 +99,7 @@ public class AdminNodeInfoTest {
     when(blockchainQueries.getBlockHashByNumber(anyLong())).thenReturn(Optional.of(Hash.EMPTY));
     when(blockchain.getChainHead()).thenReturn(testChainHead);
     when(natService.queryExternalIPAddress(anyString())).thenReturn("1.2.3.4");
-    when(protocolSpec.getName()).thenReturn("London");
+    when(protocolSpec.getHardforkId()).thenReturn(LONDON);
     when(protocolSchedule.getByBlockHeader(any())).thenReturn(protocolSpec);
     method =
         new AdminNodeInfo(

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetTransactionReceiptTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetTransactionReceiptTest.java
@@ -23,6 +23,7 @@ import org.hyperledger.besu.crypto.SECPSignature;
 import org.hyperledger.besu.crypto.SignatureAlgorithmFactory;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.BlobGas;
+import org.hyperledger.besu.datatypes.HardforkId;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.TransactionType;
 import org.hyperledger.besu.datatypes.Wei;
@@ -56,6 +57,7 @@ import org.hyperledger.besu.evm.gascalculator.CancunGasCalculator;
 import java.math.BigInteger;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
@@ -64,6 +66,21 @@ import org.apache.tuweni.units.bigints.UInt256s;
 import org.junit.jupiter.api.Test;
 
 public class EthGetTransactionReceiptTest {
+  private enum TestHardforkId implements HardforkId {
+    ROOT,
+    STATUS;
+
+    @Override
+    public boolean finalized() {
+      return true;
+    }
+
+    @Override
+    public String description() {
+      return name().toLowerCase(Locale.ROOT);
+    }
+  }
+
   private static final int MAX_BLOBS_PER_BLOCK = 6;
   private static final int TARGET_BLOBS_PER_BLOCK = 3;
   private final TransactionReceipt statusReceipt =
@@ -124,7 +141,7 @@ public class EthGetTransactionReceiptTest {
 
   private final ProtocolSpec rootTransactionTypeSpec =
       new ProtocolSpec(
-          "root",
+          TestHardforkId.ROOT,
           null,
           null,
           null,
@@ -155,7 +172,7 @@ public class EthGetTransactionReceiptTest {
           Optional.empty());
   private final ProtocolSpec statusTransactionTypeSpec =
       new ProtocolSpec(
-          "status",
+          TestHardforkId.STATUS,
           null,
           null,
           null,

--- a/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/BlockMinerTest.java
+++ b/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/BlockMinerTest.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.ethereum.blockcreation;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.FRONTIER;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
@@ -68,7 +69,7 @@ public class BlockMinerTest {
 
     final BlockImporter blockImporter = mock(BlockImporter.class);
     final ProtocolSpec protocolSpec = mock(ProtocolSpec.class);
-
+    when(protocolSpec.getHardforkId()).thenReturn(FRONTIER);
     final ProtocolSchedule protocolSchedule = singleSpecSchedule(protocolSpec);
 
     when(protocolSpec.getBlockImporter()).thenReturn(blockImporter);
@@ -109,6 +110,7 @@ public class BlockMinerTest {
 
     final BlockImporter blockImporter = mock(BlockImporter.class);
     final ProtocolSpec protocolSpec = mock(ProtocolSpec.class);
+    when(protocolSpec.getHardforkId()).thenReturn(FRONTIER);
     final ProtocolSchedule protocolSchedule = singleSpecSchedule(protocolSpec);
 
     when(protocolSpec.getBlockImporter()).thenReturn(blockImporter);
@@ -154,6 +156,7 @@ public class BlockMinerTest {
 
     final BlockImporter blockImporter = mock(BlockImporter.class);
     final ProtocolSpec protocolSpec = mock(ProtocolSpec.class);
+    when(protocolSpec.getHardforkId()).thenReturn(FRONTIER);
     final ProtocolSchedule protocolSchedule = singleSpecSchedule(protocolSpec);
 
     when(protocolSpec.getBlockImporter()).thenReturn(blockImporter);

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/BlockHeaderBuilder.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/BlockHeaderBuilder.java
@@ -133,6 +133,33 @@ public class BlockHeaderBuilder {
         .requestsHash(header.getRequestsHash().orElse(null));
   }
 
+  public static BlockHeaderBuilder fromHeader(
+      final org.hyperledger.besu.plugin.data.BlockHeader header) {
+    return create()
+        .parentHash(header.getParentHash())
+        .ommersHash(header.getOmmersHash())
+        .coinbase(header.getCoinbase())
+        .stateRoot(header.getStateRoot())
+        .transactionsRoot(header.getTransactionsRoot())
+        .receiptsRoot(header.getReceiptsRoot())
+        .logsBloom(new LogsBloomFilter(header.getLogsBloom()))
+        .difficulty(Difficulty.of(header.getDifficulty().getAsBigInteger()))
+        .number(header.getNumber())
+        .gasLimit(header.getGasLimit())
+        .gasUsed(header.getGasUsed())
+        .timestamp(header.getTimestamp())
+        .extraData(header.getExtraData())
+        .baseFee(header.getBaseFee().map(Wei::fromQuantity).orElse(null))
+        .mixHash(header.getMixHash())
+        .nonce(header.getNonce())
+        .prevRandao(header.getPrevRandao().orElse(null))
+        .withdrawalsRoot(header.getWithdrawalsRoot().orElse(null))
+        .blobGasUsed(header.getBlobGasUsed().orElse(null))
+        .excessBlobGas(header.getExcessBlobGas().map(BlobGas::fromQuantity).orElse(null))
+        .parentBeaconBlockRoot(header.getParentBeaconBlockRoot().orElse(null))
+        .requestsHash(header.getRequestsHash().orElse(null));
+  }
+
   public static BlockHeaderBuilder fromBuilder(final BlockHeaderBuilder fromBuilder) {
     final BlockHeaderBuilder toBuilder =
         create()

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ClassicProtocolSpecs.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ClassicProtocolSpecs.java
@@ -14,6 +14,18 @@
  */
 package org.hyperledger.besu.ethereum.mainnet;
 
+import static org.hyperledger.besu.datatypes.HardforkId.ClassicHardforkId.AGHARTA;
+import static org.hyperledger.besu.datatypes.HardforkId.ClassicHardforkId.ATLANTIS;
+import static org.hyperledger.besu.datatypes.HardforkId.ClassicHardforkId.CLASSIC_RECOVERY_INIT;
+import static org.hyperledger.besu.datatypes.HardforkId.ClassicHardforkId.CLASSIC_TANGERINE_WHISTLE;
+import static org.hyperledger.besu.datatypes.HardforkId.ClassicHardforkId.DEFUSE_DIFFICULTY_BOMB;
+import static org.hyperledger.besu.datatypes.HardforkId.ClassicHardforkId.DIE_HARD;
+import static org.hyperledger.besu.datatypes.HardforkId.ClassicHardforkId.GOTHAM;
+import static org.hyperledger.besu.datatypes.HardforkId.ClassicHardforkId.MAGNETO;
+import static org.hyperledger.besu.datatypes.HardforkId.ClassicHardforkId.MYSTIQUE;
+import static org.hyperledger.besu.datatypes.HardforkId.ClassicHardforkId.PHOENIX;
+import static org.hyperledger.besu.datatypes.HardforkId.ClassicHardforkId.SPIRAL;
+import static org.hyperledger.besu.datatypes.HardforkId.ClassicHardforkId.THANOS;
 import static org.hyperledger.besu.ethereum.mainnet.MainnetProtocolSpecs.powHasher;
 
 import org.hyperledger.besu.config.PowAlgorithm;
@@ -63,7 +75,7 @@ public class ClassicProtocolSpecs {
         .blockHeaderValidatorBuilder(
             (feeMarket, gasCalculator, gasLimitCalculator) ->
                 MainnetBlockHeaderValidator.createClassicValidator())
-        .name("ClassicRecoveryInit");
+        .hardforkId(CLASSIC_RECOVERY_INIT);
   }
 
   public static ProtocolSpecBuilder tangerineWhistleDefinition(
@@ -79,7 +91,7 @@ public class ClassicProtocolSpecs {
             (evm, gasLimitCalculator, feeMarket) ->
                 new TransactionValidatorFactory(
                     evm.getGasCalculator(), gasLimitCalculator, true, chainId))
-        .name("ClassicTangerineWhistle");
+        .hardforkId(CLASSIC_TANGERINE_WHISTLE);
   }
 
   public static ProtocolSpecBuilder dieHardDefinition(
@@ -91,7 +103,7 @@ public class ClassicProtocolSpecs {
             chainId, evmConfiguration, isParallelTxProcessingEnabled, metricsSystem)
         .gasCalculator(DieHardGasCalculator::new)
         .difficultyCalculator(ClassicDifficultyCalculators.DIFFICULTY_BOMB_PAUSED)
-        .name("DieHard");
+        .hardforkId(DIE_HARD);
   }
 
   public static ProtocolSpecBuilder gothamDefinition(
@@ -119,7 +131,7 @@ public class ClassicProtocolSpecs {
                     skipZeroBlockRewards,
                     ecip1017EraRounds,
                     protocolSchedule))
-        .name("Gotham");
+        .hardforkId(GOTHAM);
   }
 
   public static ProtocolSpecBuilder defuseDifficultyBombDefinition(
@@ -139,7 +151,7 @@ public class ClassicProtocolSpecs {
             (evm, gasLimitCalculator, feeMarket) ->
                 new TransactionValidatorFactory(
                     evm.getGasCalculator(), gasLimitCalculator, true, chainId))
-        .name("DefuseDifficultyBomb");
+        .hardforkId(DEFUSE_DIFFICULTY_BOMB);
   }
 
   public static ProtocolSpecBuilder atlantisDefinition(
@@ -187,7 +199,7 @@ public class ClassicProtocolSpecs {
                     .feeMarket(feeMarket)
                     .coinbaseFeePriceCalculator(CoinbaseFeePriceCalculator.frontier())
                     .build())
-        .name("Atlantis");
+        .hardforkId(ATLANTIS);
   }
 
   public static ProtocolSpecBuilder aghartaDefinition(
@@ -208,7 +220,7 @@ public class ClassicProtocolSpecs {
         .gasCalculator(PetersburgGasCalculator::new)
         .evmBuilder(MainnetEVMs::constantinople)
         .precompileContractRegistryBuilder(MainnetPrecompiledContractRegistries::istanbul)
-        .name("Agharta");
+        .hardforkId(AGHARTA);
   }
 
   public static ProtocolSpecBuilder phoenixDefinition(
@@ -231,7 +243,7 @@ public class ClassicProtocolSpecs {
                 MainnetEVMs.istanbul(
                     gasCalculator, chainId.orElse(BigInteger.ZERO), evmConfiguration))
         .precompileContractRegistryBuilder(MainnetPrecompiledContractRegistries::istanbul)
-        .name("Phoenix");
+        .hardforkId(PHOENIX);
   }
 
   public static ProtocolSpecBuilder thanosDefinition(
@@ -256,7 +268,7 @@ public class ClassicProtocolSpecs {
             (feeMarket, gasCalculator, gasLimitCalculator) ->
                 MainnetBlockHeaderValidator.createLegacyFeeMarketOmmerValidator(
                     new EpochCalculator.Ecip1099EpochCalculator(), powHasher(PowAlgorithm.ETHASH)))
-        .name("Thanos");
+        .hardforkId(THANOS);
   }
 
   private static TransactionReceipt byzantiumTransactionReceiptFactory(
@@ -306,7 +318,7 @@ public class ClassicProtocolSpecs {
             enableRevertReason
                 ? MainnetProtocolSpecs::berlinTransactionReceiptFactoryWithReasonEnabled
                 : MainnetProtocolSpecs::berlinTransactionReceiptFactory)
-        .name("Magneto");
+        .hardforkId(MAGNETO);
   }
 
   public static ProtocolSpecBuilder mystiqueDefinition(
@@ -328,7 +340,7 @@ public class ClassicProtocolSpecs {
             evm ->
                 new ContractCreationProcessor(
                     evm, true, List.of(MaxCodeSizeRule.from(evm), PrefixCodeRule.of()), 1))
-        .name("Mystique");
+        .hardforkId(MYSTIQUE);
   }
 
   public static ProtocolSpecBuilder spiralDefinition(
@@ -370,6 +382,6 @@ public class ClassicProtocolSpecs {
                     .feeMarket(feeMarket)
                     .coinbaseFeePriceCalculator(CoinbaseFeePriceCalculator.frontier())
                     .build())
-        .name("Spiral");
+        .hardforkId(SPIRAL);
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetProtocolSpecs.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetProtocolSpecs.java
@@ -14,6 +14,34 @@
  */
 package org.hyperledger.besu.ethereum.mainnet;
 
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.ARROW_GLACIER;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.BERLIN;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.BPO1;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.BPO2;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.BPO3;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.BPO4;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.BPO5;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.BYZANTIUM;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.CANCUN;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.CANCUN_EOF;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.CONSTANTINOPLE;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.DAO_RECOVERY_INIT;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.DAO_RECOVERY_TRANSITION;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.EXPERIMENTAL_EIPS;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.FRONTIER;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.FUTURE_EIPS;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.GRAY_GLACIER;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.HOMESTEAD;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.ISTANBUL;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.LONDON;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.MUIR_GLACIER;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.OSAKA;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.PARIS;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.PETERSBURG;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.PRAGUE;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.SHANGHAI;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.SPURIOUS_DRAGON;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.TANGERINE_WHISTLE;
 import static org.hyperledger.besu.ethereum.mainnet.requests.MainnetRequestsProcessor.pragueRequestsProcessors;
 
 import org.hyperledger.besu.config.BlobSchedule;
@@ -24,6 +52,7 @@ import org.hyperledger.besu.crypto.SignatureAlgorithm;
 import org.hyperledger.besu.crypto.SignatureAlgorithmFactory;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.BlobType;
+import org.hyperledger.besu.datatypes.HardforkId;
 import org.hyperledger.besu.datatypes.TransactionType;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.BlockProcessingResult;
@@ -174,7 +203,7 @@ public abstract class MainnetProtocolSpecs {
         .miningBeneficiaryCalculator(BlockHeader::getCoinbase)
         .evmConfiguration(evmConfiguration)
         .blockHashProcessor(new FrontierBlockHashProcessor())
-        .name("Frontier");
+        .hardforkId(FRONTIER);
   }
 
   public static PoWHasher powHasher(final PowAlgorithm powAlgorithm) {
@@ -200,7 +229,7 @@ public abstract class MainnetProtocolSpecs {
                 new TransactionValidatorFactory(
                     evm.getGasCalculator(), gasLimitCalculator, true, Optional.empty()))
         .difficultyCalculator(MainnetDifficultyCalculators.HOMESTEAD)
-        .name("Homestead");
+        .hardforkId(HOMESTEAD);
   }
 
   public static ProtocolSpecBuilder daoRecoveryInitDefinition(
@@ -235,7 +264,7 @@ public abstract class MainnetProtocolSpecs {
                             miningBeneficiaryCalculator,
                             skipZeroBlockRewards,
                             protocolSchedule)))
-        .name("DaoRecoveryInit");
+        .hardforkId(DAO_RECOVERY_INIT);
   }
 
   public static ProtocolSpecBuilder daoRecoveryTransitionDefinition(
@@ -247,7 +276,7 @@ public abstract class MainnetProtocolSpecs {
             isParallelTxProcessingEnabled
                 ? new MainnetParallelBlockProcessor.ParallelBlockProcessorBuilder(metricsSystem)
                 : MainnetBlockProcessor::new)
-        .name("DaoRecoveryTransition");
+        .hardforkId(DAO_RECOVERY_TRANSITION);
   }
 
   public static ProtocolSpecBuilder tangerineWhistleDefinition(
@@ -256,7 +285,7 @@ public abstract class MainnetProtocolSpecs {
       final MetricsSystem metricsSystem) {
     return homesteadDefinition(evmConfiguration, isParallelTxProcessingEnabled, metricsSystem)
         .gasCalculator(TangerineWhistleGasCalculator::new)
-        .name("TangerineWhistle");
+        .hardforkId(TANGERINE_WHISTLE);
   }
 
   public static ProtocolSpecBuilder spuriousDragonDefinition(
@@ -304,7 +333,7 @@ public abstract class MainnetProtocolSpecs {
                     .feeMarket(feeMarket)
                     .coinbaseFeePriceCalculator(CoinbaseFeePriceCalculator.frontier())
                     .build())
-        .name("SpuriousDragon");
+        .hardforkId(SPURIOUS_DRAGON);
   }
 
   public static ProtocolSpecBuilder byzantiumDefinition(
@@ -324,7 +353,7 @@ public abstract class MainnetProtocolSpecs {
                 ? MainnetProtocolSpecs::byzantiumTransactionReceiptFactoryWithReasonEnabled
                 : MainnetProtocolSpecs::byzantiumTransactionReceiptFactory)
         .blockReward(BYZANTIUM_BLOCK_REWARD)
-        .name("Byzantium");
+        .hardforkId(BYZANTIUM);
   }
 
   public static ProtocolSpecBuilder constantinopleDefinition(
@@ -343,7 +372,7 @@ public abstract class MainnetProtocolSpecs {
         .gasCalculator(ConstantinopleGasCalculator::new)
         .evmBuilder(MainnetEVMs::constantinople)
         .blockReward(CONSTANTINOPLE_BLOCK_REWARD)
-        .name("Constantinople");
+        .hardforkId(CONSTANTINOPLE);
   }
 
   public static ProtocolSpecBuilder petersburgDefinition(
@@ -359,7 +388,7 @@ public abstract class MainnetProtocolSpecs {
             isParallelTxProcessingEnabled,
             metricsSystem)
         .gasCalculator(PetersburgGasCalculator::new)
-        .name("Petersburg");
+        .hardforkId(PETERSBURG);
   }
 
   public static ProtocolSpecBuilder istanbulDefinition(
@@ -388,7 +417,7 @@ public abstract class MainnetProtocolSpecs {
                     Collections.singletonList(MaxCodeSizeRule.from(evm)),
                     1,
                     SPURIOUS_DRAGON_FORCE_DELETE_WHEN_EMPTY_ADDRESSES))
-        .name("Istanbul");
+        .hardforkId(ISTANBUL);
   }
 
   static ProtocolSpecBuilder muirGlacierDefinition(
@@ -404,7 +433,7 @@ public abstract class MainnetProtocolSpecs {
             isParallelTxProcessingEnabled,
             metricsSystem)
         .difficultyCalculator(MainnetDifficultyCalculators.MUIR_GLACIER)
-        .name("MuirGlacier");
+        .hardforkId(MUIR_GLACIER);
   }
 
   static ProtocolSpecBuilder berlinDefinition(
@@ -432,7 +461,7 @@ public abstract class MainnetProtocolSpecs {
             enableRevertReason
                 ? MainnetProtocolSpecs::berlinTransactionReceiptFactoryWithReasonEnabled
                 : MainnetProtocolSpecs::berlinTransactionReceiptFactory)
-        .name("Berlin");
+        .hardforkId(BERLIN);
   }
 
   static ProtocolSpecBuilder londonDefinition(
@@ -516,7 +545,7 @@ public abstract class MainnetProtocolSpecs {
                 MainnetBlockHeaderValidator.createBaseFeeMarketOmmerValidator(
                     (BaseFeeMarket) feeMarket))
         .blockBodyValidatorBuilder(BaseFeeBlockBodyValidator::new)
-        .name("London");
+        .hardforkId(LONDON);
   }
 
   static ProtocolSpecBuilder arrowGlacierDefinition(
@@ -536,7 +565,7 @@ public abstract class MainnetProtocolSpecs {
             isParallelTxProcessingEnabled,
             metricsSystem)
         .difficultyCalculator(MainnetDifficultyCalculators.ARROW_GLACIER)
-        .name("ArrowGlacier");
+        .hardforkId(ARROW_GLACIER);
   }
 
   static ProtocolSpecBuilder grayGlacierDefinition(
@@ -556,7 +585,7 @@ public abstract class MainnetProtocolSpecs {
             isParallelTxProcessingEnabled,
             metricsSystem)
         .difficultyCalculator(MainnetDifficultyCalculators.GRAY_GLACIER)
-        .name("GrayGlacier");
+        .hardforkId(GRAY_GLACIER);
   }
 
   static ProtocolSpecBuilder parisDefinition(
@@ -584,7 +613,7 @@ public abstract class MainnetProtocolSpecs {
         .blockReward(Wei.ZERO)
         .skipZeroBlockRewards(true)
         .isPoS(true)
-        .name("ParisFork");
+        .hardforkId(PARIS);
   }
 
   static ProtocolSpecBuilder shanghaiDefinition(
@@ -645,7 +674,7 @@ public abstract class MainnetProtocolSpecs {
         .withdrawalsProcessor(new WithdrawalsProcessor())
         .withdrawalsValidator(new WithdrawalsValidator.AllowedWithdrawals())
         .blockHeaderValidatorBuilder(MainnetBlockHeaderValidator::noBlobBlockHeaderValidator)
-        .name("Shanghai");
+        .hardforkId(SHANGHAI);
   }
 
   static ProtocolSpecBuilder cancunDefinition(
@@ -735,7 +764,7 @@ public abstract class MainnetProtocolSpecs {
         .precompileContractRegistryBuilder(MainnetPrecompiledContractRegistries::cancun)
         .blockHeaderValidatorBuilder(MainnetBlockHeaderValidator::blobAwareBlockHeaderValidator)
         .blockHashProcessor(new CancunBlockHashProcessor())
-        .name("Cancun");
+        .hardforkId(CANCUN);
   }
 
   static ProtocolSpecBuilder cancunEOFDefinition(
@@ -756,7 +785,7 @@ public abstract class MainnetProtocolSpecs {
             miningConfiguration,
             isParallelTxProcessingEnabled,
             metricsSystem);
-    return addEOF(chainId, evmConfiguration, protocolSpecBuilder).name("CancunEOF");
+    return addEOF(chainId, evmConfiguration, protocolSpecBuilder).hardforkId(CANCUN_EOF);
   }
 
   static ProtocolSpecBuilder pragueDefinition(
@@ -835,7 +864,7 @@ public abstract class MainnetProtocolSpecs {
                         .build())
             // EIP-2935 Blockhash processor
             .blockHashProcessor(new PragueBlockHashProcessor())
-            .name("Prague");
+            .hardforkId(PRAGUE);
     try {
       RequestContractAddresses requestContractAddresses =
           RequestContractAddresses.fromGenesis(genesisConfigOptions);
@@ -900,7 +929,7 @@ public abstract class MainnetProtocolSpecs {
         .transactionPoolPreProcessor(new OsakaTransactionPoolPreProcessor())
         .precompileContractRegistryBuilder(MainnetPrecompiledContractRegistries::osaka)
         .blockValidatorBuilder(MainnetBlockValidatorBuilder::osaka)
-        .name("Osaka");
+        .hardforkId(OSAKA);
   }
 
   static ProtocolSpecBuilder bpo1Definition(
@@ -920,7 +949,7 @@ public abstract class MainnetProtocolSpecs {
             miningConfiguration,
             isParallelTxProcessingEnabled,
             metricsSystem);
-    return applyBlobSchedule(builder, genesisConfigOptions, BlobScheduleOptions::getBpo1, "BPO1");
+    return applyBlobSchedule(builder, genesisConfigOptions, BlobScheduleOptions::getBpo1, BPO1);
   }
 
   static ProtocolSpecBuilder bpo2Definition(
@@ -940,7 +969,7 @@ public abstract class MainnetProtocolSpecs {
             miningConfiguration,
             isParallelTxProcessingEnabled,
             metricsSystem);
-    return applyBlobSchedule(builder, genesisConfigOptions, BlobScheduleOptions::getBpo2, "BPO2");
+    return applyBlobSchedule(builder, genesisConfigOptions, BlobScheduleOptions::getBpo2, BPO2);
   }
 
   static ProtocolSpecBuilder bpo3Definition(
@@ -960,7 +989,7 @@ public abstract class MainnetProtocolSpecs {
             miningConfiguration,
             isParallelTxProcessingEnabled,
             metricsSystem);
-    return applyBlobSchedule(builder, genesisConfigOptions, BlobScheduleOptions::getBpo3, "BPO3");
+    return applyBlobSchedule(builder, genesisConfigOptions, BlobScheduleOptions::getBpo3, BPO3);
   }
 
   static ProtocolSpecBuilder bpo4Definition(
@@ -980,7 +1009,7 @@ public abstract class MainnetProtocolSpecs {
             miningConfiguration,
             isParallelTxProcessingEnabled,
             metricsSystem);
-    return applyBlobSchedule(builder, genesisConfigOptions, BlobScheduleOptions::getBpo4, "BPO4");
+    return applyBlobSchedule(builder, genesisConfigOptions, BlobScheduleOptions::getBpo4, BPO4);
   }
 
   static ProtocolSpecBuilder bpo5Definition(
@@ -1000,19 +1029,19 @@ public abstract class MainnetProtocolSpecs {
             miningConfiguration,
             isParallelTxProcessingEnabled,
             metricsSystem);
-    return applyBlobSchedule(builder, genesisConfigOptions, BlobScheduleOptions::getBpo5, "BPO5");
+    return applyBlobSchedule(builder, genesisConfigOptions, BlobScheduleOptions::getBpo5, BPO5);
   }
 
   private static ProtocolSpecBuilder applyBlobSchedule(
       final ProtocolSpecBuilder builder,
       final GenesisConfigOptions genesisConfigOptions,
       final Function<BlobScheduleOptions, Optional<BlobSchedule>> blobGetter,
-      final String name) {
+      final HardforkId hardforkId) {
     genesisConfigOptions
         .getBlobScheduleOptions()
         .flatMap(blobGetter)
         .ifPresent(builder::blobSchedule);
-    return builder.name(name);
+    return builder.hardforkId(hardforkId);
   }
 
   private static ProtocolSpecBuilder addEOF(
@@ -1056,7 +1085,7 @@ public abstract class MainnetProtocolSpecs {
                 isParallelTxProcessingEnabled,
                 metricsSystem)
             .precompileContractRegistryBuilder(MainnetPrecompiledContractRegistries::futureEips)
-            .name("FutureEips");
+            .hardforkId(FUTURE_EIPS);
 
     return addEOF(chainId, evmConfiguration, protocolSpecBuilder);
   }
@@ -1082,7 +1111,7 @@ public abstract class MainnetProtocolSpecs {
             (gasCalculator, jdCacheConfig) ->
                 MainnetEVMs.experimentalEips(
                     gasCalculator, chainId.orElse(BigInteger.ZERO), evmConfiguration))
-        .name("ExperimentalEips");
+        .hardforkId(EXPERIMENTAL_EIPS);
   }
 
   private static TransactionReceipt frontierTransactionReceiptFactory(

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ProtocolSchedule.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ProtocolSchedule.java
@@ -32,12 +32,13 @@ public interface ProtocolSchedule {
   ProtocolSpec getByBlockHeader(final ProcessableBlockHeader blockHeader);
 
   default ProtocolSpec getForNextBlockHeader(
-      final BlockHeader parentBlockHeader, final long timestampForNextBlock) {
+      final org.hyperledger.besu.plugin.data.BlockHeader parentBlockHeader,
+      final long timestampForNextBlock) {
     final BlockHeader nextBlockHeader =
         BlockHeaderBuilder.fromHeader(parentBlockHeader)
             .number(parentBlockHeader.getNumber() + 1)
             .timestamp(timestampForNextBlock)
-            .parentHash(parentBlockHeader.getHash())
+            .parentHash(parentBlockHeader.getBlockHash())
             .blockHeaderFunctions(new MainnetBlockHeaderFunctions())
             .buildBlockHeader();
     return getByBlockHeader(nextBlockHeader);

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ProtocolSpec.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ProtocolSpec.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.ethereum.mainnet;
 
+import org.hyperledger.besu.datatypes.HardforkId;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.BlockValidator;
 import org.hyperledger.besu.ethereum.GasLimitCalculator;
@@ -33,7 +34,8 @@ import java.util.Optional;
 /** A protocol specification. */
 public class ProtocolSpec {
 
-  private final String name;
+  private final HardforkId hardforkId;
+
   private final EVM evm;
 
   private final GasCalculator gasCalculator;
@@ -86,7 +88,7 @@ public class ProtocolSpec {
   /**
    * Creates a new protocol specification instance.
    *
-   * @param name the protocol specification name
+   * @param hardforkId the protocol specification hardforkId
    * @param evm the EVM supporting the appropriate operations for this specification
    * @param transactionValidatorFactory the transaction validator factory to use
    * @param transactionProcessor the transaction processor to use
@@ -116,7 +118,7 @@ public class ProtocolSpec {
    *     protection
    */
   public ProtocolSpec(
-      final String name,
+      final HardforkId hardforkId,
       final EVM evm,
       final TransactionValidatorFactory transactionValidatorFactory,
       final MainnetTransactionProcessor transactionProcessor,
@@ -145,7 +147,7 @@ public class ProtocolSpec {
       final boolean isPoS,
       final boolean isReplayProtectionSupported,
       final Optional<TransactionPoolPreProcessor> transactionPoolPreProcessor) {
-    this.name = name;
+    this.hardforkId = hardforkId;
     this.evm = evm;
     this.transactionValidatorFactory = transactionValidatorFactory;
     this.transactionProcessor = transactionProcessor;
@@ -177,12 +179,12 @@ public class ProtocolSpec {
   }
 
   /**
-   * Returns the protocol specification name.
+   * Returns the protocol hardfork ID.
    *
-   * @return the protocol specification name
+   * @return the protocol hardfork ID
    */
-  public String getName() {
-    return name;
+  public HardforkId getHardforkId() {
+    return hardforkId;
   }
 
   /**

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ProtocolSpecBuilder.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ProtocolSpecBuilder.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.ethereum.mainnet;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import org.hyperledger.besu.config.BlobSchedule;
+import org.hyperledger.besu.datatypes.HardforkId;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.BlockValidator;
 import org.hyperledger.besu.ethereum.GasLimitCalculator;
@@ -67,7 +68,7 @@ public class ProtocolSpecBuilder {
   private BlockValidatorBuilder blockValidatorBuilder;
   private BlockImporterBuilder blockImporterBuilder;
 
-  private String name;
+  private HardforkId hardforkId;
   private MiningBeneficiaryCalculator miningBeneficiaryCalculator;
   private WithdrawalsValidator withdrawalsValidator =
       new WithdrawalsValidator.ProhibitedWithdrawals();
@@ -204,8 +205,8 @@ public class ProtocolSpecBuilder {
     return this;
   }
 
-  public ProtocolSpecBuilder name(final String name) {
-    this.name = name;
+  public ProtocolSpecBuilder hardforkId(final HardforkId hardforkId) {
+    this.hardforkId = hardforkId;
     return this;
   }
 
@@ -297,7 +298,7 @@ public class ProtocolSpecBuilder {
     checkNotNull(blockReward, "Missing block reward");
     checkNotNull(difficultyCalculator, "Missing difficulty calculator");
     checkNotNull(transactionReceiptFactory, "Missing transaction receipt factory");
-    checkNotNull(name, "Missing name");
+    checkNotNull(hardforkId, "Missing hardfork id");
     checkNotNull(miningBeneficiaryCalculator, "Missing Mining Beneficiary Calculator");
     checkNotNull(protocolSchedule, "Missing protocol schedule");
     checkNotNull(feeMarketBuilder, "Missing fee market");
@@ -343,7 +344,7 @@ public class ProtocolSpecBuilder {
         blockValidatorBuilder.apply(blockHeaderValidator, blockBodyValidator, blockProcessor);
     final BlockImporter blockImporter = blockImporterBuilder.apply(blockValidator);
     return new ProtocolSpec(
-        name,
+        hardforkId,
         evm,
         transactionValidatorFactory,
         transactionProcessor,

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ScheduledProtocolSpec.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ScheduledProtocolSpec.java
@@ -74,7 +74,7 @@ public interface ScheduledProtocolSpec {
 
     @Override
     public Hardfork fork() {
-      return new Hardfork(protocolSpec.getName(), timestamp);
+      return new Hardfork(protocolSpec.getHardforkId().description(), timestamp);
     }
 
     @Override
@@ -110,7 +110,7 @@ public interface ScheduledProtocolSpec {
 
     @Override
     public Hardfork fork() {
-      return new Hardfork(protocolSpec.getName(), blockNumber);
+      return new Hardfork(protocolSpec.getHardforkId().description(), blockNumber);
     }
 
     @Override

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/DefaultProtocolScheduleTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/DefaultProtocolScheduleTest.java
@@ -15,8 +15,17 @@
 package org.hyperledger.besu.ethereum.mainnet;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hyperledger.besu.datatypes.HardforkId.ClassicHardforkId.MYSTIQUE;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.BYZANTIUM;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.CANCUN;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.FRONTIER;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.GRAY_GLACIER;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.HOMESTEAD;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.LONDON;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.SHANGHAI;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.config.StubGenesisConfigOptions;
 import org.hyperledger.besu.ethereum.chain.BadBlockManager;
@@ -76,6 +85,8 @@ public class DefaultProtocolScheduleTest {
   public void conflictingSchedules() {
     final ProtocolSpec spec1 = mock(ProtocolSpec.class);
     final ProtocolSpec spec2 = mock(ProtocolSpec.class);
+    when(spec1.getHardforkId()).thenReturn(FRONTIER);
+    when(spec2.getHardforkId()).thenReturn(HOMESTEAD);
 
     final DefaultProtocolSchedule protocolSchedule = new DefaultProtocolSchedule(CHAIN_ID);
     protocolSchedule.putBlockNumberMilestone(0, spec1);
@@ -89,6 +100,10 @@ public class DefaultProtocolScheduleTest {
     final ProtocolSpec spec2 = mock(ProtocolSpec.class);
     final ProtocolSpec spec3 = mock(ProtocolSpec.class);
 
+    when(spec1.getHardforkId()).thenReturn(FRONTIER);
+    when(spec2.getHardforkId()).thenReturn(HOMESTEAD);
+    when(spec3.getHardforkId()).thenReturn(BYZANTIUM);
+
     final DefaultProtocolSchedule protocolSchedule = new DefaultProtocolSchedule(CHAIN_ID);
     protocolSchedule.putTimestampMilestone(0, spec1);
     protocolSchedule.putTimestampMilestone(10, spec2);
@@ -101,6 +116,10 @@ public class DefaultProtocolScheduleTest {
     final ProtocolSpec spec1 = mock(ProtocolSpec.class);
     final ProtocolSpec spec2 = mock(ProtocolSpec.class);
     final ProtocolSpec spec3 = mock(ProtocolSpec.class);
+
+    when(spec1.getHardforkId()).thenReturn(FRONTIER);
+    when(spec2.getHardforkId()).thenReturn(HOMESTEAD);
+    when(spec3.getHardforkId()).thenReturn(BYZANTIUM);
 
     final DefaultProtocolSchedule protocolSchedule = new DefaultProtocolSchedule(CHAIN_ID);
     protocolSchedule.putBlockNumberMilestone(0, spec1);
@@ -116,10 +135,10 @@ public class DefaultProtocolScheduleTest {
     config.cancunTime(FIRST_TIMESTAMP_FORK + 2);
     final ProtocolSchedule schedule = builder.createProtocolSchedule();
 
-    assertThat(schedule.getByBlockHeader(header(2, FIRST_TIMESTAMP_FORK + 2)).getName())
-        .isEqualTo("Cancun");
-    assertThat(schedule.getByBlockHeader(header(3, FIRST_TIMESTAMP_FORK + 3)).getName())
-        .isEqualTo("Cancun");
+    assertThat(schedule.getByBlockHeader(header(2, FIRST_TIMESTAMP_FORK + 2)).getHardforkId())
+        .isEqualTo(CANCUN);
+    assertThat(schedule.getByBlockHeader(header(3, FIRST_TIMESTAMP_FORK + 3)).getHardforkId())
+        .isEqualTo(CANCUN);
   }
 
   @Test
@@ -129,10 +148,10 @@ public class DefaultProtocolScheduleTest {
     config.cancunTime(FIRST_TIMESTAMP_FORK + 2);
     final ProtocolSchedule schedule = builder.createProtocolSchedule();
 
-    assertThat(schedule.getByBlockHeader(header(2, FIRST_TIMESTAMP_FORK)).getName())
-        .isEqualTo("Shanghai");
-    assertThat(schedule.getByBlockHeader(header(3, FIRST_TIMESTAMP_FORK + 1)).getName())
-        .isEqualTo("Shanghai");
+    assertThat(schedule.getByBlockHeader(header(2, FIRST_TIMESTAMP_FORK)).getHardforkId())
+        .isEqualTo(SHANGHAI);
+    assertThat(schedule.getByBlockHeader(header(3, FIRST_TIMESTAMP_FORK + 1)).getHardforkId())
+        .isEqualTo(SHANGHAI);
   }
 
   @Test
@@ -142,8 +161,10 @@ public class DefaultProtocolScheduleTest {
     config.shanghaiTime(9992L);
     final ProtocolSchedule schedule = builder.createProtocolSchedule();
 
-    assertThat(schedule.getByBlockHeader(header(100, 8881L)).getName()).isEqualTo("GrayGlacier");
-    assertThat(schedule.getByBlockHeader(header(200, 9991L)).getName()).isEqualTo("GrayGlacier");
+    assertThat(schedule.getByBlockHeader(header(100, 8881L)).getHardforkId())
+        .isEqualTo(GRAY_GLACIER);
+    assertThat(schedule.getByBlockHeader(header(200, 9991L)).getHardforkId())
+        .isEqualTo(GRAY_GLACIER);
   }
 
   @Test
@@ -154,7 +175,7 @@ public class DefaultProtocolScheduleTest {
     config.shanghaiTime(9992L);
     final ProtocolSchedule schedule = builder.createProtocolSchedule();
 
-    assertThat(schedule.getByBlockHeader(header(99, 8881L)).getName()).isEqualTo("London");
+    assertThat(schedule.getByBlockHeader(header(99, 8881L)).getHardforkId()).isEqualTo(LONDON);
   }
 
   @Test
@@ -163,16 +184,19 @@ public class DefaultProtocolScheduleTest {
     config.mystique(100);
     final ProtocolSchedule schedule = builder.createProtocolSchedule();
 
-    assertThat(schedule.getByBlockHeader(header(100, Long.MAX_VALUE)).getName())
-        .isEqualTo("Mystique");
-    assertThat(schedule.getByBlockHeader(header(200, Long.MAX_VALUE)).getName())
-        .isEqualTo("Mystique");
+    assertThat(schedule.getByBlockHeader(header(100, Long.MAX_VALUE)).getHardforkId())
+        .isEqualTo(MYSTIQUE);
+    assertThat(schedule.getByBlockHeader(header(200, Long.MAX_VALUE)).getHardforkId())
+        .isEqualTo(MYSTIQUE);
   }
 
   @Test
   public void getForNextBlockHeader_shouldGetHeaderForNextBlockNumber() {
     final ProtocolSpec spec1 = mock(ProtocolSpec.class);
     final ProtocolSpec spec2 = mock(ProtocolSpec.class);
+
+    when(spec1.getHardforkId()).thenReturn(FRONTIER);
+    when(spec2.getHardforkId()).thenReturn(HOMESTEAD);
 
     final DefaultProtocolSchedule protocolSchedule = new DefaultProtocolSchedule(CHAIN_ID);
     protocolSchedule.putBlockNumberMilestone(0, spec1);
@@ -190,6 +214,9 @@ public class DefaultProtocolScheduleTest {
   public void getForNextBlockHeader_shouldGetHeaderForNextTimestamp() {
     final ProtocolSpec spec1 = mock(ProtocolSpec.class);
     final ProtocolSpec spec2 = mock(ProtocolSpec.class);
+
+    when(spec1.getHardforkId()).thenReturn(FRONTIER);
+    when(spec2.getHardforkId()).thenReturn(HOMESTEAD);
 
     final DefaultProtocolSchedule protocolSchedule = new DefaultProtocolSchedule(CHAIN_ID);
     protocolSchedule.putBlockNumberMilestone(0, spec1);

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/MainnetProtocolScheduleTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/MainnetProtocolScheduleTest.java
@@ -14,6 +14,22 @@
  */
 package org.hyperledger.besu.ethereum.mainnet;
 
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.ARROW_GLACIER;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.BERLIN;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.BYZANTIUM;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.CONSTANTINOPLE;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.DAO_RECOVERY_INIT;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.DAO_RECOVERY_TRANSITION;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.FRONTIER;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.GRAY_GLACIER;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.HOMESTEAD;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.ISTANBUL;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.LONDON;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.MUIR_GLACIER;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.PETERSBURG;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.SPURIOUS_DRAGON;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.TANGERINE_WHISTLE;
+
 import org.hyperledger.besu.config.GenesisConfig;
 import org.hyperledger.besu.ethereum.chain.BadBlockManager;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
@@ -31,40 +47,41 @@ public class MainnetProtocolScheduleTest {
   @Test
   public void shouldReturnDefaultProtocolSpecsWhenCustomNumbersAreNotUsed() {
     final ProtocolSchedule sched = ProtocolScheduleFixture.MAINNET;
-    Assertions.assertThat(sched.getByBlockHeader(blockHeader(1L)).getName()).isEqualTo("Frontier");
-    Assertions.assertThat(sched.getByBlockHeader(blockHeader(1_150_000L)).getName())
-        .isEqualTo("Homestead");
-    Assertions.assertThat(sched.getByBlockHeader(blockHeader(1_920_000L)).getName())
-        .isEqualTo("DaoRecoveryInit");
-    Assertions.assertThat(sched.getByBlockHeader(blockHeader(1_920_001L)).getName())
-        .isEqualTo("DaoRecoveryTransition");
-    Assertions.assertThat(sched.getByBlockHeader(blockHeader(1_920_010L)).getName())
-        .isEqualTo("Homestead");
-    Assertions.assertThat(sched.getByBlockHeader(blockHeader(2_463_000L)).getName())
-        .isEqualTo("TangerineWhistle");
-    Assertions.assertThat(sched.getByBlockHeader(blockHeader(2_675_000L)).getName())
-        .isEqualTo("SpuriousDragon");
-    Assertions.assertThat(sched.getByBlockHeader(blockHeader(4_730_000L)).getName())
-        .isEqualTo("Byzantium");
+    Assertions.assertThat(sched.getByBlockHeader(blockHeader(1L)).getHardforkId())
+        .isEqualTo(FRONTIER);
+    Assertions.assertThat(sched.getByBlockHeader(blockHeader(1_150_000L)).getHardforkId())
+        .isEqualTo(HOMESTEAD);
+    Assertions.assertThat(sched.getByBlockHeader(blockHeader(1_920_000L)).getHardforkId())
+        .isEqualTo(DAO_RECOVERY_INIT);
+    Assertions.assertThat(sched.getByBlockHeader(blockHeader(1_920_001L)).getHardforkId())
+        .isEqualTo(DAO_RECOVERY_TRANSITION);
+    Assertions.assertThat(sched.getByBlockHeader(blockHeader(1_920_010L)).getHardforkId())
+        .isEqualTo(HOMESTEAD);
+    Assertions.assertThat(sched.getByBlockHeader(blockHeader(2_463_000L)).getHardforkId())
+        .isEqualTo(TANGERINE_WHISTLE);
+    Assertions.assertThat(sched.getByBlockHeader(blockHeader(2_675_000L)).getHardforkId())
+        .isEqualTo(SPURIOUS_DRAGON);
+    Assertions.assertThat(sched.getByBlockHeader(blockHeader(4_730_000L)).getHardforkId())
+        .isEqualTo(BYZANTIUM);
     // Constantinople was originally scheduled for 7_080_000, but postponed
-    Assertions.assertThat(sched.getByBlockHeader(blockHeader(7_080_000L)).getName())
-        .isEqualTo("Byzantium");
-    Assertions.assertThat(sched.getByBlockHeader(blockHeader(7_280_000L)).getName())
-        .isEqualTo("Petersburg");
-    Assertions.assertThat(sched.getByBlockHeader(blockHeader(9_069_000L)).getName())
-        .isEqualTo("Istanbul");
-    Assertions.assertThat(sched.getByBlockHeader(blockHeader(9_200_000L)).getName())
-        .isEqualTo("MuirGlacier");
-    Assertions.assertThat(sched.getByBlockHeader(blockHeader(12_244_000L)).getName())
-        .isEqualTo("Berlin");
-    Assertions.assertThat(sched.getByBlockHeader(blockHeader(12_965_000L)).getName())
-        .isEqualTo("London");
-    Assertions.assertThat(sched.getByBlockHeader(blockHeader(13_773_000L)).getName())
-        .isEqualTo("ArrowGlacier");
-    Assertions.assertThat(sched.getByBlockHeader(blockHeader(15_050_000L)).getName())
-        .isEqualTo("GrayGlacier");
-    Assertions.assertThat(sched.getByBlockHeader(blockHeader(Long.MAX_VALUE)).getName())
-        .isEqualTo("GrayGlacier");
+    Assertions.assertThat(sched.getByBlockHeader(blockHeader(7_080_000L)).getHardforkId())
+        .isEqualTo(BYZANTIUM);
+    Assertions.assertThat(sched.getByBlockHeader(blockHeader(7_280_000L)).getHardforkId())
+        .isEqualTo(PETERSBURG);
+    Assertions.assertThat(sched.getByBlockHeader(blockHeader(9_069_000L)).getHardforkId())
+        .isEqualTo(ISTANBUL);
+    Assertions.assertThat(sched.getByBlockHeader(blockHeader(9_200_000L)).getHardforkId())
+        .isEqualTo(MUIR_GLACIER);
+    Assertions.assertThat(sched.getByBlockHeader(blockHeader(12_244_000L)).getHardforkId())
+        .isEqualTo(BERLIN);
+    Assertions.assertThat(sched.getByBlockHeader(blockHeader(12_965_000L)).getHardforkId())
+        .isEqualTo(LONDON);
+    Assertions.assertThat(sched.getByBlockHeader(blockHeader(13_773_000L)).getHardforkId())
+        .isEqualTo(ARROW_GLACIER);
+    Assertions.assertThat(sched.getByBlockHeader(blockHeader(15_050_000L)).getHardforkId())
+        .isEqualTo(GRAY_GLACIER);
+    Assertions.assertThat(sched.getByBlockHeader(blockHeader(Long.MAX_VALUE)).getHardforkId())
+        .isEqualTo(GRAY_GLACIER);
   }
 
   @Test
@@ -77,9 +94,10 @@ public class MainnetProtocolScheduleTest {
             new BadBlockManager(),
             false,
             new NoOpMetricsSystem());
-    Assertions.assertThat(sched.getByBlockHeader(blockHeader(1L)).getName()).isEqualTo("Frontier");
-    Assertions.assertThat(sched.getByBlockHeader(blockHeader(Long.MAX_VALUE)).getName())
-        .isEqualTo("Frontier");
+    Assertions.assertThat(sched.getByBlockHeader(blockHeader(1L)).getHardforkId())
+        .isEqualTo(FRONTIER);
+    Assertions.assertThat(sched.getByBlockHeader(blockHeader(Long.MAX_VALUE)).getHardforkId())
+        .isEqualTo(FRONTIER);
   }
 
   @Test
@@ -94,22 +112,26 @@ public class MainnetProtocolScheduleTest {
             new BadBlockManager(),
             false,
             new NoOpMetricsSystem());
-    Assertions.assertThat(sched.getByBlockHeader(blockHeader(1)).getName()).isEqualTo("Frontier");
-    Assertions.assertThat(sched.getByBlockHeader(blockHeader(2)).getName()).isEqualTo("Homestead");
-    Assertions.assertThat(sched.getByBlockHeader(blockHeader(3)).getName())
-        .isEqualTo("DaoRecoveryInit");
-    Assertions.assertThat(sched.getByBlockHeader(blockHeader(4)).getName())
-        .isEqualTo("DaoRecoveryTransition");
-    Assertions.assertThat(sched.getByBlockHeader(blockHeader(13)).getName()).isEqualTo("Homestead");
-    Assertions.assertThat(sched.getByBlockHeader(blockHeader(14)).getName())
-        .isEqualTo("TangerineWhistle");
-    Assertions.assertThat(sched.getByBlockHeader(blockHeader(15)).getName())
-        .isEqualTo("SpuriousDragon");
-    Assertions.assertThat(sched.getByBlockHeader(blockHeader(16)).getName()).isEqualTo("Byzantium");
-    Assertions.assertThat(sched.getByBlockHeader(blockHeader(18)).getName())
-        .isEqualTo("Constantinople");
-    Assertions.assertThat(sched.getByBlockHeader(blockHeader(19)).getName())
-        .isEqualTo("Petersburg");
+    Assertions.assertThat(sched.getByBlockHeader(blockHeader(1)).getHardforkId())
+        .isEqualTo(FRONTIER);
+    Assertions.assertThat(sched.getByBlockHeader(blockHeader(2)).getHardforkId())
+        .isEqualTo(HOMESTEAD);
+    Assertions.assertThat(sched.getByBlockHeader(blockHeader(3)).getHardforkId())
+        .isEqualTo(DAO_RECOVERY_INIT);
+    Assertions.assertThat(sched.getByBlockHeader(blockHeader(4)).getHardforkId())
+        .isEqualTo(DAO_RECOVERY_TRANSITION);
+    Assertions.assertThat(sched.getByBlockHeader(blockHeader(13)).getHardforkId())
+        .isEqualTo(HOMESTEAD);
+    Assertions.assertThat(sched.getByBlockHeader(blockHeader(14)).getHardforkId())
+        .isEqualTo(TANGERINE_WHISTLE);
+    Assertions.assertThat(sched.getByBlockHeader(blockHeader(15)).getHardforkId())
+        .isEqualTo(SPURIOUS_DRAGON);
+    Assertions.assertThat(sched.getByBlockHeader(blockHeader(16)).getHardforkId())
+        .isEqualTo(BYZANTIUM);
+    Assertions.assertThat(sched.getByBlockHeader(blockHeader(18)).getHardforkId())
+        .isEqualTo(CONSTANTINOPLE);
+    Assertions.assertThat(sched.getByBlockHeader(blockHeader(19)).getHardforkId())
+        .isEqualTo(PETERSBURG);
   }
 
   @Test

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/ProtocolScheduleBuilderTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/ProtocolScheduleBuilderTest.java
@@ -22,9 +22,15 @@ import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.BPO2;
 import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.BPO3;
 import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.BPO4;
 import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.BPO5;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.BYZANTIUM;
 import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.CANCUN;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.DAO_RECOVERY_INIT;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.DAO_RECOVERY_TRANSITION;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.FRONTIER;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.HOMESTEAD;
 import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.LONDON;
 import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.OSAKA;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.PARIS;
 import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.PRAGUE;
 import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.SHANGHAI;
 import static org.mockito.ArgumentMatchers.any;
@@ -100,72 +106,77 @@ class ProtocolScheduleBuilderTest {
     final ProtocolSchedule protocolSchedule = builder.createProtocolSchedule();
 
     assertThat(protocolSchedule.getChainId()).contains(CHAIN_ID);
-    assertThat(protocolSchedule.getByBlockHeader(blockHeader(0)).getName()).isEqualTo("Frontier");
-    assertThat(protocolSchedule.getByBlockHeader(blockHeader(1)).getName()).isEqualTo("Homestead");
-    assertThat(protocolSchedule.getByBlockHeader(blockHeader(2)).getName())
-        .isEqualTo("DaoRecoveryInit");
-    assertThat(protocolSchedule.getByBlockHeader(blockHeader(3)).getName())
-        .isEqualTo("DaoRecoveryTransition");
-    assertThat(protocolSchedule.getByBlockHeader(blockHeader(12)).getName()).isEqualTo("Homestead");
-    assertThat(protocolSchedule.getByBlockHeader(blockHeader(13)).getName()).isEqualTo("Byzantium");
-    assertThat(protocolSchedule.getByBlockHeader(blockHeader(14)).getName()).isEqualTo("Byzantium");
-    assertThat(protocolSchedule.getByBlockHeader(blockHeader(15)).getName()).isEqualTo("ParisFork");
-    assertThat(protocolSchedule.getByBlockHeader(blockHeader(50)).getName()).isEqualTo("ParisFork");
+    assertThat(protocolSchedule.getByBlockHeader(blockHeader(0)).getHardforkId())
+        .isEqualTo(FRONTIER);
+    assertThat(protocolSchedule.getByBlockHeader(blockHeader(1)).getHardforkId())
+        .isEqualTo(HOMESTEAD);
+    assertThat(protocolSchedule.getByBlockHeader(blockHeader(2)).getHardforkId())
+        .isEqualTo(DAO_RECOVERY_INIT);
+    assertThat(protocolSchedule.getByBlockHeader(blockHeader(3)).getHardforkId())
+        .isEqualTo(DAO_RECOVERY_TRANSITION);
+    assertThat(protocolSchedule.getByBlockHeader(blockHeader(12)).getHardforkId())
+        .isEqualTo(HOMESTEAD);
+    assertThat(protocolSchedule.getByBlockHeader(blockHeader(13)).getHardforkId())
+        .isEqualTo(BYZANTIUM);
+    assertThat(protocolSchedule.getByBlockHeader(blockHeader(14)).getHardforkId())
+        .isEqualTo(BYZANTIUM);
+    assertThat(protocolSchedule.getByBlockHeader(blockHeader(15)).getHardforkId()).isEqualTo(PARIS);
+    assertThat(protocolSchedule.getByBlockHeader(blockHeader(50)).getHardforkId()).isEqualTo(PARIS);
     assertThat(
             protocolSchedule
                 .getByBlockHeader(blockHeader(51, PRE_SHANGHAI_TIMESTAMP + 1))
-                .getName())
-        .isEqualTo("Shanghai");
+                .getHardforkId())
+        .isEqualTo(SHANGHAI);
     assertThat(
             protocolSchedule
                 .getByBlockHeader(blockHeader(52, PRE_SHANGHAI_TIMESTAMP + 2))
-                .getName())
-        .isEqualTo("Shanghai");
+                .getHardforkId())
+        .isEqualTo(SHANGHAI);
     assertThat(
             protocolSchedule
                 .getByBlockHeader(blockHeader(53, PRE_SHANGHAI_TIMESTAMP + 3))
-                .getName())
-        .isEqualTo("Cancun");
+                .getHardforkId())
+        .isEqualTo(CANCUN);
     assertThat(
             protocolSchedule
                 .getByBlockHeader(blockHeader(54, PRE_SHANGHAI_TIMESTAMP + 4))
-                .getName())
-        .isEqualTo("Cancun");
+                .getHardforkId())
+        .isEqualTo(CANCUN);
     assertThat(
             protocolSchedule
                 .getByBlockHeader(blockHeader(55, PRE_SHANGHAI_TIMESTAMP + 5))
-                .getName())
-        .isEqualTo("Prague");
+                .getHardforkId())
+        .isEqualTo(PRAGUE);
     assertThat(
             protocolSchedule
                 .getByBlockHeader(blockHeader(56, PRE_SHANGHAI_TIMESTAMP + 7))
-                .getName())
-        .isEqualTo("Osaka");
+                .getHardforkId())
+        .isEqualTo(OSAKA);
     assertThat(
             protocolSchedule
                 .getByBlockHeader(blockHeader(57, PRE_SHANGHAI_TIMESTAMP + 9))
-                .getName())
-        .isEqualTo("BPO1");
+                .getHardforkId())
+        .isEqualTo(BPO1);
     assertThat(
             protocolSchedule
                 .getByBlockHeader(blockHeader(58, PRE_SHANGHAI_TIMESTAMP + 11))
-                .getName())
-        .isEqualTo("BPO2");
+                .getHardforkId())
+        .isEqualTo(BPO2);
     assertThat(
             protocolSchedule
                 .getByBlockHeader(blockHeader(59, PRE_SHANGHAI_TIMESTAMP + 13))
-                .getName())
-        .isEqualTo("BPO3");
+                .getHardforkId())
+        .isEqualTo(BPO3);
     assertThat(
             protocolSchedule
                 .getByBlockHeader(blockHeader(60, PRE_SHANGHAI_TIMESTAMP + 15))
-                .getName())
-        .isEqualTo("BPO4");
+                .getHardforkId())
+        .isEqualTo(BPO4);
     assertThat(
             protocolSchedule
                 .getByBlockHeader(blockHeader(61, PRE_SHANGHAI_TIMESTAMP + 17))
-                .getName())
-        .isEqualTo("BPO5");
+                .getHardforkId())
+        .isEqualTo(BPO5);
   }
 
   @Test
@@ -246,8 +257,10 @@ class ProtocolScheduleBuilderTest {
     final ProtocolSchedule protocolSchedule = builder.createProtocolSchedule();
 
     assertThat(protocolSchedule.getChainId()).contains(CHAIN_ID);
-    assertThat(protocolSchedule.getByBlockHeader(blockHeader(0)).getName()).isEqualTo("Byzantium");
-    assertThat(protocolSchedule.getByBlockHeader(blockHeader(1)).getName()).isEqualTo("Byzantium");
+    assertThat(protocolSchedule.getByBlockHeader(blockHeader(0)).getHardforkId())
+        .isEqualTo(BYZANTIUM);
+    assertThat(protocolSchedule.getByBlockHeader(blockHeader(1)).getHardforkId())
+        .isEqualTo(BYZANTIUM);
   }
 
   @Test
@@ -283,9 +296,9 @@ class ProtocolScheduleBuilderTest {
     // added at the point at which the modifier is applied.
     assertThat(schedule.streamMilestoneBlocks().collect(Collectors.toList()))
         .containsExactly(0L, 2L, 5L);
-    assertThat(schedule.getByBlockHeader(blockHeader(0)).getName()).isEqualTo("Frontier");
-    assertThat(schedule.getByBlockHeader(blockHeader(2)).getName()).isEqualTo("Frontier");
-    assertThat(schedule.getByBlockHeader(blockHeader(5)).getName()).isEqualTo("Homestead");
+    assertThat(schedule.getByBlockHeader(blockHeader(0)).getHardforkId()).isEqualTo(FRONTIER);
+    assertThat(schedule.getByBlockHeader(blockHeader(2)).getHardforkId()).isEqualTo(FRONTIER);
+    assertThat(schedule.getByBlockHeader(blockHeader(5)).getHardforkId()).isEqualTo(HOMESTEAD);
 
     verify(modifier, times(2)).apply(any());
   }
@@ -301,8 +314,8 @@ class ProtocolScheduleBuilderTest {
     // added at the point at which the modifier is applied.
     assertThat(schedule.streamMilestoneBlocks().collect(Collectors.toList()))
         .containsExactly(0L, 2L);
-    assertThat(schedule.getByBlockHeader(blockHeader(0)).getName()).isEqualTo("Frontier");
-    assertThat(schedule.getByBlockHeader(blockHeader(2)).getName()).isEqualTo("Frontier");
+    assertThat(schedule.getByBlockHeader(blockHeader(0)).getHardforkId()).isEqualTo(FRONTIER);
+    assertThat(schedule.getByBlockHeader(blockHeader(2)).getHardforkId()).isEqualTo(FRONTIER);
 
     verify(modifier, times(1)).apply(any());
   }
@@ -319,8 +332,8 @@ class ProtocolScheduleBuilderTest {
     // added at the point at which the modifier is applied.
     assertThat(schedule.streamMilestoneBlocks().collect(Collectors.toList()))
         .containsExactly(0L, 5L);
-    assertThat(schedule.getByBlockHeader(blockHeader(0)).getName()).isEqualTo("Frontier");
-    assertThat(schedule.getByBlockHeader(blockHeader(5)).getName()).isEqualTo("Homestead");
+    assertThat(schedule.getByBlockHeader(blockHeader(0)).getHardforkId()).isEqualTo(FRONTIER);
+    assertThat(schedule.getByBlockHeader(blockHeader(5)).getHardforkId()).isEqualTo(HOMESTEAD);
     verify(modifier, times(1)).apply(any());
   }
 

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/EvmToolCommand.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/EvmToolCommand.java
@@ -564,7 +564,7 @@ public class EvmToolCommand implements Runnable {
               .put("output", initialMessageFrame.getOutputData().toHexString())
               .put("gasUsed", "0x" + Long.toHexString(evmGas))
               .put("pass", initialMessageFrame.getExceptionalHaltReason().isEmpty())
-              .put("fork", protocolSpec.getName());
+              .put("fork", protocolSpec.getHardforkId().description());
           if (!noTime) {
             resultLine.put("timens", lastTime).put("time", lastTime / 1000);
           }

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -71,7 +71,7 @@ Calculated : ${currentHash}
 tasks.register('checkAPIChanges', FileStateChecker) {
   description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
   files = sourceSets.main.allJava.files
-  knownHash = 'lIxtWb7w8OQAqxaSQIva/H4fC6GxlkCbGVri0ibMYIc='
+  knownHash = 'IoOg4tWjHeQ/DDOnBtIcIknUhHe+jGHgk4ez0zDHDf8='
 }
 check.dependsOn('checkAPIChanges')
 

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/BlockchainService.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/BlockchainService.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.plugin.services;
 
+import org.hyperledger.besu.datatypes.HardforkId;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.plugin.Unstable;
@@ -139,4 +140,23 @@ public interface BlockchainService extends BesuService {
    * @return the chain id
    */
   Optional<BigInteger> getChainId();
+
+  /**
+   * Get the hardfork identifier for the given block header
+   *
+   * @param blockHeader the block header to determine the hardfork for
+   * @return the hardfork identifier applicable to the given block
+   */
+  @Unstable
+  HardforkId getHardforkId(BlockHeader blockHeader);
+
+  /**
+   * Get the hardfork identifier for the next block based on the parent block and timestamp
+   *
+   * @param parentBlockHeader the parent block header
+   * @param timestampForNextBlock the timestamp for the next block
+   * @return the hardfork identifier that will be applicable to the next block
+   */
+  @Unstable
+  HardforkId getNextBlockHardforkId(BlockHeader parentBlockHeader, long timestampForNextBlock);
 }


### PR DESCRIPTION
## PR description

Expose 2 new method in the Plugin API to let plugins query hardfork by blockheader or the hardfork of the next build block.

Since the `HardforkId` was already part of the Plugin API, it is now used internally when creating the milestone schedule in place of raw string names.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

