### PR TITLE
fix: MessageCallProcessor - precompile trace call

### DIFF
--- a/evm/src/main/java/org/hyperledger/besu/evm/processor/MessageCallProcessor.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/processor/MessageCallProcessor.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import com.google.common.annotations.VisibleForTesting;
+import org.apache.tuweni.bytes.Bytes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -152,26 +153,28 @@ public class MessageCallProcessor extends AbstractMessageProcessor {
       final MessageFrame frame,
       final OperationTracer operationTracer) {
     final long gasRequirement = contract.gasRequirement(frame.getInputData());
+    final Bytes output;
     if (frame.getRemainingGas() < gasRequirement) {
       frame.setExceptionalHaltReason(Optional.of(ExceptionalHaltReason.INSUFFICIENT_GAS));
       frame.setState(MessageFrame.State.EXCEPTIONAL_HALT);
-      operationTracer.tracePrecompileCall(frame, gasRequirement, null);
+      output = null;
     } else {
       frame.decrementRemainingGas(gasRequirement);
       final PrecompiledContract.PrecompileContractResult result =
           contract.computePrecompile(frame.getInputData(), frame);
-      operationTracer.tracePrecompileCall(frame, gasRequirement, result.output());
+      output = result.output();
       if (result.isRefundGas()) {
         frame.incrementRemainingGas(gasRequirement);
       }
       if (frame.getState() == MessageFrame.State.REVERT) {
-        frame.setRevertReason(result.output());
+        frame.setRevertReason(output);
       } else {
-        frame.setOutputData(result.output());
+        frame.setOutputData(output);
       }
       frame.setState(result.state());
       frame.setExceptionalHaltReason(result.haltReason());
     }
+    operationTracer.tracePrecompileCall(frame, gasRequirement, output);
   }
 
   /**


### PR DESCRIPTION
## PR description
In `MessageCallProcessor.executePrecompile`, move the operation tracer's `tracePrecompileCall` after the MessageFrame state is updated. This will help in operations tracers to not miss any exceptional halts or revert reasons resulted from precompiles. 

## Related Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Related to https://github.com/hyperledger/besu/issues/8326
Related to https://github.com/hyperledger/besu/pull/9111
Related to https://github.com/hyperledger/besu/pull/9072

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew build`
- [x] acceptance tests: `./gradlew acceptanceTest`
- [x] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

