### PR TITLE
Feat (api): Add more information on NewPayload validation logs

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayload.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayload.java
@@ -571,29 +571,33 @@ public abstract class AbstractEngineNewPayload extends ExecutionEngineJsonRpcMet
 
     // Validate excessBlobGas
     if (maybeParentHeader.isPresent()) {
-      Optional<BlobGas> maybeCalculatedExcess = validateExcessBlobGas(header, maybeParentHeader.get(), protocolSpec);
+      Optional<BlobGas> maybeCalculatedExcess =
+          validateExcessBlobGas(header, maybeParentHeader.get(), protocolSpec);
       if (maybeCalculatedExcess.isPresent()) {
         BlobGas calculated = maybeCalculatedExcess.get();
         BlobGas actual = header.getExcessBlobGas().orElse(BlobGas.ZERO);
         return ValidationResult.invalid(
             RpcErrorType.INVALID_EXCESS_BLOB_GAS_PARAMS,
-            String.format("Payload excessBlobGas does not match calculated excessBlobGas. Expected %s, got %s",
-                    calculated, actual));
+            String.format(
+                "Payload excessBlobGas does not match calculated excessBlobGas. Expected %s, got %s",
+                calculated, actual));
       }
     }
 
-      // Validate blobGasUsed
-      if (header.getBlobGasUsed().isPresent() && maybeVersionedHashes.isPresent()) {
-          Optional<Long> maybeCalculatedBlobGas = validateBlobGasUsed(header, maybeVersionedHashes.get(), protocolSpec);
-          if (maybeCalculatedBlobGas.isPresent()) {
-              long calculated = maybeCalculatedBlobGas.get();
-              long actual = header.getBlobGasUsed().orElse(0L);
-              return ValidationResult.invalid(
-                      RpcErrorType.INVALID_BLOB_GAS_USED_PARAMS,
-                      String.format("Payload BlobGasUsed does not match calculated BlobGasUsed. Expected %s, got %s",
-                              calculated, actual));
-          }
+    // Validate blobGasUsed
+    if (header.getBlobGasUsed().isPresent() && maybeVersionedHashes.isPresent()) {
+      Optional<Long> maybeCalculatedBlobGas =
+          validateBlobGasUsed(header, maybeVersionedHashes.get(), protocolSpec);
+      if (maybeCalculatedBlobGas.isPresent()) {
+        long calculated = maybeCalculatedBlobGas.get();
+        long actual = header.getBlobGasUsed().orElse(0L);
+        return ValidationResult.invalid(
+            RpcErrorType.INVALID_BLOB_GAS_USED_PARAMS,
+            String.format(
+                "Payload BlobGasUsed does not match calculated BlobGasUsed. Expected %s, got %s",
+                calculated, actual));
       }
+    }
 
     if (protocolSpec.getGasCalculator().blobGasCost(transactionVersionedHashes.size())
         > protocolSpec.getGasLimitCalculator().currentBlobGasLimit()) {
@@ -606,19 +610,22 @@ public abstract class AbstractEngineNewPayload extends ExecutionEngineJsonRpcMet
 
   private Optional<BlobGas> validateExcessBlobGas(
       final BlockHeader header, final BlockHeader parentHeader, final ProtocolSpec protocolSpec) {
-      BlobGas calculated = ExcessBlobGasCalculator.calculateExcessBlobGasForParent(protocolSpec, parentHeader);
-      BlobGas actual = parentHeader.getExcessBlobGas().orElse(BlobGas.ZERO);
+    BlobGas calculated =
+        ExcessBlobGasCalculator.calculateExcessBlobGasForParent(protocolSpec, parentHeader);
+    BlobGas actual = parentHeader.getExcessBlobGas().orElse(BlobGas.ZERO);
 
-      return calculated.equals(actual) ? Optional.empty() : Optional.of(calculated);
+    return calculated.equals(actual) ? Optional.empty() : Optional.of(calculated);
   }
 
   private Optional<Long> validateBlobGasUsed(
-      final BlockHeader header, final List<VersionedHash> versionedHashes, final ProtocolSpec protocolSpec) {
-      long calculated = protocolSpec.getGasCalculator().blobGasCost(versionedHashes.size());
-      long actual = header.getBlobGasUsed().orElse(0L);
+      final BlockHeader header,
+      final List<VersionedHash> versionedHashes,
+      final ProtocolSpec protocolSpec) {
+    long calculated = protocolSpec.getGasCalculator().blobGasCost(versionedHashes.size());
+    long actual = header.getBlobGasUsed().orElse(0L);
 
-      return calculated == actual ? Optional.empty() : Optional.of(calculated);
-    }
+    return calculated == actual ? Optional.empty() : Optional.of(calculated);
+  }
 
   private Optional<List<VersionedHash>> extractVersionedHashes(
       final Optional<List<String>> maybeVersionedHashParam) {


### PR DESCRIPTION
## PR description
Enhanced engine API blob validation error messages to include specific expected and actual values. 
Previously, validation failures only returned generic messages like "Payload excessBlobGas does not match calculated excessBlobGas". Now they will provide detailed information matching other clients like Nethermind: "Expected 20107103, got 18988895". 
This change modifies error message formatting in AbstractEngineNewPayload.validateBlobs() for both excessBlobGas and blobGasUsed validation failures.
Changes
- modified validateBlobs() method: Updated error message formatting to include calculated vs actual values for both excess blob gas and blob gas used validation failures
- modifierd validateExcessBlobGas() and validateBlobGasUsed() helper methods: These private methods now extract and return the calculated values that are used in the improved error messages instead of boolean validation results like before.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fixes: #9071 


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

