### PR TITLE
Support multiple transaction selector plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Additions and Improvements
 - Update log4j [#9131](https://github.com/hyperledger/besu/pull/9131)
 - Expose new method to query hardfork by block number Plugin API [#9115](https://github.com/hyperledger/besu/pull/9115)
+- Support loading multiple transaction selector plugins [#8743](https://github.com/hyperledger/besu/pull/9139)
 
 #### Performance
 - Add jmh benchmarks for some compute-related opcodes [#9069](https://github.com/hyperledger/besu/pull/9069)

--- a/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/tests/acceptance/plugins/AbstractTestTransactionSelectorPlugin.java
+++ b/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/tests/acceptance/plugins/AbstractTestTransactionSelectorPlugin.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.tests.acceptance.plugins;
+
+import static org.hyperledger.besu.plugin.data.TransactionSelectionResult.SELECTED;
+
+import org.hyperledger.besu.plugin.BesuPlugin;
+import org.hyperledger.besu.plugin.ServiceManager;
+import org.hyperledger.besu.plugin.data.TransactionProcessingResult;
+import org.hyperledger.besu.plugin.data.TransactionSelectionResult;
+import org.hyperledger.besu.plugin.services.PicoCLIOptions;
+import org.hyperledger.besu.plugin.services.TransactionSelectionService;
+import org.hyperledger.besu.plugin.services.txselection.PluginTransactionSelector;
+import org.hyperledger.besu.plugin.services.txselection.PluginTransactionSelectorFactory;
+import org.hyperledger.besu.plugin.services.txselection.SelectorsStateManager;
+import org.hyperledger.besu.plugin.services.txselection.TransactionEvaluationContext;
+
+public abstract class AbstractTestTransactionSelectorPlugin implements BesuPlugin {
+  private ServiceManager serviceManager;
+
+  private final int pluginNum;
+  private final int preMultiple;
+  private final int postMultiple;
+
+  public AbstractTestTransactionSelectorPlugin(
+      final int pluginNum, final int preMultiple, final int postMultiple) {
+    this.pluginNum = pluginNum;
+    this.preMultiple = preMultiple;
+    this.postMultiple = postMultiple;
+  }
+
+  @Override
+  public void register(final ServiceManager serviceManager) {
+    this.serviceManager = serviceManager;
+    serviceManager
+        .getService(PicoCLIOptions.class)
+        .orElseThrow()
+        .addPicoCLIOptions("tx-selector" + pluginNum, this);
+  }
+
+  protected abstract boolean isEnabled();
+
+  @Override
+  public void beforeExternalServices() {
+    if (isEnabled()) {
+      serviceManager
+          .getService(TransactionSelectionService.class)
+          .orElseThrow()
+          .registerPluginTransactionSelectorFactory(
+              new PluginTransactionSelectorFactory() {
+                @Override
+                public PluginTransactionSelector create(
+                    final SelectorsStateManager selectorsStateManager) {
+                  return new PluginTransactionSelector() {
+
+                    @Override
+                    public TransactionSelectionResult evaluateTransactionPreProcessing(
+                        final TransactionEvaluationContext evaluationContext) {
+                      if (evaluationContext
+                                  .getPendingTransaction()
+                                  .getTransaction()
+                                  .getValue()
+                                  .getAsBigInteger()
+                                  .longValue()
+                              % preMultiple
+                          == 0) {
+                        return TransactionSelectionResult.invalid(
+                            "value multiple of " + preMultiple);
+                      }
+                      return SELECTED;
+                    }
+
+                    @Override
+                    public TransactionSelectionResult evaluateTransactionPostProcessing(
+                        final TransactionEvaluationContext evaluationContext,
+                        final TransactionProcessingResult processingResult) {
+                      if (evaluationContext
+                                  .getPendingTransaction()
+                                  .getTransaction()
+                                  .getValue()
+                                  .getAsBigInteger()
+                                  .longValue()
+                              % postMultiple
+                          == 0) {
+                        return TransactionSelectionResult.invalid(
+                            "value multiple of " + postMultiple);
+                      }
+                      return SELECTED;
+                    }
+                  };
+                }
+              });
+    }
+  }
+
+  @Override
+  public void start() {}
+
+  @Override
+  public void stop() {}
+}

--- a/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/tests/acceptance/plugins/TestTransactionSelectorPlugin1.java
+++ b/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/tests/acceptance/plugins/TestTransactionSelectorPlugin1.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.tests.acceptance.plugins;
+
+import org.hyperledger.besu.plugin.BesuPlugin;
+
+import com.google.auto.service.AutoService;
+import picocli.CommandLine.Option;
+
+@AutoService(BesuPlugin.class)
+public class TestTransactionSelectorPlugin1 extends AbstractTestTransactionSelectorPlugin {
+
+  @Option(names = "--plugin-tx-selector1-test-enabled")
+  boolean enabled = false;
+
+  public TestTransactionSelectorPlugin1() {
+    super(1, 3, 5);
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return enabled;
+  }
+}

--- a/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/tests/acceptance/plugins/TestTransactionSelectorPlugin2.java
+++ b/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/tests/acceptance/plugins/TestTransactionSelectorPlugin2.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.tests.acceptance.plugins;
+
+import org.hyperledger.besu.plugin.BesuPlugin;
+
+import com.google.auto.service.AutoService;
+import picocli.CommandLine.Option;
+
+@AutoService(BesuPlugin.class)
+public class TestTransactionSelectorPlugin2 extends AbstractTestTransactionSelectorPlugin {
+
+  @Option(names = "--plugin-tx-selector2-test-enabled")
+  boolean enabled = false;
+
+  public TestTransactionSelectorPlugin2() {
+    super(2, 7, 11);
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return enabled;
+  }
+}

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/plugins/BlockchainServicePluginTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/plugins/BlockchainServicePluginTest.java
@@ -37,7 +37,7 @@ public class BlockchainServicePluginTest extends AcceptanceTestBase {
         besu.createQbftPluginsNode(
             "pluginNode",
             Collections.singletonList("testPlugins"),
-            Collections.singletonList("--plugin-tx-validator-test-enabled=true"),
+            Collections.singletonList("--plugin-blockchain-service-test-enabled=true"),
             "DEBUG");
 
     cluster.start(pluginNode);

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/plugins/TransactionSelectorPluginTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/plugins/TransactionSelectorPluginTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.tests.acceptance.plugins;
+
+import org.hyperledger.besu.tests.acceptance.dsl.AcceptanceTestBase;
+import org.hyperledger.besu.tests.acceptance.dsl.account.Account;
+import org.hyperledger.besu.tests.acceptance.dsl.blockchain.Amount;
+import org.hyperledger.besu.tests.acceptance.dsl.node.BesuNode;
+
+import java.math.BigInteger;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class TransactionSelectorPluginTest extends AcceptanceTestBase {
+  private BesuNode node;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    node =
+        besu.createQbftPluginsNode(
+            "node",
+            Collections.singletonList("testPlugins"),
+            List.of(
+                "--plugin-tx-selector1-test-enabled=true",
+                "--plugin-tx-selector2-test-enabled=true"),
+            "DEBUG");
+    cluster.start(node);
+  }
+
+  @Test
+  public void transactionIsMined() {
+    final Account recipient = accounts.createAccount("recipient");
+
+    // selector plugins reject values that are multiple of: 3,5,7,11
+    final var transferTx =
+        accountTransactions.createTransfer(recipient, Amount.wei(BigInteger.ONE));
+
+    final var txHash = node.execute(transferTx);
+
+    node.verify(eth.expectSuccessfulTransactionReceipt(txHash.toHexString()));
+  }
+
+  @ParameterizedTest
+  // selector plugins reject amount that are multiple of: 3,5,7,11
+  @ValueSource(longs = {3, 5, 7, 11, 3 * 5})
+  public void badMultipleOfValueTransactionIsNotSelectedByPlugin(final long amount) {
+    final Account recipient = accounts.createAccount("recipient");
+
+    final var badTx =
+        accountTransactions.createTransfer(recipient, Amount.wei(BigInteger.valueOf(amount)));
+
+    final var sameSenderGoodTx =
+        accountTransactions.createTransfer(recipient, Amount.wei(BigInteger.ONE));
+
+    final var anotherSenderGoodTx =
+        accountTransactions.createTransfer(
+            accounts.getSecondaryBenefactor(), recipient, Amount.wei(BigInteger.ONE));
+
+    final var badHash = node.execute(badTx);
+    final var sameSenderGoodHash = node.execute(sameSenderGoodTx);
+    final var anotherSenderGoodHash = node.execute(anotherSenderGoodTx);
+
+    node.verify(eth.expectSuccessfulTransactionReceipt(anotherSenderGoodHash.toHexString()));
+    node.verify(eth.expectNoTransactionReceipt(badHash.toHexString()));
+    // good tx from the same sender is not mined due to the nonce gap
+    node.verify(eth.expectNoTransactionReceipt(sameSenderGoodHash.toHexString()));
+  }
+}

--- a/app/src/main/java/org/hyperledger/besu/services/TransactionSelectionServiceImpl.java
+++ b/app/src/main/java/org/hyperledger/besu/services/TransactionSelectionServiceImpl.java
@@ -14,14 +14,33 @@
  */
 package org.hyperledger.besu.services;
 
-import static com.google.common.base.Preconditions.checkState;
-
+import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.datatypes.Transaction;
+import org.hyperledger.besu.datatypes.Wei;
+import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
+import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.log.Log;
+import org.hyperledger.besu.evm.operation.Operation;
+import org.hyperledger.besu.evm.worldstate.WorldView;
+import org.hyperledger.besu.plugin.data.BlockBody;
+import org.hyperledger.besu.plugin.data.BlockHeader;
 import org.hyperledger.besu.plugin.data.ProcessableBlockHeader;
+import org.hyperledger.besu.plugin.data.TransactionProcessingResult;
+import org.hyperledger.besu.plugin.data.TransactionSelectionResult;
 import org.hyperledger.besu.plugin.services.TransactionSelectionService;
+import org.hyperledger.besu.plugin.services.tracer.BlockAwareOperationTracer;
 import org.hyperledger.besu.plugin.services.txselection.BlockTransactionSelectionService;
 import org.hyperledger.besu.plugin.services.txselection.PluginTransactionSelector;
 import org.hyperledger.besu.plugin.services.txselection.PluginTransactionSelectorFactory;
 import org.hyperledger.besu.plugin.services.txselection.SelectorsStateManager;
+import org.hyperledger.besu.plugin.services.txselection.TransactionEvaluationContext;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.apache.tuweni.bytes.Bytes;
 
 /** The Transaction Selection service implementation. */
 public class TransactionSelectionServiceImpl implements TransactionSelectionService {
@@ -29,27 +48,224 @@ public class TransactionSelectionServiceImpl implements TransactionSelectionServ
   /** Default Constructor. */
   public TransactionSelectionServiceImpl() {}
 
-  private PluginTransactionSelectorFactory factory = PluginTransactionSelectorFactory.NO_OP_FACTORY;
+  private List<PluginTransactionSelectorFactory> factories;
 
   @Override
   public PluginTransactionSelector createPluginTransactionSelector(
       final SelectorsStateManager selectorsStateManager) {
-    return factory.create(selectorsStateManager);
+    if (factories == null) {
+      return PluginTransactionSelector.ACCEPT_ALL;
+    }
+    return new AggregatedPluginTransactionSelector(
+        factories.stream().map(factory -> factory.create(selectorsStateManager)).toList());
   }
 
   @Override
   public void selectPendingTransactions(
       final BlockTransactionSelectionService selectionService,
       final ProcessableBlockHeader pendingBlockHeader) {
-    factory.selectPendingTransactions(selectionService, pendingBlockHeader);
+    if (factories != null) {
+      factories.forEach(
+          factory -> factory.selectPendingTransactions(selectionService, pendingBlockHeader));
+    }
   }
 
   @Override
   public void registerPluginTransactionSelectorFactory(
       final PluginTransactionSelectorFactory pluginTransactionSelectorFactory) {
-    checkState(
-        factory == PluginTransactionSelectorFactory.NO_OP_FACTORY,
-        "PluginTransactionSelectorFactory was already registered");
-    factory = pluginTransactionSelectorFactory;
+    if (factories == null) {
+      factories = new ArrayList<>();
+    }
+    factories.add(pluginTransactionSelectorFactory);
+  }
+
+  private static class AggregatedPluginTransactionSelector implements PluginTransactionSelector {
+    private final List<PluginTransactionSelector> pluginTransactionSelectors;
+
+    AggregatedPluginTransactionSelector(
+        final List<PluginTransactionSelector> pluginTransactionSelectors) {
+      this.pluginTransactionSelectors = pluginTransactionSelectors;
+    }
+
+    @Override
+    public BlockAwareOperationTracer getOperationTracer() {
+      return new TracerAggregator(
+          pluginTransactionSelectors.stream()
+              .map(PluginTransactionSelector::getOperationTracer)
+              .toList());
+    }
+
+    @Override
+    public TransactionSelectionResult evaluateTransactionPreProcessing(
+        final TransactionEvaluationContext evaluationContext) {
+      return pluginTransactionSelectors.stream()
+          .map(selector -> selector.evaluateTransactionPreProcessing(evaluationContext))
+          .filter(result -> !result.selected())
+          .findAny()
+          .orElse(TransactionSelectionResult.SELECTED);
+    }
+
+    @Override
+    public TransactionSelectionResult evaluateTransactionPostProcessing(
+        final TransactionEvaluationContext evaluationContext,
+        final TransactionProcessingResult processingResult) {
+
+      return pluginTransactionSelectors.stream()
+          .map(
+              selector ->
+                  selector.evaluateTransactionPostProcessing(evaluationContext, processingResult))
+          .filter(result -> !result.selected())
+          .findAny()
+          .orElse(TransactionSelectionResult.SELECTED);
+    }
+
+    @Override
+    public void onTransactionSelected(
+        final TransactionEvaluationContext evaluationContext,
+        final TransactionProcessingResult processingResult) {
+      pluginTransactionSelectors.forEach(
+          pluginTransactionSelector ->
+              pluginTransactionSelector.onTransactionSelected(evaluationContext, processingResult));
+    }
+
+    @Override
+    public void onTransactionNotSelected(
+        final TransactionEvaluationContext evaluationContext,
+        final TransactionSelectionResult transactionSelectionResult) {
+      pluginTransactionSelectors.forEach(
+          pluginTransactionSelector ->
+              pluginTransactionSelector.onTransactionNotSelected(
+                  evaluationContext, transactionSelectionResult));
+    }
+  }
+
+  private static class TracerAggregator implements BlockAwareOperationTracer {
+    private final List<BlockAwareOperationTracer> blockAwareOperationTracers;
+
+    public TracerAggregator(final List<BlockAwareOperationTracer> blockAwareOperationTracers) {
+      this.blockAwareOperationTracers = blockAwareOperationTracers;
+    }
+
+    @Override
+    public void traceStartBlock(
+        final WorldView worldView,
+        final BlockHeader blockHeader,
+        final BlockBody blockBody,
+        final Address miningBeneficiary) {
+      blockAwareOperationTracers.forEach(
+          blockAwareOperationTracer ->
+              blockAwareOperationTracer.traceStartBlock(
+                  worldView, blockHeader, blockBody, miningBeneficiary));
+    }
+
+    @Override
+    public void traceEndBlock(final BlockHeader blockHeader, final BlockBody blockBody) {
+      blockAwareOperationTracers.forEach(
+          blockAwareOperationTracer ->
+              blockAwareOperationTracer.traceEndBlock(blockHeader, blockBody));
+    }
+
+    @Override
+    public void traceStartBlock(
+        final WorldView worldView,
+        final ProcessableBlockHeader processableBlockHeader,
+        final Address miningBeneficiary) {
+      blockAwareOperationTracers.forEach(
+          blockAwareOperationTracer ->
+              blockAwareOperationTracer.traceStartBlock(
+                  worldView, processableBlockHeader, miningBeneficiary));
+    }
+
+    @Override
+    public boolean isExtendedTracing() {
+      return blockAwareOperationTracers.stream()
+          .anyMatch(BlockAwareOperationTracer::isExtendedTracing);
+    }
+
+    @Override
+    public void tracePreExecution(final MessageFrame frame) {
+      blockAwareOperationTracers.forEach(
+          blockAwareOperationTracer -> blockAwareOperationTracer.tracePreExecution(frame));
+    }
+
+    @Override
+    public void tracePostExecution(
+        final MessageFrame frame, final Operation.OperationResult operationResult) {
+      blockAwareOperationTracers.forEach(
+          blockAwareOperationTracer ->
+              blockAwareOperationTracer.tracePostExecution(frame, operationResult));
+    }
+
+    @Override
+    public void tracePrecompileCall(
+        final MessageFrame frame, final long gasRequirement, final Bytes output) {
+      blockAwareOperationTracers.forEach(
+          blockAwareOperationTracer ->
+              blockAwareOperationTracer.tracePrecompileCall(frame, gasRequirement, output));
+    }
+
+    @Override
+    public void traceAccountCreationResult(
+        final MessageFrame frame, final Optional<ExceptionalHaltReason> haltReason) {
+      blockAwareOperationTracers.forEach(
+          blockAwareOperationTracer ->
+              blockAwareOperationTracer.traceAccountCreationResult(frame, haltReason));
+    }
+
+    @Override
+    public void tracePrepareTransaction(final WorldView worldView, final Transaction transaction) {
+      blockAwareOperationTracers.forEach(
+          blockAwareOperationTracer ->
+              blockAwareOperationTracer.tracePrepareTransaction(worldView, transaction));
+    }
+
+    @Override
+    public void traceStartTransaction(final WorldView worldView, final Transaction transaction) {
+      blockAwareOperationTracers.forEach(
+          blockAwareOperationTracer ->
+              blockAwareOperationTracer.traceStartTransaction(worldView, transaction));
+    }
+
+    @Override
+    public void traceBeforeRewardTransaction(
+        final WorldView worldView, final Transaction tx, final Wei miningReward) {
+      blockAwareOperationTracers.forEach(
+          blockAwareOperationTracer ->
+              blockAwareOperationTracer.traceBeforeRewardTransaction(worldView, tx, miningReward));
+    }
+
+    @Override
+    public void traceEndTransaction(
+        final WorldView worldView,
+        final Transaction tx,
+        final boolean status,
+        final Bytes output,
+        final List<Log> logs,
+        final long gasUsed,
+        final Set<Address> selfDestructs,
+        final long timeNs) {
+      blockAwareOperationTracers.forEach(
+          blockAwareOperationTracer ->
+              blockAwareOperationTracer.traceEndTransaction(
+                  worldView, tx, status, output, logs, gasUsed, selfDestructs, timeNs));
+    }
+
+    @Override
+    public void traceContextEnter(final MessageFrame frame) {
+      blockAwareOperationTracers.forEach(
+          blockAwareOperationTracer -> blockAwareOperationTracer.traceContextEnter(frame));
+    }
+
+    @Override
+    public void traceContextReEnter(final MessageFrame frame) {
+      blockAwareOperationTracers.forEach(
+          blockAwareOperationTracer -> blockAwareOperationTracer.traceContextReEnter(frame));
+    }
+
+    @Override
+    public void traceContextExit(final MessageFrame frame) {
+      blockAwareOperationTracers.forEach(
+          blockAwareOperationTracer -> blockAwareOperationTracer.traceContextExit(frame));
+    }
   }
 }

--- a/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockTransactionSelectorTest.java
+++ b/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockTransactionSelectorTest.java
@@ -684,8 +684,23 @@ public abstract class AbstractBlockTransactionSelectorTest {
           }
         };
 
+    final var colletorPluginTransactionSelector = new CollectorPluginTransactionSelector();
+
+    final PluginTransactionSelectorFactory collectorTransactionSelectorFactory =
+        new PluginTransactionSelectorFactory() {
+          @Override
+          public PluginTransactionSelector create(
+              final SelectorsStateManager selectorsStateManager) {
+            return colletorPluginTransactionSelector;
+          }
+        };
+
     transactionSelectionService.registerPluginTransactionSelectorFactory(
         transactionSelectorFactory);
+    // registering the collector factory as second factory, mean that txs that do not pass the first
+    // selector should not be processed by this one and thus not collected
+    transactionSelectionService.registerPluginTransactionSelectorFactory(
+        collectorTransactionSelectorFactory);
 
     final BlockTransactionSelector selector =
         createBlockSelectorAndSetupTxPool(
@@ -711,6 +726,11 @@ public abstract class AbstractBlockTransactionSelectorTest {
                 notSelectedTransient,
                 PluginTransactionSelectionResult.GENERIC_PLUGIN_INVALID_TRANSIENT),
             entry(notSelectedInvalid, PluginTransactionSelectionResult.GENERIC_PLUGIN_INVALID));
+
+    assertThat(colletorPluginTransactionSelector.getSeenPreProcessing())
+        .containsExactly(selected.getHash());
+    assertThat(colletorPluginTransactionSelector.getSeenPostProcessing())
+        .containsExactly(selected.getHash());
   }
 
   @Test
@@ -755,8 +775,21 @@ public abstract class AbstractBlockTransactionSelectorTest {
           }
         };
 
+    final var colletorPluginTransactionSelector = new CollectorPluginTransactionSelector();
+
+    final PluginTransactionSelectorFactory collectorTransactionSelectorFactory =
+        new PluginTransactionSelectorFactory() {
+          @Override
+          public PluginTransactionSelector create(
+              final SelectorsStateManager selectorsStateManager) {
+            return colletorPluginTransactionSelector;
+          }
+        };
+
     transactionSelectionService.registerPluginTransactionSelectorFactory(
         transactionSelectorFactory);
+    transactionSelectionService.registerPluginTransactionSelectorFactory(
+        collectorTransactionSelectorFactory);
 
     final Address miningBeneficiary = AddressHelpers.ofValue(1);
     final BlockTransactionSelector selector =
@@ -781,19 +814,41 @@ public abstract class AbstractBlockTransactionSelectorTest {
     assertThat(transactionSelectionResults.getNotSelectedTransactions())
         .containsOnly(
             entry(notSelected, PluginTransactionSelectionResult.GENERIC_PLUGIN_INVALID_TRANSIENT));
+
+    // notSelected is seen preprocessing since it is marked invalid only in the postprocessing
+    // evaluation
+    assertThat(colletorPluginTransactionSelector.getSeenPreProcessing())
+        .containsExactly(selected.getHash(), notSelected.getHash());
+    assertThat(colletorPluginTransactionSelector.getSeenPostProcessing())
+        .containsExactly(selected.getHash());
   }
 
   @Test
-  public void transactionSelectionPluginShouldBeNotifiedWhenTransactionSelectionCompletes() {
-    final PluginTransactionSelectorFactory transactionSelectorFactory =
-        mock(PluginTransactionSelectorFactory.class);
-    PluginTransactionSelector transactionSelector = mock(PluginTransactionSelector.class);
-    when(transactionSelector.evaluateTransactionPreProcessing(any())).thenReturn(SELECTED);
-    when(transactionSelector.evaluateTransactionPostProcessing(any(), any())).thenReturn(SELECTED);
-    when(transactionSelectorFactory.create(any())).thenReturn(transactionSelector);
+  public void transactionSelectionPluginsShouldBeNotifiedWhenTransactionSelectionCompletes() {
+    record Mocks(
+        PluginTransactionSelectorFactory pluginTransactionSelectorFactory,
+        PluginTransactionSelector pluginTransactionSelector) {}
 
-    transactionSelectionService.registerPluginTransactionSelectorFactory(
-        transactionSelectorFactory);
+    final Supplier<Mocks> transactionSelectorFactoryGenerator =
+        () -> {
+          final PluginTransactionSelectorFactory transactionSelectorFactory =
+              mock(PluginTransactionSelectorFactory.class);
+          final PluginTransactionSelector transactionSelector =
+              mock(PluginTransactionSelector.class);
+          when(transactionSelector.evaluateTransactionPreProcessing(any())).thenReturn(SELECTED);
+          when(transactionSelector.evaluateTransactionPostProcessing(any(), any()))
+              .thenReturn(SELECTED);
+          when(transactionSelectorFactory.create(any())).thenReturn(transactionSelector);
+          return new Mocks(transactionSelectorFactory, transactionSelector);
+        };
+
+    final var transactionSelectorFactories =
+        List.of(
+            transactionSelectorFactoryGenerator.get(), transactionSelectorFactoryGenerator.get());
+
+    transactionSelectorFactories.stream()
+        .map(Mocks::pluginTransactionSelectorFactory)
+        .forEach(transactionSelectionService::registerPluginTransactionSelectorFactory);
 
     final Transaction transaction = createTransaction(0, Wei.of(10), 21_000);
     ensureTransactionIsValid(transaction, 21_000, 0);
@@ -822,18 +877,30 @@ public abstract class AbstractBlockTransactionSelectorTest {
         ArgumentCaptor.forClass(TransactionEvaluationContext.class);
 
     // selected transaction must be notified to the selector
-    verify(transactionSelector)
-        .onTransactionSelected(argumentCaptor.capture(), any(TransactionProcessingResult.class));
-    PendingTransaction selected = argumentCaptor.getValue().getPendingTransaction();
-    assertThat(selected.getTransaction()).isEqualTo(transaction);
+    transactionSelectorFactories.stream()
+        .map(Mocks::pluginTransactionSelector)
+        .forEach(
+            pluginTransactionSelector -> {
+              verify(pluginTransactionSelector)
+                  .onTransactionSelected(
+                      argumentCaptor.capture(), any(TransactionProcessingResult.class));
+              PendingTransaction selected = argumentCaptor.getValue().getPendingTransaction();
+              assertThat(selected.getTransaction()).isEqualTo(transaction);
+            });
 
     // unselected transaction must be notified to the selector with correct reason
-    verify(transactionSelector)
-        .onTransactionNotSelected(
-            argumentCaptor.capture(),
-            eq(TransactionSelectionResult.invalid(invalidReason.toString())));
-    PendingTransaction rejectedTransaction = argumentCaptor.getValue().getPendingTransaction();
-    assertThat(rejectedTransaction.getTransaction()).isEqualTo(invalidTransaction);
+    transactionSelectorFactories.stream()
+        .map(Mocks::pluginTransactionSelector)
+        .forEach(
+            pluginTransactionSelector -> {
+              verify(pluginTransactionSelector)
+                  .onTransactionNotSelected(
+                      argumentCaptor.capture(),
+                      eq(TransactionSelectionResult.invalid(invalidReason.toString())));
+              PendingTransaction rejectedTransaction =
+                  argumentCaptor.getValue().getPendingTransaction();
+              assertThat(rejectedTransaction.getTransaction()).isEqualTo(invalidTransaction);
+            });
   }
 
   @Test
@@ -1584,6 +1651,34 @@ public abstract class AbstractBlockTransactionSelectorTest {
 
     public Address address() {
       return address;
+    }
+  }
+
+  private static class CollectorPluginTransactionSelector implements PluginTransactionSelector {
+    private final List<Hash> seenPreProcessing = new ArrayList<>();
+    private final List<Hash> seenPostProcessing = new ArrayList<>();
+
+    @Override
+    public TransactionSelectionResult evaluateTransactionPreProcessing(
+        final TransactionEvaluationContext evaluationContext) {
+      seenPreProcessing.add(evaluationContext.getPendingTransaction().getTransaction().getHash());
+      return SELECTED;
+    }
+
+    @Override
+    public TransactionSelectionResult evaluateTransactionPostProcessing(
+        final TransactionEvaluationContext evaluationContext,
+        final org.hyperledger.besu.plugin.data.TransactionProcessingResult processingResult) {
+      seenPostProcessing.add(evaluationContext.getPendingTransaction().getTransaction().getHash());
+      return SELECTED;
+    }
+
+    public List<Hash> getSeenPreProcessing() {
+      return seenPreProcessing;
+    }
+
+    public List<Hash> getSeenPostProcessing() {
+      return seenPostProcessing;
     }
   }
 }

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -71,7 +71,7 @@ Calculated : ${currentHash}
 tasks.register('checkAPIChanges', FileStateChecker) {
   description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
   files = sourceSets.main.allJava.files
-  knownHash = 'fhbRRCXyfMDwSkyEe+YhgUhzIu2/OWSMhttKCnmTqlc='
+  knownHash = 'wGhK7HnU3AMYkKVLJplwZQW0joG5aKFS3Z0747X76r8='
 }
 check.dependsOn('checkAPIChanges')
 

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/txselection/PluginTransactionSelectorFactory.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/txselection/PluginTransactionSelectorFactory.java
@@ -24,11 +24,6 @@ import org.hyperledger.besu.plugin.data.ProcessableBlockHeader;
 @Unstable
 public interface PluginTransactionSelectorFactory {
   /**
-   * A default factory that does not propose any pending transactions and does not apply any filter
-   */
-  PluginTransactionSelectorFactory NO_OP_FACTORY = new PluginTransactionSelectorFactory() {};
-
-  /**
    * Create a plugin transaction selector, that can be used during block creation to apply custom
    * filters to proposed pending transactions
    *


### PR DESCRIPTION
## PR description

Currently is only possible to register one `PluginTransactionSelectorFactory` with the `TransactionSelectionService`, so it is not possible to have multiple transaction selector plugins deployed at the same time.
This PR extends the registration mechanism to allow the registration of an arbitrary number of `PluginTransactionSelectorFactory`, thus allowing multiple transaction selector plugins to work together.

Note that at this point there is no way to force a specific order for the transaction selectors, and the order is based on the plugin registration order, a future PR will add the possibility to specify the order in which the plugin are called. For example this could be important when calling `PluginTransactionSelectorFactory::selectPendingTransactions`

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


