### PR TITLE
Improve BENCHMARKING.md documentation

### DIFF
--- a/BENCHMARKING.md
+++ b/BENCHMARKING.md
@@ -54,10 +54,10 @@ To profile benchmarks with [Async Profiler](https://github.com/jvm-profiling-too
 ./gradlew :ethereum:core:jmh \
   -Pincludes=SomeBenchmark \
   -PasyncProfiler=/path/to/libasyncProfiler.so \
-  -PasyncProfilerOptions="flamegraph;output=flames.svg"
+  -PasyncProfilerOptions="output=flamegraph"
 ```
 
-This will generate a `flames.svg` file after the benchmark run.
+This will generate two html profiling files flame-cpu-forward.html and flame-cpu-reverse.html after the benchmark run.
 
 ---
 
@@ -73,5 +73,6 @@ SomeBenchmark.benchmark                  avgt   20  8.951 ± 0.149  ns/op
 
 ## 📚 References
 
+- [JMH Gradle plugin documentation](https://github.com/melix/jmh-gradle-plugin)
 - [JMH Documentation](https://openjdk.org/projects/code-tools/jmh/)
 - [Async Profiler GitHub](https://github.com/jvm-profiling-tools/async-profiler)


### PR DESCRIPTION
## PR description
When running this task :
```
./gradlew clean :ethereum:core:jmh -Pf=1 -Pwi=1 -Pi=5 -Pincludes=CountLeadingZerosOperation -PasyncProfiler=/Users/ameziane.hamlat/async-profiler-4.1-macos/lib/libasyncProfiler.dylib -PasyncProfilerOptions="flamegraph;output=flames.svg"
```
We have this error

```
Profilers failed to initialize, exiting.
f is not a recognized option
Usage: -prof <profiler-name>:opt1=value1,value2;opt2=value3

Options accepted by async:                                   

  output=<format+>                 Output format(s). Supported: [text, collapsed, 
                                   flamegraph, tree, jfr]. (default: [text]) 
```

This PR fixes the documentation with the correct command that doesn't trigger the error. I added also a link to the documentation of the gradle as flags we need to use are defined there.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

