### PR TITLE
remove fast sync from genesis tests from RunnerTest

### DIFF
--- a/app/src/test/java/org/hyperledger/besu/RunnerTest.java
+++ b/app/src/test/java/org/hyperledger/besu/RunnerTest.java
@@ -164,22 +164,6 @@ public final class RunnerTest {
     syncFromGenesis(SyncMode.FULL, getFastSyncGenesis(), true);
   }
 
-  @Test
-  public void fastSyncFromGenesis() throws Exception {
-    // set merge flag to false, otherwise this test can fail if a merge test runs first
-    MergeConfiguration.setMergeEnabled(false);
-
-    syncFromGenesis(SyncMode.FAST, getFastSyncGenesis(), false);
-  }
-
-  @Test
-  public void fastSyncFromGenesisUsingPeerTaskSystem() throws Exception {
-    // set merge flag to false, otherwise this test can fail if a merge test runs first
-    MergeConfiguration.setMergeEnabled(false);
-
-    syncFromGenesis(SyncMode.FAST, getFastSyncGenesis(), true);
-  }
-
   private void syncFromGenesis(
       final SyncMode mode, final GenesisConfig genesisConfig, final boolean isPeerTaskSystemEnabled)
       throws Exception {
@@ -378,10 +362,8 @@ public final class RunnerTest {
   }
 
   private int getNumber(final Response response) throws IOException {
-    final int currentBlock =
-        UInt256.fromHexString(new JsonObject(response.body().string()).getString("result"))
-            .intValue();
-    return currentBlock;
+    return UInt256.fromHexString(new JsonObject(response.body().string()).getString("result"))
+        .intValue();
   }
 
   private Request getRequest(final String method, final String baseUrl) {


### PR DESCRIPTION
## PR description
Remove these fast sync tests that are flaky eg https://github.com/hyperledger/besu/actions/runs/16333574965/job/46141294930?pr=8967 

## Fixed Issue(s)
Fast sync is deprecated per #7906 and broken per #7511


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

