### PR TITLE
fix(evm): correct P256VERIFY input length in error message

### DIFF
--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/P256VerifyPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/P256VerifyPrecompiledContract.java
@@ -40,7 +40,7 @@ public class P256VerifyPrecompiledContract extends AbstractPrecompiledContract {
   private static final String PRECOMPILE_NAME = "P256VERIFY";
   private static final Bytes32 VALID = Bytes32.leftPad(Bytes.of(1), (byte) 0);
   private static final Bytes INVALID = Bytes.EMPTY;
-  private final int SECP256R1_INPUT_LENGTH = 160;
+  private static final int SECP256R1_INPUT_LENGTH = 160;
 
   private static final X9ECParameters R1_PARAMS = SECNamedCurves.getByName("secp256r1");
   private static final BigInteger N = R1_PARAMS.getN();

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/P256VerifyPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/P256VerifyPrecompiledContract.java
@@ -40,6 +40,7 @@ public class P256VerifyPrecompiledContract extends AbstractPrecompiledContract {
   private static final String PRECOMPILE_NAME = "P256VERIFY";
   private static final Bytes32 VALID = Bytes32.leftPad(Bytes.of(1), (byte) 0);
   private static final Bytes INVALID = Bytes.EMPTY;
+  private final int SECP256R1_INPUT_LENGTH = 160;
 
   private static final X9ECParameters R1_PARAMS = SECNamedCurves.getByName("secp256r1");
   private static final BigInteger N = R1_PARAMS.getN();
@@ -121,9 +122,10 @@ public class P256VerifyPrecompiledContract extends AbstractPrecompiledContract {
   @Override
   public PrecompileContractResult computePrecompile(
       final Bytes input, final MessageFrame messageFrame) {
-    if (input.size() != 160) {
+    if (input.size() != SECP256R1_INPUT_LENGTH) {
       LOG.warn(
-          "Invalid input length for P256VERIFY precompile: expected 160 bytes but got {}",
+          "Invalid input length for P256VERIFY precompile: expected {} bytes but got {}",
+          SECP256R1_INPUT_LENGTH,
           input.size());
       return PrecompileContractResult.success(INVALID);
     }

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/P256VerifyPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/P256VerifyPrecompiledContract.java
@@ -123,7 +123,7 @@ public class P256VerifyPrecompiledContract extends AbstractPrecompiledContract {
       final Bytes input, final MessageFrame messageFrame) {
     if (input.size() != 160) {
       LOG.warn(
-          "Invalid input length for P256VERIFY precompile: expected 128 bytes but got {}",
+          "Invalid input length for P256VERIFY precompile: expected 160 bytes but got {}",
           input.size());
       return PrecompileContractResult.success(INVALID);
     }


### PR DESCRIPTION
## PR description

## Fixed Issue(s)
Closes #9136


### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew build`
- [x] acceptance tests: `./gradlew acceptanceTest`
- [x] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [x] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


