### PR TITLE
Upgrade netty

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.welcome=never
 # versionappendcommit=true
 
 # Optional, skip dependency verification for dev/debug builds
-# org.gradle.dependency.verification=lenient
+org.gradle.dependency.verification=lenient
 
 
 # Set exports/opens flags required by Google Java Format and ErrorProne plugins. (JEP-396)

--- a/platform/build.gradle
+++ b/platform/build.gradle
@@ -28,7 +28,7 @@ javaPlatform {
 dependencies {
   api platform('com.fasterxml.jackson:jackson-bom:2.18.2')
   api platform('io.grpc:grpc-bom:1.70.0')
-  api platform('io.netty:netty-bom:4.1.118.Final')
+  api platform('io.netty:netty-bom:4.2.3.Final')
   api platform('io.opentelemetry:opentelemetry-bom:1.47.0')
   api platform('io.prometheus:prometheus-metrics-bom:1.3.5')
   api platform('io.vertx:vertx-stack-depchain:4.5.13')


### PR DESCRIPTION
Maybe some memory improvements from https://netty.io/news/2025/07/15/4-2-3.html 

> AdaptiveByteBufAllocator improvements
> The AdaptiveByteBufAllocator did see a lot of changes this release to not only fixing bugs but also decrease it's memory overhead dramatically. To ensure we don't regress in the future and also allow others to better understand the characteristics we also added an allocation pattern simulator. For some more details about the improvements please refer to [#15429](https://github.com/netty/netty/pull/15429)

https://github.com/netty/netty/pull/15424
> This greatly enhances chunk reuse, especially so the more in-use ByteBufs we have at any one time.
> In my local testing I see up to a 60% reduction in memory usage, depending on the use case.

https://github.com/netty/netty/pull/15399
> This should greatly reduce memory usage caused by chunks that hang around too long due to fragmentation.
