### PR TITLE
feat: Soft failure reason for evm op results

### DIFF
--- a/evm/src/main/java/org/hyperledger/besu/evm/frame/SoftFailureReason.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/frame/SoftFailureReason.java
@@ -17,58 +17,58 @@ package org.hyperledger.besu.evm.frame;
 /** The interface Soft Failure reason. */
 public interface SoftFailureReason {
 
-    /** The constant NONE. */
-    SoftFailureReason NONE = DefaultSelfFailureReason.NONE;
+  /** The constant NONE. */
+  SoftFailureReason NONE = DefaultSelfFailureReason.NONE;
 
-    /** The constant INSUFFICIENT_BALANCE */
-    SoftFailureReason INSUFFICIENT_BALANCE = DefaultSelfFailureReason.INSUFFICIENT_BALANCE;
+  /** The constant INSUFFICIENT_BALANCE */
+  SoftFailureReason INSUFFICIENT_BALANCE = DefaultSelfFailureReason.INSUFFICIENT_BALANCE;
 
-    /** The constant MAX_CALL_DEPTH */
-    SoftFailureReason MAX_CALL_DEPTH = DefaultSelfFailureReason.MAX_CALL_DEPTH;
+  /** The constant MAX_CALL_DEPTH */
+  SoftFailureReason MAX_CALL_DEPTH = DefaultSelfFailureReason.MAX_CALL_DEPTH;
 
-    /** The constant MAX_BLOCK_ARG_SIZE */
-    SoftFailureReason MAX_BLOCK_ARG_SIZE = DefaultSelfFailureReason.MAX_BLOCK_ARG_SIZE;
+  /** The constant MAX_BLOCK_ARG_SIZE */
+  SoftFailureReason MAX_BLOCK_ARG_SIZE = DefaultSelfFailureReason.MAX_BLOCK_ARG_SIZE;
+
+  /**
+   * Name string.
+   *
+   * @return the string
+   */
+  String name();
+
+  /**
+   * Gets description.
+   *
+   * @return the description
+   */
+  String getDescription();
+
+  /** The enum Default self failure reasons. */
+  enum DefaultSelfFailureReason implements SoftFailureReason {
+    /** None default soft failure reason. */
+    NONE(""),
+    /** Soft failure due to insufficient balance for transfer */
+    INSUFFICIENT_BALANCE("insufficient balance for transfer"),
+    /** Soft failure due to max call depth */
+    MAX_CALL_DEPTH("max call depth exceeded"),
+    /** Soft failure due to max block argument size */
+    MAX_BLOCK_ARG_SIZE("max block argument size exceeded");
+
+    /** The Description of soft failure. */
+    final String description;
 
     /**
-     * Name string.
+     * Instantiate DefaultSelfFailureReason with a description
      *
-     * @return the string
+     * @param description The description to use
      */
-    String name();
-
-    /**
-     * Gets description.
-     *
-     * @return the description
-     */
-    String getDescription();
-
-    /** The enum Default self failure reasons. */
-    enum DefaultSelfFailureReason implements SoftFailureReason {
-        /** None default soft failure reason. */
-        NONE(""),
-        /** Soft failure due to insufficient balance for transfer */
-        INSUFFICIENT_BALANCE("insufficient balance for transfer"),
-        /** Soft failure due to max call depth */
-        MAX_CALL_DEPTH("max call depth exceeded"),
-        /** Soft failure due to max block argument size */
-        MAX_BLOCK_ARG_SIZE("max block argument size exceeded");
-
-        /** The Description of soft failure. */
-        final String description;
-
-        /**
-         * Instantiate DefaultSelfFailureReason with a description
-         *
-         * @param description The description to use
-         */
-        DefaultSelfFailureReason(final String description) {
-            this.description = description;
-        }
-
-        @Override
-        public String getDescription() {
-            return description;
-        }
+    DefaultSelfFailureReason(final String description) {
+      this.description = description;
     }
+
+    @Override
+    public String getDescription() {
+      return description;
+    }
+  }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/frame/SoftFailureReason.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/frame/SoftFailureReason.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.evm.frame;
+
+/** The interface Soft Failure reason. */
+public interface SoftFailureReason {
+
+    /** The constant NONE. */
+    SoftFailureReason NONE = DefaultSelfFailureReason.NONE;
+
+    /** The constant INSUFFICIENT_BALANCE */
+    SoftFailureReason INSUFFICIENT_BALANCE = DefaultSelfFailureReason.INSUFFICIENT_BALANCE;
+
+    /** The constant MAX_CALL_DEPTH */
+    SoftFailureReason MAX_CALL_DEPTH = DefaultSelfFailureReason.MAX_CALL_DEPTH;
+
+    /** The constant MAX_BLOCK_ARG_SIZE */
+    SoftFailureReason MAX_BLOCK_ARG_SIZE = DefaultSelfFailureReason.MAX_BLOCK_ARG_SIZE;
+
+    /**
+     * Name string.
+     *
+     * @return the string
+     */
+    String name();
+
+    /**
+     * Gets description.
+     *
+     * @return the description
+     */
+    String getDescription();
+
+    /** The enum Default self failure reasons. */
+    enum DefaultSelfFailureReason implements SoftFailureReason {
+        /** None default soft failure reason. */
+        NONE(""),
+        /** Soft failure due to insufficient balance for transfer */
+        INSUFFICIENT_BALANCE("insufficient balance for transfer"),
+        /** Soft failure due to max call depth */
+        MAX_CALL_DEPTH("max call depth exceeded"),
+        /** Soft failure due to max block argument size */
+        MAX_BLOCK_ARG_SIZE("max block argument size exceeded");
+
+        /** The Description of soft failure. */
+        final String description;
+
+        /**
+         * Instantiate DefaultSelfFailureReason with a description
+         *
+         * @param description The description to use
+         */
+        DefaultSelfFailureReason(final String description) {
+            this.description = description;
+        }
+
+        @Override
+        public String getDescription() {
+            return description;
+        }
+    }
+}

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/AbstractCallOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/AbstractCallOperation.java
@@ -14,6 +14,8 @@
  */
 package org.hyperledger.besu.evm.operation;
 
+import static org.hyperledger.besu.evm.frame.SoftFailureReason.INSUFFICIENT_BALANCE;
+import static org.hyperledger.besu.evm.frame.SoftFailureReason.MAX_CALL_DEPTH;
 import static org.hyperledger.besu.evm.internal.Words.clampedAdd;
 import static org.hyperledger.besu.evm.internal.Words.clampedToLong;
 import static org.hyperledger.besu.evm.worldstate.CodeDelegationHelper.getTarget;
@@ -29,6 +31,7 @@ import org.hyperledger.besu.evm.code.CodeV0;
 import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.frame.MessageFrame.State;
+import org.hyperledger.besu.evm.frame.SoftFailureReason;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.worldstate.CodeDelegationHelper;
 
@@ -204,7 +207,9 @@ public abstract class AbstractCallOperation extends AbstractOperation {
 
     // If the call is sending more value than the account has or the message frame is too deep
     // return a failed call
-    if (value(frame).compareTo(balance) > 0 || frame.getDepth() >= 1024) {
+    final boolean insufficientBalance = value(frame).compareTo(balance) > 0;
+    final boolean isFrameDepthTooDeep = frame.getDepth() >= 1024;
+    if (insufficientBalance || isFrameDepthTooDeep) {
       frame.expandMemory(inputDataOffset(frame), inputDataLength(frame));
       frame.expandMemory(outputDataOffset(frame), outputDataLength(frame));
       // For the following, we either increment the gas or return zero, so we don't get double
@@ -212,7 +217,9 @@ public abstract class AbstractCallOperation extends AbstractOperation {
       frame.incrementRemainingGas(gasAvailableForChildCall(frame) + cost);
       frame.popStackItems(getStackItemsConsumed());
       frame.pushStackItem(LEGACY_FAILURE_STACK_ITEM);
-      return new OperationResult(cost, null);
+      final SoftFailureReason softFailureReason =
+          insufficientBalance ? INSUFFICIENT_BALANCE : MAX_CALL_DEPTH;
+      return new OperationResult(cost, 1, softFailureReason);
     }
 
     final Bytes inputData = frame.readMutableMemory(inputDataOffset(frame), inputDataLength(frame));

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/Operation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/Operation.java
@@ -17,6 +17,9 @@ package org.hyperledger.besu.evm.operation;
 import org.hyperledger.besu.evm.EVM;
 import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.frame.SoftFailureReason;
+
+import java.util.Optional;
 
 /** The interface Operation. */
 public interface Operation {
@@ -31,6 +34,8 @@ public interface Operation {
 
     /** The increment. */
     final int pcIncrement;
+
+    final SoftFailureReason softFailureReason;
 
     /**
      * Instantiates a new Operation result.
@@ -54,6 +59,22 @@ public interface Operation {
       this.gasCost = gasCost;
       this.haltReason = haltReason;
       this.pcIncrement = pcIncrement;
+      this.softFailureReason = null;
+    }
+
+    /**
+     * Instantiate a new Operation Result with a Soft Failure Reason.
+     *
+     * @param gasCost Gas Cost
+     * @param pcIncrement The increment
+     * @param softFailureReason The Soft Failure Reason
+     */
+    public OperationResult(
+        final long gasCost, final int pcIncrement, final SoftFailureReason softFailureReason) {
+      this.gasCost = gasCost;
+      this.haltReason = null;
+      this.pcIncrement = pcIncrement;
+      this.softFailureReason = softFailureReason;
     }
 
     /**
@@ -81,6 +102,10 @@ public interface Operation {
      */
     public int getPcIncrement() {
       return pcIncrement;
+    }
+
+    public Optional<SoftFailureReason> getSoftFailureReason() {
+      return Optional.ofNullable(this.softFailureReason);
     }
   }
 


### PR DESCRIPTION
## PR description
Add Soft failure reason for evm op results. This will help in tracer implementations such as call tracer which need soft failure reasons.

** New File:**
SoftFailureReason

Main Modifications:

org.hyperledger.besu.evm.operation.Operation
org.hyperledger.besu.evm.operation.AbstractCallOperation#execute

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew build`
- [x] acceptance tests: `./gradlew acceptanceTest`
- [x] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

