### PR TITLE
Backport Make the Bft expiry time algorithm configurable (#9085)

### DIFF
--- a/app/src/main/java/org/hyperledger/besu/controller/IbftBesuControllerBuilder.java
+++ b/app/src/main/java/org/hyperledger/besu/controller/IbftBesuControllerBuilder.java
@@ -25,6 +25,7 @@ import org.hyperledger.besu.consensus.common.bft.BftEventQueue;
 import org.hyperledger.besu.consensus.common.bft.BftExecutors;
 import org.hyperledger.besu.consensus.common.bft.BftProcessor;
 import org.hyperledger.besu.consensus.common.bft.BftProtocolSchedule;
+import org.hyperledger.besu.consensus.common.bft.BftRoundExpiryTimeCalculator;
 import org.hyperledger.besu.consensus.common.bft.BlockTimer;
 import org.hyperledger.besu.consensus.common.bft.EthSynchronizerUpdater;
 import org.hyperledger.besu.consensus.common.bft.EventMultiplexer;
@@ -183,7 +184,8 @@ public class IbftBesuControllerBuilder extends BesuControllerBuilder {
             uniqueMessageMulticaster,
             new RoundTimer(
                 bftEventQueue,
-                Duration.ofSeconds(bftConfig.getRequestTimeoutSeconds()),
+                new BftRoundExpiryTimeCalculator(
+                    Duration.ofSeconds(bftConfig.getRequestTimeoutSeconds())),
                 bftExecutors),
             new BlockTimer(bftEventQueue, forksSchedule, bftExecutors, clock),
             blockCreatorFactory,

--- a/app/src/main/java/org/hyperledger/besu/controller/QbftBesuControllerBuilder.java
+++ b/app/src/main/java/org/hyperledger/besu/controller/QbftBesuControllerBuilder.java
@@ -29,6 +29,7 @@ import org.hyperledger.besu.consensus.common.bft.BftEventQueue;
 import org.hyperledger.besu.consensus.common.bft.BftExecutors;
 import org.hyperledger.besu.consensus.common.bft.BftProcessor;
 import org.hyperledger.besu.consensus.common.bft.BftProtocolSchedule;
+import org.hyperledger.besu.consensus.common.bft.BftRoundExpiryTimeCalculator;
 import org.hyperledger.besu.consensus.common.bft.BlockTimer;
 import org.hyperledger.besu.consensus.common.bft.EthSynchronizerUpdater;
 import org.hyperledger.besu.consensus.common.bft.EventMultiplexer;
@@ -250,7 +251,8 @@ public class QbftBesuControllerBuilder extends BesuControllerBuilder {
             uniqueMessageMulticaster,
             new RoundTimer(
                 bftEventQueue,
-                Duration.ofSeconds(qbftConfig.getRequestTimeoutSeconds()),
+                new BftRoundExpiryTimeCalculator(
+                    Duration.ofSeconds(qbftConfig.getRequestTimeoutSeconds())),
                 bftExecutors),
             new BlockTimer(bftEventQueue, qbftForksSchedule, bftExecutors, clock),
             new QbftBlockCreatorFactoryAdaptor(blockCreatorFactory, qbftExtraDataCodec),

--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/BftRoundExpiryTimeCalculator.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/BftRoundExpiryTimeCalculator.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.consensus.common.bft;
+
+import java.time.Duration;
+
+/**
+ * Default implementation of {@link RoundExpiryTimeCalculator} for BFT consensus algorithms. This
+ * implementation calculates the expiry time for a round based on an exponential backoff strategy
+ * where round expiry = baseExpiryPeriod * 2^roundNumber.
+ */
+public class BftRoundExpiryTimeCalculator implements RoundExpiryTimeCalculator {
+  private final Duration baseExpiryPeriod;
+
+  /**
+   * Constructs a BftRoundExpiryTimeCalculator with a specified base expiry period.
+   *
+   * @param baseExpiryPeriod the base duration for round expiry calculations
+   */
+  public BftRoundExpiryTimeCalculator(final Duration baseExpiryPeriod) {
+    this.baseExpiryPeriod = baseExpiryPeriod;
+  }
+
+  /**
+   * Calculates the expiry time for a given round based on an exponential backoff strategy.
+   *
+   * @param round the round identifier for which to calculate the expiry time
+   * @return the duration until the round expires
+   */
+  @Override
+  public Duration calculateRoundExpiry(final ConsensusRoundIdentifier round) {
+    return Duration.ofMillis(
+        baseExpiryPeriod.toMillis() * (long) Math.pow(2, round.getRoundNumber()));
+  }
+}

--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/RoundExpiryTimeCalculator.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/RoundExpiryTimeCalculator.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.consensus.common.bft;
+
+import java.time.Duration;
+
+/** Calculates the expiry time of a round in a BFT consensus algorithm. */
+public interface RoundExpiryTimeCalculator {
+  /**
+   * Calculate the expiry time for a given round.
+   *
+   * @param round the round identifier for which to calculate the expiry time
+   * @return the expiry time
+   */
+  Duration calculateRoundExpiry(ConsensusRoundIdentifier round);
+}

--- a/consensus/common/src/test/java/org/hyperledger/besu/consensus/common/bft/BftRoundExpiryTimeCalculatorTest.java
+++ b/consensus/common/src/test/java/org/hyperledger/besu/consensus/common/bft/BftRoundExpiryTimeCalculatorTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.consensus.common.bft;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+
+class BftRoundExpiryTimeCalculatorTest {
+
+  @Test
+  public void calculatesRoundExpiry() {
+    final Duration baseExpiry = Duration.ofSeconds(2);
+    final BftRoundExpiryTimeCalculator calculator = new BftRoundExpiryTimeCalculator(baseExpiry);
+
+    // Round 0: 2000 * 2^0 = 2000ms
+    assertThat(calculator.calculateRoundExpiry(new ConsensusRoundIdentifier(1, 0))).hasMillis(2000);
+
+    // Round 1: 2000 * 2^1 = 4000ms
+    assertThat(calculator.calculateRoundExpiry(new ConsensusRoundIdentifier(1, 1))).hasMillis(4000);
+
+    // Round 2: 2000 * 2^2 = 8000ms
+    assertThat(calculator.calculateRoundExpiry(new ConsensusRoundIdentifier(1, 2))).hasMillis(8000);
+
+    // Round 3: 2000 * 2^3 = 16000ms
+    assertThat(calculator.calculateRoundExpiry(new ConsensusRoundIdentifier(1, 3)))
+        .hasMillis(16000);
+
+    // Round 5: 2000 * 2^5 = 64000ms
+    assertThat(calculator.calculateRoundExpiry(new ConsensusRoundIdentifier(1, 5)))
+        .hasMillis(64000);
+  }
+}

--- a/consensus/common/src/test/java/org/hyperledger/besu/consensus/common/bft/RoundTimerTest.java
+++ b/consensus/common/src/test/java/org/hyperledger/besu/consensus/common/bft/RoundTimerTest.java
@@ -47,7 +47,9 @@ public class RoundTimerTest {
     bftExecutors = mock(BftExecutors.class);
     queue = new BftEventQueue(1000);
     queue.start();
-    timer = new RoundTimer(queue, Duration.ofSeconds(1), bftExecutors);
+    timer =
+        new RoundTimer(
+            queue, new BftRoundExpiryTimeCalculator(Duration.ofSeconds(1)), bftExecutors);
   }
 
   @Test

--- a/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/support/TestContextBuilder.java
+++ b/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/support/TestContextBuilder.java
@@ -35,6 +35,7 @@ import org.hyperledger.besu.consensus.common.bft.BftExecutors;
 import org.hyperledger.besu.consensus.common.bft.BftExtraData;
 import org.hyperledger.besu.consensus.common.bft.BftHelpers;
 import org.hyperledger.besu.consensus.common.bft.BftProtocolSchedule;
+import org.hyperledger.besu.consensus.common.bft.BftRoundExpiryTimeCalculator;
 import org.hyperledger.besu.consensus.common.bft.BlockTimer;
 import org.hyperledger.besu.consensus.common.bft.EventMultiplexer;
 import org.hyperledger.besu.consensus.common.bft.Gossiper;
@@ -405,7 +406,10 @@ public class TestContextBuilder {
             Util.publicKeyToAddress(nodeKey.getPublicKey()),
             proposerSelector,
             multicaster,
-            new RoundTimer(bftEventQueue, Duration.ofSeconds(ROUND_TIMER_SEC), bftExecutors),
+            new RoundTimer(
+                bftEventQueue,
+                new BftRoundExpiryTimeCalculator(Duration.ofSeconds(ROUND_TIMER_SEC)),
+                bftExecutors),
             new BlockTimer(bftEventQueue, forksSchedule, bftExecutors, TestClock.fixed()),
             blockCreatorFactory,
             clock);

--- a/consensus/qbft-core/src/integration-test/java/org/hyperledger/besu/consensus/qbft/core/support/TestContextBuilder.java
+++ b/consensus/qbft-core/src/integration-test/java/org/hyperledger/besu/consensus/qbft/core/support/TestContextBuilder.java
@@ -40,6 +40,7 @@ import org.hyperledger.besu.consensus.common.bft.BftExecutors;
 import org.hyperledger.besu.consensus.common.bft.BftExtraData;
 import org.hyperledger.besu.consensus.common.bft.BftHelpers;
 import org.hyperledger.besu.consensus.common.bft.BftProtocolSchedule;
+import org.hyperledger.besu.consensus.common.bft.BftRoundExpiryTimeCalculator;
 import org.hyperledger.besu.consensus.common.bft.BlockTimer;
 import org.hyperledger.besu.consensus.common.bft.EventMultiplexer;
 import org.hyperledger.besu.consensus.common.bft.Gossiper;
@@ -534,7 +535,10 @@ public class TestContextBuilder {
             Util.publicKeyToAddress(nodeKey.getPublicKey()),
             proposerSelector,
             multicaster,
-            new RoundTimer(bftEventQueue, Duration.ofSeconds(ROUND_TIMER_SEC), bftExecutors),
+            new RoundTimer(
+                bftEventQueue,
+                new BftRoundExpiryTimeCalculator(Duration.ofSeconds(ROUND_TIMER_SEC)),
+                bftExecutors),
             new BlockTimer(bftEventQueue, forksSchedule, bftExecutors, TestClock.fixed()),
             new QbftBlockCreatorFactoryAdaptor(blockCreatorFactory, BFT_EXTRA_DATA_ENCODER),
             clock);


### PR DESCRIPTION
## PR description
Backport Make the Bft expiry time algorithm configurable (#9085)

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


