### PR TITLE
refresh the mainnet.json used for blockchain util tests

### DIFF
--- a/testutil/src/main/resources/mainnet-data/mainnet.json
+++ b/testutil/src/main/resources/mainnet-data/mainnet.json
@@ -6,10 +6,39 @@
     "eip150Block": 2463000,
     "eip158Block": 2675000,
     "byzantiumBlock": 4370000,
-    "constantinopleBlock": 7280000,
     "petersburgBlock": 7280000,
+    "istanbulBlock": 9069000,
+    "muirGlacierBlock": 9200000,
+    "berlinBlock": 12244000,
+    "londonBlock": 12965000,
+    "arrowGlacierBlock": 13773000,
+    "grayGlacierBlock": 15050000,
+    "terminalTotalDifficulty": 58750000000000000000000,
+    "shanghaiTime": 1681338455,
+    "cancunTime": 1710338135,
+    "pragueTime": 1746612311,
+    "depositContractAddress": "0x00000000219ab540356cbb839cbe05303d7705fa",
+    "withdrawalRequestContractAddress": "0x00000961ef480eb55e80d19ad83579a64c007002",
+    "consolidationRequestContractAddress": "0x0000bbddc7ce488642fb579f8b00f3a590007251",
+    "blobSchedule": {
+      "cancun": {
+        "target": 3,
+        "max": 6,
+        "baseFeeUpdateFraction": 3338477
+      },
+      "prague": {
+        "target": 6,
+        "max": 9,
+        "baseFeeUpdateFraction": 5007716
+      }
+    },
     "ethash": {
-
+    },
+    "checkpoint": {
+      "comment": "Start sync from first proof of stake block",
+      "hash": "0x56a9bb0302da44b8c0b3df540781424684c3af04d0b7a38d72842b762076a664",
+      "number": 15537394,
+      "totalDifficulty": "0xC70D815D562D3CFA955"
     }
   },
   "nonce": "0x42",
@@ -26699,8 +26728,5 @@
     "fff7ac99c8e4feb60c9750054bdc14ce1857f181": {
       "balance": "0x3635c9adc5dea00000"
     }
-  },
-  "number": "0x0",
-  "gasUsed": "0x0",
-  "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000"
+  }
 }


### PR DESCRIPTION
## PR description
Think it makes sense for this (test) genesis file to be fairly up to date. Used by BlockchainSetupUtil

## Fixed Issue(s)
related to #8944 


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

