### PR TITLE
Point referenceTests to LegacyTests/Cancun version of GeneralStateTests

### DIFF
--- a/ethereum/referencetests/build.gradle
+++ b/ethereum/referencetests/build.gradle
@@ -80,7 +80,7 @@ def executionSpecTests = tasks.register("executionSpecTests") {
 }
 
 def generalstateReferenceTests = tasks.register("generalstateReferenceTests")  {
-  final referenceTestsPath = "src/reference-test/external-resources/GeneralStateTests"
+  final referenceTestsPath = "src/reference-test/external-resources/LegacyTests/Cancun/GeneralStateTests"
   final generatedTestsPath = "$buildDir/generated/sources/reference-test/$name/java"
   inputs.files fileTree(referenceTestsPath),
     fileTree(generatedTestsPath)
@@ -88,7 +88,7 @@ def generalstateReferenceTests = tasks.register("generalstateReferenceTests")  {
   generateTestFiles(
     fileTree(referenceTestsPath),
     file("src/reference-test/templates/GeneralStateReferenceTest.java.template"),
-    "GeneralStateTests",
+    "LegacyTests/Cancun/GeneralStateTests",
     "$generatedTestsPath/org/hyperledger/besu/ethereum/vm/generalstate",
     "GeneralStateReferenceTest",
     "org.hyperledger.besu.ethereum.vm.generalstate",


### PR DESCRIPTION
The previous path wasn't generating any tests since it's moved to LegacyTests

Old path removed here: https://github.com/ethereum/tests/commit/613f53571c1b45593671575d1a9181fbbdd65242

New path:
https://github.com/ethereum/legacytests/tree/master/Cancun/GeneralStateTests

https://github.com/ethereum/legacytests/blob/master/Constantinople/README.md
> Sanpshot of the ethereum/tests vectors as of Cancun development filled for (ConstantinopleFix, Cancun]

---

Note, there's a second Constantinople path being tested out in this PR: https://github.com/hyperledger/besu/pull/9126

---

Local run...
<img width="672" height="193" alt="Screenshot 2025-08-28 at 2 21 04 pm" src="https://github.com/user-attachments/assets/c86d11fb-50b4-4c48-8486-9d644b080dca" />
