### PR TITLE
Add majority vote rule to removal of maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -124,6 +124,8 @@ This can occur in the following situations:
     leave such as parental leave and medical leave.
 - Other unspecified circumstances.
 
+If one of the above reasons applies to an existing maintainer, removal of the maintainer is completed through a PR approved by a majority of the existing maintainers.
+
 As for adding a maintainer, the record and governance process for moving a
 maintainer to emeritus status is recorded using review approval in the PR making that change.
 


### PR DESCRIPTION
## PR description

See the Besu Charter conversation at https://github.com/hyperledger/besu/pull/8716/files#r2121409576

On the most recent community call we agreed to keep maintainer addition/removal rules in one place, so rather than have them in both the charter and the `Maintainers.md`, we we have them in the latter and the charter would refer to it.

This PR updates `Maintainers.md` to include the text from the charter about requiring a majority of maintainers to vote on removal of an existing maintainer.

There is perhaps a follow on question about whether we do indeed want to require a majority approval to remove a maintainer. That would be a higher bar than is required to become a maintainer in the first place (3 votes + 0 vetoes). Should removing a maintainer be the same?

