### PR TITLE
fix inconsistent synchronisation of getter and setter

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapWorldDownloadState.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapWorldDownloadState.java
@@ -328,7 +328,7 @@ public class SnapWorldDownloadState extends WorldDownloadState<SnapDataRequest> 
     }
   }
 
-  public Set<Bytes> getAccountsHealingList() {
+  public synchronized Set<Bytes> getAccountsHealingList() {
     return accountsHealingList;
   }
 


### PR DESCRIPTION
## PR description

## Fixed Issue(s)
Inconsistent synchronization of getter and setter

To fix the problem, we must ensure that all access to the shared mutable field (accountsHealingList) is properly synchronized. This means the getter method getAccountsHealingList should be declared as synchronized in addition to the setter and modifier methods. This ensures that reads and writes to the field cannot interleave in a way that exposes inconsistent or partially updated state. The best way to fix this is simply to add the synchronized modifier to the getAccountsHealingList method, declared at line 331 of the file.


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

