### PR TITLE
getBlobsV2 prohibits partial responses

### DIFF
--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV2Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV2Test.java
@@ -82,12 +82,12 @@ public class EngineGetBlobsV2Test extends TrustedSetupClassLoaderExtension {
     VersionedHash unknown = new VersionedHash((byte) 1, Hash.ZERO);
     JsonRpcSuccessResponse response = getSuccessResponse(buildRequestContext(unknown));
     List<BlobAndProofV2> result = extractResult(response);
-    assertThat(result).hasSize(1);
-    assertThat(result.getFirst()).isNull();
+
+    assertThat(result).isNull();
   }
 
   @Test
-  public void shouldReturnPartialResults() {
+  public void shouldNotReturnPartialResults() {
     BlobProofBundle bundle = createBundleAndRegisterToPool();
     VersionedHash known = bundle.getVersionedHash();
     VersionedHash unknown = new VersionedHash((byte) 1, Hash.ZERO);
@@ -96,10 +96,7 @@ public class EngineGetBlobsV2Test extends TrustedSetupClassLoaderExtension {
         getSuccessResponse(buildRequestContext(known, unknown, known));
     List<BlobAndProofV2> result = extractResult(response);
 
-    assertThat(result).hasSize(3);
-    assertThat(result.get(0)).isNotNull();
-    assertThat(result.get(1)).isNull();
-    assertThat(result.get(2)).isNotNull();
+    assertThat(result).isNull();
   }
 
   @Test
@@ -112,8 +109,8 @@ public class EngineGetBlobsV2Test extends TrustedSetupClassLoaderExtension {
     JsonRpcRequestContext requestContext = buildRequestContext(versionedHash);
     JsonRpcSuccessResponse response = getSuccessResponse(requestContext);
     List<BlobAndProofV2> result = extractResult(response);
-    assertThat(result).hasSize(1);
-    assertThat(result.getFirst()).isNull();
+
+    assertThat(result).isNull();
   }
 
   @Test


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <macfarla.github@gmail.com>
## PR description
* ~added getBlobsv3 as a copy of current v2~ this is going to be added later
* revert getBlobsv2 to previous behavior: return null response if any blobs missing

refer to https://github.com/hyperledger/besu/pull/8891/files

this is a copy of #8967 to get this change onto devnet 3 branch

## Fixed Issue(s)
#8966


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

