### PR TITLE
allow underpriced ie below baseFee

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AbstractEstimateGas.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AbstractEstimateGas.java
@@ -199,7 +199,7 @@ public abstract class AbstractEstimateGas extends AbstractBlockParameterMethod {
 
     return isAllowExceedingBalance
         ? TransactionValidationParams.transactionSimulatorAllowExceedingBalanceAndFutureNonce()
-        : TransactionValidationParams.transactionSimulatorAllowFutureNonce();
+        : TransactionValidationParams.transactionSimulatorAllowUnderpricedAndFutureNonce();
   }
 
   @VisibleForTesting

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_estimateGas_from_contract.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_estimateGas_from_contract.json
@@ -7,6 +7,7 @@
       {
         "to": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
         "from": "0x6295ee1b4f6dd65047762f924ecd367c17eabf8f",
+        "gasPrice": "0x0",
         "data": "0x123456"
       }
     ]
@@ -14,9 +15,7 @@
   "response": {
     "jsonrpc": "2.0",
     "id": 3,
-    "error":{
-      "code":-32004,
-      "message":"Upfront cost exceeds account balance (transaction up-front cost 0x1120ed6c5d23b0 exceeds transaction sender account balance 0x140)"}
+    "result": "0x52dd"
   },
   "statusCode": 200
 }

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_estimateGas_transfer_zeroGas.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_estimateGas_transfer_zeroGas.json
@@ -1,0 +1,21 @@
+{
+  "request": {
+    "id": 3,
+    "jsonrpc": "2.0",
+    "method": "eth_estimateGas",
+    "params": [
+      {
+        "from": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+        "to": "0x8888f1f195afa192cfee860698584c030f4c9db1",
+        "gasPrice": "0x000000000000000000000000000000000000000000000000000000002dbc88c0",
+        "value": "0x1"
+      }
+    ]
+  },
+  "response": {
+    "jsonrpc": "2.0",
+    "id": 3,
+    "result": "0x5208"
+  },
+  "statusCode": 200
+}

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionValidator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionValidator.java
@@ -217,6 +217,7 @@ public class MainnetTransactionValidator implements TransactionValidator {
       final Wei price = feeMarket.getTransactionPriceCalculator().price(transaction, maybeBaseFee);
       if (!transactionValidationParams.allowUnderpriced()
           && price.compareTo(maybeBaseFee.orElseThrow()) < 0) {
+        LOG.debug("gasPrice {} is less than the current baseFee {}", price, maybeBaseFee);
         return ValidationResult.invalid(
             TransactionInvalidReason.GAS_PRICE_BELOW_CURRENT_BASE_FEE,
             "gasPrice is less than the current BaseFee");


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <macfarla.github@gmail.com>
## PR description
Allow underpriced (ie below baseFee) tx for eth_estimateGas

## Fixed Issue(s)
fixes #9051 


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

