### PR TITLE
fix: potential NullPointerException in `abort(Throwable)`

### DIFF
--- a/services/pipeline/src/main/java/org/hyperledger/besu/services/pipeline/Pipeline.java
+++ b/services/pipeline/src/main/java/org/hyperledger/besu/services/pipeline/Pipeline.java
@@ -198,9 +198,6 @@ public class Pipeline<I> {
             try {
               abort(t);
             } catch (final Throwable t2) {
-              // Seems excessive but exceptions that propagate out of this method won't be logged
-              // because the executor just completes the future exceptionally, and we never
-              // need to call get on it which would normally expose the error.
               LOG.error("Failed to abort pipeline after error", t2);
             }
           } finally {
@@ -216,7 +213,9 @@ public class Pipeline<I> {
     if (completing.compareAndSet(false, true)) {
       inputPipe.abort();
       pipes.forEach(Pipe::abort);
-      futures.forEach(future -> future.cancel(true));
+      if (futures != null) {
+        futures.forEach(future -> future.cancel(true));
+      }
       overallFuture.completeExceptionally(error);
     }
   }


### PR DESCRIPTION
## PR description

added a null check for `futures` in the `abort(Throwable)` method to prevent a `NullPointerException` when `abort()` is called before `start()`.

## Fixed Issue(s)

potential `NullPointerException` when calling `abort()` before `start()`.

### Thanks for sending a pull request! Have you done the following?

* [x] Checked out our [[contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
* [x] Considered documentation and added the `doc-change-required` label to this PR [[if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation)](https://wiki.hyperledger.org/display/BESU/Documentation).
* [x] Considered the changelog and included an [[update if required](https://wiki.hyperledger.org/display/BESU/Changelog)](https://wiki.hyperledger.org/display/BESU/Changelog).
* [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

* [x] spotless: `./gradlew spotlessApply`
* [x] unit tests: `./gradlew build`
* [x] acceptance tests: `./gradlew acceptanceTest`
* [x] integration tests: `./gradlew integrationTest`
* [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
