### PR TITLE
fix(block-validator): Invalid Java Documentation comment with Osaka method added

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/MainnetBlockValidatorBuilder.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/MainnetBlockValidatorBuilder.java
@@ -28,7 +28,7 @@ public class MainnetBlockValidatorBuilder {
   private MainnetBlockValidatorBuilder() {}
 
   /**
-   * Creates a block validator for the Frontier network with no block size limit.
+   * Creates a block validator for the networks prior to Osaka, with no block size limit.
    *
    * @param blockHeaderValidator the block header validator
    * @param blockBodyValidator the block body validator

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/MainnetBlockValidatorBuilder.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/MainnetBlockValidatorBuilder.java
@@ -28,7 +28,7 @@ public class MainnetBlockValidatorBuilder {
   private MainnetBlockValidatorBuilder() {}
 
   /**
-   * Creates a block validator for the mainnet with no block size limit.
+   * Creates a block validator for the Frontier network with no block size limit.
    *
    * @param blockHeaderValidator the block header validator
    * @param blockBodyValidator the block body validator


### PR DESCRIPTION
Closes #9144 
Due to the addition of the Osaka fork, this comment is now out of date