### PR TITLE
Extend `CallParameter` for unsigned delegation

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/SimulationCodeDelegation.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/SimulationCodeDelegation.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.core;
+
+import org.hyperledger.besu.crypto.SECPSignature;
+import org.hyperledger.besu.crypto.SignatureAlgorithm;
+import org.hyperledger.besu.crypto.SignatureAlgorithmFactory;
+import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.datatypes.CodeDelegation;
+import org.hyperledger.besu.ethereum.core.json.ChainIdDeserializer;
+
+import java.math.BigInteger;
+import java.util.Optional;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.apache.tuweni.bytes.Bytes;
+
+/**
+ * Code delegation used only for simulations where the authority is provided directly rather than
+ * recovered from a signature.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SimulationCodeDelegation implements CodeDelegation {
+  private static final SignatureAlgorithm SIGNATURE_ALGORITHM =
+      SignatureAlgorithmFactory.getInstance();
+  // A placeholder SECPSignature is needed to satisfy the CodeDelegation interface. This approach is
+  // consistent
+  // with the simulator’s existing use of a fixed fake signature for transactions and does not leak
+  // into any
+  // transaction-handling code.
+  private static final SECPSignature DUMMY_SIGNATURE =
+      SIGNATURE_ALGORITHM.createSignature(BigInteger.ONE, BigInteger.ONE, (byte) 0);
+
+  private final BigInteger chainId;
+  private final Address address;
+  private final long nonce;
+  private final Address authority;
+
+  @JsonCreator
+  public SimulationCodeDelegation(
+      @JsonProperty("chainId") @JsonDeserialize(using = ChainIdDeserializer.class)
+          final BigInteger chainId,
+      @JsonProperty("address") final Address address,
+      @JsonProperty("nonce") final String nonce,
+      @JsonProperty("authority") final Address authority) {
+    this.chainId = chainId;
+    this.address = address;
+    this.nonce = Bytes.fromHexString(nonce).toLong();
+    this.authority = authority;
+  }
+
+  @Override
+  @JsonProperty("chainId")
+  public BigInteger chainId() {
+    return chainId;
+  }
+
+  @Override
+  @JsonProperty("address")
+  public Address address() {
+    return address;
+  }
+
+  @Override
+  @JsonIgnore
+  public SECPSignature signature() {
+    return DUMMY_SIGNATURE;
+  }
+
+  @Override
+  @JsonProperty("authority")
+  public Optional<Address> authorizer() {
+    return Optional.of(authority);
+  }
+
+  @Override
+  public long nonce() {
+    return nonce;
+  }
+
+  @Override
+  @JsonIgnore
+  public byte v() {
+    return DUMMY_SIGNATURE.getRecId();
+  }
+
+  @Override
+  @JsonIgnore
+  public BigInteger r() {
+    return DUMMY_SIGNATURE.getR();
+  }
+
+  @Override
+  @JsonIgnore
+  public BigInteger s() {
+    return DUMMY_SIGNATURE.getS();
+  }
+}

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/CallParameter.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/CallParameter.java
@@ -78,7 +78,7 @@ public abstract class CallParameter implements org.hyperledger.besu.datatypes.Ca
 
   @Override
   @JsonProperty("authorizationList")
-  @JsonDeserialize(contentAs = org.hyperledger.besu.ethereum.core.CodeDelegation.class)
+  @JsonDeserialize(contentUsing = CodeDelegationParameterDeserializer.class)
   public abstract List<CodeDelegation> getCodeDelegationAuthorizations();
 
   @Override

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/CodeDelegationParameterDeserializer.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/CodeDelegationParameterDeserializer.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.transaction;
+
+import org.hyperledger.besu.datatypes.CodeDelegation;
+import org.hyperledger.besu.ethereum.core.SimulationCodeDelegation;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Deserializes code delegation entries for call parameters, accepting either signed delegations or
+ * simulation-only delegations that specify an authority directly.
+ */
+public class CodeDelegationParameterDeserializer extends JsonDeserializer<CodeDelegation> {
+
+  @Override
+  public CodeDelegation deserialize(final JsonParser p, final DeserializationContext ctxt)
+      throws IOException {
+    final ObjectMapper mapper = (ObjectMapper) p.getCodec();
+    final JsonNode node = mapper.readTree(p);
+
+    final boolean hasAuthority = node.hasNonNull("authority");
+    final boolean hasSignature =
+        node.hasNonNull("r")
+            || node.hasNonNull("s")
+            || node.hasNonNull("v")
+            || node.hasNonNull("yParity");
+
+    if (hasAuthority && hasSignature) {
+      throw new IllegalArgumentException(
+          "code delegation cannot specify both authority and signature fields");
+    }
+
+    if (hasAuthority) {
+      return mapper.treeToValue(node, SimulationCodeDelegation.class);
+    }
+
+    return mapper.treeToValue(node, org.hyperledger.besu.ethereum.core.CodeDelegation.class);
+  }
+}


### PR DESCRIPTION
Adds support for `authorizationList` entries in `CallParameter` that specify an `authority` instead of a signature, for use in simulation endpoints.

* Introduces `SimulationCodeDelegation` class to represent unsigned delegations.
* Adds `CodeDelegationParameterDeserializer` to accept either signed or unsigned forms and reject inputs that contain both authority and signature fields.
* Includes tests for serialization, deserialization, and invalid mixed cases.

Closes: #9043