### PR TITLE
Invalid jump dest not charged

### DIFF
--- a/ethereum/referencetests/build.gradle
+++ b/ethereum/referencetests/build.gradle
@@ -253,7 +253,7 @@ tasks.register('validateReferenceTestSubmodule') {
   description = "Checks that the reference tests submodule is not accidentally changed"
   doLast {
     def result = new ByteArrayOutputStream()
-    def expectedHash = '9201075490807f58811078e9bb5ec895b4ac01a5'
+    def expectedHash = 'c67e485ff8b5be9abc8ad15345ec21aa22e290d9'
     def submodulePath = java.nio.file.Path.of("${rootProject.projectDir}", "ethereum/referencetests/src/reference-test/external-resources").toAbsolutePath()
     try {
       exec {

--- a/evm/src/main/java/org/hyperledger/besu/evm/EVM.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/EVM.java
@@ -214,27 +214,25 @@ public class EVM {
 
     Operation[] operationArray = operations.getOperations();
     while (frame.getState() == MessageFrame.State.CODE_EXECUTING) {
+
+      final Address contractAddress = frame.getContractAddress();
+      long statelessGas =
+          frame
+              .getAccessWitness()
+              .touchCodeChunks(
+                  contractAddress,
+                  frame.wasCreatedInTransaction(contractAddress),
+                  frame.getPC(),
+                  1,
+                  code.length,
+                  frame.getRemainingGas());
+      frame.decrementRemainingGas(statelessGas);
+
       Operation currentOperation;
       int opcode;
-      int pc = frame.getPC();
-
       try {
-        opcode = code[pc] & 0xff;
+        opcode = code[frame.getPC()] & 0xff;
         currentOperation = operationArray[opcode];
-
-        final Address contractAddress = frame.getContractAddress();
-        long statelessGas =
-            frame
-                .getAccessWitness()
-                .touchCodeChunks(
-                    contractAddress,
-                    frame.wasCreatedInTransaction(contractAddress),
-                    frame.getPC(),
-                    1,
-                    code.length,
-                    frame.getRemainingGas());
-        frame.decrementRemainingGas(statelessGas);
-
       } catch (ArrayIndexOutOfBoundsException aiiobe) {
         opcode = 0;
         currentOperation = endOfScriptStop;

--- a/evm/src/main/java/org/hyperledger/besu/evm/EVM.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/EVM.java
@@ -214,25 +214,27 @@ public class EVM {
 
     Operation[] operationArray = operations.getOperations();
     while (frame.getState() == MessageFrame.State.CODE_EXECUTING) {
-
-      final Address contractAddress = frame.getContractAddress();
-      long statelessGas =
-          frame
-              .getAccessWitness()
-              .touchCodeChunks(
-                  contractAddress,
-                  frame.wasCreatedInTransaction(contractAddress),
-                  frame.getPC(),
-                  1,
-                  code.length,
-                  frame.getRemainingGas());
-      frame.decrementRemainingGas(statelessGas);
-
       Operation currentOperation;
       int opcode;
+      int pc = frame.getPC();
+
       try {
-        opcode = code[frame.getPC()] & 0xff;
+        opcode = code[pc] & 0xff;
         currentOperation = operationArray[opcode];
+
+        final Address contractAddress = frame.getContractAddress();
+        long statelessGas =
+            frame
+                .getAccessWitness()
+                .touchCodeChunks(
+                    contractAddress,
+                    frame.wasCreatedInTransaction(contractAddress),
+                    pc,
+                    1,
+                    code.length,
+                    frame.getRemainingGas());
+        frame.decrementRemainingGas(statelessGas);
+
       } catch (ArrayIndexOutOfBoundsException aiiobe) {
         opcode = 0;
         currentOperation = endOfScriptStop;

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/JumpService.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/JumpService.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.evm.operation;
 
+import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.Code;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 
@@ -48,8 +49,17 @@ public class JumpService {
     }
 
     final Code code = frame.getCode();
-
     if (code.isJumpDestInvalid(jumpDestination)) {
+      final Address contractAddress = frame.getContractAddress();
+      frame
+          .getAccessWitness()
+          .touchCodeChunks(
+              contractAddress,
+              frame.wasCreatedInTransaction(contractAddress),
+              frame.getPC(),
+              jumpDestination - frame.getPC(),
+              code.getSize(),
+              frame.getRemainingGas());
       return invalidJumpResponse;
     }
 


### PR DESCRIPTION
## PR description
This PR is to align with Geth after https://github.com/gballet/go-ethereum/pull/530.

I noticed we are already accounting for the JUMP and JUMPI charges if jumps are valid because the next PC at the start of the interpreter loop will point to the exact code chunk to charge for but not the case where the destination is not JUMPDEST.
I also moved the touch code chunks before getting the operation because charges should come immediately after we know what's the new PC (start of the loop).

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #8150

### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

