### PR TITLE
Improve info logs during block creation

### DIFF
--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/PostMergeContext.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/PostMergeContext.java
@@ -16,6 +16,7 @@ package org.hyperledger.besu.consensus.merge;
 
 import org.hyperledger.besu.consensus.merge.blockcreation.PayloadIdentifier;
 import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.ConsensusContext;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
@@ -210,13 +211,12 @@ public class PostMergeContext implements MergeContext {
       maybeCurrBestPayload.ifPresent(
           currBestPayload -> {
             if (newBlockValue.greaterThan(currBestPayload.blockValue())) {
-              LOG.atDebug()
+              LOG.atInfo()
                   .setMessage(
-                      "New proposal for payloadId {} {} is better than the previous one {} by {}")
+                      "New proposal for payloadId {} {} is better than the previous one by {}")
                   .addArgument(newPayload.payloadIdentifier())
-                  .addArgument(() -> logBlockProposal(newBlockWithReceipts.getBlock()))
                   .addArgument(
-                      () -> logBlockProposal(currBestPayload.blockWithReceipts().getBlock()))
+                      () -> logBlockProposal(newBlockWithReceipts.getBlock(), newBlockValue))
                   .addArgument(
                       () ->
                           newBlockValue
@@ -261,13 +261,15 @@ public class PostMergeContext implements MergeContext {
     return blocksInProgress.stream().filter(z -> z.payloadIdentifier().equals(payloadId));
   }
 
-  private String logBlockProposal(final Block block) {
+  private String logBlockProposal(final Block block, final Wei value) {
     return "block "
         + block.toLogString()
         + " gas used "
         + block.getHeader().getGasUsed()
         + " transactions "
-        + block.getBody().getTransactions().size();
+        + block.getBody().getTransactions().size()
+        + " reward "
+        + value.toHumanReadableString();
   }
 
   @Override

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineGetPayload.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineGetPayload.java
@@ -80,19 +80,16 @@ public abstract class AbstractEngineGetPayload extends ExecutionEngineJsonRpcMet
     mergeMiningCoordinator.finalizeProposalById(payloadId);
     final Optional<PayloadWrapper> maybePayload = mergeContext.get().retrievePayloadById(payloadId);
     if (maybePayload.isPresent()) {
-      final BlockWithReceipts proposal = maybePayload.get().blockWithReceipts();
-      LOG.atDebug()
-          .setMessage("assembledBlock for payloadId {}: {}")
-          .addArgument(() -> payloadId)
-          .addArgument(() -> proposal.getBlock().toLogString())
-          .log();
-      LOG.atTrace().setMessage("assembledBlock with receipts {}").addArgument(() -> proposal).log();
+      final PayloadWrapper payload = maybePayload.get();
+      final BlockWithReceipts proposal = payload.blockWithReceipts();
+      LOG.trace("assembledBlock with receipts {}", proposal);
       ValidationResult<RpcErrorType> forkValidationResult =
           validateForkSupported(proposal.getHeader().getTimestamp());
       if (!forkValidationResult.isValid()) {
         return new JsonRpcErrorResponse(request.getRequest().getId(), forkValidationResult);
       }
-      return createResponse(request, maybePayload.get());
+      logProposal(payload);
+      return createResponse(request, payload);
     }
     return new JsonRpcErrorResponse(request.getRequest().getId(), RpcErrorType.UNKNOWN_PAYLOAD);
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadV1.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadV1.java
@@ -46,7 +46,6 @@ public class EngineGetPayloadV1 extends AbstractEngineGetPayload {
       final JsonRpcRequestContext request, final PayloadWrapper payload) {
     final var result =
         blockResultFactory.payloadTransactionCompleteV1(payload.blockWithReceipts().getBlock());
-    logProposal(payload);
     return new JsonRpcSuccessResponse(request.getRequest().getId(), result);
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadV2.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadV2.java
@@ -62,7 +62,6 @@ public class EngineGetPayloadV2 extends AbstractEngineGetPayload {
   protected JsonRpcResponse createResponse(
       final JsonRpcRequestContext request, final PayloadWrapper payload) {
     final var result = blockResultFactory.payloadTransactionCompleteV2(payload);
-    logProposal(payload);
     return new JsonRpcSuccessResponse(request.getRequest().getId(), result);
   }
 


### PR DESCRIPTION
## PR description

Currently the logs during block creation are broken, since Besu lost the log that was done when the consensus client fetches the payload, that is fixed, and to make the logs more informative, the best proposal built so far is logged as well, that could be useful to see the progression and to reconstruct what happened in case of investigations.

Logs will look like this (non relevant parts removed):

```
:"Start building proposals for block 8868631 identified by 0x282b5c1167ce49e4","throwable":""}
ated","message":"FCU(VALID) | head: 604ca.....1c4bf | safe: 1ec4d.....26dd8 | finalized: 25051.....8b3c2","throwable":""}
ssage":"New proposal for payloadId 0x282b5c1167ce49e4 block 8868631 (0x5a30fdc5016ea856020b24a48b7b93a97e80db02245862e3f3844c167cc0280d) gas used 12968343 transactions 32 reward 1.31 finney is better than the previous one by 1.31 finney","throwable":""}
ssage":"New proposal for payloadId 0x282b5c1167ce49e4 block 8868631 (0xe00d75963546e4b655736131b47c0d662566f996debfc368c47c485fa646efb2) gas used 14089606 transactions 35 reward 1.50 finney is better than the previous one by 190.82 szabo","throwable":""}
ssage":"New proposal for payloadId 0x282b5c1167ce49e4 block 8868631 (0xf494505535a685abac206721f649deb6fb46430672d8525a05a0a9b87726d154) gas used 17849863 transactions 42 reward 1.89 finney is better than the previous one by 389.94 szabo","throwable":""}
ssage":"New proposal for payloadId 0x282b5c1167ce49e4 block 8868631 (0xf0cc23cca04a85682aca557b5cef9951c3bda30fb98fdbafaed031cee40bd244) gas used 18440382 transactions 46 reward 2.49 finney is better than the previous one by 600.60 szabo","throwable":""}
ssage":"New proposal for payloadId 0x282b5c1167ce49e4 block 8868631 (0x1a453e595dfe1be415976a4d6e9bb337b541e8a2bcfe0bd6f501d0f02ad287a1) gas used 19134163 transactions 52 reward 2.56 finney is better than the previous one by 73.64 szabo","throwable":""}
ssage":"New proposal for payloadId 0x282b5c1167ce49e4 block 8868631 (0xd96e98b5409152ea59e735d1211d95a44e75db363a64d56785e7e6387953cd39) gas used 21117104 transactions 65 reward 2.70 finney is better than the previous one by 135.10 szabo","throwable":""}
ssage":"New proposal for payloadId 0x282b5c1167ce49e4 block 8868631 (0xc647372f1cd9c7f72d5a08bb0568ee7f89a874c1cfcb98f1892a0336b42798e4) gas used 21573251 transactions 70 reward 3.33 finney is better than the previous one by 630.80 szabo","throwable":""}
ssage":"New proposal for payloadId 0x282b5c1167ce49e4 block 8868631 (0xc9fb2615d2874dd0895eff3709405b469b420366acc02d6b061520d53bfb5c57) gas used 34343765 transactions 81 reward 4.16 finney is better than the previous one by 833.67 szabo","throwable":""}
ssage":"New proposal for payloadId 0x282b5c1167ce49e4 block 8868631 (0x9adf5e5b1b72f16b0138f8edc1cd456f2c10022f1a09dcf000d8f7ea7e747ea1) gas used 35255749 transactions 91 reward 4.39 finney is better than the previous one by 227.98 szabo","throwable":""}
ssage":"New proposal for payloadId 0x282b5c1167ce49e4 block 8868631 (0x9ecccedc5a869dc368626326ad27638ecda1d841853c1387a415436fba1d5e5b) gas used 47667355 transactions 98 reward 5.56 finney is better than the previous one by 1.17 finney","throwable":""}
ssage":"New proposal for payloadId 0x282b5c1167ce49e4 block 8868631 (0x010409642515ca99a570e6c7e59e24f69facfe3dd6ca152f6f09d8acaa5673e8) gas used 48034876 transactions 104 reward 5.63 finney is better than the previous one by 75.08 szabo","throwable":""}
ssage":"New proposal for payloadId 0x282b5c1167ce49e4 block 8868631 (0x2e7003a60ca30efa23838f0030526e1e2ac66f3cf910a74e38321f7d8cff7a12) gas used 58801664 transactions 110 reward 5.90 finney is better than the previous one by 265.16 szabo","throwable":""}
ssage":"New proposal for payloadId 0x282b5c1167ce49e4 block 8868631 (0x701fb7040fbfee458fffa7770f102fab57583a0401cb5779942a84195a2951f4) gas used 59204940 transactions 116 reward 6.06 finney is better than the previous one by 162.91 szabo","throwable":""}
ssage":"New proposal for payloadId 0x282b5c1167ce49e4 block 8868631 (0x927ec193d44b0e9ee1a1da9ac60765aa9cb88be4c496f2608ce374ae39f8c4ad) gas used 59803260 transactions 124 reward 7.45 finney is better than the previous one by 1.39 finney","throwable":""}
ssage":"New proposal for payloadId 0x282b5c1167ce49e4 block 8868631 (0xc2f3b00cc872e38ff341cba575a3390fb94c637842764d534c33712121474053) gas used 59704574 transactions 131 reward 7.55 finney is better than the previous one by 93.00 szabo","throwable":""}
ssage":"New proposal for payloadId 0x282b5c1167ce49e4 block 8868631 (0x0770bf5d06fee7bea21a055b4b98015a05d3d6e4a8daf4d4b812c3054fe28ef7) gas used 59544564 transactions 140 reward 8.27 finney is better than the previous one by 726.54 szabo","throwable":""}
ssage":"New proposal for payloadId 0x282b5c1167ce49e4 block 8868631 (0x36061605e87b68c396cc92e8179d64660bd9ea28a4a572c4573f73fd5beeb45d) gas used 59799946 transactions 149 reward 8.99 finney is better than the previous one by 721.27 szabo","throwable":""}
ssage":"New proposal for payloadId 0x282b5c1167ce49e4 block 8868631 (0xa2833c9ae711f0afed18e2f0f4f6ea5c6b33d589370dcf65368682cde3fc533c) gas used 59993720 transactions 155 reward 9.28 finney is better than the previous one by 282.36 szabo","throwable":""}
ssage":"New proposal for payloadId 0x282b5c1167ce49e4 block 8868631 (0x60d7348e52175fa1eb464c49cb880f1ed677b83589af2337f211fb03a7bad29c) gas used 59883573 transactions 166 reward 10.00 finney is better than the previous one by 721.52 szabo","throwable":""}
ssage":"New proposal for payloadId 0x282b5c1167ce49e4 block 8868631 (0x04330317249ae6279ff78be8fba696e4c9ffe12f159241917de771af91ab7e9c) gas used 59998532 transactions 170 reward 10.12 finney is better than the previous one by 126.51 szabo","throwable":""}
ssage":"New proposal for payloadId 0x282b5c1167ce49e4 block 8868631 (0xf5918699d5e69f3cfaf18744800587f0406d113010ce047323a317ff0c9bafdb) gas used 59995548 transactions 163 reward 10.22 finney is better than the previous one by 95.62 szabo","throwable":""}
ssage":"New proposal for payloadId 0x282b5c1167ce49e4 block 8868631 (0xc784794335ed26ad51950a6fbbcf28e39cc967deebcc51513f4d09851e7fc400) gas used 59986429 transactions 178 reward 10.74 finney is better than the previous one by 525.30 szabo","throwable":""}
message":"Fetch block proposal by identifier: 0x282b5c1167ce49e4,hash: 0xc784794335ed26ad51950a6fbbcf28e39cc967deebcc51513f4d09851e7fc400, number: 8868631, coinbase: 0x3826539cbd8d68dcf119e80b994557b4278cec9f, transaction count: 178, gas used: 99.98% reward: 10.74 finney","throwable":""}
```

You can see the `Fetch block proposal by identifier:` log is back, plus all the intermediate new best proposals found, they could be a few, but since block building is not a frequent task on PoS, I do not think it is noisy, and could actually be informative and maybe entertaining :) 


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

