### PR TITLE
Backport Skip header validation if the chain is POS (#9038)

### DIFF
--- a/ethereum/eth/src/jmh/java/org/hyperledger/besu/ethereum/eth/sync/worldstate/WorldStateDownloaderBenchmark.java
+++ b/ethereum/eth/src/jmh/java/org/hyperledger/besu/ethereum/eth/sync/worldstate/WorldStateDownloaderBenchmark.java
@@ -152,7 +152,7 @@ public class WorldStateDownloaderBenchmark {
   @Benchmark
   public Optional<Bytes> downloadWorldState() {
     final CompletableFuture<Void> result =
-        worldStateDownloader.run(null, new FastSyncState(blockHeader));
+        worldStateDownloader.run(null, new FastSyncState(blockHeader, false));
     if (result.isDone()) {
       throw new IllegalStateException("World state download was already complete");
     }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastSyncActions.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastSyncActions.java
@@ -141,7 +141,7 @@ public class FastSyncActions {
             unused ->
                 currentState
                     .getPivotBlockHash()
-                    .map(this::downloadPivotBlockHeader)
+                    .map(hash -> downloadPivotBlockHeader(hash, currentState.isSourceTrusted()))
                     .orElseGet(
                         () ->
                             new PivotBlockRetriever(
@@ -177,7 +177,8 @@ public class FastSyncActions {
         syncDurationMetrics);
   }
 
-  private CompletableFuture<FastSyncState> downloadPivotBlockHeader(final Hash hash) {
+  private CompletableFuture<FastSyncState> downloadPivotBlockHeader(
+      final Hash hash, final boolean sourceIsTrusted) {
     LOG.debug("Downloading pivot block header by hash {}", hash);
     CompletableFuture<BlockHeader> blockHeaderFuture;
     if (syncConfig.isPeerTaskSystemEnabled()) {
@@ -240,7 +241,7 @@ public class FastSyncActions {
                     .log();
               }
             })
-        .thenApply(FastSyncState::new);
+        .thenApply(blockHeader -> new FastSyncState(blockHeader, sourceIsTrusted));
   }
 
   public boolean isBlockchainBehind(final long blockNumber) {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastSyncDownloadPipelineFactory.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastSyncDownloadPipelineFactory.java
@@ -15,7 +15,11 @@
 package org.hyperledger.besu.ethereum.eth.sync.fastsync;
 
 import static org.hyperledger.besu.ethereum.mainnet.HeaderValidationMode.DETACHED_ONLY;
+import static org.hyperledger.besu.ethereum.mainnet.HeaderValidationMode.FULL;
+import static org.hyperledger.besu.ethereum.mainnet.HeaderValidationMode.LIGHT;
 import static org.hyperledger.besu.ethereum.mainnet.HeaderValidationMode.LIGHT_DETACHED_ONLY;
+import static org.hyperledger.besu.ethereum.mainnet.HeaderValidationMode.LIGHT_SKIP_DETACHED;
+import static org.hyperledger.besu.ethereum.mainnet.HeaderValidationMode.SKIP_DETACHED;
 
 import org.hyperledger.besu.ethereum.ConsensusContext;
 import org.hyperledger.besu.ethereum.ProtocolContext;
@@ -60,7 +64,9 @@ public class FastSyncDownloadPipelineFactory implements DownloadPipelineFactory 
   protected final EthContext ethContext;
   protected final FastSyncState fastSyncState;
   protected final MetricsSystem metricsSystem;
+  protected final FastSyncValidationPolicy attachedValidationPolicy;
   protected final FastSyncValidationPolicy detachedValidationPolicy;
+  protected final FastSyncValidationPolicy ommerValidationPolicy;
   protected final ValidationPolicy downloadHeaderValidation;
 
   public FastSyncDownloadPipelineFactory(
@@ -82,6 +88,18 @@ public class FastSyncDownloadPipelineFactory implements DownloadPipelineFactory 
             "fast_sync_validation_mode",
             "Number of blocks validated using light vs full validation during fast sync",
             "validationMode");
+    attachedValidationPolicy =
+        new FastSyncValidationPolicy(
+            this.syncConfig.getFastSyncFullValidationRate(),
+            LIGHT_SKIP_DETACHED,
+            SKIP_DETACHED,
+            fastSyncValidationCounter);
+    ommerValidationPolicy =
+        new FastSyncValidationPolicy(
+            this.syncConfig.getFastSyncFullValidationRate(),
+            LIGHT,
+            FULL,
+            fastSyncValidationCounter);
     detachedValidationPolicy =
         new FastSyncValidationPolicy(
             this.syncConfig.getFastSyncFullValidationRate(),

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastSyncDownloadPipelineFactory.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastSyncDownloadPipelineFactory.java
@@ -15,11 +15,7 @@
 package org.hyperledger.besu.ethereum.eth.sync.fastsync;
 
 import static org.hyperledger.besu.ethereum.mainnet.HeaderValidationMode.DETACHED_ONLY;
-import static org.hyperledger.besu.ethereum.mainnet.HeaderValidationMode.FULL;
-import static org.hyperledger.besu.ethereum.mainnet.HeaderValidationMode.LIGHT;
 import static org.hyperledger.besu.ethereum.mainnet.HeaderValidationMode.LIGHT_DETACHED_ONLY;
-import static org.hyperledger.besu.ethereum.mainnet.HeaderValidationMode.LIGHT_SKIP_DETACHED;
-import static org.hyperledger.besu.ethereum.mainnet.HeaderValidationMode.SKIP_DETACHED;
 
 import org.hyperledger.besu.ethereum.ConsensusContext;
 import org.hyperledger.besu.ethereum.ProtocolContext;
@@ -32,6 +28,7 @@ import org.hyperledger.besu.ethereum.eth.sync.DownloadHeadersStep;
 import org.hyperledger.besu.ethereum.eth.sync.DownloadPipelineFactory;
 import org.hyperledger.besu.ethereum.eth.sync.SavePreMergeHeadersStep;
 import org.hyperledger.besu.ethereum.eth.sync.SynchronizerConfiguration;
+import org.hyperledger.besu.ethereum.eth.sync.ValidationPolicy;
 import org.hyperledger.besu.ethereum.eth.sync.fastsync.checkpoint.Checkpoint;
 import org.hyperledger.besu.ethereum.eth.sync.fullsync.SyncTerminationCondition;
 import org.hyperledger.besu.ethereum.eth.sync.range.RangeHeadersFetcher;
@@ -40,6 +37,7 @@ import org.hyperledger.besu.ethereum.eth.sync.range.SyncTargetRange;
 import org.hyperledger.besu.ethereum.eth.sync.range.SyncTargetRangeSource;
 import org.hyperledger.besu.ethereum.eth.sync.state.SyncState;
 import org.hyperledger.besu.ethereum.eth.sync.state.SyncTarget;
+import org.hyperledger.besu.ethereum.mainnet.HeaderValidationMode;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.metrics.BesuMetricCategory;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
@@ -62,9 +60,8 @@ public class FastSyncDownloadPipelineFactory implements DownloadPipelineFactory 
   protected final EthContext ethContext;
   protected final FastSyncState fastSyncState;
   protected final MetricsSystem metricsSystem;
-  protected final FastSyncValidationPolicy attachedValidationPolicy;
   protected final FastSyncValidationPolicy detachedValidationPolicy;
-  protected final FastSyncValidationPolicy ommerValidationPolicy;
+  protected final ValidationPolicy downloadHeaderValidation;
 
   public FastSyncDownloadPipelineFactory(
       final SynchronizerConfiguration syncConfig,
@@ -85,24 +82,18 @@ public class FastSyncDownloadPipelineFactory implements DownloadPipelineFactory 
             "fast_sync_validation_mode",
             "Number of blocks validated using light vs full validation during fast sync",
             "validationMode");
-    attachedValidationPolicy =
-        new FastSyncValidationPolicy(
-            this.syncConfig.getFastSyncFullValidationRate(),
-            LIGHT_SKIP_DETACHED,
-            SKIP_DETACHED,
-            fastSyncValidationCounter);
-    ommerValidationPolicy =
-        new FastSyncValidationPolicy(
-            this.syncConfig.getFastSyncFullValidationRate(),
-            LIGHT,
-            FULL,
-            fastSyncValidationCounter);
     detachedValidationPolicy =
         new FastSyncValidationPolicy(
             this.syncConfig.getFastSyncFullValidationRate(),
             LIGHT_DETACHED_ONLY,
             DETACHED_ONLY,
             fastSyncValidationCounter);
+    final ValidationPolicy noneValidationPolicy = () -> HeaderValidationMode.NONE;
+    downloadHeaderValidation =
+        fastSyncState.isSourceTrusted() ? noneValidationPolicy : detachedValidationPolicy;
+    if (fastSyncState.isSourceTrusted()) {
+      LOG.trace("Pivot block is from trusted source, skipping header validation");
+    }
   }
 
   @Override
@@ -136,12 +127,11 @@ public class FastSyncDownloadPipelineFactory implements DownloadPipelineFactory 
             protocolSchedule,
             protocolContext,
             ethContext,
-            detachedValidationPolicy,
+            downloadHeaderValidation,
             syncConfig,
             headerRequestSize,
             metricsSystem);
-    final RangeHeadersValidationStep validateHeadersJoinUpStep =
-        new RangeHeadersValidationStep(protocolSchedule, protocolContext, detachedValidationPolicy);
+    final RangeHeadersValidationStep validateHeadersJoinUpStep = new RangeHeadersValidationStep();
     final SavePreMergeHeadersStep savePreMergeHeadersStep =
         new SavePreMergeHeadersStep(
             protocolContext.getBlockchain(),

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/PivotBlockConfirmer.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/PivotBlockConfirmer.java
@@ -145,7 +145,7 @@ class PivotBlockConfirmer {
     } else if (votes >= numberOfPeersToQuery) {
       // We've received the required number of votes and have selected our pivot block
       LOG.info("Confirmed pivot block at {}: {}", pivotBlockNumber, blockHeader.getHash());
-      result.complete(new FastSyncState(blockHeader));
+      result.complete(new FastSyncState(blockHeader, false));
     } else {
       LOG.info(
           "Received {} confirmation(s) for pivot block header {}: {}",

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/PivotSelectorFromPeers.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/PivotSelectorFromPeers.java
@@ -83,7 +83,7 @@ public class PivotSelectorFromPeers implements PivotBlockSelector {
       return Optional.empty();
     }
     LOG.info("Selecting block number {} as fast sync pivot block.", pivotBlockNumber);
-    return Optional.of(new FastSyncState(pivotBlockNumber));
+    return Optional.of(new FastSyncState(pivotBlockNumber, false));
   }
 
   protected Optional<EthPeer> selectBestPeer() {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/PivotSelectorFromSafeBlock.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/PivotSelectorFromSafeBlock.java
@@ -131,7 +131,7 @@ public class PivotSelectorFromSafeBlock implements PivotBlockSelector {
 
   private FastSyncState selectLastSafeBlockAsPivot(final Hash safeHash) {
     LOG.debug("Returning safe block hash {} as pivot", safeHash);
-    return new FastSyncState(safeHash);
+    return new FastSyncState(safeHash, true);
   }
 
   private FastSyncState selectFallbackBlockAsPivot(final Hash fallbackBlockHash) {
@@ -139,7 +139,7 @@ public class PivotSelectorFromSafeBlock implements PivotBlockSelector {
         "Safe block not changed in the last {} min, using a previous head block {} as fallback",
         UNCHANGED_PIVOT_BLOCK_FALLBACK_INTERVAL / 60,
         fallbackBlockHash);
-    return new FastSyncState(fallbackBlockHash);
+    return new FastSyncState(fallbackBlockHash, true);
   }
 
   @Override

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fullsync/FullSyncDownloadPipelineFactory.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fullsync/FullSyncDownloadPipelineFactory.java
@@ -104,8 +104,7 @@ public class FullSyncDownloadPipelineFactory implements DownloadPipelineFactory 
             syncConfig,
             headerRequestSize,
             metricsSystem);
-    final RangeHeadersValidationStep validateHeadersJoinUpStep =
-        new RangeHeadersValidationStep(protocolSchedule, protocolContext, detachedValidationPolicy);
+    final RangeHeadersValidationStep validateHeadersJoinUpStep = new RangeHeadersValidationStep();
     final DownloadBodiesStep downloadBodiesStep =
         new DownloadBodiesStep(protocolSchedule, ethContext, syncConfig, metricsSystem);
     final ExtractTxSignaturesStep extractTxSignaturesStep = new ExtractTxSignaturesStep();

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapSyncProcessState.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapSyncProcessState.java
@@ -36,7 +36,8 @@ public class SnapSyncProcessState extends FastSyncState {
     super(
         fastSyncState.getPivotBlockNumber(),
         fastSyncState.getPivotBlockHash(),
-        fastSyncState.getPivotBlockHeader());
+        fastSyncState.getPivotBlockHeader(),
+        fastSyncState.isSourceTrusted());
   }
 
   public boolean isHealTrieInProgress() {

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/RangeHeadersFetcherTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/RangeHeadersFetcherTest.java
@@ -330,7 +330,7 @@ public class RangeHeadersFetcherTest {
             .build(),
         protocolSchedule,
         ethContext,
-        new FastSyncState(targetHeader),
+        new FastSyncState(targetHeader, false),
         metricsSystem);
   }
 

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/checkpointsync/CheckPointSyncChainDownloaderTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/checkpointsync/CheckPointSyncChainDownloaderTest.java
@@ -204,7 +204,7 @@ public class CheckPointSyncChainDownloaderTest {
         ethContext,
         syncState,
         new NoOpMetricsSystem(),
-        new FastSyncState(otherBlockchain.getBlockHeader(pivotBlockNumber).get()),
+        new FastSyncState(otherBlockchain.getBlockHeader(pivotBlockNumber).get(), false),
         SyncDurationMetrics.NO_OP_SYNC_DURATION_METRICS);
   }
 

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastSyncActionsTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastSyncActionsTest.java
@@ -137,7 +137,7 @@ public class FastSyncActionsTest {
     }
     final CompletableFuture<FastSyncState> result =
         fastSyncActions.selectPivotBlock(FastSyncState.EMPTY_SYNC_STATE);
-    assertThat(result).isCompletedWithValue(new FastSyncState(5));
+    assertThat(result).isCompletedWithValue(new FastSyncState(5, false));
   }
 
   @ParameterizedTest
@@ -145,7 +145,7 @@ public class FastSyncActionsTest {
   public void returnTheSamePivotBlockIfAlreadySelected(final DataStorageFormat storageFormat) {
     setUp(storageFormat, false);
     final BlockHeader pivotHeader = new BlockHeaderTestFixture().number(1024).buildHeader();
-    final FastSyncState fastSyncState = new FastSyncState(pivotHeader);
+    final FastSyncState fastSyncState = new FastSyncState(pivotHeader, false);
     final CompletableFuture<FastSyncState> result = fastSyncActions.selectPivotBlock(fastSyncState);
     assertThat(result).isDone();
     assertThat(result).isCompletedWithValue(fastSyncState);
@@ -160,8 +160,8 @@ public class FastSyncActionsTest {
     EthProtocolManagerTestUtil.createPeer(ethProtocolManager, 5000);
 
     final CompletableFuture<FastSyncState> result =
-        fastSyncActions.selectPivotBlock(new FastSyncState(pivotHeader));
-    final FastSyncState expected = new FastSyncState(pivotHeader);
+        fastSyncActions.selectPivotBlock(new FastSyncState(pivotHeader, false));
+    final FastSyncState expected = new FastSyncState(pivotHeader, false);
     assertThat(result).isCompletedWithValue(expected);
   }
 
@@ -179,7 +179,7 @@ public class FastSyncActionsTest {
 
     final CompletableFuture<FastSyncState> result =
         fastSyncActions.selectPivotBlock(FastSyncState.EMPTY_SYNC_STATE);
-    final FastSyncState expected = new FastSyncState(4000);
+    final FastSyncState expected = new FastSyncState(4000, false);
     assertThat(result).isCompletedWithValue(expected);
   }
 
@@ -197,7 +197,7 @@ public class FastSyncActionsTest {
 
     final CompletableFuture<FastSyncState> result =
         fastSyncActions.selectPivotBlock(FastSyncState.EMPTY_SYNC_STATE);
-    final FastSyncState expected = new FastSyncState(3000);
+    final FastSyncState expected = new FastSyncState(3000, false);
     assertThat(result).isCompletedWithValue(expected);
   }
 
@@ -225,7 +225,7 @@ public class FastSyncActionsTest {
     EthProtocolManagerTestUtil.createPeer(ethProtocolManager, 5000);
     EthProtocolManagerTestUtil.runPendingFutures(ethProtocolManager);
     assertThat(result).isDone();
-    final FastSyncState expected = new FastSyncState(4000);
+    final FastSyncState expected = new FastSyncState(4000, false);
     assertThat(result).isCompletedWithValue(expected);
   }
 
@@ -238,7 +238,7 @@ public class FastSyncActionsTest {
     PivotBlockSelector pivotBlockSelector = mock(PivotBlockSelector.class);
     fastSyncActions = createFastSyncActions(syncConfig, pivotBlockSelector);
 
-    FastSyncState expectedResult = new FastSyncState(123);
+    FastSyncState expectedResult = new FastSyncState(123, false);
 
     when(pivotBlockSelector.selectNewPivotBlock())
         .thenReturn(Optional.empty())
@@ -318,7 +318,7 @@ public class FastSyncActionsTest {
     final long expectedBestChainHeight =
         peers.get(1).getEthPeer().chainState().getEstimatedHeight();
     final FastSyncState expected =
-        new FastSyncState(expectedBestChainHeight - syncConfig.getSyncPivotDistance());
+        new FastSyncState(expectedBestChainHeight - syncConfig.getSyncPivotDistance(), false);
     EthProtocolManagerTestUtil.runPendingFutures(ethProtocolManager);
     assertThat(result).isCompletedWithValue(expected);
   }
@@ -344,7 +344,7 @@ public class FastSyncActionsTest {
 
     final long validHeight = pivotDistance + 1;
     EthProtocolManagerTestUtil.createPeer(ethProtocolManager, validHeight);
-    final FastSyncState expected = new FastSyncState(1);
+    final FastSyncState expected = new FastSyncState(1, false);
     EthProtocolManagerTestUtil.runPendingFutures(ethProtocolManager);
     assertThat(result).isCompletedWithValue(expected);
   }
@@ -369,7 +369,7 @@ public class FastSyncActionsTest {
 
     final long validHeight = pivotDistance + 1;
     EthProtocolManagerTestUtil.createPeer(ethProtocolManager, validHeight);
-    final FastSyncState expected = new FastSyncState(1);
+    final FastSyncState expected = new FastSyncState(1, false);
     EthProtocolManagerTestUtil.runPendingFutures(ethProtocolManager);
     assertThat(result).isCompletedWithValue(expected);
   }
@@ -380,7 +380,7 @@ public class FastSyncActionsTest {
       final DataStorageFormat storageFormat) {
     setUp(storageFormat, false);
     final BlockHeader pivotHeader = new BlockHeaderTestFixture().number(1024).buildHeader();
-    final FastSyncState expected = new FastSyncState(pivotHeader);
+    final FastSyncState expected = new FastSyncState(pivotHeader, false);
     assertThat(fastSyncActions.downloadPivotBlockHeader(expected)).isCompletedWithValue(expected);
   }
 
@@ -395,13 +395,14 @@ public class FastSyncActionsTest {
 
     final RespondingEthPeer peer = EthProtocolManagerTestUtil.createPeer(ethProtocolManager, 1001);
     final CompletableFuture<FastSyncState> result =
-        fastSyncActions.downloadPivotBlockHeader(new FastSyncState(1));
+        fastSyncActions.downloadPivotBlockHeader(new FastSyncState(1, false));
     assertThat(result).isNotCompleted();
 
     final RespondingEthPeer.Responder responder = RespondingEthPeer.blockchainResponder(blockchain);
     peer.respond(responder);
 
-    assertThat(result).isCompletedWithValue(new FastSyncState(blockchain.getBlockHeader(1).get()));
+    assertThat(result)
+        .isCompletedWithValue(new FastSyncState(blockchain.getBlockHeader(1).get(), false));
   }
 
   @ParameterizedTest
@@ -435,13 +436,14 @@ public class FastSyncActionsTest {
     final RespondingEthPeer peer = EthProtocolManagerTestUtil.createPeer(ethProtocolManager, 1001);
     final CompletableFuture<FastSyncState> result =
         fastSyncActions.downloadPivotBlockHeader(
-            new FastSyncState(finalizedEvent.get().getSafeBlockHash()));
+            new FastSyncState(finalizedEvent.get().getSafeBlockHash(), false));
     assertThat(result).isNotCompleted();
 
     final RespondingEthPeer.Responder responder = RespondingEthPeer.blockchainResponder(blockchain);
     peer.respond(responder);
 
-    assertThat(result).isCompletedWithValue(new FastSyncState(blockchain.getBlockHeader(3).get()));
+    assertThat(result)
+        .isCompletedWithValue(new FastSyncState(blockchain.getBlockHeader(3).get(), false));
   }
 
   private FastSyncActions createFastSyncActions(

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastSyncChainDownloaderTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastSyncChainDownloaderTest.java
@@ -114,7 +114,7 @@ public class FastSyncChainDownloaderTest {
         ethContext,
         syncState,
         new NoOpMetricsSystem(),
-        new FastSyncState(otherBlockchain.getBlockHeader(pivotBlockNumber).get()),
+        new FastSyncState(otherBlockchain.getBlockHeader(pivotBlockNumber).get(), false),
         SyncDurationMetrics.NO_OP_SYNC_DURATION_METRICS);
   }
 

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastSyncDownloadPipelineFactoryTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastSyncDownloadPipelineFactoryTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.eth.sync.fastsync;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import org.hyperledger.besu.ethereum.ProtocolContext;
+import org.hyperledger.besu.ethereum.eth.manager.EthContext;
+import org.hyperledger.besu.ethereum.eth.sync.SynchronizerConfiguration;
+import org.hyperledger.besu.ethereum.eth.sync.snapsync.SnapSyncConfiguration;
+import org.hyperledger.besu.ethereum.mainnet.HeaderValidationMode;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
+import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class FastSyncDownloadPipelineFactoryTest {
+  @Mock private SynchronizerConfiguration syncConfig;
+  @Mock private ProtocolSchedule protocolSchedule;
+  @Mock private ProtocolContext protocolContext;
+  @Mock private EthContext ethContext;
+  @Mock private FastSyncState fastSyncState;
+  @Mock private SnapSyncConfiguration snapSyncConfiguration;
+
+  @BeforeEach
+  void setUp() {
+    when(syncConfig.getSnapSyncConfiguration()).thenReturn(snapSyncConfiguration);
+    when(snapSyncConfiguration.isSnapSyncTransactionIndexingEnabled()).thenReturn(false);
+  }
+
+  @Test
+  void shouldUseNoneValidationWhenFastSyncStateSourceIsTrusted() {
+    when(fastSyncState.isSourceTrusted()).thenReturn(true);
+
+    var downloadPipelineFactory =
+        new FastSyncDownloadPipelineFactory(
+            syncConfig,
+            protocolSchedule,
+            protocolContext,
+            ethContext,
+            fastSyncState,
+            new NoOpMetricsSystem());
+
+    assertThat(downloadPipelineFactory.downloadHeaderValidation).isNotNull();
+    assertThat(downloadPipelineFactory.downloadHeaderValidation.getValidationModeForNextBlock())
+        .isEqualTo(HeaderValidationMode.NONE);
+  }
+
+  @Test
+  void shouldUseDetachedValidationWhenFastSyncStateSourceIsNotTrusted() {
+    when(fastSyncState.isSourceTrusted()).thenReturn(false);
+
+    var downloadPipelineFactory =
+        new FastSyncDownloadPipelineFactory(
+            syncConfig,
+            protocolSchedule,
+            protocolContext,
+            ethContext,
+            fastSyncState,
+            new NoOpMetricsSystem());
+
+    assertThat(downloadPipelineFactory.downloadHeaderValidation).isNotNull();
+    assertThat(downloadPipelineFactory.downloadHeaderValidation.getValidationModeForNextBlock())
+        .isNotEqualTo(HeaderValidationMode.NONE);
+  }
+}

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastSyncDownloaderTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastSyncDownloaderTest.java
@@ -114,9 +114,9 @@ public class FastSyncDownloaderTest {
   @ArgumentsSource(FastSyncDownloaderTestArguments.class)
   public void shouldCompleteFastSyncSuccessfully(final DataStorageFormat dataStorageFormat) {
     setup(dataStorageFormat);
-    final FastSyncState selectPivotBlockState = new FastSyncState(50);
+    final FastSyncState selectPivotBlockState = new FastSyncState(50, false);
     final BlockHeader pivotBlockHeader = new BlockHeaderTestFixture().number(50).buildHeader();
-    final FastSyncState downloadPivotBlockHeaderState = new FastSyncState(pivotBlockHeader);
+    final FastSyncState downloadPivotBlockHeaderState = new FastSyncState(pivotBlockHeader, false);
     when(fastSyncActions.selectPivotBlock(FastSyncState.EMPTY_SYNC_STATE))
         .thenReturn(completedFuture(selectPivotBlockState));
     when(fastSyncActions.downloadPivotBlockHeader(selectPivotBlockState))
@@ -126,7 +126,7 @@ public class FastSyncDownloaderTest {
         .thenReturn(chainDownloader);
     when(chainDownloader.start()).thenReturn(completedFuture(null));
     when(worldStateDownloader.run(
-            any(FastSyncActions.class), eq(new FastSyncState(pivotBlockHeader))))
+            any(FastSyncActions.class), eq(new FastSyncState(pivotBlockHeader, false))))
         .thenReturn(completedFuture(null));
 
     final CompletableFuture<FastSyncState> result = downloader.start();
@@ -139,7 +139,7 @@ public class FastSyncDownloaderTest {
             downloadPivotBlockHeaderState, SyncDurationMetrics.NO_OP_SYNC_DURATION_METRICS);
     verify(chainDownloader).start();
     verify(worldStateDownloader)
-        .run(any(FastSyncActions.class), eq(new FastSyncState(pivotBlockHeader)));
+        .run(any(FastSyncActions.class), eq(new FastSyncState(pivotBlockHeader, false)));
     verifyNoMoreInteractions(fastSyncActions, worldStateDownloader, storage);
     assertThat(result).isCompletedWithValue(downloadPivotBlockHeaderState);
   }
@@ -149,7 +149,7 @@ public class FastSyncDownloaderTest {
   public void shouldResumeFastSync(final DataStorageFormat dataStorageFormat) {
     setup(dataStorageFormat);
     final BlockHeader pivotBlockHeader = new BlockHeaderTestFixture().number(50).buildHeader();
-    final FastSyncState fastSyncState = new FastSyncState(pivotBlockHeader);
+    final FastSyncState fastSyncState = new FastSyncState(pivotBlockHeader, false);
     final CompletableFuture<FastSyncState> complete = completedFuture(fastSyncState);
     when(fastSyncActions.selectPivotBlock(fastSyncState)).thenReturn(complete);
     when(fastSyncActions.downloadPivotBlockHeader(fastSyncState)).thenReturn(complete);
@@ -158,7 +158,7 @@ public class FastSyncDownloaderTest {
         .thenReturn(chainDownloader);
     when(chainDownloader.start()).thenReturn(completedFuture(null));
     when(worldStateDownloader.run(
-            any(FastSyncActions.class), eq(new FastSyncState(pivotBlockHeader))))
+            any(FastSyncActions.class), eq(new FastSyncState(pivotBlockHeader, false))))
         .thenReturn(completedFuture(null));
 
     final FastSyncDownloader<NodeDataRequest> resumedDownloader =
@@ -181,7 +181,7 @@ public class FastSyncDownloaderTest {
         .createChainDownloader(fastSyncState, SyncDurationMetrics.NO_OP_SYNC_DURATION_METRICS);
     verify(chainDownloader).start();
     verify(worldStateDownloader)
-        .run(any(FastSyncActions.class), eq(new FastSyncState(pivotBlockHeader)));
+        .run(any(FastSyncActions.class), eq(new FastSyncState(pivotBlockHeader, false)));
     verifyNoMoreInteractions(fastSyncActions, worldStateDownloader, storage);
     assertThat(result).isCompletedWithValue(fastSyncState);
   }
@@ -207,9 +207,9 @@ public class FastSyncDownloaderTest {
     setup(dataStorageFormat);
     final CompletableFuture<Void> worldStateFuture = new CompletableFuture<>();
     final CompletableFuture<Void> chainFuture = new CompletableFuture<>();
-    final FastSyncState selectPivotBlockState = new FastSyncState(50);
+    final FastSyncState selectPivotBlockState = new FastSyncState(50, false);
     final BlockHeader pivotBlockHeader = new BlockHeaderTestFixture().number(50).buildHeader();
-    final FastSyncState downloadPivotBlockHeaderState = new FastSyncState(pivotBlockHeader);
+    final FastSyncState downloadPivotBlockHeaderState = new FastSyncState(pivotBlockHeader, false);
 
     when(fastSyncActions.selectPivotBlock(FastSyncState.EMPTY_SYNC_STATE))
         .thenReturn(completedFuture(selectPivotBlockState));
@@ -220,7 +220,7 @@ public class FastSyncDownloaderTest {
         .thenReturn(chainDownloader);
     when(chainDownloader.start()).thenReturn(chainFuture);
     when(worldStateDownloader.run(
-            any(FastSyncActions.class), eq(new FastSyncState(pivotBlockHeader))))
+            any(FastSyncActions.class), eq(new FastSyncState(pivotBlockHeader, false))))
         .thenReturn(worldStateFuture);
 
     final CompletableFuture<FastSyncState> result = downloader.start();
@@ -232,7 +232,7 @@ public class FastSyncDownloaderTest {
         .createChainDownloader(
             downloadPivotBlockHeaderState, SyncDurationMetrics.NO_OP_SYNC_DURATION_METRICS);
     verify(worldStateDownloader)
-        .run(any(FastSyncActions.class), eq(new FastSyncState(pivotBlockHeader)));
+        .run(any(FastSyncActions.class), eq(new FastSyncState(pivotBlockHeader, false)));
     verifyNoMoreInteractions(fastSyncActions, worldStateDownloader, storage);
 
     assertThat(result).isNotDone();
@@ -250,9 +250,9 @@ public class FastSyncDownloaderTest {
     setup(dataStorageFormat);
     final CompletableFuture<Void> chainFuture = new CompletableFuture<>();
     final CompletableFuture<Void> worldStateFuture = new CompletableFuture<>();
-    final FastSyncState selectPivotBlockState = new FastSyncState(50);
+    final FastSyncState selectPivotBlockState = new FastSyncState(50, false);
     final BlockHeader pivotBlockHeader = new BlockHeaderTestFixture().number(50).buildHeader();
-    final FastSyncState downloadPivotBlockHeaderState = new FastSyncState(pivotBlockHeader);
+    final FastSyncState downloadPivotBlockHeaderState = new FastSyncState(pivotBlockHeader, false);
 
     when(fastSyncActions.selectPivotBlock(FastSyncState.EMPTY_SYNC_STATE))
         .thenReturn(completedFuture(selectPivotBlockState));
@@ -263,7 +263,7 @@ public class FastSyncDownloaderTest {
         .thenReturn(chainDownloader);
     when(chainDownloader.start()).thenReturn(chainFuture);
     when(worldStateDownloader.run(
-            any(FastSyncActions.class), eq(new FastSyncState(pivotBlockHeader))))
+            any(FastSyncActions.class), eq(new FastSyncState(pivotBlockHeader, false))))
         .thenReturn(worldStateFuture);
 
     final CompletableFuture<FastSyncState> result = downloader.start();
@@ -274,7 +274,7 @@ public class FastSyncDownloaderTest {
         .createChainDownloader(
             downloadPivotBlockHeaderState, SyncDurationMetrics.NO_OP_SYNC_DURATION_METRICS);
     verify(worldStateDownloader)
-        .run(any(FastSyncActions.class), eq(new FastSyncState(pivotBlockHeader)));
+        .run(any(FastSyncActions.class), eq(new FastSyncState(pivotBlockHeader, false)));
     verifyNoMoreInteractions(fastSyncActions);
     verifyNoMoreInteractions(worldStateDownloader);
 
@@ -289,9 +289,9 @@ public class FastSyncDownloaderTest {
   @ArgumentsSource(FastSyncDownloaderTestArguments.class)
   public void shouldAbortIfStopped(final DataStorageFormat dataStorageFormat) {
     setup(dataStorageFormat);
-    final FastSyncState selectPivotBlockState = new FastSyncState(50);
+    final FastSyncState selectPivotBlockState = new FastSyncState(50, false);
     final BlockHeader pivotBlockHeader = new BlockHeaderTestFixture().number(50).buildHeader();
-    final FastSyncState downloadPivotBlockHeaderState = new FastSyncState(pivotBlockHeader);
+    final FastSyncState downloadPivotBlockHeaderState = new FastSyncState(pivotBlockHeader, false);
 
     when(fastSyncActions.selectPivotBlock(FastSyncState.EMPTY_SYNC_STATE))
         .thenReturn(completedFuture(selectPivotBlockState));
@@ -328,9 +328,9 @@ public class FastSyncDownloaderTest {
     setup(dataStorageFormat);
     final CompletableFuture<Void> chainFuture = new CompletableFuture<>();
     final CompletableFuture<Void> worldStateFuture = new CompletableFuture<>();
-    final FastSyncState selectPivotBlockState = new FastSyncState(50);
+    final FastSyncState selectPivotBlockState = new FastSyncState(50, false);
     final BlockHeader pivotBlockHeader = new BlockHeaderTestFixture().number(50).buildHeader();
-    final FastSyncState downloadPivotBlockHeaderState = new FastSyncState(pivotBlockHeader);
+    final FastSyncState downloadPivotBlockHeaderState = new FastSyncState(pivotBlockHeader, false);
 
     when(fastSyncActions.selectPivotBlock(FastSyncState.EMPTY_SYNC_STATE))
         .thenReturn(completedFuture(selectPivotBlockState));
@@ -341,7 +341,7 @@ public class FastSyncDownloaderTest {
         .thenReturn(chainDownloader);
     when(chainDownloader.start()).thenReturn(chainFuture);
     when(worldStateDownloader.run(
-            any(FastSyncActions.class), eq(new FastSyncState(pivotBlockHeader))))
+            any(FastSyncActions.class), eq(new FastSyncState(pivotBlockHeader, false))))
         .thenReturn(worldStateFuture);
 
     final CompletableFuture<FastSyncState> result = downloader.start();
@@ -352,7 +352,7 @@ public class FastSyncDownloaderTest {
         .createChainDownloader(
             downloadPivotBlockHeaderState, SyncDurationMetrics.NO_OP_SYNC_DURATION_METRICS);
     verify(worldStateDownloader)
-        .run(any(FastSyncActions.class), eq(new FastSyncState(pivotBlockHeader)));
+        .run(any(FastSyncActions.class), eq(new FastSyncState(pivotBlockHeader, false)));
     verifyNoMoreInteractions(fastSyncActions);
     verifyNoMoreInteractions(worldStateDownloader);
 
@@ -369,9 +369,9 @@ public class FastSyncDownloaderTest {
     setup(dataStorageFormat);
     final CompletableFuture<Void> chainFuture = new CompletableFuture<>();
     final CompletableFuture<Void> worldStateFuture = new CompletableFuture<>();
-    final FastSyncState selectPivotBlockState = new FastSyncState(50);
+    final FastSyncState selectPivotBlockState = new FastSyncState(50, false);
     final BlockHeader pivotBlockHeader = new BlockHeaderTestFixture().number(50).buildHeader();
-    final FastSyncState downloadPivotBlockHeaderState = new FastSyncState(pivotBlockHeader);
+    final FastSyncState downloadPivotBlockHeaderState = new FastSyncState(pivotBlockHeader, false);
 
     when(fastSyncActions.selectPivotBlock(FastSyncState.EMPTY_SYNC_STATE))
         .thenReturn(completedFuture(selectPivotBlockState));
@@ -382,7 +382,7 @@ public class FastSyncDownloaderTest {
         .thenReturn(chainDownloader);
     when(chainDownloader.start()).thenReturn(chainFuture);
     when(worldStateDownloader.run(
-            any(FastSyncActions.class), eq(new FastSyncState(pivotBlockHeader))))
+            any(FastSyncActions.class), eq(new FastSyncState(pivotBlockHeader, false))))
         .thenReturn(worldStateFuture);
 
     final CompletableFuture<FastSyncState> result = downloader.start();
@@ -393,7 +393,7 @@ public class FastSyncDownloaderTest {
         .createChainDownloader(
             downloadPivotBlockHeaderState, SyncDurationMetrics.NO_OP_SYNC_DURATION_METRICS);
     verify(worldStateDownloader)
-        .run(any(FastSyncActions.class), eq(new FastSyncState(pivotBlockHeader)));
+        .run(any(FastSyncActions.class), eq(new FastSyncState(pivotBlockHeader, false)));
     verifyNoMoreInteractions(fastSyncActions);
     verifyNoMoreInteractions(worldStateDownloader);
 
@@ -413,14 +413,14 @@ public class FastSyncDownloaderTest {
     final CompletableFuture<Void> secondWorldStateFuture = new CompletableFuture<>();
     final CompletableFuture<Void> chainFuture = new CompletableFuture<>();
     final ChainDownloader secondChainDownloader = mock(ChainDownloader.class);
-    final FastSyncState selectPivotBlockState = new FastSyncState(50);
-    final FastSyncState secondSelectPivotBlockState = new FastSyncState(90);
+    final FastSyncState selectPivotBlockState = new FastSyncState(50, false);
+    final FastSyncState secondSelectPivotBlockState = new FastSyncState(90, false);
     final BlockHeader pivotBlockHeader = new BlockHeaderTestFixture().number(50).buildHeader();
     final BlockHeader secondPivotBlockHeader =
         new BlockHeaderTestFixture().number(90).buildHeader();
-    final FastSyncState downloadPivotBlockHeaderState = new FastSyncState(pivotBlockHeader);
+    final FastSyncState downloadPivotBlockHeaderState = new FastSyncState(pivotBlockHeader, false);
     final FastSyncState secondDownloadPivotBlockHeaderState =
-        new FastSyncState(secondPivotBlockHeader);
+        new FastSyncState(secondPivotBlockHeader, false);
 
     // First attempt
     when(fastSyncActions.selectPivotBlock(FastSyncState.EMPTY_SYNC_STATE))
@@ -433,7 +433,7 @@ public class FastSyncDownloaderTest {
         .thenReturn(chainDownloader);
     when(chainDownloader.start()).thenReturn(chainFuture);
     when(worldStateDownloader.run(
-            any(FastSyncActions.class), eq(new FastSyncState(pivotBlockHeader))))
+            any(FastSyncActions.class), eq(new FastSyncState(pivotBlockHeader, false))))
         .thenReturn(firstWorldStateFuture);
 
     // Second attempt with new pivot block
@@ -445,7 +445,7 @@ public class FastSyncDownloaderTest {
         .thenReturn(secondChainDownloader);
     when(secondChainDownloader.start()).thenReturn(completedFuture(null));
     when(worldStateDownloader.run(
-            any(FastSyncActions.class), eq(new FastSyncState(secondPivotBlockHeader))))
+            any(FastSyncActions.class), eq(new FastSyncState(secondPivotBlockHeader, false))))
         .thenReturn(secondWorldStateFuture);
 
     final CompletableFuture<FastSyncState> result = downloader.start();
@@ -457,7 +457,7 @@ public class FastSyncDownloaderTest {
         .createChainDownloader(
             downloadPivotBlockHeaderState, SyncDurationMetrics.NO_OP_SYNC_DURATION_METRICS);
     verify(worldStateDownloader)
-        .run(any(FastSyncActions.class), eq(new FastSyncState(pivotBlockHeader)));
+        .run(any(FastSyncActions.class), eq(new FastSyncState(pivotBlockHeader, false)));
     verifyNoMoreInteractions(fastSyncActions, worldStateDownloader, storage);
 
     assertThat(result).isNotDone();
@@ -475,7 +475,7 @@ public class FastSyncDownloaderTest {
         .createChainDownloader(
             secondDownloadPivotBlockHeaderState, SyncDurationMetrics.NO_OP_SYNC_DURATION_METRICS);
     verify(worldStateDownloader)
-        .run(any(FastSyncActions.class), eq(new FastSyncState(secondPivotBlockHeader)));
+        .run(any(FastSyncActions.class), eq(new FastSyncState(secondPivotBlockHeader, false)));
     verifyNoMoreInteractions(fastSyncActions, worldStateDownloader, storage);
 
     secondWorldStateFuture.complete(null);
@@ -493,14 +493,14 @@ public class FastSyncDownloaderTest {
     final CompletableFuture<Void> secondWorldStateFuture = new CompletableFuture<>();
     final CompletableFuture<Void> chainFuture = new CompletableFuture<>();
     final ChainDownloader secondChainDownloader = mock(ChainDownloader.class);
-    final FastSyncState selectPivotBlockState = new FastSyncState(50);
-    final FastSyncState secondSelectPivotBlockState = new FastSyncState(90);
+    final FastSyncState selectPivotBlockState = new FastSyncState(50, false);
+    final FastSyncState secondSelectPivotBlockState = new FastSyncState(90, false);
     final BlockHeader pivotBlockHeader = new BlockHeaderTestFixture().number(50).buildHeader();
     final BlockHeader secondPivotBlockHeader =
         new BlockHeaderTestFixture().number(90).buildHeader();
-    final FastSyncState downloadPivotBlockHeaderState = new FastSyncState(pivotBlockHeader);
+    final FastSyncState downloadPivotBlockHeaderState = new FastSyncState(pivotBlockHeader, false);
     final FastSyncState secondDownloadPivotBlockHeaderState =
-        new FastSyncState(secondPivotBlockHeader);
+        new FastSyncState(secondPivotBlockHeader, false);
 
     // First attempt
     when(fastSyncActions.selectPivotBlock(FastSyncState.EMPTY_SYNC_STATE))
@@ -513,7 +513,7 @@ public class FastSyncDownloaderTest {
         .thenReturn(chainDownloader);
     when(chainDownloader.start()).thenReturn(chainFuture);
     when(worldStateDownloader.run(
-            any(FastSyncActions.class), eq(new FastSyncState(pivotBlockHeader))))
+            any(FastSyncActions.class), eq(new FastSyncState(pivotBlockHeader, false))))
         .thenReturn(firstWorldStateFuture);
     when(fastSyncActions.scheduleFutureTask(any(), any()))
         .thenAnswer(invocation -> ((Supplier) invocation.getArgument(0)).get());
@@ -527,7 +527,7 @@ public class FastSyncDownloaderTest {
         .thenReturn(secondChainDownloader);
     when(secondChainDownloader.start()).thenReturn(completedFuture(null));
     when(worldStateDownloader.run(
-            any(FastSyncActions.class), eq(new FastSyncState(secondPivotBlockHeader))))
+            any(FastSyncActions.class), eq(new FastSyncState(secondPivotBlockHeader, false))))
         .thenReturn(secondWorldStateFuture);
 
     final CompletableFuture<FastSyncState> result = downloader.start();
@@ -539,7 +539,7 @@ public class FastSyncDownloaderTest {
         .createChainDownloader(
             downloadPivotBlockHeaderState, SyncDurationMetrics.NO_OP_SYNC_DURATION_METRICS);
     verify(worldStateDownloader)
-        .run(any(FastSyncActions.class), eq(new FastSyncState(pivotBlockHeader)));
+        .run(any(FastSyncActions.class), eq(new FastSyncState(pivotBlockHeader, false)));
     verifyNoMoreInteractions(fastSyncActions, worldStateDownloader, storage);
 
     assertThat(result).isNotDone();
@@ -559,7 +559,7 @@ public class FastSyncDownloaderTest {
         .createChainDownloader(
             secondDownloadPivotBlockHeaderState, SyncDurationMetrics.NO_OP_SYNC_DURATION_METRICS);
     verify(worldStateDownloader)
-        .run(any(FastSyncActions.class), eq(new FastSyncState(secondPivotBlockHeader)));
+        .run(any(FastSyncActions.class), eq(new FastSyncState(secondPivotBlockHeader, false)));
     verifyNoMoreInteractions(fastSyncActions, worldStateDownloader, storage);
 
     secondWorldStateFuture.complete(null);
@@ -581,9 +581,9 @@ public class FastSyncDownloaderTest {
   public void shouldNotAllowPeersBeforePivotBlockOnceSelected(
       final DataStorageFormat dataStorageFormat) {
     setup(dataStorageFormat);
-    final FastSyncState selectPivotBlockState = new FastSyncState(50);
+    final FastSyncState selectPivotBlockState = new FastSyncState(50, false);
     final BlockHeader pivotBlockHeader = new BlockHeaderTestFixture().number(50).buildHeader();
-    final FastSyncState downloadPivotBlockHeaderState = new FastSyncState(pivotBlockHeader);
+    final FastSyncState downloadPivotBlockHeaderState = new FastSyncState(pivotBlockHeader, false);
 
     when(fastSyncActions.selectPivotBlock(FastSyncState.EMPTY_SYNC_STATE))
         .thenReturn(completedFuture(selectPivotBlockState));
@@ -594,7 +594,7 @@ public class FastSyncDownloaderTest {
         .thenReturn(chainDownloader);
     when(chainDownloader.start()).thenReturn(new CompletableFuture<>());
     when(worldStateDownloader.run(
-            any(FastSyncActions.class), eq(new FastSyncState(pivotBlockHeader))))
+            any(FastSyncActions.class), eq(new FastSyncState(pivotBlockHeader, false))))
         .thenReturn(new CompletableFuture<>());
 
     downloader.start();
@@ -607,9 +607,9 @@ public class FastSyncDownloaderTest {
   public void shouldNotHaveTrailingPeerRequirementsAfterDownloadCompletes(
       final DataStorageFormat dataStorageFormat) {
     setup(dataStorageFormat);
-    final FastSyncState selectPivotBlockState = new FastSyncState(50);
+    final FastSyncState selectPivotBlockState = new FastSyncState(50, false);
     final BlockHeader pivotBlockHeader = new BlockHeaderTestFixture().number(50).buildHeader();
-    final FastSyncState downloadPivotBlockHeaderState = new FastSyncState(pivotBlockHeader);
+    final FastSyncState downloadPivotBlockHeaderState = new FastSyncState(pivotBlockHeader, false);
 
     when(fastSyncActions.selectPivotBlock(FastSyncState.EMPTY_SYNC_STATE))
         .thenReturn(completedFuture(selectPivotBlockState));
@@ -620,7 +620,7 @@ public class FastSyncDownloaderTest {
         .thenReturn(chainDownloader);
     when(chainDownloader.start()).thenReturn(completedFuture(null));
     when(worldStateDownloader.run(
-            any(FastSyncActions.class), eq(new FastSyncState(pivotBlockHeader))))
+            any(FastSyncActions.class), eq(new FastSyncState(pivotBlockHeader, false))))
         .thenReturn(completedFuture(null));
 
     final CompletableFuture<FastSyncState> result = downloader.start();

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/PivotBlockConfirmerTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/PivotBlockConfirmerTest.java
@@ -144,7 +144,7 @@ public class PivotBlockConfirmerTest {
 
     assertThat(future)
         .isCompletedWithValue(
-            new FastSyncState(blockchain.getBlockHeader(PIVOT_BLOCK_NUMBER).get()));
+            new FastSyncState(blockchain.getBlockHeader(PIVOT_BLOCK_NUMBER).get(), false));
   }
 
   @ParameterizedTest
@@ -184,7 +184,7 @@ public class PivotBlockConfirmerTest {
     future.join();
     assertThat(future)
         .isCompletedWithValue(
-            new FastSyncState(blockchain.getBlockHeader(PIVOT_BLOCK_NUMBER).get()));
+            new FastSyncState(blockchain.getBlockHeader(PIVOT_BLOCK_NUMBER).get(), false));
   }
 
   @ParameterizedTest
@@ -219,7 +219,7 @@ public class PivotBlockConfirmerTest {
 
     assertThat(future)
         .isCompletedWithValue(
-            new FastSyncState(blockchain.getBlockHeader(PIVOT_BLOCK_NUMBER).get()));
+            new FastSyncState(blockchain.getBlockHeader(PIVOT_BLOCK_NUMBER).get(), false));
   }
 
   @ParameterizedTest
@@ -261,7 +261,7 @@ public class PivotBlockConfirmerTest {
 
     assertThat(future)
         .isCompletedWithValue(
-            new FastSyncState(blockchain.getBlockHeader(PIVOT_BLOCK_NUMBER).get()));
+            new FastSyncState(blockchain.getBlockHeader(PIVOT_BLOCK_NUMBER).get(), false));
   }
 
   @ParameterizedTest
@@ -303,7 +303,7 @@ public class PivotBlockConfirmerTest {
 
     assertThat(future)
         .isCompletedWithValue(
-            new FastSyncState(blockchain.getBlockHeader(PIVOT_BLOCK_NUMBER).get()));
+            new FastSyncState(blockchain.getBlockHeader(PIVOT_BLOCK_NUMBER).get(), false));
   }
 
   @ParameterizedTest
@@ -337,7 +337,7 @@ public class PivotBlockConfirmerTest {
 
     assertThat(future)
         .isCompletedWithValue(
-            new FastSyncState(blockchain.getBlockHeader(PIVOT_BLOCK_NUMBER).get()));
+            new FastSyncState(blockchain.getBlockHeader(PIVOT_BLOCK_NUMBER).get(), false));
   }
 
   @ParameterizedTest
@@ -381,7 +381,7 @@ public class PivotBlockConfirmerTest {
 
     assertThat(future)
         .isCompletedWithValue(
-            new FastSyncState(blockchain.getBlockHeader(PIVOT_BLOCK_NUMBER).get()));
+            new FastSyncState(blockchain.getBlockHeader(PIVOT_BLOCK_NUMBER).get(), false));
   }
 
   @ParameterizedTest

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/PivotBlockRetrieverTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/PivotBlockRetrieverTest.java
@@ -133,7 +133,7 @@ public class PivotBlockRetrieverTest {
 
     assertThat(future)
         .isCompletedWithValue(
-            new FastSyncState(blockchain.getBlockHeader(PIVOT_BLOCK_NUMBER).get()));
+            new FastSyncState(blockchain.getBlockHeader(PIVOT_BLOCK_NUMBER).get(), false));
   }
 
   @ParameterizedTest
@@ -182,7 +182,7 @@ public class PivotBlockRetrieverTest {
 
     assertThat(future)
         .isCompletedWithValue(
-            new FastSyncState(blockchain.getBlockHeader(PIVOT_BLOCK_NUMBER).get()));
+            new FastSyncState(blockchain.getBlockHeader(PIVOT_BLOCK_NUMBER).get(), false));
   }
 
   @ParameterizedTest
@@ -240,7 +240,7 @@ public class PivotBlockRetrieverTest {
 
     assertThat(future)
         .isCompletedWithValue(
-            new FastSyncState(blockchain.getBlockHeader(PIVOT_BLOCK_NUMBER).get()));
+            new FastSyncState(blockchain.getBlockHeader(PIVOT_BLOCK_NUMBER).get(), false));
   }
 
   @ParameterizedTest
@@ -270,7 +270,7 @@ public class PivotBlockRetrieverTest {
     assertThat(peerB.hasOutstandingRequests()).isFalse();
     assertThat(future)
         .isCompletedWithValue(
-            new FastSyncState(blockchain.getBlockHeader(PIVOT_BLOCK_NUMBER).get()));
+            new FastSyncState(blockchain.getBlockHeader(PIVOT_BLOCK_NUMBER).get(), false));
   }
 
   @ParameterizedTest
@@ -307,7 +307,7 @@ public class PivotBlockRetrieverTest {
 
     assertThat(future)
         .isCompletedWithValue(
-            new FastSyncState(blockchain.getBlockHeader(PIVOT_BLOCK_NUMBER).get()));
+            new FastSyncState(blockchain.getBlockHeader(PIVOT_BLOCK_NUMBER).get(), false));
   }
 
   @ParameterizedTest
@@ -344,7 +344,8 @@ public class PivotBlockRetrieverTest {
     respondingPeerB.respond(responderB);
 
     assertThat(future)
-        .isCompletedWithValue(new FastSyncState(blockchain.getBlockHeader(newPivotBlock).get()));
+        .isCompletedWithValue(
+            new FastSyncState(blockchain.getBlockHeader(newPivotBlock).get(), false));
   }
 
   @ParameterizedTest

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/worldstate/FastWorldStateDownloaderTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/worldstate/FastWorldStateDownloaderTest.java
@@ -171,7 +171,7 @@ class FastWorldStateDownloaderTest {
             .block(BlockOptions.create().setStateRoot(EMPTY_TRIE_ROOT).setBlockNumber(10))
             .getHeader();
 
-    final FastSyncState fastSyncState = new FastSyncState(header);
+    final FastSyncState fastSyncState = new FastSyncState(header, false);
 
     // Create some peers
     final List<RespondingEthPeer> peers =
@@ -225,7 +225,7 @@ class FastWorldStateDownloaderTest {
             worldStateArchive.getWorldStateStorage(),
             taskCollection);
 
-    final FastSyncState fastSyncState = new FastSyncState(header);
+    final FastSyncState fastSyncState = new FastSyncState(header, false);
 
     final CompletableFuture<Void> future = downloader.run(null, fastSyncState);
     assertThat(future).isDone();
@@ -275,7 +275,7 @@ class FastWorldStateDownloaderTest {
     final WorldStateDownloader downloader =
         createDownloader(ethProtocolManager.ethContext(), localStorage, taskCollection);
 
-    final FastSyncState fastSyncState = new FastSyncState(header);
+    final FastSyncState fastSyncState = new FastSyncState(header, false);
 
     final CompletableFuture<Void> result = downloader.run(null, fastSyncState);
 
@@ -340,7 +340,7 @@ class FastWorldStateDownloaderTest {
     final WorldStateDownloader downloader =
         createDownloader(ethProtocolManager.ethContext(), localStorage, taskCollection);
 
-    final FastSyncState fastSyncState = new FastSyncState(header);
+    final FastSyncState fastSyncState = new FastSyncState(header, false);
 
     final CompletableFuture<Void> result = downloader.run(null, fastSyncState);
 
@@ -420,7 +420,7 @@ class FastWorldStateDownloaderTest {
     final WorldStateDownloader downloader =
         createDownloader(ethProtocolManager.ethContext(), localStorage, taskCollection);
 
-    final FastSyncState fastSyncState = new FastSyncState(header);
+    final FastSyncState fastSyncState = new FastSyncState(header, false);
 
     final CompletableFuture<Void> result = downloader.run(null, fastSyncState);
 
@@ -518,7 +518,7 @@ class FastWorldStateDownloaderTest {
     final WorldStateDownloader downloader =
         createDownloader(ethProtocolManager.ethContext(), localStorage, taskCollection);
 
-    final FastSyncState fastSyncState = new FastSyncState(header);
+    final FastSyncState fastSyncState = new FastSyncState(header, false);
 
     final CompletableFuture<Void> result = downloader.run(null, fastSyncState);
 
@@ -624,7 +624,7 @@ class FastWorldStateDownloaderTest {
     final WorldStateDownloader downloader =
         createDownloader(ethProtocolManager.ethContext(), localStorage, taskCollection);
 
-    final FastSyncState fastSyncState = new FastSyncState(header);
+    final FastSyncState fastSyncState = new FastSyncState(header, false);
 
     final CompletableFuture<Void> result = downloader.run(null, fastSyncState);
 
@@ -709,10 +709,12 @@ class FastWorldStateDownloaderTest {
             new FastSyncState(
                 new BlockHeaderTestFixture()
                     .stateRoot(Hash.hash(Bytes.of(1, 2, 3, 4)))
-                    .buildHeader()));
+                    .buildHeader(),
+                false));
 
     // A second run should return an error without impacting the first result
-    final CompletableFuture<?> secondResult = downloader.run(null, new FastSyncState(header));
+    final CompletableFuture<?> secondResult =
+        downloader.run(null, new FastSyncState(header, false));
     assertThat(secondResult).isCompletedExceptionally();
     assertThat(result).isNotCompletedExceptionally();
 
@@ -724,7 +726,8 @@ class FastWorldStateDownloaderTest {
 
     // Finally, check that when we restart the download with state that is available it works
 
-    final CompletableFuture<Void> retryResult = downloader.run(null, new FastSyncState(header));
+    final CompletableFuture<Void> retryResult =
+        downloader.run(null, new FastSyncState(header, false));
 
     final RespondingEthPeer.Responder responder =
         RespondingEthPeer.blockchainResponder(mock(Blockchain.class), remoteWorldStateArchive);
@@ -784,7 +787,7 @@ class FastWorldStateDownloaderTest {
     final RespondingEthPeer.Responder responder =
         RespondingEthPeer.wrapResponderWithCollector(blockChainResponder, sentMessages);
 
-    CompletableFuture<Void> result = downloader.run(null, new FastSyncState(header));
+    CompletableFuture<Void> result = downloader.run(null, new FastSyncState(header, false));
     peer.respondWhileOtherThreadsWork(responder, () -> !result.isDone());
     assertThat(localStorage.isWorldStateAvailable(stateRoot)).isTrue();
 
@@ -937,9 +940,10 @@ class FastWorldStateDownloaderTest {
             .toList();
 
     // Start downloader
-    final CompletableFuture<?> result = downloader.run(null, new FastSyncState(header));
+    final CompletableFuture<?> result = downloader.run(null, new FastSyncState(header, false));
     // A second run should return an error without impacting the first result
-    final CompletableFuture<?> secondResult = downloader.run(null, new FastSyncState(header));
+    final CompletableFuture<?> secondResult =
+        downloader.run(null, new FastSyncState(header, false));
     assertThat(secondResult).isCompletedExceptionally();
     assertThat(result).isNotCompletedExceptionally();
 

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/DynamicPivotBlockManagerTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/DynamicPivotBlockManagerTest.java
@@ -66,9 +66,9 @@ public class DynamicPivotBlockManagerTest {
 
   @Test
   public void shouldSearchNewPivotBlockWhenNotCloseToTheHead() {
-    final FastSyncState selectPivotBlockState = new FastSyncState(1090);
+    final FastSyncState selectPivotBlockState = new FastSyncState(1090, false);
     final BlockHeader pivotBlockHeader = new BlockHeaderTestFixture().number(1090).buildHeader();
-    final FastSyncState downloadPivotBlockHeaderState = new FastSyncState(pivotBlockHeader);
+    final FastSyncState downloadPivotBlockHeaderState = new FastSyncState(pivotBlockHeader, false);
     when(fastSyncActions.selectPivotBlock(FastSyncState.EMPTY_SYNC_STATE))
         .thenReturn(completedFuture(selectPivotBlockState));
     when(fastSyncActions.downloadPivotBlockHeader(selectPivotBlockState))
@@ -83,9 +83,9 @@ public class DynamicPivotBlockManagerTest {
 
   @Test
   public void shouldSwitchToNewPivotBlockWhenNeeded() {
-    final FastSyncState selectPivotBlockState = new FastSyncState(1060);
+    final FastSyncState selectPivotBlockState = new FastSyncState(1060, false);
     final BlockHeader pivotBlockHeader = new BlockHeaderTestFixture().number(1060).buildHeader();
-    final FastSyncState downloadPivotBlockHeaderState = new FastSyncState(pivotBlockHeader);
+    final FastSyncState downloadPivotBlockHeaderState = new FastSyncState(pivotBlockHeader, false);
     when(fastSyncActions.selectPivotBlock(FastSyncState.EMPTY_SYNC_STATE))
         .thenReturn(completedFuture(selectPivotBlockState));
     when(fastSyncActions.downloadPivotBlockHeader(selectPivotBlockState))
@@ -112,9 +112,9 @@ public class DynamicPivotBlockManagerTest {
 
   @Test
   public void shouldSwitchToNewPivotOnlyOnce() {
-    final FastSyncState selectPivotBlockState = new FastSyncState(1060);
+    final FastSyncState selectPivotBlockState = new FastSyncState(1060, false);
     final BlockHeader pivotBlockHeader = new BlockHeaderTestFixture().number(1060).buildHeader();
-    final FastSyncState downloadPivotBlockHeaderState = new FastSyncState(pivotBlockHeader);
+    final FastSyncState downloadPivotBlockHeaderState = new FastSyncState(pivotBlockHeader, false);
     when(fastSyncActions.selectPivotBlock(FastSyncState.EMPTY_SYNC_STATE))
         .thenReturn(completedFuture(selectPivotBlockState));
     when(fastSyncActions.downloadPivotBlockHeader(selectPivotBlockState))


### PR DESCRIPTION
## PR description
Backport Skip header validation if the chain is POS (#9038) from main.

Also adding back the attachedValidationPolicy and ommerValidationPolicy for the ImportBlocksStep. These were removed on main when we changed to using the ImportSyncBlocksStep.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

