### PR TITLE
Add execution time and mgas/s on blockchain tests

### DIFF
--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/BlockchainTestSubCommand.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/BlockchainTestSubCommand.java
@@ -211,12 +211,11 @@ public class BlockchainTestSubCommand implements Runnable {
               block.getHash(),
               importResult.isImported() ? "Failed to be rejected" : "Failed to import");
         } else {
-          final long gasUsed = block.getHeader().getGasUsed();
-          final long timeNs = timer.elapsed(TimeUnit.NANOSECONDS);
-          final float mGps = gasUsed * 1000.0f / timeNs;
-          final double timeMs = timeNs / 1_000_000.0; // Convert nanoseconds to milliseconds
-
           if (importResult.isImported()) {
+            final long gasUsed = block.getHeader().getGasUsed();
+            final long timeNs = timer.elapsed(TimeUnit.NANOSECONDS);
+            final float mGps = gasUsed * 1000.0f / timeNs;
+            final double timeMs = timeNs / 1_000_000.0;
             parentCommand.out.printf(
                 "Block %d (%s) Imported in %.2f ms (%.2f MGas/s)%n",
                 block.getHeader().getNumber(), block.getHash(), timeMs, mGps);


### PR DESCRIPTION
## PR description
Change the output of blockchain tests in BlockchainTestSubCommand to include the execution time and mgas/s.
We have now the output below 

```
Considering tests/benchmark/test_worst_memory.py::test_worst_calldatacopy[fork_Prague-benchmark-gas-value_60M-blockchain_test_from_state_test-non_zero_data_True-fixed_src_dst_True-100 bytes-transaction]
Block 1 (0x4201ced7cea6359b93bbbb31e8141fc37d7c46a6bdb8b96cdad003b938dafe09) Imported in 305.16 ms (196.62 MGas/s)
Chain import successful - tests/benchmark/test_worst_memory.py::test_worst_calldatacopy[fork_Prague-benchmark-gas-value_60M-blockchain_test_from_state_test-non_zero_data_True-fixed_src_dst_True-100 bytes-transaction]
Considering tests/benchmark/test_worst_memory.py::test_worst_calldatacopy[fork_Prague-benchmark-gas-value_60M-blockchain_test_from_state_test-non_zero_data_True-fixed_src_dst_True-10KiB-call]
Block 1 (0x655b63f955a1b670792e2dd6369d18439bb3f89719e748437e84d6501d46db85) Imported in 67.95 ms (883.04 MGas/s)
Chain import successful - tests/benchmark/test_worst_memory.py::test_worst_calldatacopy[fork_Prague-benchmark-gas-value_60M-blockchain_test_from_state_test-non_zero_data_True-fixed_src_dst_True-10KiB-call]
Considering tests/benchmark/test_worst_memory.py::test_worst_calldatacopy[fork_Prague-benchmark-gas-value_60M-blockchain_test_from_state_test-non_zero_data_True-fixed_src_dst_True-10KiB-transaction]
Block 1 (0x9f06d08cd93fc6c5aa52f6a430b6dc766477d072787c86ea818c9d0b2b66d566) Imported in 116.46 ms (515.18 MGas/s)
Chain import successful - tests/benchmark/test_worst_memory.py::test_worst_calldatacopy[fork_Prague-benchmark-gas-value_60M-blockchain_test_from_state_test-non_zero_data_True-fixed_src_dst_True-10KiB-transaction]
Considering tests/benchmark/test_worst_memory.py::test_worst_calldatacopy[fork_Prague-benchmark-gas-value_60M-blockchain_test_from_state_test-non_zero_data_True-fixed_src_dst_True-1MiB-call]
Block 1 (0x3922c5a28c5792f4f085d94fb49efac0c44f826896d4e1d323ac65e5fa1db18e) Imported in 60.87 ms (985.74 MGas/s)
Chain import successful - tests/benchmark/test_worst_memory.py::test_worst_calldatacopy[fork_Prague-benchmark-gas-value_60M-blockchain_test_from_state_test-non_zero_data_True-fixed_src_dst_True-1MiB-call]
Considering tests/benchmark/test_worst_memory.py::test_worst_calldatacopy[fork_Prague-benchmark-gas-value_60M-blockchain_test_from_state_test-non_zero_data_True-fixed_src_dst_True-1MiB-transaction]
Block 1 (0x7dba9418ae451138971edc6fceb1119765a9de86b94dc32b0dce754e632c2e8c) Imported in 102.27 ms (586.68 MGas/s)
Chain import successful - tests/benchmark/test_worst_memory.py::test_worst_calldatacopy[fork_Prague-benchmark-gas-value_60M-blockchain_test_from_state_test-non_zero_data_True-fixed_src_dst_True-1MiB-transaction]

```

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


