### PR TITLE
feat: Soft failure reason for evm op results

### DIFF
--- a/evm/src/main/java/org/hyperledger/besu/evm/frame/SoftFailureReason.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/frame/SoftFailureReason.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.evm.frame;
+
+/** The interface Soft Failure reason. */
+public interface SoftFailureReason {
+
+  /** The constant NONE. */
+  SoftFailureReason NONE = DefaultSelfFailureReason.NONE;
+
+  /** The constant INSUFFICIENT_BALANCE */
+  SoftFailureReason INSUFFICIENT_BALANCE = DefaultSelfFailureReason.INSUFFICIENT_BALANCE;
+
+  /** The constant MAX_CALL_DEPTH */
+  SoftFailureReason MAX_CALL_DEPTH = DefaultSelfFailureReason.MAX_CALL_DEPTH;
+
+  /**
+   * Name string.
+   *
+   * @return the string
+   */
+  String name();
+
+  /**
+   * Gets description.
+   *
+   * @return the description
+   */
+  String getDescription();
+
+  /** The enum Default self failure reasons. */
+  enum DefaultSelfFailureReason implements SoftFailureReason {
+    /** None default soft failure reason. */
+    NONE(""),
+    /** Soft failure due to insufficient balance for transfer */
+    INSUFFICIENT_BALANCE("insufficient balance for transfer"),
+    /** Soft failure due to max call depth */
+    MAX_CALL_DEPTH("max call depth exceeded");
+
+    /** The Description of soft failure. */
+    final String description;
+
+    /**
+     * Instantiate DefaultSelfFailureReason with a description
+     *
+     * @param description The description to use
+     */
+    DefaultSelfFailureReason(final String description) {
+      this.description = description;
+    }
+
+    @Override
+    public String getDescription() {
+      return description;
+    }
+  }
+}

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/AbstractCreateOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/AbstractCreateOperation.java
@@ -120,7 +120,7 @@ public abstract class AbstractCreateOperation extends AbstractOperation {
         frame.incrementRemainingGas(cost);
       }
     }
-    return new OperationResult(cost, null, getPcIncrement());
+    return new OperationResult(cost, getPcIncrement());
   }
 
   /**

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/AbstractExtCallOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/AbstractExtCallOperation.java
@@ -23,6 +23,7 @@ import org.hyperledger.besu.evm.EVM;
 import org.hyperledger.besu.evm.account.Account;
 import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.frame.SoftFailureReason;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.internal.Words;
 
@@ -200,13 +201,13 @@ public abstract class AbstractExtCallOperation extends AbstractCallOperation {
         .build();
 
     frame.setState(MessageFrame.State.CODE_SUSPENDED);
-    return new OperationResult(clampedAdd(cost, childGas), null, 0);
+    return new OperationResult(clampedAdd(cost, childGas), 0);
   }
 
   private @NotNull OperationResult softFailure(final MessageFrame frame, final long cost) {
     frame.popStackItems(getStackItemsConsumed());
     frame.pushStackItem(EOF1_EXCEPTION_STACK_ITEM);
-    return new OperationResult(cost, null);
+    return new OperationResult(cost, SoftFailureReason.NONE); // TODO: Add actual reason
   }
 
   @Override

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/JumpOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/JumpOperation.java
@@ -24,7 +24,7 @@ public class JumpOperation extends AbstractFixedCostOperation {
 
   private static final Operation.OperationResult invalidJumpResponse =
       new Operation.OperationResult(8L, ExceptionalHaltReason.INVALID_JUMP_DESTINATION);
-  private static final OperationResult jumpResponse = new OperationResult(8L, null, 0);
+  private static final OperationResult jumpResponse = new OperationResult(8L, 0);
 
   private static final JumpService jumpService = new JumpService();
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/JumpiOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/JumpiOperation.java
@@ -26,8 +26,8 @@ public class JumpiOperation extends AbstractFixedCostOperation {
 
   private static final OperationResult invalidJumpResponse =
       new Operation.OperationResult(10L, ExceptionalHaltReason.INVALID_JUMP_DESTINATION);
-  private static final OperationResult jumpiResponse = new OperationResult(10L, null, 0);
-  private static final OperationResult nojumpResponse = new OperationResult(10L, null);
+  private static final OperationResult jumpiResponse = new OperationResult(10L, 0);
+  private static final OperationResult nojumpResponse = new OperationResult(10L, 1);
 
   private static final JumpService jumpService = new JumpService();
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/Operation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/Operation.java
@@ -17,6 +17,9 @@ package org.hyperledger.besu.evm.operation;
 import org.hyperledger.besu.evm.EVM;
 import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.frame.SoftFailureReason;
+
+import java.util.Optional;
 
 /** The interface Operation. */
 public interface Operation {
@@ -29,11 +32,15 @@ public interface Operation {
     /** The Halt reason. */
     final ExceptionalHaltReason haltReason;
 
+    /** The soft failure reason that didn't result in revert of the operation */
+    final SoftFailureReason softFailureReason;
+
     /** The increment. */
     final int pcIncrement;
 
     /**
-     * Instantiates a new Operation result.
+     * Instantiates a new Operation result with exceptional halt reason which can result in revert
+     * of operation.
      *
      * @param gasCost the gas cost
      * @param haltReason the halt reason
@@ -43,7 +50,18 @@ public interface Operation {
     }
 
     /**
-     * Instantiates a new Operation result.
+     * Instantiates a new Operation result with soft failure reason which doesn't result in a
+     * revert.
+     *
+     * @param gasCost the gas cost
+     * @param softFailureReason the error reason which doesn't result in halt of operation
+     */
+    public OperationResult(final long gasCost, final SoftFailureReason softFailureReason) {
+      this(gasCost, null, softFailureReason, 1);
+    }
+
+    /**
+     * Instantiates a new Operation result with exceptional halt reason and increment.
      *
      * @param gasCost the gas cost
      * @param haltReason the halt reason
@@ -51,8 +69,35 @@ public interface Operation {
      */
     public OperationResult(
         final long gasCost, final ExceptionalHaltReason haltReason, final int pcIncrement) {
+      this(gasCost, haltReason, null, pcIncrement);
+    }
+
+    /**
+     * Instantiate a new Operation Result without any failures.
+     *
+     * @param gasCost Gas Cost
+     * @param pcIncrement Increment
+     */
+    public OperationResult(final long gasCost, final int pcIncrement) {
+      this(gasCost, null, null, pcIncrement);
+    }
+
+    /**
+     * Instantiate a new Operation Result
+     *
+     * @param gasCost the Gas Cost
+     * @param haltReason The Halt reason
+     * @param softFailureReason The soft failure reason that doesn't result in revert.
+     * @param pcIncrement The increment
+     */
+    public OperationResult(
+        long gasCost,
+        ExceptionalHaltReason haltReason,
+        SoftFailureReason softFailureReason,
+        int pcIncrement) {
       this.gasCost = gasCost;
       this.haltReason = haltReason;
+      this.softFailureReason = softFailureReason;
       this.pcIncrement = pcIncrement;
     }
 
@@ -72,6 +117,15 @@ public interface Operation {
      */
     public ExceptionalHaltReason getHaltReason() {
       return haltReason;
+    }
+
+    /**
+     * Gets Soft Failure Reason.
+     *
+     * @return optional soft failure reason
+     */
+    public Optional<SoftFailureReason> getSoftFailureReason() {
+      return Optional.ofNullable(softFailureReason);
     }
 
     /**

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/PayOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/PayOperation.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.evm.operation;
 
+import static org.hyperledger.besu.evm.frame.SoftFailureReason.INSUFFICIENT_BALANCE;
 import static org.hyperledger.besu.evm.internal.Words.clampedAdd;
 import static org.hyperledger.besu.evm.operation.AbstractCallOperation.LEGACY_FAILURE_STACK_ITEM;
 import static org.hyperledger.besu.evm.operation.AbstractCallOperation.LEGACY_SUCCESS_STACK_ITEM;
@@ -71,14 +72,14 @@ public class PayOperation extends AbstractOperation {
     if (!hasValue || Objects.equals(frame.getSenderAddress(), to)) {
       frame.popStackItems(getStackItemsConsumed());
       frame.pushStackItem(LEGACY_SUCCESS_STACK_ITEM);
-      return new OperationResult(cost, null);
+      return new OperationResult(cost, 1);
     }
 
     final MutableAccount senderAccount = frame.getWorldUpdater().getSenderAccount(frame);
     if (value.compareTo(senderAccount.getBalance()) > 0) {
       frame.popStackItems(getStackItemsConsumed());
       frame.pushStackItem(LEGACY_FAILURE_STACK_ITEM);
-      return new OperationResult(cost, null);
+      return new OperationResult(cost, INSUFFICIENT_BALANCE);
     }
 
     final MutableAccount recipientAccount = frame.getWorldUpdater().getOrCreate(to);
@@ -87,7 +88,7 @@ public class PayOperation extends AbstractOperation {
 
     frame.popStackItems(getStackItemsConsumed());
     frame.pushStackItem(LEGACY_SUCCESS_STACK_ITEM);
-    return new OperationResult(cost, null);
+    return new OperationResult(cost, 1);
   }
 
   private long cost(

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/RelativeJumpIfOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/RelativeJumpIfOperation.java
@@ -45,9 +45,9 @@ public class RelativeJumpIfOperation extends AbstractFixedCostOperation {
     final Bytes condition = frame.popStackItem();
     if (!condition.isZero()) {
       final int pcPostInstruction = frame.getPC() + 1;
-      return new OperationResult(gasCost, null, 2 + code.readBigEndianI16(pcPostInstruction) + 1);
+      return new OperationResult(gasCost, 2 + code.readBigEndianI16(pcPostInstruction) + 1);
     } else {
-      return new OperationResult(gasCost, null, 2 + 1);
+      return new OperationResult(gasCost, 2 + 1);
     }
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/RelativeJumpOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/RelativeJumpOperation.java
@@ -61,6 +61,6 @@ public class RelativeJumpOperation extends AbstractFixedCostOperation {
       return InvalidOperation.INVALID_RESULT;
     }
     final int pcPostInstruction = frame.getPC() + 1;
-    return new OperationResult(gasCost, null, 2 + code.readBigEndianI16(pcPostInstruction) + 1);
+    return new OperationResult(gasCost, 2 + code.readBigEndianI16(pcPostInstruction) + 1);
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/RelativeJumpVectorOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/RelativeJumpVectorOperation.java
@@ -59,7 +59,6 @@ public class RelativeJumpVectorOperation extends AbstractFixedCostOperation {
             : 0; // if offsetCase is outside the vector the jump delta is zero / next opcode.
     return new OperationResult(
         gasCost,
-        null,
         2 // Opcode + length immediate
             + 2 * vectorSize // vector size
             + jumpDelta);


### PR DESCRIPTION
## PR description
Add Soft failure reason for evm op results. This will help in tracer implementations such as call tracer which need soft failure reasons.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew build`
- [x] acceptance tests: `./gradlew acceptanceTest`
- [x] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

