### PR TITLE
[MINOR] deduplicated `JsonRpcHttpServiceTlsMisconfigurationTest`

### DIFF
--- a/app/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/app/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -437,7 +437,7 @@ public class BesuCommandTest extends CommandTestAbstract {
       // Verify TOML stores it by the appropriate type
       if (optionSpec.type().equals(Boolean.class)) {
         tomlResult.getBoolean(tomlKey);
-      } else if (optionSpec.isMultiValue() || optionSpec.arity().max > 1) {
+      } else if (optionSpec.isMultiValue() || optionSpec.arity().max() > 1) {
         tomlResult.getArray(tomlKey);
       } else if (optionSpec.type().equals(Double.class)) {
         tomlResult.getDouble(tomlKey);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTlsMisconfigurationTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTlsMisconfigurationTest.java
@@ -73,8 +73,6 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnJre;
-import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.io.TempDir;
 
 class JsonRpcHttpServiceTlsMisconfigurationTest {
@@ -206,23 +204,6 @@ class JsonRpcHttpServiceTlsMisconfigurationTest {
   }
 
   @Test
-  @DisabledOnJre({JRE.JAVA_17, JRE.JAVA_18}) // error message changed
-  void exceptionRaisedWhenInvalidKeystoreFileIsSpecified() throws IOException {
-    service =
-        createJsonRpcHttpService(
-            rpcMethods, createJsonRpcConfig(invalidKeystoreFileTlsConfiguration()));
-    assertThatExceptionOfType(CompletionException.class)
-        .isThrownBy(
-            () -> {
-              service.start().join();
-              Assertions.fail("service.start should have failed");
-            })
-        .withCauseInstanceOf(JsonRpcServiceException.class)
-        .withMessageContaining("Tag number over 30 is not supported");
-  }
-
-  @Test
-  @DisabledOnJre({JRE.JAVA_11, JRE.JAVA_12, JRE.JAVA_13, JRE.JAVA_14, JRE.JAVA_15, JRE.JAVA_16})
   void exceptionRaisedWhenInvalidKeystoreFileIsSpecified_NewJava() throws IOException {
     service =
         createJsonRpcHttpService(
@@ -305,8 +286,6 @@ class JsonRpcHttpServiceTlsMisconfigurationTest {
 
   private JsonRpcHttpService createJsonRpcHttpService(
       final Map<String, JsonRpcMethod> rpcMethods, final JsonRpcConfiguration jsonRpcConfig) {
-    final Path testDir = tempDir.resolve("createJsonRpcHttpSercice");
-    testDir.toFile().mkdirs();
     return new JsonRpcHttpService(
         vertx,
         tempDir,

--- a/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/ReferenceTestBlockchain.java
+++ b/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/ReferenceTestBlockchain.java
@@ -46,8 +46,7 @@ import org.apache.tuweni.bytes.Bytes;
  * that must not affect the execution of its transactions.
  *
  * <p>The Ethereum reference tests for VM execution (VMTests) and transaction processing
- * (GeneralStateTests) require a block's hash to be to be the hash of the string of it's block
- * number.
+ * (GeneralStateTests) require a block's hash to be the hash of the string of its block number.
  */
 public class ReferenceTestBlockchain implements Blockchain {
 


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <macfarla.github@gmail.com>

## PR description
* deduplicated 2x test that had no differences - it probably did at some point
* max -> max() optionSpec.arity().max()
* fixed some typos

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

