### PR TITLE
Add metrics to peer task executor usage to better compare directly with old system

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/BufferedGetPooledTransactionsFromPeerFetcher.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/BufferedGetPooledTransactionsFromPeerFetcher.java
@@ -25,6 +25,8 @@ import org.hyperledger.besu.ethereum.eth.manager.peertask.PeerTaskExecutorResult
 import org.hyperledger.besu.ethereum.eth.transactions.PeerTransactionTracker;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolMetrics;
+import org.hyperledger.besu.metrics.BesuMetricCategory;
+import org.hyperledger.besu.plugin.services.metrics.OperationTimer;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -94,14 +96,25 @@ public class BufferedGetPooledTransactionsFromPeerFetcher {
                 .getScheduler()
                 .scheduleSyncWorkerTask(
                     () -> {
-                      PeerTaskExecutorResult<List<Transaction>> taskResult =
-                          ethContext.getPeerTaskExecutor().executeAgainstPeer(task, peer);
-                      if (taskResult.responseCode() != PeerTaskExecutorResponseCode.SUCCESS
-                          || taskResult.result().isEmpty()) {
-                        return CompletableFuture.failedFuture(
-                            new RuntimeException("Failed to retrieve transactions for hashes"));
+                      try (OperationTimer.TimingContext ignored =
+                          metrics
+                              .getMetricsSystem()
+                              .createLabelledTimer(
+                                  BesuMetricCategory.SYNCHRONIZER,
+                                  "task",
+                                  "Internal processing tasks",
+                                  "taskName")
+                              .labels(GetPooledTransactionsFromPeerTask.class.getSimpleName())
+                              .startTimer()) {
+                        PeerTaskExecutorResult<List<Transaction>> taskResult =
+                            ethContext.getPeerTaskExecutor().executeAgainstPeer(task, peer);
+                        if (taskResult.responseCode() != PeerTaskExecutorResponseCode.SUCCESS
+                            || taskResult.result().isEmpty()) {
+                          return CompletableFuture.failedFuture(
+                              new RuntimeException("Failed to retrieve transactions for hashes"));
+                        }
+                        return CompletableFuture.completedFuture(taskResult.result().get());
                       }
-                      return CompletableFuture.completedFuture(taskResult.result().get());
                     });
       } else {
         final GetPooledTransactionsFromPeerTask task =

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/peervalidation/AbstractPeerBlockValidator.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/peervalidation/AbstractPeerBlockValidator.java
@@ -24,10 +24,13 @@ import org.hyperledger.besu.ethereum.eth.manager.peertask.PeerTaskExecutorRespon
 import org.hyperledger.besu.ethereum.eth.manager.peertask.PeerTaskExecutorResult;
 import org.hyperledger.besu.ethereum.eth.manager.peertask.task.GetHeadersFromPeerTask;
 import org.hyperledger.besu.ethereum.eth.manager.task.AbstractPeerTask;
+import org.hyperledger.besu.ethereum.eth.manager.task.GetHeadersFromPeerByHashTask;
 import org.hyperledger.besu.ethereum.eth.manager.task.GetHeadersFromPeerByNumberTask;
 import org.hyperledger.besu.ethereum.eth.sync.SynchronizerConfiguration;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
+import org.hyperledger.besu.metrics.BesuMetricCategory;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
+import org.hyperledger.besu.plugin.services.metrics.OperationTimer;
 
 import java.time.Duration;
 import java.util.List;
@@ -73,25 +76,36 @@ abstract class AbstractPeerBlockValidator implements PeerValidator {
           .getScheduler()
           .scheduleServiceTask(
               () -> {
-                GetHeadersFromPeerTask task =
-                    new GetHeadersFromPeerTask(
-                        blockNumber,
-                        1,
-                        0,
-                        GetHeadersFromPeerTask.Direction.FORWARD,
-                        protocolSchedule);
-                PeerTaskExecutorResult<List<BlockHeader>> taskResult =
-                    peerTaskExecutor.executeAgainstPeer(task, ethPeer);
-                CompletableFuture<Boolean> resultFuture;
-                if (taskResult.responseCode() != PeerTaskExecutorResponseCode.SUCCESS
-                    || taskResult.result().isEmpty()) {
-                  resultFuture = CompletableFuture.completedFuture(false);
-                } else {
-                  resultFuture =
-                      CompletableFuture.completedFuture(
-                          validateBlockHeaders(ethPeer, taskResult.result().get()));
+                try (OperationTimer.TimingContext ignored =
+                    metricsSystem
+                        .createLabelledTimer(
+                            BesuMetricCategory.SYNCHRONIZER,
+                            "task",
+                            "Internal processing tasks",
+                            "taskName")
+                        .labels(GetHeadersFromPeerByHashTask.class.getSimpleName())
+                        .startTimer()) {
+                  GetHeadersFromPeerTask task =
+                      new GetHeadersFromPeerTask(
+                          blockNumber,
+                          1,
+                          0,
+                          GetHeadersFromPeerTask.Direction.FORWARD,
+                          protocolSchedule);
+                  PeerTaskExecutorResult<List<BlockHeader>> taskResult =
+                      peerTaskExecutor.executeAgainstPeer(task, ethPeer);
+                  CompletableFuture<Boolean> resultFuture;
+
+                  if (taskResult.responseCode() != PeerTaskExecutorResponseCode.SUCCESS
+                      || taskResult.result().isEmpty()) {
+                    resultFuture = CompletableFuture.completedFuture(false);
+                  } else {
+                    resultFuture =
+                        CompletableFuture.completedFuture(
+                            validateBlockHeaders(ethPeer, taskResult.result().get()));
+                  }
+                  return resultFuture;
                 }
-                return resultFuture;
               });
     } else {
       final AbstractPeerTask<List<BlockHeader>> getHeaderTask =

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/ChainHeadTracker.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/ChainHeadTracker.java
@@ -27,7 +27,9 @@ import org.hyperledger.besu.ethereum.eth.manager.task.AbstractPeerTask;
 import org.hyperledger.besu.ethereum.eth.manager.task.GetHeadersFromPeerByHashTask;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.messages.DisconnectMessage;
+import org.hyperledger.besu.metrics.BesuMetricCategory;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
+import org.hyperledger.besu.plugin.services.metrics.OperationTimer;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -83,40 +85,50 @@ public class ChainHeadTracker {
           .getScheduler()
           .scheduleServiceTask(
               () -> {
-                GetHeadersFromPeerTask task =
-                    new GetHeadersFromPeerTask(
-                        Hash.wrap(peer.chainState().getBestBlock().getHash()),
-                        0,
-                        1,
-                        0,
-                        Direction.FORWARD,
-                        protocolSchedule);
-                PeerTaskExecutorResult<List<BlockHeader>> taskResult =
-                    ethContext.getPeerTaskExecutor().executeAgainstPeer(task, peer);
-                if (taskResult.responseCode() == PeerTaskExecutorResponseCode.SUCCESS
-                    && taskResult.result().isPresent()) {
-                  BlockHeader chainHeadHeader = taskResult.result().get().getFirst();
-                  LOG.atDebug()
-                      .setMessage("Retrieved chain head info {} from {}...")
-                      .addArgument(
-                          () ->
-                              chainHeadHeader.getNumber()
-                                  + " ("
-                                  + chainHeadHeader.getBlockHash()
-                                  + ")")
-                      .addArgument(peer::getLoggableId)
-                      .log();
-                  return CompletableFuture.completedFuture(chainHeadHeader);
-                } else {
-                  LOG.atDebug()
-                      .setMessage("Failed to retrieve chain head info. Disconnecting {}... {}")
-                      .addArgument(peer::getLoggableId)
-                      .addArgument(taskResult.responseCode())
-                      .log();
-                  peer.disconnect(
-                      DisconnectMessage.DisconnectReason
-                          .USELESS_PEER_FAILED_TO_RETRIEVE_CHAIN_HEAD);
-                  return CompletableFuture.completedFuture(null);
+                try (OperationTimer.TimingContext ignored =
+                    metricsSystem
+                        .createLabelledTimer(
+                            BesuMetricCategory.SYNCHRONIZER,
+                            "task",
+                            "Internal processing tasks",
+                            "taskName")
+                        .labels(GetHeadersFromPeerByHashTask.class.getSimpleName())
+                        .startTimer()) {
+                  GetHeadersFromPeerTask task =
+                      new GetHeadersFromPeerTask(
+                          Hash.wrap(peer.chainState().getBestBlock().getHash()),
+                          0,
+                          1,
+                          0,
+                          Direction.FORWARD,
+                          protocolSchedule);
+                  PeerTaskExecutorResult<List<BlockHeader>> taskResult =
+                      ethContext.getPeerTaskExecutor().executeAgainstPeer(task, peer);
+                  if (taskResult.responseCode() == PeerTaskExecutorResponseCode.SUCCESS
+                      && taskResult.result().isPresent()) {
+                    BlockHeader chainHeadHeader = taskResult.result().get().getFirst();
+                    LOG.atDebug()
+                        .setMessage("Retrieved chain head info {} from {}...")
+                        .addArgument(
+                            () ->
+                                chainHeadHeader.getNumber()
+                                    + " ("
+                                    + chainHeadHeader.getBlockHash()
+                                    + ")")
+                        .addArgument(peer::getLoggableId)
+                        .log();
+                    return CompletableFuture.completedFuture(chainHeadHeader);
+                  } else {
+                    LOG.atDebug()
+                        .setMessage("Failed to retrieve chain head info. Disconnecting {}... {}")
+                        .addArgument(peer::getLoggableId)
+                        .addArgument(taskResult.responseCode())
+                        .log();
+                    peer.disconnect(
+                        DisconnectMessage.DisconnectReason
+                            .USELESS_PEER_FAILED_TO_RETRIEVE_CHAIN_HEAD);
+                    return CompletableFuture.completedFuture(null);
+                  }
                 }
               });
     } else {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/DownloadBodiesStep.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/DownloadBodiesStep.java
@@ -20,7 +20,9 @@ import org.hyperledger.besu.ethereum.eth.manager.EthContext;
 import org.hyperledger.besu.ethereum.eth.sync.tasks.CompleteBlocksTask;
 import org.hyperledger.besu.ethereum.eth.sync.tasks.CompleteBlocksWithPeerTask;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
+import org.hyperledger.besu.metrics.BesuMetricCategory;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
+import org.hyperledger.besu.plugin.services.metrics.OperationTimer;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -60,10 +62,17 @@ public class DownloadBodiesStep
 
   private CompletableFuture<List<Block>> getBodiesWithPeerTaskSystem(
       final List<BlockHeader> headers) {
-
-    final CompleteBlocksWithPeerTask completeBlocksWithPeerTask =
-        new CompleteBlocksWithPeerTask(protocolSchedule, headers, ethContext.getPeerTaskExecutor());
-    final List<Block> blocks = completeBlocksWithPeerTask.retrieveBlocksFromPeers();
-    return CompletableFuture.completedFuture(blocks);
+    try (OperationTimer.TimingContext ignored =
+        metricsSystem
+            .createLabelledTimer(
+                BesuMetricCategory.SYNCHRONIZER, "task", "Internal processing tasks", "taskName")
+            .labels(CompleteBlocksTask.class.getSimpleName())
+            .startTimer()) {
+      final CompleteBlocksWithPeerTask completeBlocksWithPeerTask =
+          new CompleteBlocksWithPeerTask(
+              protocolSchedule, headers, ethContext.getPeerTaskExecutor());
+      final List<Block> blocks = completeBlocksWithPeerTask.retrieveBlocksFromPeers();
+      return CompletableFuture.completedFuture(blocks);
+    }
   }
 }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/DownloadSyncBodiesStep.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/DownloadSyncBodiesStep.java
@@ -22,7 +22,9 @@ import org.hyperledger.besu.ethereum.eth.manager.peertask.PeerTaskExecutorResult
 import org.hyperledger.besu.ethereum.eth.manager.peertask.task.GetSyncBlockBodiesFromPeerTask;
 import org.hyperledger.besu.ethereum.eth.sync.tasks.CompleteSyncBlocksTask;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
+import org.hyperledger.besu.metrics.BesuMetricCategory;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
+import org.hyperledger.besu.plugin.services.metrics.OperationTimer;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -65,20 +67,27 @@ public class DownloadSyncBodiesStep
       final List<BlockHeader> headers) {
     final int numSyncBlocksToGet = headers.size();
     final List<SyncBlock> syncBlocks = new ArrayList<>(numSyncBlocksToGet);
-    do {
-      final List<BlockHeader> headersForBodiesStillToGet =
-          headers.subList(syncBlocks.size(), numSyncBlocksToGet);
-      GetSyncBlockBodiesFromPeerTask task =
-          new GetSyncBlockBodiesFromPeerTask(headersForBodiesStillToGet, protocolSchedule);
-      PeerTaskExecutorResult<List<SyncBlock>> result =
-          ethContext.getPeerTaskExecutor().execute(task);
-      if (result.responseCode() == PeerTaskExecutorResponseCode.SUCCESS
-          && result.result().isPresent()) {
-        List<SyncBlock> taskResult = result.result().get();
-        syncBlocks.addAll(taskResult);
-      }
-      // repeat until all sync blocks have been downloaded
-    } while (syncBlocks.size() < numSyncBlocksToGet);
-    return CompletableFuture.completedFuture(syncBlocks);
+    try (OperationTimer.TimingContext ignored =
+        metricsSystem
+            .createLabelledTimer(
+                BesuMetricCategory.SYNCHRONIZER, "task", "Internal processing tasks", "taskName")
+            .labels(CompleteSyncBlocksTask.class.getSimpleName())
+            .startTimer()) {
+      do {
+        final List<BlockHeader> headersForBodiesStillToGet =
+            headers.subList(syncBlocks.size(), numSyncBlocksToGet);
+        GetSyncBlockBodiesFromPeerTask task =
+            new GetSyncBlockBodiesFromPeerTask(headersForBodiesStillToGet, protocolSchedule);
+        PeerTaskExecutorResult<List<SyncBlock>> result =
+            ethContext.getPeerTaskExecutor().execute(task);
+        if (result.responseCode() == PeerTaskExecutorResponseCode.SUCCESS
+            && result.result().isPresent()) {
+          List<SyncBlock> taskResult = result.result().get();
+          syncBlocks.addAll(taskResult);
+        }
+        // repeat until all sync blocks have been downloaded
+      } while (syncBlocks.size() < numSyncBlocksToGet);
+      return CompletableFuture.completedFuture(syncBlocks);
+    }
   }
 }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardSyncStep.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardSyncStep.java
@@ -21,6 +21,8 @@ import org.hyperledger.besu.ethereum.eth.manager.peertask.PeerTaskExecutorResult
 import org.hyperledger.besu.ethereum.eth.manager.peertask.task.GetHeadersFromPeerTask;
 import org.hyperledger.besu.ethereum.eth.manager.peertask.task.GetHeadersFromPeerTask.Direction;
 import org.hyperledger.besu.ethereum.eth.manager.task.RetryingGetHeadersEndingAtFromPeerByHashTask;
+import org.hyperledger.besu.metrics.BesuMetricCategory;
+import org.hyperledger.besu.plugin.services.metrics.OperationTimer;
 
 import java.util.List;
 import java.util.Optional;
@@ -81,22 +83,34 @@ public class BackwardSyncStep {
               .getScheduler()
               .scheduleSyncWorkerTask(
                   () -> {
-                    GetHeadersFromPeerTask task =
-                        new GetHeadersFromPeerTask(
-                            hash,
-                            0,
-                            batchSize,
-                            0,
-                            Direction.REVERSE,
-                            context.getEthContext().getEthPeers().peerCount(),
-                            context.getProtocolSchedule());
-                    PeerTaskExecutorResult<List<BlockHeader>> taskResult =
-                        context.getEthContext().getPeerTaskExecutor().execute(task);
-                    if (taskResult.responseCode() != PeerTaskExecutorResponseCode.SUCCESS
-                        || taskResult.result().isEmpty()) {
-                      throw new RuntimeException("Unable to retrieve headers");
+                    try (OperationTimer.TimingContext ignored =
+                        context
+                            .getMetricsSystem()
+                            .createLabelledTimer(
+                                BesuMetricCategory.SYNCHRONIZER,
+                                "task",
+                                "Internal processing tasks",
+                                "taskName")
+                            .labels(
+                                RetryingGetHeadersEndingAtFromPeerByHashTask.class.getSimpleName())
+                            .startTimer()) {
+                      GetHeadersFromPeerTask task =
+                          new GetHeadersFromPeerTask(
+                              hash,
+                              0,
+                              batchSize,
+                              0,
+                              Direction.REVERSE,
+                              context.getEthContext().getEthPeers().peerCount(),
+                              context.getProtocolSchedule());
+                      PeerTaskExecutorResult<List<BlockHeader>> taskResult =
+                          context.getEthContext().getPeerTaskExecutor().execute(task);
+                      if (taskResult.responseCode() != PeerTaskExecutorResponseCode.SUCCESS
+                          || taskResult.result().isEmpty()) {
+                        throw new RuntimeException("Unable to retrieve headers");
+                      }
+                      return CompletableFuture.completedFuture(taskResult.result().get());
                     }
-                    return CompletableFuture.completedFuture(taskResult.result().get());
                   });
     } else {
       final RetryingGetHeadersEndingAtFromPeerByHashTask

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/ForwardSyncStep.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/ForwardSyncStep.java
@@ -21,6 +21,8 @@ import org.hyperledger.besu.ethereum.eth.manager.peertask.PeerTaskExecutorResult
 import org.hyperledger.besu.ethereum.eth.manager.peertask.task.GetBodiesFromPeerTask;
 import org.hyperledger.besu.ethereum.eth.manager.task.AbstractPeerTask;
 import org.hyperledger.besu.ethereum.eth.manager.task.RetryingGetBlocksFromPeersTask;
+import org.hyperledger.besu.metrics.BesuMetricCategory;
+import org.hyperledger.besu.plugin.services.metrics.OperationTimer;
 
 import java.util.Comparator;
 import java.util.List;
@@ -87,19 +89,30 @@ public class ForwardSyncStep {
               .getScheduler()
               .scheduleServiceTask(
                   () -> {
-                    GetBodiesFromPeerTask task =
-                        new GetBodiesFromPeerTask(
-                            blockHeaders,
-                            context.getProtocolSchedule(),
-                            context.getEthContext().getEthPeers().peerCount());
-                    PeerTaskExecutorResult<List<Block>> taskResult =
-                        context.getEthContext().getPeerTaskExecutor().execute(task);
-                    if (taskResult.responseCode() == PeerTaskExecutorResponseCode.SUCCESS
-                        && taskResult.result().isPresent()) {
-                      return CompletableFuture.completedFuture(taskResult.result().get());
-                    } else {
-                      return CompletableFuture.failedFuture(
-                          new RuntimeException(taskResult.responseCode().toString()));
+                    try (OperationTimer.TimingContext ignored =
+                        context
+                            .getMetricsSystem()
+                            .createLabelledTimer(
+                                BesuMetricCategory.SYNCHRONIZER,
+                                "task",
+                                "Internal processing tasks",
+                                "taskName")
+                            .labels(RetryingGetBlocksFromPeersTask.class.getSimpleName())
+                            .startTimer()) {
+                      GetBodiesFromPeerTask task =
+                          new GetBodiesFromPeerTask(
+                              blockHeaders,
+                              context.getProtocolSchedule(),
+                              context.getEthContext().getEthPeers().peerCount());
+                      PeerTaskExecutorResult<List<Block>> taskResult =
+                          context.getEthContext().getPeerTaskExecutor().execute(task);
+                      if (taskResult.responseCode() == PeerTaskExecutorResponseCode.SUCCESS
+                          && taskResult.result().isPresent()) {
+                        return CompletableFuture.completedFuture(taskResult.result().get());
+                      } else {
+                        return CompletableFuture.failedFuture(
+                            new RuntimeException(taskResult.responseCode().toString()));
+                      }
                     }
                   });
     } else {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/PivotBlockConfirmer.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/PivotBlockConfirmer.java
@@ -24,7 +24,9 @@ import org.hyperledger.besu.ethereum.eth.manager.task.EthTask;
 import org.hyperledger.besu.ethereum.eth.sync.SynchronizerConfiguration;
 import org.hyperledger.besu.ethereum.eth.sync.tasks.RetryingGetHeaderFromPeerByNumberTask;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
+import org.hyperledger.besu.metrics.BesuMetricCategory;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
+import org.hyperledger.besu.plugin.services.metrics.OperationTimer;
 import org.hyperledger.besu.util.FutureUtils;
 
 import java.time.Duration;
@@ -233,19 +235,30 @@ class PivotBlockConfirmer {
         .getScheduler()
         .scheduleServiceTask(
             () -> {
-              PeerTaskExecutorResult<List<BlockHeader>> taskResult =
-                  ethContext.getPeerTaskExecutor().executeAgainstPeer(task, ethPeer);
-              if (taskResult.responseCode() == PeerTaskExecutorResponseCode.INTERNAL_SERVER_ERROR) {
-                // something is probably wrong with the request, so we won't retry as below
-                return CompletableFuture.failedFuture(
-                    new RuntimeException("Unexpected internal issue"));
-              } else if (taskResult.responseCode() != PeerTaskExecutorResponseCode.SUCCESS
-                  || taskResult.result().isEmpty()) {
-                // recursively call executePivotQueryWithPeerTaskSystem to retry with a different
-                // peer.
-                return executePivotQueryWithPeerTaskSystem(blockNumber);
+              try (OperationTimer.TimingContext ignored =
+                  metricsSystem
+                      .createLabelledTimer(
+                          BesuMetricCategory.SYNCHRONIZER,
+                          "task",
+                          "Internal processing tasks",
+                          "taskName")
+                      .labels(RetryingGetHeaderFromPeerByNumberTask.class.getSimpleName())
+                      .startTimer()) {
+                PeerTaskExecutorResult<List<BlockHeader>> taskResult =
+                    ethContext.getPeerTaskExecutor().executeAgainstPeer(task, ethPeer);
+                if (taskResult.responseCode()
+                    == PeerTaskExecutorResponseCode.INTERNAL_SERVER_ERROR) {
+                  // something is probably wrong with the request, so we won't retry as below
+                  return CompletableFuture.failedFuture(
+                      new RuntimeException("Unexpected internal issue"));
+                } else if (taskResult.responseCode() != PeerTaskExecutorResponseCode.SUCCESS
+                    || taskResult.result().isEmpty()) {
+                  // recursively call executePivotQueryWithPeerTaskSystem to retry with a different
+                  // peer.
+                  return executePivotQueryWithPeerTaskSystem(blockNumber);
+                }
+                return CompletableFuture.completedFuture(taskResult.result().get().getFirst());
               }
-              return CompletableFuture.completedFuture(taskResult.result().get().getFirst());
             });
   }
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/SyncTargetManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/SyncTargetManager.java
@@ -31,7 +31,9 @@ import org.hyperledger.besu.ethereum.eth.sync.tasks.RetryingGetHeaderFromPeerByN
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.messages.DisconnectMessage.DisconnectReason;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateStorageCoordinator;
+import org.hyperledger.besu.metrics.BesuMetricCategory;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
+import org.hyperledger.besu.plugin.services.metrics.OperationTimer;
 
 import java.time.Duration;
 import java.util.List;
@@ -129,22 +131,32 @@ public class SyncTargetManager extends AbstractSyncTargetManager {
               .getScheduler()
               .scheduleServiceTask(
                   () -> {
-                    GetHeadersFromPeerTask task =
-                        new GetHeadersFromPeerTask(
-                            pivotBlockHeader.getNumber(),
-                            1,
-                            0,
-                            GetHeadersFromPeerTask.Direction.FORWARD,
-                            PivotBlockRetriever.MAX_QUERY_RETRIES_PER_PEER,
-                            protocolSchedule);
-                    PeerTaskExecutorResult<List<BlockHeader>> taskResult =
-                        ethContext.getPeerTaskExecutor().executeAgainstPeer(task, bestPeer);
-                    if (taskResult.responseCode() != PeerTaskExecutorResponseCode.SUCCESS
-                        || taskResult.result().isEmpty()) {
-                      return CompletableFuture.failedFuture(
-                          new RuntimeException("Unable to retrieve requested header from peer"));
+                    try (OperationTimer.TimingContext ignored =
+                        metricsSystem
+                            .createLabelledTimer(
+                                BesuMetricCategory.SYNCHRONIZER,
+                                "task",
+                                "Internal processing tasks",
+                                "taskName")
+                            .labels(RetryingGetHeaderFromPeerByNumberTask.class.getSimpleName())
+                            .startTimer()) {
+                      GetHeadersFromPeerTask task =
+                          new GetHeadersFromPeerTask(
+                              pivotBlockHeader.getNumber(),
+                              1,
+                              0,
+                              GetHeadersFromPeerTask.Direction.FORWARD,
+                              PivotBlockRetriever.MAX_QUERY_RETRIES_PER_PEER,
+                              protocolSchedule);
+                      PeerTaskExecutorResult<List<BlockHeader>> taskResult =
+                          ethContext.getPeerTaskExecutor().executeAgainstPeer(task, bestPeer);
+                      if (taskResult.responseCode() != PeerTaskExecutorResponseCode.SUCCESS
+                          || taskResult.result().isEmpty()) {
+                        return CompletableFuture.failedFuture(
+                            new RuntimeException("Unable to retrieve requested header from peer"));
+                      }
+                      return CompletableFuture.completedFuture(taskResult.result().get());
                     }
-                    return CompletableFuture.completedFuture(taskResult.result().get());
                   });
 
     } else {


### PR DESCRIPTION
## PR description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

