### PR TITLE
fix hex regex in era1 filename match

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fullsync/era1prepipeline/Era1FileSource.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fullsync/era1prepipeline/Era1FileSource.java
@@ -27,7 +27,7 @@ import java.util.regex.Pattern;
 
 public class Era1FileSource implements Iterator<URI> {
   private static final Pattern ERA1_FILE_PATTERN =
-      Pattern.compile("(?:mainnet|sepolia)-(?<fileNumber>\\d{5})-[0-9a-fA-f]{8}.era1");
+      Pattern.compile("(?:mainnet|sepolia)-(?<fileNumber>\\d{5})-[0-9a-fA-F]{8}.era1");
   private static final String ERA1_PATTERN_FILE_NUMBER_GROUP = "fileNumber";
   private static final int ERA1_BLOCK_COUNT = 8192;
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fullsync/era1prepipeline/Era1HttpFileSource.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fullsync/era1prepipeline/Era1HttpFileSource.java
@@ -28,7 +28,7 @@ import java.util.regex.Pattern;
 public class Era1HttpFileSource implements Iterator<URI> {
   private static final Pattern ERA1_LINK_PATTERN =
       Pattern.compile(
-          "<a href=\"(?<fileName>(?:mainnet|sepolia)-(?<fileNumber>\\d{5})-[0-9a-fA-f]{8}.era1)\">");
+          "<a href=\"(?<fileName>(?:mainnet|sepolia)-(?<fileNumber>\\d{5})-[0-9a-fA-F]{8}.era1)\">");
   private static final String ERA1_PATTERN_FILE_NAME_GROUP = "fileName";
   private static final String ERA1_PATTERN_FILE_NUMBER_GROUP = "fileNumber";
   private static final int ERA1_BLOCK_COUNT = 8192;


### PR DESCRIPTION
## PR description
make regex more precise

## Fixed Issue(s)
Fix Overly permissive regular expression range


### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew build`
- [x] acceptance tests: `./gradlew acceptanceTest`
- [x] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


