### PR TITLE
Improve EcRecover precompile performance

### DIFF
--- a/app/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/app/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -137,6 +137,7 @@ import org.hyperledger.besu.evm.precompile.AbstractAltBnPrecompiledContract;
 import org.hyperledger.besu.evm.precompile.AbstractBLS12PrecompiledContract;
 import org.hyperledger.besu.evm.precompile.AbstractPrecompiledContract;
 import org.hyperledger.besu.evm.precompile.BigIntegerModularExponentiationPrecompiledContract;
+import org.hyperledger.besu.evm.precompile.ECRECPrecompiledContract;
 import org.hyperledger.besu.evm.precompile.KZGPointEvalPrecompiledContract;
 import org.hyperledger.besu.evm.precompile.P256VerifyPrecompiledContract;
 import org.hyperledger.besu.metrics.BesuMetricCategory;
@@ -1356,6 +1357,18 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
     } else {
       SignatureAlgorithmFactory.getInstance().disableNative();
       logger.info("Using the Java implementation of the signature algorithm");
+    }
+
+    if (unstableNativeLibraryOptions.getNativeEcRecoverPrecompile()
+        && ECRECPrecompiledContract.maybeEnableNative()) {
+      logger.info("Using the native implementation of ecrecover precompile");
+    } else {
+      ECRECPrecompiledContract.disableNative();
+      if (SignatureAlgorithmFactory.getInstance().isNative()) {
+        logger.info("Using the native secp256k1 signature algorithm implementation of ecrecover");
+      } else {
+        logger.info("Using the Java secp256k1 implementation of ecrecover");
+      }
     }
 
     if (unstableNativeLibraryOptions.getNativeBlake2bf()

--- a/app/src/main/java/org/hyperledger/besu/cli/options/NativeLibraryOptions.java
+++ b/app/src/main/java/org/hyperledger/besu/cli/options/NativeLibraryOptions.java
@@ -60,9 +60,18 @@ public class NativeLibraryOptions {
       names = {"--Xp256verify-native-enabled"},
       description =
           "Per default a BoringSSL native library is used for p256verify. "
-              + "If the secp256r1 native implementation should be used instead, this option must be set to false",
+              + "If the secp256r1 native signature algorithm implementation should be used instead, this option must be set to false",
       arity = "1")
   private final Boolean nativeP256Verify = Boolean.TRUE;
+
+  @CommandLine.Option(
+      hidden = true,
+      names = {"--Xecrecover-precompile-native-enabled"},
+      description =
+          "Per default a native library is used for ecrecover precompile. "
+              + "If the secp256k1 native signature algorithm implementation should be used instead, this option must be set to false",
+      arity = "1")
+  private final Boolean nativeEcRecoverPrecompile = Boolean.TRUE;
 
   /** Default constructor. */
   NativeLibraryOptions() {}
@@ -119,5 +128,14 @@ public class NativeLibraryOptions {
    */
   public Boolean getNativeP256Verify() {
     return nativeP256Verify;
+  }
+
+  /**
+   * Whether native ecrecover precompile is enabled.
+   *
+   * @return true if enabled, false otherwise.
+   */
+  public Boolean getNativeEcRecoverPrecompile() {
+    return nativeEcRecoverPrecompile;
   }
 }

--- a/crypto/algorithms/src/main/java/org/hyperledger/besu/crypto/SECP256K1.java
+++ b/crypto/algorithms/src/main/java/org/hyperledger/besu/crypto/SECP256K1.java
@@ -83,6 +83,19 @@ public class SECP256K1 extends AbstractSECP256 {
     return useNative;
   }
 
+  /**
+   * Check if the native library is available.
+   *
+   * @return true if the native library is available, false otherwise.
+   */
+  public static boolean isNativeAvailable() {
+    try {
+      return LibSecp256k1.CONTEXT != null;
+    } catch (UnsatisfiedLinkError | NoClassDefFoundError e) {
+      return false;
+    }
+  }
+
   @Override
   public boolean isNative() {
     return useNative;

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/benchmarks/ECRecoverBenchmark.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/benchmarks/ECRecoverBenchmark.java
@@ -19,6 +19,7 @@ import org.hyperledger.besu.crypto.SignatureAlgorithmFactory;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.EvmSpecVersion;
 import org.hyperledger.besu.evm.fluent.EvmSpec;
+import org.hyperledger.besu.evm.precompile.ECRECPrecompiledContract;
 import org.hyperledger.besu.evm.precompile.PrecompiledContract;
 
 import java.io.PrintStream;
@@ -455,14 +456,17 @@ public class ECRecoverBenchmark extends BenchmarkExecutor {
     SignatureAlgorithm signatureAlgorithm = SignatureAlgorithmFactory.getInstance();
     if (attemptNative != null && (!attemptNative || !signatureAlgorithm.maybeEnableNative())) {
       signatureAlgorithm.disableNative();
+      ECRECPrecompiledContract.disableNative();
     }
-    output.println(signatureAlgorithm.isNative() ? "Native EcRecover" : "Java EcRecover");
+    output.println(
+        signatureAlgorithm.isNative() ? "Native LibSecp256k1JNI EcRecover" : "Java EcRecover");
 
     final PrecompiledContract contract =
         EvmSpec.evmSpec(evmSpecVersion).getPrecompileContractRegistry().get(Address.ECREC);
 
-    warmIterations = warmIterations / testCases.size();
-    execIterations = execIterations / testCases.size();
+    // TODO SLD
+    // warmIterations = warmIterations / testCases.size();
+    // execIterations = execIterations / testCases.size();
     double execTime = Double.MIN_VALUE; // a way to dodge divide by zero
     long gasCost = 0;
     for (final Map.Entry<String, Bytes> testCase : testCases.entrySet()) {

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/benchmarks/P256VerifyBenchmark.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/benchmarks/P256VerifyBenchmark.java
@@ -45,7 +45,6 @@ public class P256VerifyBenchmark extends BenchmarkExecutor {
     if (attemptNative != null && (!attemptNative || !signatureAlgorithm.maybeEnableNative())) {
       signatureAlgorithm.disableNative();
       P256VerifyPrecompiledContract.disableNativeBoringSSL();
-      ;
     }
     output.println(
         P256VerifyPrecompiledContract.isNativeBoringSSL() ? "Native BoringSSL" : "Java secp256r1");
@@ -53,6 +52,7 @@ public class P256VerifyBenchmark extends BenchmarkExecutor {
     final P256VerifyPrecompiledContract contract =
         new P256VerifyPrecompiledContract(gasCalculatorForFork(fork), signatureAlgorithm);
 
+    // TODO SLD
     //    warmIterations = warmIterations / testCases.size();
     //    execIterations = execIterations / testCases.size();
     double execTime = Double.MIN_VALUE; // a way to dodge divide by zero

--- a/evm/build.gradle
+++ b/evm/build.gradle
@@ -49,6 +49,7 @@ dependencies {
   implementation 'io.consensys.tuweni:tuweni-units'
   implementation 'org.hyperledger.besu:arithmetic'
   implementation 'org.hyperledger.besu:gnark'
+  implementation 'org.hyperledger.besu:secp256k1'
   implementation 'org.hyperledger.besu:boringssl'
   implementation 'io.consensys.protocols:jc-kzg-4844'
 

--- a/evm/src/test/java/org/hyperledger/besu/evm/precompile/ECRECPrecompiledContractTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/precompile/ECRECPrecompiledContractTest.java
@@ -349,7 +349,18 @@ class ECRECPrecompiledContractTest {
 
   @ParameterizedTest
   @MethodSource("parameters")
+  void shouldRecoverAddressNativePrecompile(final String inputString, final String expectedResult) {
+    ECRECPrecompiledContract.maybeEnableNative();
+    final Bytes input = Bytes.fromHexString(inputString);
+    final Bytes expected =
+        expectedResult == null ? Bytes.EMPTY : Bytes32.fromHexString(expectedResult);
+    assertThat(contract.computePrecompile(input, messageFrame).output()).isEqualTo(expected);
+  }
+
+  @ParameterizedTest
+  @MethodSource("parameters")
   void shouldRecoverAddressNative(final String inputString, final String expectedResult) {
+    ECRECPrecompiledContract.disableNative();
     contract.signatureAlgorithm.maybeEnableNative();
     final Bytes input = Bytes.fromHexString(inputString);
     final Bytes expected =


### PR DESCRIPTION
- Use LibSecp256k1JNI by default and fallback to SECP256K1 signature algorithm which uses LibSecp256k1 native lib (as well as Java fallback).
- ECRecoverBenchmark switches between LibSecp256k1JNI and Java.
- Add --Xecrecover-precompile-native-enabled to disable LibSecp256k1JNI.

Flag combinations showing interaction between LibSecp256k1JNI used for precompile-only versus SECP256K1 used for precompile fallback as well as other key operations apart from EcRecover. The default for both flags is `true`:

default:
```
--Xecrecover-precompile-native-enabled=true --Xsecp-native-enabled=true
2025-08-11 13:16:34.899+10:00 | main | INFO  | Besu | Using the native implementation of the signature algorithm
2025-08-11 13:16:35.039+10:00 | main | INFO  | Besu | Using the native implementation of ecrecover precompile
 ```

JNI lib used for ecrecover, but Java used for other secp operations:
```
--Xecrecover-precompile-native-enabled=true --Xsecp-native-enabled=false
2025-08-11 13:16:48.220+10:00 | main | INFO  | Besu | Using the Java implementation of the signature algorithm
2025-08-11 13:16:48.373+10:00 | main | INFO  | Besu | Using the native implementation of ecrecover precompile
```
 
Disable JNI lib, fallback to SECP256K1 for ecrecover:
 ```
 --Xecrecover-precompile-native-enabled=false --Xsecp-native-enabled=true
 2025-08-11 13:16:15.395+10:00 | main | INFO  | Besu | Using the native implementation of the signature algorithm
2025-08-11 13:16:15.544+10:00 | main | INFO  | Besu | Using the native secp256k1 signature algorithm implementation of ecrecover
 ```
 
 Disable both, use Java for ecrecover:
 ```
 --Xecrecover-precompile-native-enabled=false --Xsecp-native-enabled=false
 2025-08-11 13:16:03.316+10:00 | main | INFO  | Besu | Using the Java implementation of the signature algorithm
2025-08-11 13:16:03.560+10:00 | main | INFO  | Besu | Using the Java secp256k1 implementation of ecrecover
```
