### PR TITLE
[TESTS] refactor log parsing to make tests more robust

### DIFF
--- a/app/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/app/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -2804,7 +2804,7 @@ public class BesuCommandTest extends CommandTestAbstract {
     assertThat(commandOutput.toString(UTF_8)).isEmpty();
     assertThat(commandErrorOutput.toString(UTF_8)).isEmpty();
 
-    final String startupConfigLog = stringArgumentCaptor.getAllValues().get(2);
+    final String startupConfigLog = getStartupConfigLog();
     final String targetGasLimitOutput =
         ConfigurationOverviewBuilder.normalizeGas(DEFAULT_TARGET_GAS_LIMIT);
     assertThat(startupConfigLog)
@@ -2829,7 +2829,7 @@ public class BesuCommandTest extends CommandTestAbstract {
     assertThat(miningArg.getValue().getTargetGasLimit().getAsLong())
         .isEqualTo(CUSTOM_TARGET_GAS_LIMIT);
 
-    final String startupConfigLog = stringArgumentCaptor.getAllValues().get(2);
+    final String startupConfigLog = getStartupConfigLog();
     final String targetGasLimitOutput =
         ConfigurationOverviewBuilder.normalizeGas(CUSTOM_TARGET_GAS_LIMIT);
     assertThat(startupConfigLog)
@@ -2852,7 +2852,7 @@ public class BesuCommandTest extends CommandTestAbstract {
     assertThat(commandOutput.toString(UTF_8)).isEmpty();
     assertThat(commandErrorOutput.toString(UTF_8)).isEmpty();
 
-    final String startupConfigLog = stringArgumentCaptor.getAllValues().get(2);
+    final String startupConfigLog = getStartupConfigLog();
     final String targetGasLimitOutput =
         ConfigurationOverviewBuilder.normalizeGas(DEFAULT_TARGET_GAS_LIMIT_TESTNET);
     assertThat(startupConfigLog)
@@ -2878,7 +2878,7 @@ public class BesuCommandTest extends CommandTestAbstract {
     assertThat(miningArg.getValue().getTargetGasLimit().getAsLong())
         .isEqualTo(CUSTOM_TARGET_GAS_LIMIT);
 
-    final String startupConfigLog = stringArgumentCaptor.getAllValues().get(2);
+    final String startupConfigLog = getStartupConfigLog();
     final String targetGasLimitOutput =
         ConfigurationOverviewBuilder.normalizeGas(CUSTOM_TARGET_GAS_LIMIT);
     assertThat(startupConfigLog)
@@ -2901,7 +2901,7 @@ public class BesuCommandTest extends CommandTestAbstract {
     assertThat(commandOutput.toString(UTF_8)).isEmpty();
     assertThat(commandErrorOutput.toString(UTF_8)).isEmpty();
 
-    final String startupConfigLog = stringArgumentCaptor.getAllValues().get(2);
+    final String startupConfigLog = getStartupConfigLog();
     final String targetGasLimitOutput =
         ConfigurationOverviewBuilder.normalizeGas(DEFAULT_TARGET_GAS_LIMIT);
     assertThat(startupConfigLog)
@@ -2926,13 +2926,20 @@ public class BesuCommandTest extends CommandTestAbstract {
     assertThat(miningArg.getValue().getTargetGasLimit().getAsLong())
         .isEqualTo(CUSTOM_TARGET_GAS_LIMIT);
 
-    final String startupConfigLog = stringArgumentCaptor.getAllValues().get(2);
+    final String startupConfigLog = getStartupConfigLog();
     final String targetGasLimitOutput =
         ConfigurationOverviewBuilder.normalizeGas(CUSTOM_TARGET_GAS_LIMIT);
     assertThat(startupConfigLog)
         .contains(String.format("%s: %s", "Network", NETWORK_DEV_CONFIG_LOG));
     assertThat(startupConfigLog)
         .contains(String.format("%s: %s", "Target Gas Limit", targetGasLimitOutput));
+  }
+
+  private String getStartupConfigLog() {
+    // find the startup log config summary
+    final Stream<String> stringStream =
+        stringArgumentCaptor.getAllValues().stream().filter(p -> p.contains("####"));
+    return stringStream.findFirst().orElseThrow();
   }
 
   @Test


### PR DESCRIPTION
## PR description
Refactor BesuCommandTests that use the output of the startup config summary log. Depending on local environment, some other log lines are also printed (eg "using native impl of XYZ") so changed the logic to not rely on the exact number of log lines emitted.

## Fixed Issue(s)
fix besu command tests that were failing locally

Tests that were failing:

```
BesuCommandTest > shouldShowCorrectFormatForCustomNetworkCustomTargetGasLimit() FAILED
    java.lang.AssertionError at BesuCommandTest.java:2933

BesuCommandTest > shouldShowCorrectFormatForTestnetCustomTargetGasLimit() FAILED
    java.lang.AssertionError at BesuCommandTest.java:2885

BesuCommandTest > shouldShowCorrectFormatForMainnetCustomTargetGasLimit() FAILED
    java.lang.AssertionError at BesuCommandTest.java:2836

BesuCommandTest > shouldShowCorrectFormatForTestnetDefaultTargetGasLimit() FAILED
    java.lang.AssertionError at BesuCommandTest.java:2859

BesuCommandTest > shouldShowCorrectFormatForCustomNetworkDefaultTargetGasLimit() FAILED
    java.lang.AssertionError at BesuCommandTest.java:2908

BesuCommandTest > shouldShowCorrectFormatForMainnetDefaultTargetGasLimit() FAILED
    java.lang.AssertionError at BesuCommandTest.java:2811
```

### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew build`
- [x] acceptance tests: `./gradlew acceptanceTest`
- [x] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


