### PR TITLE
use dummy coinbase in simulation if not defined

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/BlockHeaderBuilder.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/BlockHeaderBuilder.java
@@ -224,9 +224,13 @@ public class BlockHeaderBuilder {
     final Bytes32 prevRandao = maybePrevRandao.orElse(null);
     final Bytes32 parentBeaconBlockRoot = maybeParentBeaconBlockRoot.orElse(null);
 
+    // For PoS, coinbase is always configured, but for PoA it is not configured,
+    // rather generated for each block via MiningBeneficiaryCalculator.
+    // For simulation, if not configured, we use a dummy address 0x00.
+    // We don't throw an exception if coinbase is not configured.
     return BlockHeaderBuilder.create()
         .parentHash(parentHeader.getHash())
-        .coinbase(miningConfiguration.getCoinbase().orElseThrow())
+        .coinbase(miningConfiguration.getCoinbase().orElse(Address.ZERO))
         .difficulty(difficulty)
         .number(newBlockNumber)
         .gasLimit(gasLimit)

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/BlockSimulator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/BlockSimulator.java
@@ -388,6 +388,10 @@ public class BlockSimulator {
     long timestamp = blockOverrides.getTimestamp().orElseThrow();
     long blockNumber = blockOverrides.getBlockNumber().orElseThrow();
 
+    // For PoS, coinbase is always configured, but for PoA it is not configured,
+    // rather generated for each block via MiningBeneficiaryCalculator.
+    // For simulation, if not configured, we use a dummy address 0x00.
+    // We don't throw an exception if coinbase is not configured.
     BlockHeaderBuilder builder =
         BlockHeaderBuilder.createDefault()
             .parentHash(header.getHash())
@@ -396,7 +400,7 @@ public class BlockSimulator {
             .coinbase(
                 blockOverrides
                     .getFeeRecipient()
-                    .orElseGet(() -> miningConfiguration.getCoinbase().orElseThrow()))
+                    .orElseGet(() -> miningConfiguration.getCoinbase().orElse(Address.ZERO)))
             .difficulty(
                 blockOverrides.getDifficulty().map(Difficulty::of).orElseGet(header::getDifficulty))
             .gasLimit(


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <macfarla.github@gmail.com>
## PR description
The change #8627 to use pending by default means that `eth_estimateGas` doesn't work with QBFT networks, because the coinbase is generated for each block (is different per block, depending on which node is proposing). 

This PR changes to use a dummy coinbase rather than throwing an exception if the coinbase value is not configured. 

## Fixed Issue(s)
fixes #9022 


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [x] acceptance tests: `./gradlew acceptanceTest`
- [x] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

