### PR TITLE
Remove the possibility to create block before Byzantium hard-fork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Change in behavior for `eth_estimateGas`, to improve accuracy, when used on a network with a base fee market, the internal transaction simulation does not anymore underprice transactions, so if there are no gas pricing related fields specified in the request, then gas price for the transaction is set to the base fee value [#8888](https://github.com/hyperledger/besu/pull/8888)
 - Remove PoAMetricsService and IbftQueryService which have been deprecated since 2019 and are replaced by PoaQueryService and BftQueryService respectively [#8940](https://github.com/hyperledger/besu/pull/8940)
 - Remove deprecated `Quantity.getValue` method (deprecated since 2019) [#8968](https://github.com/hyperledger/besu/pull/8968)
+- Support for block creation on networks running a pre-Byzantium fork is removed, after being deprecated for a few months. If still running a pre-Byzantium network, it needs to be updated to continue to produce blocks [#9005](https://github.com/hyperledger/besu/pull/9005)
 
 ### Upcoming Breaking Changes
 

--- a/acceptance-tests/tests/src/test/resources/clique/clique.json.tpl
+++ b/acceptance-tests/tests/src/test/resources/clique/clique.json.tpl
@@ -1,10 +1,7 @@
 {
   "config": {
     "chainId": 4,
-    "homesteadBlock": 1,
-    "eip150Block": 2,
-    "eip158Block": 4,
-    "byzantiumBlock": 5,
+    "byzantiumBlock": 0,
     "constantinopleBlock": 6,
     "petersburgBlock": 7,
     "clique": {

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/BlockTransactionSelector.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/BlockTransactionSelector.java
@@ -479,7 +479,7 @@ public class BlockTransactionSelector implements BlockTransactionSelectionServic
 
           final TransactionReceipt receipt =
               transactionReceiptFactory.create(
-                  transaction.getType(), processingResult, worldState, cumulativeGasUsed);
+                  transaction.getType(), processingResult, cumulativeGasUsed);
 
           transactionSelectionResults.updateSelected(transaction, receipt, gasUsedByTransaction);
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/AbstractBlockProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/AbstractBlockProcessor.java
@@ -55,14 +55,15 @@ import org.slf4j.LoggerFactory;
 
 public abstract class AbstractBlockProcessor implements BlockProcessor {
 
-  @FunctionalInterface
   public interface TransactionReceiptFactory {
-
     TransactionReceipt create(
         TransactionType transactionType,
         TransactionProcessingResult result,
         WorldState worldState,
         long gasUsed);
+
+    TransactionReceipt create(
+        TransactionType transactionType, TransactionProcessingResult result, long gasUsed);
   }
 
   private static final Logger LOG = LoggerFactory.getLogger(AbstractBlockProcessor.class);

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ClassicProtocolSpecs.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ClassicProtocolSpecs.java
@@ -31,9 +31,7 @@ import static org.hyperledger.besu.ethereum.mainnet.MainnetProtocolSpecs.powHash
 import org.hyperledger.besu.config.PowAlgorithm;
 import org.hyperledger.besu.datatypes.TransactionType;
 import org.hyperledger.besu.datatypes.Wei;
-import org.hyperledger.besu.ethereum.core.TransactionReceipt;
 import org.hyperledger.besu.ethereum.core.feemarket.CoinbaseFeePriceCalculator;
-import org.hyperledger.besu.ethereum.processing.TransactionProcessingResult;
 import org.hyperledger.besu.evm.ClassicEVMs;
 import org.hyperledger.besu.evm.MainnetEVMs;
 import org.hyperledger.besu.evm.contractvalidation.MaxCodeSizeRule;
@@ -49,7 +47,6 @@ import org.hyperledger.besu.evm.gascalculator.TangerineWhistleGasCalculator;
 import org.hyperledger.besu.evm.internal.EvmConfiguration;
 import org.hyperledger.besu.evm.processor.ContractCreationProcessor;
 import org.hyperledger.besu.evm.processor.MessageCallProcessor;
-import org.hyperledger.besu.evm.worldstate.WorldState;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 
 import java.math.BigInteger;
@@ -175,9 +172,7 @@ public class ClassicProtocolSpecs {
         .precompileContractRegistryBuilder(MainnetPrecompiledContractRegistries::byzantium)
         .difficultyCalculator(ClassicDifficultyCalculators.EIP100)
         .transactionReceiptFactory(
-            enableRevertReason
-                ? ClassicProtocolSpecs::byzantiumTransactionReceiptFactoryWithReasonEnabled
-                : ClassicProtocolSpecs::byzantiumTransactionReceiptFactory)
+            new MainnetProtocolSpecs.ByzantiumTransactionReceiptFactory(enableRevertReason))
         .contractCreationProcessorBuilder(
             evm ->
                 new ContractCreationProcessor(
@@ -271,26 +266,6 @@ public class ClassicProtocolSpecs {
         .hardforkId(THANOS);
   }
 
-  private static TransactionReceipt byzantiumTransactionReceiptFactory(
-      // ignored because it's always FRONTIER for byzantium
-      final TransactionType __,
-      final TransactionProcessingResult result,
-      final WorldState worldState,
-      final long gasUsed) {
-    return new TransactionReceipt(
-        result.isSuccessful() ? 1 : 0, gasUsed, result.getLogs(), Optional.empty());
-  }
-
-  private static TransactionReceipt byzantiumTransactionReceiptFactoryWithReasonEnabled(
-      // ignored because it's always FRONTIER for byzantium
-      final TransactionType __,
-      final TransactionProcessingResult result,
-      final WorldState worldState,
-      final long gasUsed) {
-    return new TransactionReceipt(
-        result.isSuccessful() ? 1 : 0, gasUsed, result.getLogs(), result.getRevertReason());
-  }
-
   public static ProtocolSpecBuilder magnetoDefinition(
       final Optional<BigInteger> chainId,
       final boolean enableRevertReason,
@@ -315,9 +290,7 @@ public class ClassicProtocolSpecs {
                     chainId,
                     Set.of(TransactionType.FRONTIER, TransactionType.ACCESS_LIST)))
         .transactionReceiptFactory(
-            enableRevertReason
-                ? MainnetProtocolSpecs::berlinTransactionReceiptFactoryWithReasonEnabled
-                : MainnetProtocolSpecs::berlinTransactionReceiptFactory)
+            new MainnetProtocolSpecs.BerlinTransactionReceiptFactory(enableRevertReason))
         .hardforkId(MAGNETO);
   }
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetProtocolSpecs.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetProtocolSpecs.java
@@ -65,6 +65,7 @@ import org.hyperledger.besu.ethereum.core.MiningConfiguration;
 import org.hyperledger.besu.ethereum.core.MutableWorldState;
 import org.hyperledger.besu.ethereum.core.TransactionReceipt;
 import org.hyperledger.besu.ethereum.core.feemarket.CoinbaseFeePriceCalculator;
+import org.hyperledger.besu.ethereum.mainnet.AbstractBlockProcessor.TransactionReceiptFactory;
 import org.hyperledger.besu.ethereum.mainnet.blockhash.CancunPreExecutionProcessor;
 import org.hyperledger.besu.ethereum.mainnet.blockhash.FrontierPreExecutionProcessor;
 import org.hyperledger.besu.ethereum.mainnet.blockhash.PraguePreExecutionProcessor;
@@ -190,7 +191,7 @@ public abstract class MainnetProtocolSpecs {
             (feeMarket, gasCalculator, gasLimitCalculator) ->
                 MainnetBlockHeaderValidator.createLegacyFeeMarketOmmerValidator())
         .blockBodyValidatorBuilder(MainnetBlockBodyValidator::new)
-        .transactionReceiptFactory(MainnetProtocolSpecs::frontierTransactionReceiptFactory)
+        .transactionReceiptFactory(new FrontierTransactionReceiptFactory())
         .blockReward(FRONTIER_BLOCK_REWARD)
         .skipZeroBlockRewards(false)
         .blockProcessorBuilder(
@@ -348,10 +349,7 @@ public abstract class MainnetProtocolSpecs {
         .evmBuilder(MainnetEVMs::byzantium)
         .precompileContractRegistryBuilder(MainnetPrecompiledContractRegistries::byzantium)
         .difficultyCalculator(MainnetDifficultyCalculators.BYZANTIUM)
-        .transactionReceiptFactory(
-            enableRevertReason
-                ? MainnetProtocolSpecs::byzantiumTransactionReceiptFactoryWithReasonEnabled
-                : MainnetProtocolSpecs::byzantiumTransactionReceiptFactory)
+        .transactionReceiptFactory(new ByzantiumTransactionReceiptFactory(enableRevertReason))
         .blockReward(BYZANTIUM_BLOCK_REWARD)
         .hardforkId(BYZANTIUM);
   }
@@ -457,10 +455,7 @@ public abstract class MainnetProtocolSpecs {
                     true,
                     chainId,
                     Set.of(TransactionType.FRONTIER, TransactionType.ACCESS_LIST)))
-        .transactionReceiptFactory(
-            enableRevertReason
-                ? MainnetProtocolSpecs::berlinTransactionReceiptFactoryWithReasonEnabled
-                : MainnetProtocolSpecs::berlinTransactionReceiptFactory)
+        .transactionReceiptFactory(new BerlinTransactionReceiptFactory(enableRevertReason))
         .hardforkId(BERLIN);
   }
 
@@ -1114,63 +1109,84 @@ public abstract class MainnetProtocolSpecs {
         .hardforkId(EXPERIMENTAL_EIPS);
   }
 
-  private static TransactionReceipt frontierTransactionReceiptFactory(
-      // ignored because it's always FRONTIER
-      final TransactionType __,
-      final TransactionProcessingResult result,
-      final WorldState worldState,
-      final long gasUsed) {
-    return new TransactionReceipt(
-        worldState.frontierRootHash(),
-        gasUsed,
-        result.getLogs(),
-        Optional.empty()); // No revert reason in frontier
+  private static class FrontierTransactionReceiptFactory implements TransactionReceiptFactory {
+
+    @Override
+    public TransactionReceipt create(
+        final TransactionType transactionType,
+        final TransactionProcessingResult result,
+        final WorldState worldState,
+        final long gasUsed) {
+      return new TransactionReceipt(
+          worldState.frontierRootHash(),
+          gasUsed,
+          result.getLogs(),
+          Optional.empty()); // No revert reason in Frontier
+    }
+
+    @Override
+    public TransactionReceipt create(
+        final TransactionType transactionType,
+        final TransactionProcessingResult result,
+        final long gasUsed) {
+      throw new UnsupportedOperationException("No stateless transaction receipt in Frontier");
+    }
   }
 
-  private static TransactionReceipt byzantiumTransactionReceiptFactory(
-      // ignored because it's always FRONTIER
-      final TransactionType __,
-      final TransactionProcessingResult result,
-      final WorldState worldState,
-      final long gasUsed) {
-    return new TransactionReceipt(
-        result.isSuccessful() ? 1 : 0, gasUsed, result.getLogs(), Optional.empty());
+  private abstract static class PostFrontierTransactionReceiptFactory
+      implements TransactionReceiptFactory {
+    protected final boolean revertReasonEnabled;
+
+    public PostFrontierTransactionReceiptFactory(final boolean revertReasonEnabled) {
+      this.revertReasonEnabled = revertReasonEnabled;
+    }
+
+    @Override
+    public TransactionReceipt create(
+        final TransactionType transactionType,
+        final TransactionProcessingResult result,
+        final WorldState worldState,
+        final long gasUsed) {
+      return create(transactionType, result, gasUsed);
+    }
   }
 
-  private static TransactionReceipt byzantiumTransactionReceiptFactoryWithReasonEnabled(
-      // ignored because it's always FRONTIER
-      final TransactionType __,
-      final TransactionProcessingResult result,
-      final WorldState worldState,
-      final long gasUsed) {
-    return new TransactionReceipt(
-        result.isSuccessful() ? 1 : 0, gasUsed, result.getLogs(), result.getRevertReason());
+  static class ByzantiumTransactionReceiptFactory extends PostFrontierTransactionReceiptFactory {
+    public ByzantiumTransactionReceiptFactory(final boolean revertReasonEnabled) {
+      super(revertReasonEnabled);
+    }
+
+    @Override
+    public TransactionReceipt create(
+        final TransactionType transactionType,
+        final TransactionProcessingResult result,
+        final long gasUsed) {
+      return new TransactionReceipt(
+          result.isSuccessful() ? 1 : 0,
+          gasUsed,
+          result.getLogs(),
+          revertReasonEnabled ? result.getRevertReason() : Optional.empty());
+    }
   }
 
-  static TransactionReceipt berlinTransactionReceiptFactory(
-      final TransactionType transactionType,
-      final TransactionProcessingResult transactionProcessingResult,
-      final WorldState worldState,
-      final long gasUsed) {
-    return new TransactionReceipt(
-        transactionType,
-        transactionProcessingResult.isSuccessful() ? 1 : 0,
-        gasUsed,
-        transactionProcessingResult.getLogs(),
-        Optional.empty());
-  }
+  static class BerlinTransactionReceiptFactory extends PostFrontierTransactionReceiptFactory {
 
-  static TransactionReceipt berlinTransactionReceiptFactoryWithReasonEnabled(
-      final TransactionType transactionType,
-      final TransactionProcessingResult transactionProcessingResult,
-      final WorldState worldState,
-      final long gasUsed) {
-    return new TransactionReceipt(
-        transactionType,
-        transactionProcessingResult.isSuccessful() ? 1 : 0,
-        gasUsed,
-        transactionProcessingResult.getLogs(),
-        transactionProcessingResult.getRevertReason());
+    public BerlinTransactionReceiptFactory(final boolean revertReasonEnabled) {
+      super(revertReasonEnabled);
+    }
+
+    @Override
+    public TransactionReceipt create(
+        final TransactionType transactionType,
+        final TransactionProcessingResult result,
+        final long gasUsed) {
+      return new TransactionReceipt(
+          transactionType,
+          result.isSuccessful() ? 1 : 0,
+          gasUsed,
+          result.getLogs(),
+          revertReasonEnabled ? result.getRevertReason() : Optional.empty());
+    }
   }
 
   private record DaoBlockProcessor(BlockProcessor wrapped) implements BlockProcessor {


### PR DESCRIPTION
## PR description

Support for block creation on networks running a pre-Byzantium fork is removed, after being deprecated for a few months. Besu on nodes that build blocks needs to be upgraded at least to the Byzantium fork. 

The main reason is to simplify world state management during block creation, since before Byzantium for each selected transaction, the receipt must contain the root hash of the modified world state, and this does not play well with the new plugin features, optimization and future work on parallelism.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

