### PR TITLE
chore: increase number of blobs kept in the priorized layer

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolConfiguration.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolConfiguration.java
@@ -87,7 +87,7 @@ public interface TransactionPoolConfiguration {
   long DEFAULT_PENDING_TRANSACTIONS_LAYER_MAX_CAPACITY_BYTES = 25_000_000L;
   int DEFAULT_MAX_PRIORITIZED_TRANSACTIONS = 4000;
   EnumMap<TransactionType, Integer> DEFAULT_MAX_PRIORITIZED_TRANSACTIONS_BY_TYPE =
-      new EnumMap<>(Map.of(TransactionType.BLOB, 20));
+      new EnumMap<>(Map.of(TransactionType.BLOB, 72));
   int DEFAULT_MAX_FUTURE_BY_SENDER = 200;
   Implementation DEFAULT_TX_POOL_IMPLEMENTATION = Implementation.LAYERED;
   Set<Address> DEFAULT_PRIORITY_SENDERS = Set.of();


### PR DESCRIPTION
## PR description

BPOs can include up to 72 blobs per block, so we need to keep more blobs in the prioritised layer to ensure we can build blocks with that many blobs.