### PR TITLE
Fix SnapServerTest for `FlatDbMode.ARCHIVE`

### DIFF
--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/snap/SnapServerTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/snap/SnapServerTest.java
@@ -882,6 +882,12 @@ public class SnapServerTest {
     }
     storageTrie.commit(updater::putAccountStateTrieNode);
     updater.commit();
+    inMemoryStorage
+        .getWorldStateBlockNumber()
+        .ifPresent(
+            currentBlock ->
+                updateStorageArchiveBlock(
+                    inMemoryStorage.getComposedWorldStateStorage(), currentBlock + 1));
   }
 
   boolean assertIsValidAccountRangeProof(


### PR DESCRIPTION
The tests in `SnapServerTest` are currently failing for `FlatDbMode.ARCHIVE`.

In `FlatDbMode.ARCHIVE`, every flat database read and write needs a context that is taken from `WORLD_BLOCK_NUMBER_KEY`. The write path adds one to this value before storing the entry, while the read path uses the stored value directly.

Because `insertTestAccounts` never increments the block number after committing, subsequent reads look for data tagged with the old block context and fail to find the written value.

