### PR TITLE
Propagate `EvmConfiguration` to `PathBasedCachedWorldStorageManager`

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/common/GenesisWorldStateProvider.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/common/GenesisWorldStateProvider.java
@@ -80,7 +80,8 @@ public class GenesisWorldStateProvider {
     return new BonsaiWorldState(
         bonsaiWorldStateKeyValueStorage,
         bonsaiCachedMerkleTrieLoader,
-        new NoOpBonsaiCachedWorldStorageManager(bonsaiWorldStateKeyValueStorage, codeCache),
+        new NoOpBonsaiCachedWorldStorageManager(
+            bonsaiWorldStateKeyValueStorage, EvmConfiguration.DEFAULT, codeCache),
         new NoOpTrieLogManager(),
         EvmConfiguration.DEFAULT,
         createStatefulConfigWithTrie(),

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/BonsaiWorldStateProvider.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/BonsaiWorldStateProvider.java
@@ -62,7 +62,7 @@ public class BonsaiWorldStateProvider extends PathBasedWorldStateProvider {
     this.evmConfiguration = evmConfiguration;
     provideCachedWorldStorageManager(
         new BonsaiCachedWorldStorageManager(
-            this, worldStateKeyValueStorage, worldStateConfig, codeCache));
+            this, worldStateKeyValueStorage, evmConfiguration, worldStateConfig, codeCache));
     loadHeadWorldState(
         new BonsaiWorldState(
             this, worldStateKeyValueStorage, evmConfiguration, worldStateConfig, codeCache));

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/cache/BonsaiCachedWorldStorageManager.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/cache/BonsaiCachedWorldStorageManager.java
@@ -26,15 +26,23 @@ import org.hyperledger.besu.ethereum.trie.pathbased.common.worldview.PathBasedWo
 import org.hyperledger.besu.ethereum.trie.pathbased.common.worldview.WorldStateConfig;
 import org.hyperledger.besu.evm.internal.EvmConfiguration;
 
+import java.util.concurrent.ConcurrentHashMap;
+
 public class BonsaiCachedWorldStorageManager extends PathBasedCachedWorldStorageManager {
   private final CodeCache codeCache;
 
   public BonsaiCachedWorldStorageManager(
       final BonsaiWorldStateProvider archive,
       final PathBasedWorldStateKeyValueStorage worldStateKeyValueStorage,
+      final EvmConfiguration evmConfiguration,
       final WorldStateConfig worldStateConfig,
       final CodeCache codeCache) {
-    super(archive, worldStateKeyValueStorage, worldStateConfig);
+    super(
+        archive,
+        worldStateKeyValueStorage,
+        new ConcurrentHashMap<>(),
+        evmConfiguration,
+        worldStateConfig);
 
     this.codeCache = codeCache;
   }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/cache/NoOpBonsaiCachedWorldStorageManager.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/cache/NoOpBonsaiCachedWorldStorageManager.java
@@ -19,6 +19,7 @@ import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.trie.pathbased.bonsai.storage.BonsaiWorldStateKeyValueStorage;
 import org.hyperledger.besu.ethereum.trie.pathbased.common.worldview.PathBasedWorldState;
 import org.hyperledger.besu.ethereum.trie.pathbased.common.worldview.WorldStateConfig;
+import org.hyperledger.besu.evm.internal.EvmConfiguration;
 
 import java.util.Optional;
 import java.util.function.Function;
@@ -27,10 +28,12 @@ public class NoOpBonsaiCachedWorldStorageManager extends BonsaiCachedWorldStorag
 
   public NoOpBonsaiCachedWorldStorageManager(
       final BonsaiWorldStateKeyValueStorage bonsaiWorldStateKeyValueStorage,
+      final EvmConfiguration evmConfiguration,
       final CodeCache codeCache) {
     super(
         null,
         bonsaiWorldStateKeyValueStorage,
+        evmConfiguration,
         WorldStateConfig.createStatefulConfigWithTrie(),
         codeCache);
   }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/cache/PathBasedCachedWorldStorageManager.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/cache/PathBasedCachedWorldStorageManager.java
@@ -33,7 +33,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
@@ -59,7 +58,7 @@ public abstract class PathBasedCachedWorldStorageManager implements StorageSubsc
   private final PathBasedWorldStateKeyValueStorage rootWorldStateStorage;
   private final Map<Bytes32, PathBasedCachedWorldView> cachedWorldStatesByHash;
 
-  private PathBasedCachedWorldStorageManager(
+  public PathBasedCachedWorldStorageManager(
       final PathBasedWorldStateProvider archive,
       final PathBasedWorldStateKeyValueStorage worldStateKeyValueStorage,
       final Map<Bytes32, PathBasedCachedWorldView> cachedWorldStatesByHash,
@@ -71,18 +70,6 @@ public abstract class PathBasedCachedWorldStorageManager implements StorageSubsc
     this.archive = archive;
     this.evmConfiguration = evmConfiguration;
     this.worldStateConfig = worldStateConfig;
-  }
-
-  public PathBasedCachedWorldStorageManager(
-      final PathBasedWorldStateProvider archive,
-      final PathBasedWorldStateKeyValueStorage worldStateKeyValueStorage,
-      final WorldStateConfig worldStateConfig) {
-    this(
-        archive,
-        worldStateKeyValueStorage,
-        new ConcurrentHashMap<>(),
-        EvmConfiguration.DEFAULT,
-        worldStateConfig);
   }
 
   public synchronized void addCachedLayer(

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/cache/PathBasedCachedWorldStorageManager.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/cache/PathBasedCachedWorldStorageManager.java
@@ -58,7 +58,7 @@ public abstract class PathBasedCachedWorldStorageManager implements StorageSubsc
   private final PathBasedWorldStateKeyValueStorage rootWorldStateStorage;
   private final Map<Bytes32, PathBasedCachedWorldView> cachedWorldStatesByHash;
 
-  public PathBasedCachedWorldStorageManager(
+  protected PathBasedCachedWorldStorageManager(
       final PathBasedWorldStateProvider archive,
       final PathBasedWorldStateKeyValueStorage worldStateKeyValueStorage,
       final Map<Bytes32, PathBasedCachedWorldView> cachedWorldStatesByHash,

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/parallelization/ParallelizedConcurrentTransactionProcessorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/parallelization/ParallelizedConcurrentTransactionProcessorTest.java
@@ -90,7 +90,7 @@ class ParallelizedConcurrentTransactionProcessorTest {
             bonsaiWorldStateKeyValueStorage,
             new NoopBonsaiCachedMerkleTrieLoader(),
             new NoOpBonsaiCachedWorldStorageManager(
-                bonsaiWorldStateKeyValueStorage, new CodeCache()),
+                bonsaiWorldStateKeyValueStorage, EvmConfiguration.DEFAULT, new CodeCache()),
             new NoOpTrieLogManager(),
             EvmConfiguration.DEFAULT,
             createStatefulConfigWithTrie(),

--- a/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/BonsaiReferenceTestWorldState.java
+++ b/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/BonsaiReferenceTestWorldState.java
@@ -242,7 +242,8 @@ public class BonsaiReferenceTestWorldState extends BonsaiWorldState
         new BonsaiReferenceTestWorldStateStorage(bonsaiWorldStateKeyValueStorage, preImageProxy);
 
     final NoOpBonsaiCachedWorldStorageManager noOpCachedWorldStorageManager =
-        new NoOpBonsaiCachedWorldStorageManager(bonsaiWorldStateKeyValueStorage, new CodeCache());
+        new NoOpBonsaiCachedWorldStorageManager(
+            bonsaiWorldStateKeyValueStorage, EvmConfiguration.DEFAULT, new CodeCache());
 
     final BonsaiReferenceTestWorldState worldState =
         new BonsaiReferenceTestWorldState(


### PR DESCRIPTION
`PathBasedCachedWorldStorageManager` currently only offers a public constructor that defaults to `EvmConfiguration.DEFAULT`, which always sets the world updater mode to `STACKED`.

Later, when world states are created e.g. during block processing through `BonsaiCachedWorldStorageManager`, those states are built with this default configuration, ignoring configuration set via `--Xevm-worldstate-update-mode` CLI flag.

In order to allow setting the world state update mode via CLI flag, this PR
* extends the constructor of `BonsaiCachedWorldStorageManager` to accept `EvmConfiguration`, and
* passes the global `EvmConfiguration` from `BonsaiWorldStateProvider` to `BonsaiCachedWorldStorageManager` on construction.