### PR TITLE
Rename block hash processor

### DIFF
--- a/app/src/main/java/org/hyperledger/besu/services/TraceServiceImpl.java
+++ b/app/src/main/java/org/hyperledger/besu/services/TraceServiceImpl.java
@@ -217,7 +217,7 @@ public class TraceServiceImpl implements TraceService {
                       protocolSpec.getMiningBeneficiaryCalculator().calculateBeneficiary(header),
                       tracer,
                       protocolSpec
-                          .getBlockHashProcessor()
+                          .getPreExecutionProcessor()
                           .createBlockHashLookup(blockchain, header),
                       blobGasPrice);
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthConfig.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthConfig.java
@@ -145,7 +145,7 @@ public class EthConfig implements JsonRpcMethod {
             spec.getRequestProcessorCoordinator()
                 .map(RequestProcessorCoordinator::getContractConfigs)
                 .orElse(Map.of()));
-    spec.getBlockHashProcessor()
+    spec.getPreExecutionProcessor()
         .getHistoryContract()
         .ifPresent(a -> systemContracts.put("HISTORY_STORAGE_ADDRESS", a.toHexString()));
     if (spec.getEvm().getEvmVersion().compareTo(EvmSpecVersion.CANCUN) >= 0) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ExecuteTransactionStep.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ExecuteTransactionStep.java
@@ -95,7 +95,7 @@ public class ExecuteTransactionStep implements Function<TransactionTrace, Transa
                       .map(parent -> calculateExcessBlobGasForParent(protocolSpec, parent))
                       .orElse(BlobGas.ZERO));
       final BlockHashLookup blockHashLookup =
-          protocolSpec.getBlockHashProcessor().createBlockHashLookup(blockchain, header);
+          protocolSpec.getPreExecutionProcessor().createBlockHashLookup(blockchain, header);
       result =
           transactionProcessor.processTransaction(
               chainUpdater.getNextUpdater(),

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/processor/BlockReplay.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/processor/BlockReplay.java
@@ -90,7 +90,7 @@ public class BlockReplay {
         blockHash,
         (body, header, blockchain, transactionProcessor, protocolSpec) -> {
           final BlockHashLookup blockHashLookup =
-              protocolSpec.getBlockHashProcessor().createBlockHashLookup(blockchain, header);
+              protocolSpec.getPreExecutionProcessor().createBlockHashLookup(blockchain, header);
           final Wei blobGasPrice =
               protocolSpec
                   .getFeeMarket()
@@ -136,7 +136,7 @@ public class BlockReplay {
               blockHeader,
               transaction,
               spec.getMiningBeneficiaryCalculator().calculateBeneficiary(blockHeader),
-              spec.getBlockHashProcessor().createBlockHashLookup(blockchain, blockHeader),
+              spec.getPreExecutionProcessor().createBlockHashLookup(blockchain, blockHeader),
               TransactionValidationParams.blockReplay(),
               blobGasPrice);
           return action.performAction(

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/processor/BlockTracer.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/processor/BlockTracer.java
@@ -70,7 +70,7 @@ public class BlockTracer {
               tracer,
               blockReplay
                   .getProtocolSpec(header)
-                  .getBlockHashProcessor()
+                  .getPreExecutionProcessor()
                   .createBlockHashLookup(blockchain, header),
               blobGasPrice);
       final List<TraceFrame> traceFrames = tracer.copyTraceFrames();

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/processor/TransactionTracer.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/processor/TransactionTracer.java
@@ -192,7 +192,7 @@ public class TransactionTracer {
         tracer,
         blockReplay
             .getProtocolSpec(header)
-            .getBlockHashProcessor()
+            .getPreExecutionProcessor()
             .createBlockHashLookup(blockchain, header),
         ImmutableTransactionValidationParams.builder().isAllowFutureNonce(true).build(),
         blobGasPrice);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetTransactionReceiptTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetTransactionReceiptTest.java
@@ -49,7 +49,7 @@ import org.hyperledger.besu.ethereum.mainnet.CancunTargetingGasLimitCalculator;
 import org.hyperledger.besu.ethereum.mainnet.PoWHasher;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
-import org.hyperledger.besu.ethereum.mainnet.blockhash.FrontierBlockHashProcessor;
+import org.hyperledger.besu.ethereum.mainnet.blockhash.FrontierPreExecutionProcessor;
 import org.hyperledger.besu.ethereum.mainnet.feemarket.FeeMarket;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
 import org.hyperledger.besu.evm.gascalculator.CancunGasCalculator;
@@ -166,7 +166,7 @@ public class EthGetTransactionReceiptTest {
           Optional.empty(),
           null,
           Optional.empty(),
-          new FrontierBlockHashProcessor(),
+          new FrontierPreExecutionProcessor(),
           true,
           true,
           Optional.empty());
@@ -197,7 +197,7 @@ public class EthGetTransactionReceiptTest {
           Optional.empty(),
           null,
           Optional.empty(),
-          new FrontierBlockHashProcessor(),
+          new FrontierPreExecutionProcessor(),
           true,
           true,
           Optional.empty());

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/processor/TransactionTracerTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/processor/TransactionTracerTest.java
@@ -34,7 +34,7 @@ import org.hyperledger.besu.ethereum.debug.TraceFrame;
 import org.hyperledger.besu.ethereum.mainnet.MainnetTransactionProcessor;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
-import org.hyperledger.besu.ethereum.mainnet.blockhash.BlockHashProcessor;
+import org.hyperledger.besu.ethereum.mainnet.blockhash.PreExecutionProcessor;
 import org.hyperledger.besu.ethereum.mainnet.feemarket.FeeMarket;
 import org.hyperledger.besu.ethereum.processing.TransactionProcessingResult;
 import org.hyperledger.besu.ethereum.vm.DebugOperationTracer;
@@ -87,7 +87,7 @@ public class TransactionTracerTest {
   @Mock private ProtocolSpec protocolSpec;
   @Mock private GasCalculator gasCalculator;
   @Mock private GasLimitCalculator gasLimitCalculator;
-  @Mock private BlockHashProcessor blockHashProcessor;
+  @Mock private PreExecutionProcessor preExecutionProcessor;
 
   @Mock private Tracer.TraceableState mutableWorldState;
 
@@ -125,7 +125,7 @@ public class TransactionTracerTest {
     when(blockchain.getChainHeadHeader()).thenReturn(blockHeader);
     when(protocolSpec.getGasCalculator()).thenReturn(gasCalculator);
     when(protocolSpec.getGasLimitCalculator()).thenReturn(gasLimitCalculator);
-    when(protocolSpec.getBlockHashProcessor()).thenReturn(blockHashProcessor);
+    when(protocolSpec.getPreExecutionProcessor()).thenReturn(preExecutionProcessor);
     when(protocolContext.getBadBlockManager()).thenReturn(badBlockManager);
   }
 

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreator.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreator.java
@@ -226,10 +226,10 @@ public abstract class AbstractBlockCreator implements AsyncBlockCreator {
               disposableWorldState,
               newProtocolSpec,
               newProtocolSpec
-                  .getBlockHashProcessor()
+                  .getPreExecutionProcessor()
                   .createBlockHashLookup(protocolContext.getBlockchain(), processableBlockHeader),
               operationTracer);
-      newProtocolSpec.getBlockHashProcessor().process(blockProcessingContext);
+      newProtocolSpec.getPreExecutionProcessor().process(blockProcessingContext);
 
       timings.register("preTxsSelection");
       final TransactionSelectionResults transactionResults =

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/BlockSelectionContext.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/BlockSelectionContext.java
@@ -21,7 +21,7 @@ import org.hyperledger.besu.ethereum.core.MiningConfiguration;
 import org.hyperledger.besu.ethereum.core.ProcessableBlockHeader;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
-import org.hyperledger.besu.ethereum.mainnet.blockhash.BlockHashProcessor;
+import org.hyperledger.besu.ethereum.mainnet.blockhash.PreExecutionProcessor;
 import org.hyperledger.besu.ethereum.mainnet.feemarket.FeeMarket;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
@@ -45,8 +45,8 @@ public record BlockSelectionContext(
     return protocolSpec.getGasLimitCalculator();
   }
 
-  public BlockHashProcessor blockHashProcessor() {
-    return protocolSpec.getBlockHashProcessor();
+  public PreExecutionProcessor preExecutionProcessor() {
+    return protocolSpec.getPreExecutionProcessor();
   }
 
   public int maxRlpBlockSize() {

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/BlockTransactionSelector.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/BlockTransactionSelector.java
@@ -440,7 +440,7 @@ public class BlockTransactionSelector implements BlockTransactionSelectionServic
   private TransactionProcessingResult processTransaction(final Transaction transaction) {
     final BlockHashLookup blockHashLookup =
         blockSelectionContext
-            .blockHashProcessor()
+            .preExecutionProcessor()
             .createBlockHashLookup(blockchain, blockSelectionContext.pendingBlockHeader());
     return transactionProcessor.processTransaction(
         txWorldStateUpdater,

--- a/ethereum/core/src/integration-test/java/org/hyperledger/besu/ethereum/vm/TraceTransactionIntegrationTest.java
+++ b/ethereum/core/src/integration-test/java/org/hyperledger/besu/ethereum/vm/TraceTransactionIntegrationTest.java
@@ -83,7 +83,7 @@ public class TraceTransactionIntegrationTest {
     transactionProcessor = protocolSpec.getTransactionProcessor();
     blockHashLookup =
         protocolSpec
-            .getBlockHashProcessor()
+            .getPreExecutionProcessor()
             .createBlockHashLookup(blockchain, genesisBlock.getHeader());
   }
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/AbstractBlockProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/AbstractBlockProcessor.java
@@ -156,7 +156,7 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
 
     final ProtocolSpec protocolSpec = protocolSchedule.getByBlockHeader(blockHeader);
     final BlockHashLookup blockHashLookup =
-        protocolSpec.getBlockHashProcessor().createBlockHashLookup(blockchain, blockHeader);
+        protocolSpec.getPreExecutionProcessor().createBlockHashLookup(blockchain, blockHeader);
 
     final BlockAwareOperationTracer blockTracer =
         getBlockImportTracer(protocolContext, blockHeader);
@@ -169,7 +169,7 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
     final BlockProcessingContext blockProcessingContext =
         new BlockProcessingContext(
             blockHeader, worldState, protocolSpec, blockHashLookup, blockTracer);
-    protocolSpec.getBlockHashProcessor().process(blockProcessingContext);
+    protocolSpec.getPreExecutionProcessor().process(blockProcessingContext);
 
     Optional<BlockHeader> maybeParentHeader =
         blockchain.getBlockHeader(blockHeader.getParentHash());

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetProtocolSpecs.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetProtocolSpecs.java
@@ -65,9 +65,9 @@ import org.hyperledger.besu.ethereum.core.MiningConfiguration;
 import org.hyperledger.besu.ethereum.core.MutableWorldState;
 import org.hyperledger.besu.ethereum.core.TransactionReceipt;
 import org.hyperledger.besu.ethereum.core.feemarket.CoinbaseFeePriceCalculator;
-import org.hyperledger.besu.ethereum.mainnet.blockhash.CancunBlockHashProcessor;
-import org.hyperledger.besu.ethereum.mainnet.blockhash.FrontierBlockHashProcessor;
-import org.hyperledger.besu.ethereum.mainnet.blockhash.PragueBlockHashProcessor;
+import org.hyperledger.besu.ethereum.mainnet.blockhash.CancunPreExecutionProcessor;
+import org.hyperledger.besu.ethereum.mainnet.blockhash.FrontierPreExecutionProcessor;
+import org.hyperledger.besu.ethereum.mainnet.blockhash.PraguePreExecutionProcessor;
 import org.hyperledger.besu.ethereum.mainnet.feemarket.BaseFeeMarket;
 import org.hyperledger.besu.ethereum.mainnet.feemarket.FeeMarket;
 import org.hyperledger.besu.ethereum.mainnet.parallelization.MainnetParallelBlockProcessor;
@@ -202,7 +202,7 @@ public abstract class MainnetProtocolSpecs {
         .blockHeaderFunctions(new MainnetBlockHeaderFunctions())
         .miningBeneficiaryCalculator(BlockHeader::getCoinbase)
         .evmConfiguration(evmConfiguration)
-        .blockHashProcessor(new FrontierBlockHashProcessor())
+        .preExecutionProcessor(new FrontierPreExecutionProcessor())
         .hardforkId(FRONTIER);
   }
 
@@ -763,7 +763,7 @@ public abstract class MainnetProtocolSpecs {
                     evm.getMaxInitcodeSize()))
         .precompileContractRegistryBuilder(MainnetPrecompiledContractRegistries::cancun)
         .blockHeaderValidatorBuilder(MainnetBlockHeaderValidator::blobAwareBlockHeaderValidator)
-        .blockHashProcessor(new CancunBlockHashProcessor())
+        .preExecutionProcessor(new CancunPreExecutionProcessor())
         .hardforkId(CANCUN);
   }
 
@@ -863,7 +863,7 @@ public abstract class MainnetProtocolSpecs {
                                 new CodeDelegationService()))
                         .build())
             // EIP-2935 Blockhash processor
-            .blockHashProcessor(new PragueBlockHashProcessor())
+            .preExecutionProcessor(new PraguePreExecutionProcessor())
             .hardforkId(PRAGUE);
     try {
       RequestContractAddresses requestContractAddresses =

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ProtocolSpec.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ProtocolSpec.java
@@ -20,7 +20,7 @@ import org.hyperledger.besu.ethereum.BlockValidator;
 import org.hyperledger.besu.ethereum.GasLimitCalculator;
 import org.hyperledger.besu.ethereum.core.BlockHeaderFunctions;
 import org.hyperledger.besu.ethereum.core.BlockImporter;
-import org.hyperledger.besu.ethereum.mainnet.blockhash.BlockHashProcessor;
+import org.hyperledger.besu.ethereum.mainnet.blockhash.PreExecutionProcessor;
 import org.hyperledger.besu.ethereum.mainnet.feemarket.FeeMarket;
 import org.hyperledger.besu.ethereum.mainnet.requests.RequestProcessorCoordinator;
 import org.hyperledger.besu.ethereum.mainnet.requests.RequestsValidator;
@@ -80,7 +80,7 @@ public class ProtocolSpec {
   private final Optional<WithdrawalsProcessor> withdrawalsProcessor;
   private final RequestsValidator requestsValidator;
   private final Optional<RequestProcessorCoordinator> requestProcessorCoordinator;
-  private final BlockHashProcessor blockHashProcessor;
+  private final PreExecutionProcessor preExecutionProcessor;
   private final boolean isPoS;
   private final boolean isReplayProtectionSupported;
   private final Optional<TransactionPoolPreProcessor> transactionPoolPreProcessor;
@@ -112,7 +112,7 @@ public class ProtocolSpec {
    * @param withdrawalsProcessor the Withdrawals processor to use
    * @param requestsValidator the request validator to use
    * @param requestProcessorCoordinator the request processor to use
-   * @param blockHashProcessor the blockHash processor to use
+   * @param preExecutionProcessor the blockHash processor to use
    * @param isPoS indicates whether the current spec is PoS
    * @param isReplayProtectionSupported indicates whether the current spec supports replay
    *     protection
@@ -143,7 +143,7 @@ public class ProtocolSpec {
       final Optional<WithdrawalsProcessor> withdrawalsProcessor,
       final RequestsValidator requestsValidator,
       final Optional<RequestProcessorCoordinator> requestProcessorCoordinator,
-      final BlockHashProcessor blockHashProcessor,
+      final PreExecutionProcessor preExecutionProcessor,
       final boolean isPoS,
       final boolean isReplayProtectionSupported,
       final Optional<TransactionPoolPreProcessor> transactionPoolPreProcessor) {
@@ -172,7 +172,7 @@ public class ProtocolSpec {
     this.withdrawalsProcessor = withdrawalsProcessor;
     this.requestsValidator = requestsValidator;
     this.requestProcessorCoordinator = requestProcessorCoordinator;
-    this.blockHashProcessor = blockHashProcessor;
+    this.preExecutionProcessor = preExecutionProcessor;
     this.isPoS = isPoS;
     this.isReplayProtectionSupported = isReplayProtectionSupported;
     this.transactionPoolPreProcessor = transactionPoolPreProcessor;
@@ -379,8 +379,8 @@ public class ProtocolSpec {
     return requestProcessorCoordinator;
   }
 
-  public BlockHashProcessor getBlockHashProcessor() {
-    return blockHashProcessor;
+  public PreExecutionProcessor getPreExecutionProcessor() {
+    return preExecutionProcessor;
   }
 
   /**

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ProtocolSpecBuilder.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ProtocolSpecBuilder.java
@@ -24,7 +24,7 @@ import org.hyperledger.besu.ethereum.GasLimitCalculator;
 import org.hyperledger.besu.ethereum.chain.BadBlockManager;
 import org.hyperledger.besu.ethereum.core.BlockHeaderFunctions;
 import org.hyperledger.besu.ethereum.core.BlockImporter;
-import org.hyperledger.besu.ethereum.mainnet.blockhash.BlockHashProcessor;
+import org.hyperledger.besu.ethereum.mainnet.blockhash.PreExecutionProcessor;
 import org.hyperledger.besu.ethereum.mainnet.feemarket.FeeMarket;
 import org.hyperledger.besu.ethereum.mainnet.requests.ProhibitedRequestValidator;
 import org.hyperledger.besu.ethereum.mainnet.requests.RequestProcessorCoordinator;
@@ -75,7 +75,7 @@ public class ProtocolSpecBuilder {
   private WithdrawalsProcessor withdrawalsProcessor;
   private RequestsValidator requestsValidator = new ProhibitedRequestValidator();
   private RequestProcessorCoordinator requestProcessorCoordinator;
-  protected BlockHashProcessor blockHashProcessor;
+  protected PreExecutionProcessor preExecutionProcessor;
   private FeeMarketBuilder feeMarketBuilder = (__) -> FeeMarket.legacy();
   private BlobSchedule blobSchedule = new BlobSchedule.NoBlobSchedule();
   private BadBlockManager badBlockManager;
@@ -257,8 +257,9 @@ public class ProtocolSpecBuilder {
     return this;
   }
 
-  public ProtocolSpecBuilder blockHashProcessor(final BlockHashProcessor blockHashProcessor) {
-    this.blockHashProcessor = blockHashProcessor;
+  public ProtocolSpecBuilder preExecutionProcessor(
+      final PreExecutionProcessor preExecutionProcessor) {
+    this.preExecutionProcessor = preExecutionProcessor;
     return this;
   }
 
@@ -369,7 +370,7 @@ public class ProtocolSpecBuilder {
         Optional.ofNullable(withdrawalsProcessor),
         requestsValidator,
         Optional.ofNullable(requestProcessorCoordinator),
-        blockHashProcessor,
+        preExecutionProcessor,
         isPoS,
         isReplayProtectionSupported,
         Optional.ofNullable(transactionPoolPreProcessor));

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/blockhash/CancunPreExecutionProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/blockhash/CancunPreExecutionProcessor.java
@@ -20,7 +20,7 @@ import org.hyperledger.besu.ethereum.mainnet.systemcall.BlockProcessingContext;
 import org.hyperledger.besu.evm.worldstate.WorldUpdater;
 
 /** Processes the beacon block storage if it is present in the block header. */
-public class CancunBlockHashProcessor extends FrontierBlockHashProcessor {
+public class CancunPreExecutionProcessor extends FrontierPreExecutionProcessor {
 
   @Override
   public Void process(final BlockProcessingContext context) {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/blockhash/Eip7709PreExecutionProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/blockhash/Eip7709PreExecutionProcessor.java
@@ -24,7 +24,7 @@ import org.hyperledger.besu.evm.blockhash.BlockHashLookup;
  * accordance with EIP-7709. It is not used yet since the fork that this EIP should go in has not
  * been decided yet.
  */
-public class Eip7709BlockHashProcessor extends PragueBlockHashProcessor {
+public class Eip7709PreExecutionProcessor extends PraguePreExecutionProcessor {
 
   @Override
   public BlockHashLookup createBlockHashLookup(

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/blockhash/FrontierPreExecutionProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/blockhash/FrontierPreExecutionProcessor.java
@@ -21,7 +21,7 @@ import org.hyperledger.besu.ethereum.vm.BlockchainBasedBlockHashLookup;
 import org.hyperledger.besu.evm.blockhash.BlockHashLookup;
 import org.hyperledger.besu.evm.operation.BlockHashOperation;
 
-public class FrontierBlockHashProcessor implements BlockHashProcessor {
+public class FrontierPreExecutionProcessor implements PreExecutionProcessor {
 
   @Override
   public Void process(final BlockProcessingContext context) {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/blockhash/PraguePreExecutionProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/blockhash/PraguePreExecutionProcessor.java
@@ -31,27 +31,27 @@ import org.slf4j.LoggerFactory;
  * responsible for managing the storage of block hashes to support EIP-2935, which introduces
  * historical block hash access in smart contracts.
  */
-public class PragueBlockHashProcessor extends CancunBlockHashProcessor {
-  private static final Logger LOG = LoggerFactory.getLogger(PragueBlockHashProcessor.class);
+public class PraguePreExecutionProcessor extends CancunPreExecutionProcessor {
+  private static final Logger LOG = LoggerFactory.getLogger(PraguePreExecutionProcessor.class);
 
   private static final Address HISTORY_STORAGE_ADDRESS =
       Address.fromHexString("0x0000f90827f1c53a10cb7a02335b175320002935");
 
   protected final Address historyStorageAddress;
 
-  /** Constructs a BlockHashProcessor. */
-  public PragueBlockHashProcessor() {
+  /** Constructs a PraguePreExecutionProcessor. */
+  public PraguePreExecutionProcessor() {
     this(HISTORY_STORAGE_ADDRESS);
   }
 
   /**
-   * Constructs a BlockHashProcessor with a specified history save window. This constructor is
-   * primarily used for testing.
+   * Constructs a PraguePreExecutionProcessor with a specified history save window. This constructor
+   * is primarily used for testing.
    *
    * @param historyStorageAddress the address of the contract storing the history
    */
   @VisibleForTesting
-  public PragueBlockHashProcessor(final Address historyStorageAddress) {
+  public PraguePreExecutionProcessor(final Address historyStorageAddress) {
     this.historyStorageAddress = historyStorageAddress;
   }
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/blockhash/PreExecutionProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/blockhash/PreExecutionProcessor.java
@@ -23,7 +23,14 @@ import org.hyperledger.besu.evm.blockhash.BlockHashLookup;
 
 import java.util.Optional;
 
-public interface BlockHashProcessor extends BlockContextProcessor<Void, BlockProcessingContext> {
+/**
+ * A processor that updates the state before transaction execution. This is used to implement
+ * pre-execution logic defined in Ethereum upgrades such as EIP-2935 (access to historical block
+ * hashes) and EIP-4788 (exposing the beacon chain root). *
+ *
+ * <p>This processor is invoked once per block, before any transactions are executed.
+ */
+public interface PreExecutionProcessor extends BlockContextProcessor<Void, BlockProcessingContext> {
 
   BlockHashLookup createBlockHashLookup(Blockchain blockchain, ProcessableBlockHeader blockHeader);
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/BlockSimulator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/BlockSimulator.java
@@ -217,7 +217,7 @@ public class BlockSimulator {
             protocolSpec,
             blockHashLookup,
             OperationTracer.NO_TRACING);
-    protocolSpec.getBlockHashProcessor().process(blockProcessingContext);
+    protocolSpec.getPreExecutionProcessor().process(blockProcessingContext);
 
     BlockStateCallSimulationResult blockStateCallSimulationResult =
         processTransactions(
@@ -517,7 +517,7 @@ public class BlockSimulator {
             .orElseGet(
                 () ->
                     newProtocolSpec
-                        .getBlockHashProcessor()
+                        .getPreExecutionProcessor()
                         .createBlockHashLookup(blockchain, blockHeader));
     return (frame, blockNumber) -> {
       if (blockHashCache.containsKey(blockNumber)) {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/TransactionSimulator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/TransactionSimulator.java
@@ -384,7 +384,9 @@ public class TransactionSimulator {
 
     final ProtocolSpec protocolSpec = protocolSchedule.getByBlockHeader(processableHeader);
     final BlockHashLookup blockHashLookup =
-        protocolSpec.getBlockHashProcessor().createBlockHashLookup(blockchain, processableHeader);
+        protocolSpec
+            .getPreExecutionProcessor()
+            .createBlockHashLookup(blockchain, processableHeader);
     return processWithWorldUpdater(
         callParams,
         maybeStateOverrides,

--- a/ethereum/core/src/test-support/java/org/hyperledger/besu/ethereum/core/MessageFrameTestFixture.java
+++ b/ethereum/core/src/test-support/java/org/hyperledger/besu/ethereum/core/MessageFrameTestFixture.java
@@ -182,7 +182,7 @@ public class MessageFrameTestFixture {
                 blockHashLookup.orElseGet(
                     () ->
                         protocolSpec
-                            .getBlockHashProcessor()
+                            .getPreExecutionProcessor()
                             .createBlockHashLookup(localBlockchain, localBlockHeader)))
             .maxStackSize(maxStackSize)
             .build();

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/BlockImportExceptionHandlingTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/BlockImportExceptionHandlingTest.java
@@ -41,7 +41,7 @@ import org.hyperledger.besu.ethereum.mainnet.MainnetBlockProcessor;
 import org.hyperledger.besu.ethereum.mainnet.MainnetTransactionProcessor;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
-import org.hyperledger.besu.ethereum.mainnet.blockhash.FrontierBlockHashProcessor;
+import org.hyperledger.besu.ethereum.mainnet.blockhash.FrontierPreExecutionProcessor;
 import org.hyperledger.besu.ethereum.mainnet.feemarket.FeeMarket;
 import org.hyperledger.besu.ethereum.storage.StorageProvider;
 import org.hyperledger.besu.ethereum.trie.pathbased.bonsai.BonsaiWorldStateProvider;
@@ -119,7 +119,7 @@ class BlockImportExceptionHandlingTest {
     when(protocolContext.getBlockchain()).thenReturn(blockchain);
     when(protocolContext.getWorldStateArchive()).thenReturn(worldStateArchive);
     when(protocolSchedule.getByBlockHeader(any())).thenReturn(protocolSpec);
-    when(protocolSpec.getBlockHashProcessor()).thenReturn(new FrontierBlockHashProcessor());
+    when(protocolSpec.getPreExecutionProcessor()).thenReturn(new FrontierPreExecutionProcessor());
     when(protocolSpec.getGasCalculator()).thenReturn(gasCalculator);
     when(protocolSpec.getGasLimitCalculator()).thenReturn(gasLimitCalculator);
     when(protocolSpec.getFeeMarket()).thenReturn(feeMarket);

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/AbstractBlockProcessorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/AbstractBlockProcessorTest.java
@@ -35,7 +35,7 @@ import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.MutableWorldState;
 import org.hyperledger.besu.ethereum.core.Withdrawal;
-import org.hyperledger.besu.ethereum.mainnet.blockhash.FrontierBlockHashProcessor;
+import org.hyperledger.besu.ethereum.mainnet.blockhash.FrontierPreExecutionProcessor;
 import org.hyperledger.besu.ethereum.referencetests.ReferenceTestBlockchain;
 import org.hyperledger.besu.ethereum.referencetests.ReferenceTestWorldState;
 
@@ -67,8 +67,8 @@ abstract class AbstractBlockProcessorTest {
   void baseSetup() {
     lenient().when(protocolSchedule.getByBlockHeader(any())).thenReturn(protocolSpec);
     lenient()
-        .when(protocolSpec.getBlockHashProcessor())
-        .thenReturn(new FrontierBlockHashProcessor());
+        .when(protocolSpec.getPreExecutionProcessor())
+        .thenReturn(new FrontierPreExecutionProcessor());
     blockProcessor =
         new TestBlockProcessor(
             transactionProcessor,

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/MainnetBlockProcessorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/MainnetBlockProcessorTest.java
@@ -29,7 +29,7 @@ import org.hyperledger.besu.ethereum.core.BlockBody;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.MutableWorldState;
-import org.hyperledger.besu.ethereum.mainnet.blockhash.FrontierBlockHashProcessor;
+import org.hyperledger.besu.ethereum.mainnet.blockhash.FrontierPreExecutionProcessor;
 import org.hyperledger.besu.ethereum.referencetests.ReferenceTestBlockchain;
 import org.hyperledger.besu.ethereum.referencetests.ReferenceTestWorldState;
 
@@ -52,7 +52,7 @@ public class MainnetBlockProcessorTest extends AbstractBlockProcessorTest {
   @BeforeEach
   public void setup() {
     when(protocolSchedule.getByBlockHeader(any())).thenReturn(protocolSpec);
-    when(protocolSpec.getBlockHashProcessor()).thenReturn(new FrontierBlockHashProcessor());
+    when(protocolSpec.getPreExecutionProcessor()).thenReturn(new FrontierPreExecutionProcessor());
   }
 
   @Test

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/transaction/BlockSimulatorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/transaction/BlockSimulatorTest.java
@@ -41,7 +41,7 @@ import org.hyperledger.besu.ethereum.core.MutableWorldState;
 import org.hyperledger.besu.ethereum.mainnet.MiningBeneficiaryCalculator;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
-import org.hyperledger.besu.ethereum.mainnet.blockhash.BlockHashProcessor;
+import org.hyperledger.besu.ethereum.mainnet.blockhash.PreExecutionProcessor;
 import org.hyperledger.besu.ethereum.mainnet.feemarket.FeeMarket;
 import org.hyperledger.besu.ethereum.transaction.exceptions.BlockStateCallException;
 import org.hyperledger.besu.ethereum.trie.pathbased.common.provider.WorldStateQueryParams;
@@ -101,7 +101,7 @@ public class BlockSimulatorTest {
     when(protocolSpec.getGasLimitCalculator()).thenReturn(gasLimitCalculator);
     when(gasLimitCalculator.nextGasLimit(anyLong(), anyLong(), anyLong())).thenReturn(1L);
     when(protocolSpec.getFeeMarket()).thenReturn(mock(FeeMarket.class));
-    when(protocolSpec.getBlockHashProcessor()).thenReturn(mock(BlockHashProcessor.class));
+    when(protocolSpec.getPreExecutionProcessor()).thenReturn(mock(PreExecutionProcessor.class));
   }
 
   @Test

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/transaction/TransactionSimulatorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/transaction/TransactionSimulatorTest.java
@@ -50,7 +50,7 @@ import org.hyperledger.besu.ethereum.mainnet.MainnetTransactionProcessor;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
 import org.hyperledger.besu.ethereum.mainnet.TransactionValidationParams;
-import org.hyperledger.besu.ethereum.mainnet.blockhash.BlockHashProcessor;
+import org.hyperledger.besu.ethereum.mainnet.blockhash.PreExecutionProcessor;
 import org.hyperledger.besu.ethereum.mainnet.feemarket.FeeMarket;
 import org.hyperledger.besu.ethereum.processing.TransactionProcessingResult;
 import org.hyperledger.besu.ethereum.processing.TransactionProcessingResult.Status;
@@ -999,7 +999,7 @@ public class TransactionSimulatorTest extends TrustedSetupClassLoaderExtension {
 
   private void mockProtocolSpecForProcessWithWorldUpdater(final long txGasLimitCap) {
     final BlockHeaderFunctions blockHeaderFunctions = mock(BlockHeaderFunctions.class);
-    final BlockHashProcessor blockHashProcessor = mock(BlockHashProcessor.class);
+    final PreExecutionProcessor preExecutionProcessor = mock(PreExecutionProcessor.class);
     when(protocolSchedule.getChainId()).thenReturn(Optional.of(BigInteger.ONE));
     when(protocolSchedule.getByBlockHeader(any())).thenReturn(protocolSpec);
     when(protocolSchedule.getForNextBlockHeader(any(), anyLong())).thenReturn(protocolSpec);
@@ -1007,7 +1007,7 @@ public class TransactionSimulatorTest extends TrustedSetupClassLoaderExtension {
     when(protocolSpec.getMiningBeneficiaryCalculator()).thenReturn(BlockHeader::getCoinbase);
     when(protocolSpec.getBlockHeaderFunctions()).thenReturn(blockHeaderFunctions);
     when(protocolSpec.getFeeMarket()).thenReturn(FeeMarket.london(0));
-    when(protocolSpec.getBlockHashProcessor()).thenReturn(blockHashProcessor);
+    when(protocolSpec.getPreExecutionProcessor()).thenReturn(preExecutionProcessor);
     when(protocolSpec.getGasCalculator()).thenReturn(new FrontierGasCalculator());
     when(protocolSpec.getGasLimitCalculator()).thenReturn(gasLimitCalculator);
     when(protocolSpec.getDifficultyCalculator()).thenReturn((time, parent) -> BigInteger.TEN);

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/EvmToolCommand.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/EvmToolCommand.java
@@ -526,7 +526,7 @@ public class EvmToolCommand implements Runnable {
                 .miningBeneficiary(blockHeader.getCoinbase())
                 .blockHashLookup(
                     protocolSpec
-                        .getBlockHashProcessor()
+                        .getPreExecutionProcessor()
                         .createBlockHashLookup(component.getBlockchain(), blockHeader))
                 .accessListWarmAddresses(addressList)
                 .build();

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/T8nExecutor.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/T8nExecutor.java
@@ -363,12 +363,12 @@ public class T8nExecutor {
             worldState,
             protocolSpec,
             protocolSpec
-                .getBlockHashProcessor()
+                .getPreExecutionProcessor()
                 .createBlockHashLookup(blockchain, referenceTestEnv),
             OperationTracer.NO_TRACING);
 
     if (!referenceTestEnv.isStateTest()) {
-      protocolSpec.getBlockHashProcessor().process(blockProcessingContext);
+      protocolSpec.getPreExecutionProcessor().process(blockProcessingContext);
     }
 
     final WorldUpdater rootWorldStateUpdater = worldState.updater();
@@ -403,7 +403,7 @@ public class T8nExecutor {
         tracer.tracePrepareTransaction(worldStateUpdater, transaction);
         tracer.traceStartTransaction(worldStateUpdater, transaction);
         BlockHashLookup blockHashLookup =
-            protocolSpec.getBlockHashProcessor().createBlockHashLookup(blockchain, blockHeader);
+            protocolSpec.getPreExecutionProcessor().createBlockHashLookup(blockchain, blockHeader);
         if (blockHashLookup instanceof BlockchainBasedBlockHashLookup) {
           // basically t8n test cases for blockhash are broken and one cannot create a blockchain
           // from them so need to

--- a/ethereum/referencetests/src/reference-test/java/org/hyperledger/besu/ethereum/vm/GeneralStateReferenceTestTools.java
+++ b/ethereum/referencetests/src/reference-test/java/org/hyperledger/besu/ethereum/vm/GeneralStateReferenceTestTools.java
@@ -173,7 +173,7 @@ public class GeneralStateReferenceTestTools {
             blockHeader,
             transaction,
             blockHeader.getCoinbase(),
-            protocolSpec.getBlockHashProcessor().createBlockHashLookup(blockchain, blockHeader),
+            protocolSpec.getPreExecutionProcessor().createBlockHashLookup(blockchain, blockHeader),
             TransactionValidationParams.processingBlock(),
             blobGasPrice);
     if (result.isInvalid()) {


### PR DESCRIPTION
Renamed `BlockHashProcessor` to `PreExecutionProcessor` to better reflect its extended responsibilities. In addition to EIP-2935 (historical block hash), the processor also executes  EIP-4788 (beacon root exposure). The new name more accurately represents its broader role in pre-execution state updates via system calls.