### PR TITLE
Revert "Update ethereum/tests submodule to v17.2 for Prague support (…

### DIFF
--- a/ethereum/referencetests/build.gradle
+++ b/ethereum/referencetests/build.gradle
@@ -41,8 +41,39 @@ def blockchainReferenceTests = tasks.register("blockchainReferenceTests")  {
     "$generatedTestsPath/org/hyperledger/besu/ethereum/vm/blockchain",
     "BlockchainReferenceTest",
     "org.hyperledger.besu.ethereum.vm.blockchain",
-    "BlockchainTests/InvalidBlocks/bcExpectSection", // exclude test for test filling tool
-    "BlockchainTests/.meta"
+    ("BlockchainTests/InvalidBlocks/bcExpectSection") // exclude test for test filling tool
+    )
+}
+
+def eipBlockchainReferenceTests = tasks.register("eipBlockchainReferenceTests")  {
+  final referenceTestsPath = 'src/reference-test/external-resources/EIPTests/BlockchainTests'
+  final generatedTestsPath = "$buildDir/generated/sources/reference-test/$name/java"
+  inputs.files fileTree(referenceTestsPath),
+    fileTree(generatedTestsPath)
+  outputs.files generatedTestsPath
+  generateTestFiles(
+    fileTree(referenceTestsPath),
+    file("src/reference-test/templates/BlockchainReferenceTest.java.template"),
+    "EIPTests${File.separatorChar}BlockchainTests",
+    "$generatedTestsPath/org/hyperledger/besu/ethereum/vm/eip",
+    "EIPBlockchainReferenceTest",
+    "org.hyperledger.besu.ethereum.vm.eip",
+    )
+}
+
+def eipStateReferenceTests = tasks.register("eipStateReferenceTests")  {
+  final referenceTestsPath = 'src/reference-test/external-resources/EIPTests/StateTests'
+  final generatedTestsPath = "$buildDir/generated/sources/reference-test/$name/java"
+  inputs.files fileTree(referenceTestsPath),
+    fileTree(generatedTestsPath)
+  outputs.files generatedTestsPath
+  generateTestFiles(
+    fileTree(referenceTestsPath),
+    file("src/reference-test/templates/GeneralStateReferenceTest.java.template"),
+    "EIPTests${File.separatorChar}StateTests",
+    "$generatedTestsPath/org/hyperledger/besu/ethereum/vm/eip",
+    "EIPStateReferenceTest",
+    "org.hyperledger.besu.ethereum.vm.eip",
     )
 }
 
@@ -111,6 +142,22 @@ def generalstateRegressionReferenceTests = tasks.register("generalstateRegressio
     )
 }
 
+def eofReferenceTests = tasks.register("eofReferenceTests") {
+  final referenceTestsPath = "src/reference-test/external-resources/EOFTests"
+  final generatedTestsPath = "$buildDir/generated/sources/reference-test/$name/java"
+  inputs.files fileTree(referenceTestsPath),
+    fileTree(generatedTestsPath)
+  outputs.files generatedTestsPath
+  generateTestFiles(
+    fileTree(referenceTestsPath),
+    file("src/reference-test/templates/EOFReferenceTest.java.template"),
+    "EOFTests",
+    "$generatedTestsPath/org/hyperledger/besu/ethereum/vm/eof",
+    "EOFReferenceTest",
+    "org.hyperledger.besu.ethereum.vm.eof"
+    )
+}
+
 sourceSets {
   referenceTest {
     java {
@@ -118,9 +165,12 @@ sourceSets {
       runtimeClasspath += main.output
       srcDirs "src/reference-test/java",
         blockchainReferenceTests,
+        eipBlockchainReferenceTests,
+        eipStateReferenceTests,
         executionSpecTests,
         generalstateReferenceTests,
-        generalstateRegressionReferenceTests
+        generalstateRegressionReferenceTests,
+        eofReferenceTests
     }
     resources {
       srcDirs 'src/reference-test/resources',
@@ -190,7 +240,7 @@ tasks.register('validateReferenceTestSubmodule') {
   description = "Checks that the reference tests submodule is not accidentally changed"
   doLast {
     def result = new ByteArrayOutputStream()
-    def expectedHash = 'c67e485ff8b5be9abc8ad15345ec21aa22e290d9'
+    def expectedHash = '9201075490807f58811078e9bb5ec895b4ac01a5'
     def submodulePath = java.nio.file.Path.of("${rootProject.projectDir}", "ethereum/referencetests/src/reference-test/external-resources").toAbsolutePath()
     try {
       exec {

--- a/ethereum/referencetests/src/reference-test/java/org/hyperledger/besu/ethereum/vm/GeneralStateReferenceTestTools.java
+++ b/ethereum/referencetests/src/reference-test/java/org/hyperledger/besu/ethereum/vm/GeneralStateReferenceTestTools.java
@@ -119,9 +119,6 @@ public class GeneralStateReferenceTestTools {
     // These are for the older reference tests but EIP-2537 is covered by eip2537_bls_12_381_precompiles in the execution-spec-tests
     params.ignore("/stEIP2537/");
 
-    // TODO remove this ignore once Osaka EIPs are merged to main
-    params.ignore("Osaka*");
-
   }
 
   private GeneralStateReferenceTestTools() {


### PR DESCRIPTION
…#8648)"

This reverts commit f27b7a10b941a5f6cb761228b4b86c9b8643aa6f which effectively downgrades ethereum/tests to [version 14.1](https://github.com/ethereum/tests/releases/tag/v14.1).

A lot of tests that we reference were removed here: https://github.com/ethereum/tests/commit/613f53571c1b45593671575d1a9181fbbdd65242

and so we are currently missing coverage because EEST has not closed this gap yet (an eests release in the near future should do however).

When the 17.2 change went in, our number of reference tests (including eest) were reduced from 75921 to 27829.

Current main run:
<img width="744" height="211" alt="Screenshot 2025-08-28 at 3 02 09 pm" src="https://github.com/user-attachments/assets/7c9ef4d1-5476-4352-ae4b-efe2c1398e45" />

With this PR:
<img width="708" height="218" alt="Screenshot 2025-08-28 at 2 53 16 pm" src="https://github.com/user-attachments/assets/e0e5c5ea-9b2b-44c5-8e54-d3a6ee79c87a" />

NOTE: this PR may introduce a new gap e.g. in [ethereum/tests Prague support](https://github.com/ethereum/tests/releases/tag/v16.0), however we are still pulling in the latest eests release so that should cover prague well already (if not exact same tests?)

---

Also testing out pointing to the new LegacyTest paths here:
https://github.com/hyperledger/besu/pull/9125
https://github.com/hyperledger/besu/pull/9126
