### PR TITLE
Workaround to force the txpool to be always on (#8755)

### DIFF
--- a/datatypes/src/main/java/org/hyperledger/besu/datatypes/UInt256Arith.java
+++ b/datatypes/src/main/java/org/hyperledger/besu/datatypes/UInt256Arith.java
@@ -1,0 +1,486 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.datatypes;
+
+import java.util.Arrays;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.units.bigints.UInt256;
+
+public class UInt256Arith {
+
+  private static final long LONG_MASK = 0xffffffffL;
+
+  public static Bytes divide(final boolean signed, final Bytes numerator, final Bytes denominator) {
+    if (denominator.isZero()) {
+      throw new ArithmeticException("divide by zero");
+    }
+
+    byte[] numArray =
+        numerator.size() > UInt256.SIZE
+            ? numerator.slice(numerator.size() - UInt256.SIZE).toArrayUnsafe()
+            : numerator.toArrayUnsafe();
+    byte[] denomArray =
+        denominator.size() > UInt256.SIZE
+            ? denominator.slice(denominator.size() - UInt256.SIZE).toArrayUnsafe()
+            : denominator.toArrayUnsafe();
+
+    boolean isNumeratorNegative = false;
+    boolean isDenominatorNegative = false;
+    if (signed) {
+      isNumeratorNegative = (numArray.length == UInt256.SIZE && (numArray[0] >> 7 == -1));
+      numArray = makePositive(numArray, isNumeratorNegative);
+      isDenominatorNegative = (denomArray.length == UInt256.SIZE && denomArray[0] >> 7 == -1);
+      denomArray = makePositive(denomArray, isDenominatorNegative);
+    }
+
+    final int numeratorOffset = numberOfLeadingZeros(numArray);
+    final int denominatorOffset = numberOfLeadingZeros(denomArray);
+
+    final int cmp = compare(numArray, numeratorOffset, denomArray, denominatorOffset);
+
+    if (cmp < 0) {
+      return UInt256.ZERO;
+    }
+
+    if (cmp == 0) {
+      if (signed && (isNumeratorNegative ^ isDenominatorNegative)) {
+        return UInt256.MAX_VALUE;
+      }
+      return UInt256.ONE;
+    }
+
+    final int[] intResult =
+        divideKnuth(
+            toIntLimbs(numArray, numeratorOffset), toIntLimbs(denomArray, denominatorOffset));
+    if (signed) {
+      return Bytes.wrap(fromIntLimbs(intResult, (isNumeratorNegative ^ isDenominatorNegative)));
+    }
+    return Bytes.wrap(fromIntLimbsUnsigned(intResult));
+  }
+
+  private static byte[] makePositive(final byte[] value, final boolean isNegative) {
+    if (value.length == 0 || value[0] >= 0 || !isNegative) {
+      return value;
+    }
+
+    final byte[] newValue = new byte[UInt256.SIZE];
+
+    // invert all values before
+    for (int i = 0; i < value.length; i++) {
+      newValue[i] = (byte) ~value[i];
+    }
+
+    // add 1 to the number to get signed value
+    for (int i = newValue.length - 1; i >= 0; i--) {
+      int aux = (newValue[i] & 0xFF) + 1;
+      newValue[i] = (byte) aux;
+      if ((aux & 0x100) == 0) {
+        break; // no more carry
+      }
+    }
+    return newValue;
+  }
+
+  private static int compare(
+      final byte[] numArray,
+      final int numeratorOffset,
+      final byte[] denomArray,
+      final int denominatorOffset) {
+    final int numeratorSize = numArray.length - numeratorOffset;
+    final int denominatorSize = denomArray.length - denominatorOffset;
+    if (numeratorSize != denominatorSize) {
+      return Integer.compare(numeratorSize, denominatorSize);
+    }
+    for (int i = numeratorOffset, j = denominatorOffset;
+        i < numeratorSize + numeratorOffset;
+        i++, j++) {
+      // make numbers comparable in unsigned form
+      int b1 = (int) numArray[i] + Integer.MIN_VALUE;
+      int b2 = (int) denomArray[j] + Integer.MIN_VALUE;
+      if (b1 != b2) {
+        return Integer.compare(b1, b2);
+      }
+    }
+    return 0;
+  }
+
+  private static int[] divideKnuth(final int[] num, final int[] denom) {
+    if (denom.length == 1) {
+      return divideOneWord(num, denom[0]);
+    }
+
+    // assert div.intLen > 1
+    // D1 normalize the divisor
+    int shift = Integer.numberOfLeadingZeros(denom[0]);
+    // Copy divisor value to protect divisor
+    final int dlen = denom.length;
+    int[] rem; // Remainder starts as dividend with space for a leading zero
+    int[] divisor;
+    if (shift > 0) {
+      divisor = new int[denom.length];
+      primitiveLeftShift(denom, shift, divisor, 0);
+      if (Integer.numberOfLeadingZeros(num[0]) >= shift) {
+        rem = new int[num.length + 1];
+        primitiveLeftShift(num, shift, rem, 1);
+      } else {
+        rem = new int[num.length + 2];
+        int rFrom = 0;
+        int c = 0;
+        int n2 = 32 - shift;
+        for (int i = 1; i < num.length + 1; i++, rFrom++) {
+          int b = c;
+          c = num[rFrom];
+          rem[i] = (b << shift) | (c >>> n2);
+        }
+        rem[num.length + 1] = c << shift;
+      }
+    } else {
+      divisor = Arrays.copyOfRange(denom, 0, denom.length);
+      rem = new int[num.length + 1];
+      System.arraycopy(num, 0, rem, 1, num.length);
+    }
+
+    int nlen = rem.length - 1;
+
+    // Set the quotient size
+    final int limit = nlen - dlen + 1;
+    int[] quotient = new int[limit];
+    int[] q = quotient;
+
+    // Insert leading 0 in rem
+    rem[0] = 0;
+
+    int dh = divisor[0];
+    long dhLong = dh & LONG_MASK;
+    int dl = divisor[1];
+
+    // D2 Initialize j
+    for (int j = 0; j < limit - 1; j++) {
+      // D3 Calculate qhat
+      // estimate qhat
+      int qhat = 0;
+      int qrem = 0;
+      boolean skipCorrection = false;
+      int nh = rem[j];
+      int nh2 = nh + 0x80000000;
+      int nm = rem[j + 1];
+
+      if (nh == dh) {
+        qhat = ~0;
+        qrem = nh + nm;
+        skipCorrection = qrem + 0x80000000 < nh2;
+      } else {
+        long nChunk = (((long) nh) << 32) | (nm & LONG_MASK);
+        qhat = (int) Long.divideUnsigned(nChunk, dhLong);
+        qrem = (int) Long.remainderUnsigned(nChunk, dhLong);
+      }
+
+      if (qhat == 0) continue;
+
+      if (!skipCorrection) { // Correct qhat
+        long nl = rem[j + 2] & LONG_MASK;
+        long rs = ((qrem & LONG_MASK) << 32) | nl;
+        long estProduct = (dl & LONG_MASK) * (qhat & LONG_MASK);
+
+        if (unsignedLongCompare(estProduct, rs)) {
+          qhat--;
+          qrem = (int) ((qrem & LONG_MASK) + dhLong);
+          if ((qrem & LONG_MASK) >= dhLong) {
+            estProduct -= (dl & LONG_MASK);
+            rs = ((qrem & LONG_MASK) << 32) | nl;
+            if (unsignedLongCompare(estProduct, rs)) qhat--;
+          }
+        }
+      }
+
+      // D4 Multiply and subtract
+      rem[j] = 0;
+      int borrow = mulsub(rem, divisor, qhat, dlen, j);
+
+      // D5 Test remainder
+      if (borrow + 0x80000000 > nh2) {
+        // D6 Add back
+        divadd(divisor, rem, j + 1);
+        qhat--;
+      }
+
+      // Store the quotient digit
+      q[j] = qhat;
+    } // D7 loop on j
+    // D3 Calculate qhat
+    // estimate qhat
+    int qhat = 0;
+    int qrem = 0;
+    boolean skipCorrection = false;
+    int nh = rem[limit - 1];
+    int nh2 = nh + 0x80000000;
+    int nm = rem[limit];
+
+    if (nh == dh) {
+      qhat = ~0;
+      qrem = nh + nm;
+      skipCorrection = qrem + 0x80000000 < nh2;
+    } else {
+      long nChunk = (((long) nh) << 32) | (nm & LONG_MASK);
+      qhat = (int) Long.divideUnsigned(nChunk, dhLong);
+      qrem = (int) Long.remainderUnsigned(nChunk, dhLong);
+    }
+    if (qhat != 0) {
+      if (!skipCorrection) { // Correct qhat
+        long nl = rem[limit + 1] & LONG_MASK;
+        long rs = ((qrem & LONG_MASK) << 32) | nl;
+        long estProduct = (dl & LONG_MASK) * (qhat & LONG_MASK);
+
+        if (unsignedLongCompare(estProduct, rs)) {
+          qhat--;
+          qrem = (int) ((qrem & LONG_MASK) + dhLong);
+          if ((qrem & LONG_MASK) >= dhLong) {
+            estProduct -= (dl & LONG_MASK);
+            rs = ((qrem & LONG_MASK) << 32) | nl;
+            if (unsignedLongCompare(estProduct, rs)) qhat--;
+          }
+        }
+      }
+
+      // D4 Multiply and subtract
+      int borrow;
+      rem[limit - 1] = 0;
+      borrow = mulsubBorrow(rem, divisor, qhat, dlen, limit - 1);
+
+      // D5 Test remainder
+      if (borrow + 0x80000000 > nh2) {
+        qhat--;
+      }
+
+      // Store the quotient digit
+      q[(limit - 1)] = qhat;
+    }
+
+    return normalize(quotient);
+  }
+
+  private static int[] divideOneWord(final int[] numerator, final int denominator) {
+    long divisorLong = denominator & LONG_MASK;
+
+    // Special case of one word dividend
+    if (numerator.length == 1) {
+      return new int[] {Integer.divideUnsigned(numerator[0], denominator)};
+    }
+
+    int[] quotient = new int[numerator.length];
+
+    long rem = 0;
+    for (int xlen = numerator.length; xlen > 0; xlen--) {
+      long dividendEstimate = (rem << 32) | (numerator[numerator.length - xlen] & LONG_MASK);
+      int q = (int) Long.divideUnsigned(dividendEstimate, divisorLong);
+      rem = Long.remainderUnsigned(dividendEstimate, divisorLong);
+      quotient[numerator.length - xlen] = q;
+    }
+
+    return normalize(quotient);
+  }
+
+  // removes leading zeros from value array
+  private static int[] normalize(final int[] value) {
+    final int numZeros = numberOfLeadingZeros(value);
+    if (numZeros == 0) {
+      return value;
+    }
+
+    final int[] trimmedValue = new int[value.length - numZeros];
+    System.arraycopy(value, numZeros, trimmedValue, 0, value.length - numZeros);
+    return trimmedValue;
+  }
+
+  private static byte[] fromIntLimbsUnsigned(final int[] value) {
+    if (value.length == 0) {
+      return new byte[0];
+    }
+    final byte[] valueBytes = new byte[UInt256.SIZE];
+    // package 1 int into 4 bytes by using byte shifting. stop when run out of limbs, rest is zero
+    for (int i = valueBytes.length - 1, limbIndex = value.length - 1;
+        i >= 3 && limbIndex >= 0;
+        i -= 4, limbIndex--) {
+      valueBytes[i - 3] = (byte) (value[limbIndex] >>> 24);
+      valueBytes[i - 2] = (byte) (value[limbIndex] >>> 16);
+      valueBytes[i - 1] = (byte) (value[limbIndex] >>> 8);
+      valueBytes[i] = (byte) value[limbIndex];
+    }
+    return valueBytes;
+  }
+
+  private static byte[] fromIntLimbs(final int[] value, final boolean isNegative) {
+    if (value.length == 0) {
+      return new byte[0];
+    }
+    if (!isNegative) {
+      return fromIntLimbsUnsigned(value);
+    }
+    // initialize array with two complement
+    final byte[] valueBytes =
+        new byte[] {
+          -1, -1, -1, -1, -1,
+          -1, -1, -1, -1, -1,
+          -1, -1, -1, -1, -1,
+          -1, -1, -1, -1, -1,
+          -1, -1, -1, -1, -1,
+          -1, -1, -1, -1, -1,
+          -1, -1
+        };
+
+    for (int i = valueBytes.length - 1, limbIndex = value.length - 1;
+        i >= 3 && limbIndex >= 0;
+        i -= 4, limbIndex--) {
+      // shift limb to get byte and invert it in one go for negative sign
+      valueBytes[i - 3] = (byte) ~(value[limbIndex] >>> 24);
+      valueBytes[i - 2] = (byte) ~(value[limbIndex] >>> 16);
+      valueBytes[i - 1] = (byte) ~(value[limbIndex] >>> 8);
+      valueBytes[i] = (byte) ~value[limbIndex];
+    }
+
+    // lastly grab unsigned byte and add one to complete sign conversion. need to carry bit from sum
+    for (int i = valueBytes.length - 1; i >= 0; i--) {
+      final int aByte = valueBytes[i];
+      valueBytes[i] = (byte) (aByte + 1);
+      int v = (aByte & 0xFF) + 1;
+      if ((v & 0x100) == 0) {
+        break; // no more carry
+      }
+    }
+    return valueBytes;
+  }
+
+  private static int[] toIntLimbs(final byte[] value, final int offset) {
+    if (offset < 0 || offset > value.length) {
+      throw new IllegalArgumentException(
+          "offset out of range: [0, " + value.length + "], offset=" + offset);
+    }
+    if (value.length == offset) {
+      return new int[1];
+    }
+    // limbs has the exact size needed, no zeros
+    int limbsSize = (value.length - offset) / 4;
+    limbsSize += (((value.length - offset) % 4) != 0) ? 1 : 0;
+    int[] limbs = new int[limbsSize];
+
+    // fill in limbs from 1...limbSize
+    int i = value.length - 1;
+    for (int limbIndex = limbsSize - 1; limbIndex > 0; i -= 4, limbIndex--) {
+      limbs[limbIndex] =
+          (Byte.toUnsignedInt(value[i - 3]) << 24)
+              | (Byte.toUnsignedInt(value[i - 2]) << 16)
+              | (Byte.toUnsignedInt(value[i - 1]) << 8)
+              | (Byte.toUnsignedInt(value[i]));
+    }
+
+    // last limb needs to be treated separately to no go out of bounds on byte array
+    limbs[0] =
+        (((i - 3 >= offset) ? Byte.toUnsignedInt(value[i - 3]) : 0) << 24)
+            | (((i - 2 >= offset) ? Byte.toUnsignedInt(value[i - 2]) : 0) << 16)
+            | (((i - 1 >= offset) ? Byte.toUnsignedInt(value[i - 1]) : 0) << 8)
+            | ((i >= offset) ? Byte.toUnsignedInt(value[i]) : 0);
+
+    return limbs;
+  }
+
+  private static void primitiveLeftShift(
+      final int[] value, final int n, final int[] result, final int resFrom) {
+    int n2 = 32 - n;
+    final int m = value.length - 1;
+    int b = value[0];
+    for (int i = 0; i < m; i++) {
+      int c = value[i + 1];
+      result[resFrom + i] = (b << n) | (c >>> n2);
+      b = c;
+    }
+    result[resFrom + m] = b << n;
+  }
+
+  private static boolean unsignedLongCompare(final long one, final long two) {
+    return (one + Long.MIN_VALUE) > (two + Long.MIN_VALUE);
+  }
+
+  private static int mulsub(
+      final int[] q, final int[] a, final int x, final int len, final int offSet) {
+    int offset = offSet;
+    long xLong = x & LONG_MASK;
+    long carry = 0;
+    offset += len;
+
+    for (int j = len - 1; j >= 0; j--) {
+      long product = (a[j] & LONG_MASK) * xLong + carry;
+      long difference = q[offset] - product;
+      q[offset--] = (int) difference;
+      carry =
+          (product >>> 32)
+              + (((difference & LONG_MASK) > (((~(int) product) & LONG_MASK))) ? 1 : 0);
+    }
+    return (int) carry;
+  }
+
+  private static int divadd(final int[] a, final int[] result, final int offset) {
+    long carry = 0;
+
+    for (int j = a.length - 1; j >= 0; j--) {
+      long sum = (a[j] & LONG_MASK) + (result[j + offset] & LONG_MASK) + carry;
+      result[j + offset] = (int) sum;
+      carry = sum >>> 32;
+    }
+    return (int) carry;
+  }
+
+  private static int mulsubBorrow(
+      final int[] q, final int[] a, final int x, final int len, final int offSet) {
+    int offset = offSet;
+    long xLong = x & LONG_MASK;
+    long carry = 0;
+    offset += len;
+    for (int j = len - 1; j >= 0; j--) {
+      long product = (a[j] & LONG_MASK) * xLong + carry;
+      long difference = q[offset--] - product;
+      carry =
+          (product >>> 32)
+              + (((difference & LONG_MASK) > (((~(int) product) & LONG_MASK))) ? 1 : 0);
+    }
+    return (int) carry;
+  }
+
+  private static int numberOfLeadingZeros(final byte[] value) {
+    if (value.length == 0 || value[0] != 0) {
+      return 0;
+    }
+
+    int numZeros = 0;
+    do {
+      numZeros++;
+    } while (numZeros < value.length && value[numZeros] == 0);
+
+    return numZeros;
+  }
+
+  private static int numberOfLeadingZeros(final int[] value) {
+    if (value.length == 0 || value[0] != 0) {
+      return 0;
+    }
+
+    int numZeros = 0;
+    do {
+      numZeros++;
+    } while (numZeros < value.length && value[numZeros] == 0);
+
+    return numZeros;
+  }
+}

--- a/datatypes/src/test/java/org/hyperledger/besu/datatypes/UInt256ArithTest.java
+++ b/datatypes/src/test/java/org/hyperledger/besu/datatypes/UInt256ArithTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.datatypes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Random;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.units.bigints.UInt256;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class UInt256ArithTest {
+  @Test
+  @Disabled
+  void randomUnsignedDivisionAgainstBigInteger() {
+    Random random = new Random();
+    final byte[] numArray = new byte[random.nextInt(0, UInt256.SIZE)];
+    final byte[] denomArray = new byte[random.nextInt(0, UInt256.SIZE)];
+    while (true) {
+      random.nextBytes(numArray);
+      random.nextBytes(denomArray);
+      final Bytes numerator = Bytes.wrap(numArray);
+      final Bytes denominator = Bytes.wrap(denomArray);
+
+      final BigInteger numBigInt = new BigInteger(1, numArray);
+      final BigInteger denomBigInt = new BigInteger(1, denomArray);
+      if (denomBigInt.equals(BigInteger.ZERO)) {
+        continue;
+      }
+
+      final byte[] bytesResult = UInt256Arith.divide(false, numerator, denominator).toArrayUnsafe();
+      final BigInteger result = new BigInteger(1, bytesResult);
+
+      assertNotNull(bytesResult);
+      assertEquals(
+          UInt256.SIZE, bytesResult.length, "division result got " + bytesResult.length + " bytes");
+      assertEquals(
+          numBigInt.divide(denomBigInt),
+          result,
+          () ->
+              "Division mismatch for num="
+                  + numerator.toHexString()
+                  + " denom="
+                  + denominator.toHexString());
+    }
+  }
+
+  @Test
+  @Disabled
+  void randomSignedDivisionAgainstBigInteger() {
+    Random random = new Random();
+    final byte[] numArray = new byte[random.nextInt(0, UInt256.SIZE)];
+    final byte[] denomArray = new byte[random.nextInt(0, UInt256.SIZE)];
+    while (true) {
+      random.nextBytes(numArray);
+      random.nextBytes(denomArray);
+      final Bytes numerator = Bytes.wrap(numArray);
+      final Bytes denominator = Bytes.wrap(denomArray);
+
+      final BigInteger numBigInt =
+          numerator.size() < UInt256.SIZE ? new BigInteger(1, numArray) : new BigInteger(numArray);
+      final BigInteger denomBigInt =
+          denominator.size() < UInt256.SIZE
+              ? new BigInteger(1, denomArray)
+              : new BigInteger(denomArray);
+      if (denomBigInt.equals(BigInteger.ZERO)) {
+        continue;
+      }
+
+      final byte[] bytesResult = UInt256Arith.divide(true, numerator, denominator).toArrayUnsafe();
+      final BigInteger result = new BigInteger(bytesResult);
+
+      assertNotNull(bytesResult);
+      assertEquals(
+          UInt256.SIZE, bytesResult.length, "division result got " + bytesResult.length + " bytes");
+      assertEquals(
+          numBigInt.divide(denomBigInt),
+          result,
+          () ->
+              "Division mismatch for num="
+                  + numerator.toHexString()
+                  + " denom="
+                  + denominator.toHexString());
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("testCases")
+  void divideSingle(final String numerator, final String denominator) {
+    final Bytes numeratorBytes = Bytes.fromHexString(numerator);
+    final Bytes denominatorBytes = Bytes.fromHexString(denominator);
+
+    final BigInteger numBigInt =
+        numeratorBytes.size() < UInt256.SIZE
+            ? new BigInteger(1, numeratorBytes.toArrayUnsafe())
+            : new BigInteger(numeratorBytes.toArrayUnsafe());
+    final BigInteger denomBigInt =
+        denominatorBytes.size() < UInt256.SIZE
+            ? new BigInteger(1, denominatorBytes.toArrayUnsafe())
+            : new BigInteger(denominatorBytes.toArrayUnsafe());
+
+    final Bytes resultBytes = UInt256Arith.divide(true, numeratorBytes, denominatorBytes);
+    final BigInteger result = new BigInteger(resultBytes.toArrayUnsafe());
+
+    final BigInteger expectedResult = numBigInt.divide(denomBigInt);
+
+    assertEquals(
+        expectedResult,
+        result,
+        () ->
+            "Division mismatch for num="
+                + numeratorBytes.toHexString()
+                + " denom="
+                + denominatorBytes.toHexString());
+    assertEquals(
+        Bytes.fromHexString(numerator), numeratorBytes, "Original value has been modified");
+    assertEquals(
+        Bytes.fromHexString(denominator), denominatorBytes, "Original value has been modified");
+  }
+
+  static Collection<Object[]> testCases() {
+    return Arrays.asList(
+        new Object[][] {
+          {"0x00", "0x01"},
+          {"0x50", "0x21"},
+          {
+            "0x120d7a733f5016ad9fae51cb9896e15a96147719fe0379d0cb2642a6951e0a5c",
+            "0x007cdab49aba612fb02bd738a74c76789bc9a911c90296502a35df43e939e6e2"
+          },
+          {"0xa7f576de3a6c", "0xfffffffffef1c296a4c6"},
+          {"0xffffffffffffffffffffffff6bacfb1469f9a4d5674a85b75f951d72d7a58e4a", "0x020000"},
+          {"0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", "0x01"},
+          {"0x01", "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"},
+          {"0x1598209296af93c13b2f5fde7d8e99", "0x09244c1368"},
+          {
+            "0xfffffffffffffff9309d38241af6a2545b52958d000000000000000000000000",
+            "0xb17217f7d1cf79abc9e3b398"
+          }
+        });
+  }
+}

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/BenchmarkHelper.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/BenchmarkHelper.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.vm.operations;
+
+import static org.mockito.Mockito.mock;
+
+import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.datatypes.Wei;
+import org.hyperledger.besu.evm.code.CodeV0;
+import org.hyperledger.besu.evm.frame.BlockValues;
+import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.worldstate.WorldUpdater;
+
+import java.util.Random;
+import java.util.function.Supplier;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.units.bigints.UInt256;
+
+public class BenchmarkHelper {
+  public static MessageFrame createMessageCallFrame() {
+    return MessageFrame.builder()
+        .worldUpdater(mock(WorldUpdater.class))
+        .originator(Address.ZERO)
+        .gasPrice(Wei.ONE)
+        .blobGasPrice(Wei.ONE)
+        .blockValues(mock(BlockValues.class))
+        .miningBeneficiary(Address.ZERO)
+        .blockHashLookup((__, ___) -> Hash.ZERO)
+        .type(MessageFrame.Type.MESSAGE_CALL)
+        .initialGas(Long.MAX_VALUE)
+        .address(Address.ZERO)
+        .contract(Address.ZERO)
+        .inputData(Bytes32.ZERO)
+        .sender(Address.ZERO)
+        .value(Wei.ZERO)
+        .apparentValue(Wei.ZERO)
+        .code(CodeV0.EMPTY_CODE)
+        .completer(__ -> {})
+        .build();
+  }
+
+  public static MessageFrame createMessageCallFrameWithCallData(final Bytes callData) {
+    return MessageFrame.builder()
+        .worldUpdater(mock(WorldUpdater.class))
+        .originator(Address.ZERO)
+        .gasPrice(Wei.ONE)
+        .blobGasPrice(Wei.ONE)
+        .blockValues(mock(BlockValues.class))
+        .miningBeneficiary(Address.ZERO)
+        .blockHashLookup((__, ___) -> Hash.ZERO)
+        .type(MessageFrame.Type.MESSAGE_CALL)
+        .initialGas(Long.MAX_VALUE)
+        .address(Address.ZERO)
+        .contract(Address.ZERO)
+        .inputData(callData)
+        .sender(Address.ZERO)
+        .value(Wei.ZERO)
+        .apparentValue(Wei.ZERO)
+        .code(CodeV0.EMPTY_CODE)
+        .completer(__ -> {})
+        .build();
+  }
+
+  /**
+   * Fills an array with random 32-byte values.
+   *
+   * @param pool the destination array
+   */
+  public static void fillPool(final Bytes[] pool) {
+    final Random random = new Random();
+    fillPool(pool, () -> 1 + random.nextInt(32)); //  [1, 32]
+  }
+
+  public static void fillPool(final Bytes[] pool, final Supplier<Integer> sizeSupplier) {
+    final Random random = new Random();
+    for (int i = 0; i < pool.length; i++) {
+      final byte[] a = new byte[sizeSupplier.get()];
+      random.nextBytes(a);
+      pool[i] = Bytes.wrap(a);
+    }
+  }
+
+  static Bytes createCallData(final int size, final boolean nonZero) {
+    byte[] data = new byte[size];
+    if (nonZero) {
+      for (int i = 0; i < size; i++) {
+        data[i] = (byte) (i % 256);
+      }
+    }
+    return Bytes.wrap(data);
+  }
+
+  static void fillPoolsForCallData(
+      final Bytes[] sizePool,
+      final Bytes[] destOffsetPool,
+      final Bytes[] srcOffsetPool,
+      final int dataSize,
+      final boolean fixedSrcDst) {
+    for (int i = 0; i < sizePool.length; i++) {
+      sizePool[i] = Bytes.wrap(UInt256.valueOf(dataSize));
+
+      if (fixedSrcDst) {
+        destOffsetPool[i] = Bytes.wrap(UInt256.valueOf(0));
+        srcOffsetPool[i] = Bytes.wrap(UInt256.valueOf(0));
+      } else {
+        destOffsetPool[i] = Bytes.wrap(UInt256.valueOf((i * 32) % 1024));
+        srcOffsetPool[i] = Bytes.wrap(UInt256.valueOf(i % Math.max(1, dataSize)));
+      }
+    }
+  }
+}

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/BinaryOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/BinaryOperationBenchmark.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.vm.operations;
+
+import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.operation.Operation;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiPredicate;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+@State(Scope.Thread)
+@Warmup(iterations = 2, time = 1, timeUnit = TimeUnit.SECONDS)
+@OutputTimeUnit(value = TimeUnit.NANOSECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public abstract class BinaryOperationBenchmark {
+
+  protected static final int SAMPLE_SIZE = 30_000;
+
+  protected Bytes[] aPool;
+  protected Bytes[] bPool;
+  protected int index;
+  protected MessageFrame frame;
+
+  @Setup()
+  public void setUp() {
+    frame = BenchmarkHelper.createMessageCallFrame();
+    aPool = new Bytes[SAMPLE_SIZE];
+    bPool = new Bytes[SAMPLE_SIZE];
+    BenchmarkHelper.fillPool(aPool);
+    BenchmarkHelper.fillPool(bPool);
+    index = 0;
+  }
+
+  @Benchmark
+  public void baseline() {
+    frame.pushStackItem(bPool[index]);
+    frame.pushStackItem(aPool[index]);
+    frame.popStackItem();
+    frame.popStackItem();
+
+    index = (index + 1) % SAMPLE_SIZE;
+  }
+
+  @Benchmark
+  public void executeOperation(final Blackhole blackhole) {
+    frame.pushStackItem(bPool[index]);
+    frame.pushStackItem(aPool[index]);
+
+    blackhole.consume(invoke(frame));
+
+    frame.popStackItem();
+
+    index = (index + 1) % SAMPLE_SIZE;
+  }
+
+  protected abstract Operation.OperationResult invoke(MessageFrame frame);
+
+  public <T> void fillPools(
+      final Supplier<Integer> aSizeSupplier,
+      final Supplier<Integer> bSizeSupplier,
+      final Function<byte[], T> transform,
+      final BiPredicate<T, T> swapOperands) {
+
+    aPool = new Bytes[SAMPLE_SIZE];
+    bPool = new Bytes[SAMPLE_SIZE];
+    final Random random = new Random();
+
+    for (int i = 0; i < SAMPLE_SIZE; i++) {
+      final int aSize = aSizeSupplier.get();
+      final int bSize = bSizeSupplier.get();
+      final byte[] a = new byte[aSize];
+      final byte[] b = new byte[bSize];
+      random.nextBytes(a);
+      random.nextBytes(b);
+      if (swapOperands.test(transform.apply(a), transform.apply(b))) {
+        bPool[i] = Bytes.wrap(a);
+        aPool[i] = Bytes.wrap(b);
+      } else {
+        aPool[i] = Bytes.wrap(a);
+        bPool[i] = Bytes.wrap(b);
+      }
+    }
+  }
+}

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/DivOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/DivOperationBenchmark.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.vm.operations;
+
+import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.operation.DivOperation;
+import org.hyperledger.besu.evm.operation.Operation;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Random;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+
+public class DivOperationBenchmark extends BinaryOperationBenchmark {
+
+  private static final Random RANDOM = new Random();
+
+  // public because of jmh code generator
+  public enum MODE {
+    ZERO_QUOTIENT,
+    ONE_QUOTIENT,
+    LARGER_QUOTIENT,
+    UNIFORM_OPERATORS,
+    INT_OPERATORS,
+    LONG_OPERATORS,
+    SMALL_QUOTIENT,
+    BIG_OPERATORS,
+    FULL_RANDOM
+  }
+
+  @Param private MODE mode;
+
+  @Setup
+  @Override
+  public void setUp() {
+    frame = BenchmarkHelper.createMessageCallFrame();
+
+    switch (mode) {
+      case ZERO_QUOTIENT:
+        aPool = new Bytes[SAMPLE_SIZE];
+        bPool = new Bytes[SAMPLE_SIZE];
+        Arrays.fill(aPool, Bytes.EMPTY);
+        BenchmarkHelper.fillPool(bPool, () -> 1 + RANDOM.nextInt(32));
+        break;
+      case ONE_QUOTIENT:
+        aPool = new Bytes[SAMPLE_SIZE];
+        BenchmarkHelper.fillPool(aPool, () -> 1 + RANDOM.nextInt(32));
+        bPool = aPool;
+        break;
+      case LARGER_QUOTIENT:
+        fillPools(
+            () -> 22 + RANDOM.nextInt(10),
+            () -> 1 + RANDOM.nextInt(10),
+            byteArray -> new BigInteger(1, byteArray),
+            (__, ___) -> true);
+        break;
+      case SMALL_QUOTIENT:
+        fillPools(
+            () -> 24 + RANDOM.nextInt(9),
+            () -> 24 + RANDOM.nextInt(9),
+            byteArray -> new BigInteger(1, byteArray),
+            (a, b) -> a.compareTo(b) > 0);
+        break;
+      case UNIFORM_OPERATORS:
+        fillPools(
+            () -> 1 + RANDOM.nextInt(32),
+            () -> 1 + RANDOM.nextInt(32),
+            byteArray -> new BigInteger(1, byteArray),
+            (a, b) -> a.compareTo(b) > 0);
+        break;
+      case INT_OPERATORS:
+        fillPools(
+            () -> 5 + RANDOM.nextInt(4),
+            () -> 1 + RANDOM.nextInt(4),
+            byteArray -> new BigInteger(1, byteArray),
+            (__, ___) -> true);
+        break;
+      case LONG_OPERATORS:
+        fillPools(
+            () -> 9 + RANDOM.nextInt(5),
+            () -> 4 + RANDOM.nextInt(5),
+            byteArray -> new BigInteger(1, byteArray),
+            (__, ___) -> true);
+        break;
+      case BIG_OPERATORS:
+        fillPools(
+            () -> 17 + RANDOM.nextInt(16),
+            () -> 17 + RANDOM.nextInt(16),
+            byteArray -> new BigInteger(1, byteArray),
+            (a, b) -> a.compareTo(b) > 0);
+        break;
+      case FULL_RANDOM:
+        aPool = new Bytes[SAMPLE_SIZE];
+        bPool = new Bytes[SAMPLE_SIZE];
+        BenchmarkHelper.fillPool(aPool);
+        BenchmarkHelper.fillPool(bPool);
+        break;
+    }
+    index = 0;
+  }
+
+  @Override
+  protected Operation.OperationResult invoke(final MessageFrame frame) {
+    return DivOperation.staticOperation(frame);
+  }
+}

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/SDivOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/SDivOperationBenchmark.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.vm.operations;
+
+import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.operation.Operation;
+import org.hyperledger.besu.evm.operation.SDivOperation;
+
+public class SDivOperationBenchmark extends DivOperationBenchmark {
+
+  @Override
+  protected Operation.OperationResult invoke(final MessageFrame frame) {
+    return SDivOperation.staticOperation(frame);
+  }
+}

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/DivOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/DivOperation.java
@@ -14,11 +14,10 @@
  */
 package org.hyperledger.besu.evm.operation;
 
+import org.hyperledger.besu.datatypes.UInt256Arith;
 import org.hyperledger.besu.evm.EVM;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
-
-import java.math.BigInteger;
 
 import org.apache.tuweni.bytes.Bytes;
 
@@ -50,26 +49,13 @@ public class DivOperation extends AbstractFixedCostOperation {
    * @return the operation result
    */
   public static OperationResult staticOperation(final MessageFrame frame) {
-
     final Bytes value0 = frame.popStackItem();
     final Bytes value1 = frame.popStackItem();
 
     if (value1.isZero()) {
       frame.pushStackItem(Bytes.EMPTY);
     } else {
-      BigInteger b1 = new BigInteger(1, value0.toArrayUnsafe());
-      BigInteger b2 = new BigInteger(1, value1.toArrayUnsafe());
-      final BigInteger result = b1.divide(b2);
-
-      // because it's unsigned there is a change a 33 byte result will occur
-      // there is no toByteArrayUnsigned so we have to check and trim
-      byte[] resultArray = result.toByteArray();
-      int length = resultArray.length;
-      if (length > 32) {
-        frame.pushStackItem(Bytes.wrap(resultArray, length - 32, 32));
-      } else {
-        frame.pushStackItem(Bytes.wrap(resultArray));
-      }
+      frame.pushStackItem(UInt256Arith.divide(false, value0, value1));
     }
 
     return divSuccess;

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/SDivOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/SDivOperation.java
@@ -14,14 +14,12 @@
  */
 package org.hyperledger.besu.evm.operation;
 
+import org.hyperledger.besu.datatypes.UInt256Arith;
 import org.hyperledger.besu.evm.EVM;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
-import java.math.BigInteger;
-
 import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.bytes.Bytes32;
 
 /** The SDiv operation. */
 public class SDivOperation extends AbstractFixedCostOperation {
@@ -56,21 +54,7 @@ public class SDivOperation extends AbstractFixedCostOperation {
     if (value1.isZero()) {
       frame.pushStackItem(Bytes.EMPTY);
     } else {
-      final BigInteger b1 =
-          value0.size() < 32
-              ? new BigInteger(1, value0.toArrayUnsafe())
-              : new BigInteger(value0.toArrayUnsafe());
-      final BigInteger b2 =
-          value1.size() < 32
-              ? new BigInteger(1, value1.toArrayUnsafe())
-              : new BigInteger(value1.toArrayUnsafe());
-      final BigInteger result = b1.divide(b2);
-      Bytes resultBytes = Bytes.wrap(result.toByteArray());
-      if (resultBytes.size() > 32) {
-        resultBytes = resultBytes.slice(resultBytes.size() - 32, 32);
-      }
-
-      frame.pushStackItem(Bytes32.leftPad(resultBytes, result.signum() < 0 ? (byte) 0xFF : 0x00));
+      frame.pushStackItem(UInt256Arith.divide(true, value0, value1));
     }
 
     return sdivSuccess;


### PR DESCRIPTION
Experiment to try new implementation around division

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


