### PR TITLE
Fix type safety in BesuProvider.doPrivileged call

### DIFF
--- a/crypto/algorithms/src/main/java/org/hyperledger/besu/crypto/BesuProvider.java
+++ b/crypto/algorithms/src/main/java/org/hyperledger/besu/crypto/BesuProvider.java
@@ -31,7 +31,7 @@ public final class BesuProvider extends Provider {
   public BesuProvider() {
     super(PROVIDER_NAME, "1.0", info);
     AccessController.doPrivileged(
-        (PrivilegedAction)
+        (PrivilegedAction<Void>)
             () -> {
               put("MessageDigest.Blake2bf", Blake2bfMessageDigest.class.getName());
               return null;


### PR DESCRIPTION
Use PrivilegedAction<Void> instead of raw PrivilegedAction type casting 
to improve type safety and eliminate compiler warnings.