### PR TITLE
log system call address and frame state when system call fails

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/systemcall/SystemCallProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/systemcall/SystemCallProcessor.java
@@ -24,6 +24,7 @@ import org.hyperledger.besu.evm.Code;
 import org.hyperledger.besu.evm.account.Account;
 import org.hyperledger.besu.evm.blockhash.BlockHashLookup;
 import org.hyperledger.besu.evm.code.CodeV0;
+import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.processor.AbstractMessageProcessor;
 import org.hyperledger.besu.evm.tracing.OperationTracer;
@@ -88,7 +89,8 @@ public class SystemCallProcessor {
             inputData);
 
     if (!frame.getCode().isValid()) {
-      throw new RuntimeException("System call did not execute to completion - opcode invalid");
+      throw new RuntimeException(
+          "System call did not execute to completion - opcode invalid at address: " + callAddress);
     }
 
     Deque<MessageFrame> stack = frame.getMessageFrameStack();
@@ -102,6 +104,11 @@ public class SystemCallProcessor {
     }
 
     // The call must execute to completion
+    LOG.error(
+        "System call did not execute to completion - haltReason: {}, address: {}, frame state: {}",
+        frame.getExceptionalHaltReason().orElse(ExceptionalHaltReason.NONE),
+        callAddress,
+        frame.getState());
     String errorMessage =
         frame
             .getExceptionalHaltReason()


### PR DESCRIPTION
## PR description
log system call address and frame state when system call fails to help with debugging system call failures.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

