### PR TITLE
Implement optional sender balance checks in the layered txpool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Support loading multiple transaction selector plugins [#8743](https://github.com/hyperledger/besu/pull/9139)
 - Configurable limit for how much time plugins are allowed take, to propose transactions, during block creation [#9184](https://github.com/hyperledger/besu/pull/9184)
 - Add Osaka, BPO1 and BPO2 fork times for holesky, hoodi and sepolia [#9196](https://github.com/hyperledger/besu/pull/9196/files)
+- Implement optional sender balance checks in the layered txpool [#9176](https://github.com/hyperledger/besu/pull/9176)
 
 #### Performance
 - Add jmh benchmarks for some compute-related opcodes [#9069](https://github.com/hyperledger/besu/pull/9069)

--- a/app/src/main/java/org/hyperledger/besu/cli/options/TransactionPoolOptions.java
+++ b/app/src/main/java/org/hyperledger/besu/cli/options/TransactionPoolOptions.java
@@ -157,6 +157,7 @@ public class TransactionPoolOptions implements CLIOptions<TransactionPoolConfigu
         "--tx-pool-max-prioritized-by-type";
     private static final String TX_POOL_MAX_FUTURE_BY_SENDER = "--tx-pool-max-future-by-sender";
     private static final String TX_POOL_MIN_SCORE = "--tx-pool-min-score";
+    private static final String TX_POOL_ENABLE_BALANCE_CHECK = "--tx-pool-enable-balance-check";
 
     @CommandLine.Option(
         names = {TX_POOL_LAYER_MAX_CAPACITY},
@@ -202,6 +203,15 @@ public class TransactionPoolOptions implements CLIOptions<TransactionPoolConfigu
                 + "Accepts values between -128 and 127 (default: ${DEFAULT-VALUE})",
         arity = "1")
     Byte minScore = TransactionPoolConfiguration.DEFAULT_TX_POOL_MIN_SCORE;
+
+    @CommandLine.Option(
+        names = {TX_POOL_ENABLE_BALANCE_CHECK},
+        paramLabel = "<Boolean>",
+        description =
+            "If enabled a pending transaction can stay in the prioritized layer, only if its sender has enough balance (default: ${DEFAULT-VALUE})",
+        fallbackValue = "true",
+        arity = "0..1")
+    Boolean balanceCheckEnabled = TransactionPoolConfiguration.DEFAULT_TX_POOL_ENABLE_BALANCE_CHECK;
   }
 
   @CommandLine.ArgGroup(
@@ -345,6 +355,7 @@ public class TransactionPoolOptions implements CLIOptions<TransactionPoolConfigu
         config.getMaxPrioritizedTransactionsByType();
     options.layeredOptions.txPoolMaxFutureBySender = config.getMaxFutureBySender();
     options.layeredOptions.minScore = config.getMinScore();
+    options.layeredOptions.balanceCheckEnabled = config.getEnableBalanceCheck();
     options.sequencedOptions.txPoolLimitByAccountPercentage =
         config.getTxPoolLimitByAccountPercentage();
     options.sequencedOptions.txPoolMaxSize = config.getTxPoolMaxSize();
@@ -407,6 +418,7 @@ public class TransactionPoolOptions implements CLIOptions<TransactionPoolConfigu
         .maxPrioritizedTransactionsByType(layeredOptions.txPoolMaxPrioritizedByType)
         .maxFutureBySender(layeredOptions.txPoolMaxFutureBySender)
         .minScore(layeredOptions.minScore)
+        .enableBalanceCheck(layeredOptions.balanceCheckEnabled)
         .txPoolLimitByAccountPercentage(sequencedOptions.txPoolLimitByAccountPercentage)
         .txPoolMaxSize(sequencedOptions.txPoolMaxSize)
         .pendingTxRetentionPeriod(sequencedOptions.pendingTxRetentionPeriod)

--- a/app/src/test/java/org/hyperledger/besu/cli/options/TransactionPoolOptionsTest.java
+++ b/app/src/test/java/org/hyperledger/besu/cli/options/TransactionPoolOptionsTest.java
@@ -456,6 +456,33 @@ public class TransactionPoolOptionsTest
   }
 
   @Test
+  public void balanceCheckWorks() {
+    final boolean balanceCheck = true;
+    internalTestSuccess(
+        config -> assertThat(config.getEnableBalanceCheck()).isEqualTo(balanceCheck),
+        "--tx-pool-enable-balance-check",
+        Boolean.toString(balanceCheck));
+  }
+
+  @Test
+  public void balanceCheckWorksConfigFile() throws IOException {
+    final boolean balanceCheck = true;
+    final Path tempConfigFilePath =
+        createTempFile(
+            "config",
+            String.format(
+                """
+              tx-pool-enable-balance-check=%s
+              """,
+                balanceCheck));
+
+    internalTestSuccess(
+        config -> assertThat(config.getEnableBalanceCheck()).isEqualTo(balanceCheck),
+        "--config-file",
+        tempConfigFilePath.toString());
+  }
+
+  @Test
   public void defaultForgetEvictedTxsWithSequencedIsTrue() {
     internalTestSuccess(
         config -> assertThat(config.getUnstable().getPeerTrackerForgetEvictedTxs()).isTrue(),

--- a/app/src/test/resources/everything_config.toml
+++ b/app/src/test/resources/everything_config.toml
@@ -190,6 +190,7 @@ tx-pool-layer-max-capacity=12345678
 tx-pool-max-prioritized=9876
 tx-pool-max-prioritized-by-type=["BLOB=10","FRONTIER=100"]
 tx-pool-max-future-by-sender=321
+tx-pool-enable-balance-check=false
 ## Legacy/Sequenced
 tx-pool-retention-hours=999
 tx-pool-max-size=1234

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/AbstractIsolationTests.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/AbstractIsolationTests.java
@@ -61,6 +61,7 @@ import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolReplacement
 import org.hyperledger.besu.ethereum.eth.transactions.layered.EndLayer;
 import org.hyperledger.besu.ethereum.eth.transactions.layered.GasPricePrioritizedTransactions;
 import org.hyperledger.besu.ethereum.eth.transactions.layered.LayeredPendingTransactions;
+import org.hyperledger.besu.ethereum.eth.transactions.layered.SenderBalanceChecker;
 import org.hyperledger.besu.ethereum.mainnet.MainnetProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.storage.StorageProvider;
@@ -132,6 +133,8 @@ public abstract class AbstractIsolationTests {
   protected TransactionPoolMetrics txPoolMetrics =
       new TransactionPoolMetrics(new NoOpMetricsSystem());
 
+  protected SenderBalanceChecker senderBalanceChecker = new SenderBalanceChecker.NoOpChecker();
+
   protected final PendingTransactions sorter =
       new LayeredPendingTransactions(
           poolConfiguration,
@@ -142,7 +145,8 @@ public abstract class AbstractIsolationTests {
               txPoolMetrics,
               transactionReplacementTester,
               new BlobCache(),
-              MiningConfiguration.newDefault()),
+              MiningConfiguration.newDefault(),
+              senderBalanceChecker),
           ethScheduler);
 
   protected final List<GenesisAccount> accounts =

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolConfiguration.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolConfiguration.java
@@ -93,6 +93,7 @@ public interface TransactionPoolConfiguration {
   Set<Address> DEFAULT_PRIORITY_SENDERS = Set.of();
   Wei DEFAULT_TX_POOL_MIN_GAS_PRICE = Wei.of(1000);
   byte DEFAULT_TX_POOL_MIN_SCORE = -128;
+  boolean DEFAULT_TX_POOL_ENABLE_BALANCE_CHECK = false;
 
   TransactionPoolConfiguration DEFAULT = ImmutableTransactionPoolConfiguration.builder().build();
 
@@ -189,6 +190,11 @@ public interface TransactionPoolConfiguration {
   @Value.Default
   default byte getMinScore() {
     return DEFAULT_TX_POOL_MIN_SCORE;
+  }
+
+  @Value.Default
+  default boolean getEnableBalanceCheck() {
+    return DEFAULT_TX_POOL_ENABLE_BALANCE_CHECK;
   }
 
   @Value.Default

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolFactory.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolFactory.java
@@ -28,6 +28,7 @@ import org.hyperledger.besu.ethereum.eth.transactions.layered.EndLayer;
 import org.hyperledger.besu.ethereum.eth.transactions.layered.GasPricePrioritizedTransactions;
 import org.hyperledger.besu.ethereum.eth.transactions.layered.LayeredPendingTransactions;
 import org.hyperledger.besu.ethereum.eth.transactions.layered.ReadyTransactions;
+import org.hyperledger.besu.ethereum.eth.transactions.layered.SenderBalanceChecker;
 import org.hyperledger.besu.ethereum.eth.transactions.layered.SparseTransactions;
 import org.hyperledger.besu.ethereum.eth.transactions.sorter.AbstractPendingTransactionsSorter;
 import org.hyperledger.besu.ethereum.eth.transactions.sorter.BaseFeePendingTransactionsSorter;
@@ -310,6 +311,10 @@ public class TransactionPoolFactory {
             transactionReplacementHandler.shouldReplace(
                 t1, t2, protocolContext.getBlockchain().getChainHeadHeader());
 
+    final SenderBalanceChecker senderBalanceChecker =
+        SenderBalanceChecker.create(
+            protocolSchedule, protocolContext, transactionPoolConfiguration);
+
     final EndLayer endLayer = new EndLayer(metrics);
 
     final SparseTransactions sparseTransactions =
@@ -347,7 +352,8 @@ public class TransactionPoolFactory {
               transactionReplacementTester,
               feeMarket,
               blobCache,
-              miningConfiguration);
+              miningConfiguration,
+              senderBalanceChecker);
     } else {
       pendingTransactionsSorter =
           new GasPricePrioritizedTransactions(
@@ -357,7 +363,8 @@ public class TransactionPoolFactory {
               metrics,
               transactionReplacementTester,
               blobCache,
-              miningConfiguration);
+              miningConfiguration,
+              senderBalanceChecker);
     }
 
     return new LayeredPendingTransactions(

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/layered/AbstractTransactionsLayer.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/layered/AbstractTransactionsLayer.java
@@ -342,6 +342,12 @@ public abstract class AbstractTransactionsLayer implements TransactionsLayer {
     increaseCounters(addedTx);
     metrics.incrementAdded(addedTx, addReason, name());
     internalAdd(senderTxs, addedTx);
+    LOG.atTrace()
+        .setMessage("[{}] added pending transactions {}, reason: {}")
+        .addArgument(name())
+        .addArgument(addedTx::toTraceLog)
+        .addArgument(addReason)
+        .log();
   }
 
   protected abstract void internalAdd(

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/layered/BaseFeePrioritizedTransactions.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/layered/BaseFeePrioritizedTransactions.java
@@ -39,6 +39,7 @@ import org.slf4j.LoggerFactory;
 public class BaseFeePrioritizedTransactions extends AbstractPrioritizedTransactions {
 
   private static final Logger LOG = LoggerFactory.getLogger(BaseFeePrioritizedTransactions.class);
+  private final SenderBalanceChecker senderBalanceChecker;
   private Optional<Wei> nextBlockBaseFee;
 
   public BaseFeePrioritizedTransactions(
@@ -51,7 +52,8 @@ public class BaseFeePrioritizedTransactions extends AbstractPrioritizedTransacti
           transactionReplacementTester,
       final FeeMarket feeMarket,
       final BlobCache blobCache,
-      final MiningConfiguration miningConfiguration) {
+      final MiningConfiguration miningConfiguration,
+      final SenderBalanceChecker senderBalanceChecker) {
     super(
         poolConfig,
         ethScheduler,
@@ -62,6 +64,7 @@ public class BaseFeePrioritizedTransactions extends AbstractPrioritizedTransacti
         miningConfiguration);
     this.nextBlockBaseFee =
         Optional.of(calculateNextBlockBaseFee(feeMarket, chainHeadHeaderSupplier.get()));
+    this.senderBalanceChecker = senderBalanceChecker;
   }
 
   @Override
@@ -100,6 +103,7 @@ public class BaseFeePrioritizedTransactions extends AbstractPrioritizedTransacti
 
     nextBlockBaseFee = Optional.of(newNextBlockBaseFee);
     orderByFee.clear();
+    senderBalanceChecker.clear();
 
     final var itTxsBySender = txsBySender.entrySet().iterator();
     while (itTxsBySender.hasNext()) {
@@ -188,7 +192,8 @@ public class BaseFeePrioritizedTransactions extends AbstractPrioritizedTransacti
       }
     }
 
-    return true;
+    // check is the sender has enough balance
+    return senderBalanceChecker.hasEnoughBalanceFor(pendingTransaction);
   }
 
   @Override

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/layered/GasPricePrioritizedTransactions.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/layered/GasPricePrioritizedTransactions.java
@@ -34,6 +34,7 @@ import java.util.function.BiFunction;
  * <p>This class is safe for use across multiple threads.
  */
 public class GasPricePrioritizedTransactions extends AbstractPrioritizedTransactions {
+  private final SenderBalanceChecker senderBalanceChecker;
 
   public GasPricePrioritizedTransactions(
       final TransactionPoolConfiguration poolConfig,
@@ -43,7 +44,8 @@ public class GasPricePrioritizedTransactions extends AbstractPrioritizedTransact
       final BiFunction<PendingTransaction, PendingTransaction, Boolean>
           transactionReplacementTester,
       final BlobCache blobCache,
-      final MiningConfiguration miningConfiguration) {
+      final MiningConfiguration miningConfiguration,
+      final SenderBalanceChecker senderBalanceChecker) {
     super(
         poolConfig,
         ethScheduler,
@@ -52,6 +54,7 @@ public class GasPricePrioritizedTransactions extends AbstractPrioritizedTransact
         transactionReplacementTester,
         blobCache,
         miningConfiguration);
+    this.senderBalanceChecker = senderBalanceChecker;
   }
 
   @Override
@@ -70,6 +73,11 @@ public class GasPricePrioritizedTransactions extends AbstractPrioritizedTransact
 
   @Override
   protected boolean promotionFilter(final PendingTransaction pendingTransaction) {
+
+    if (!senderBalanceChecker.hasEnoughBalanceFor(pendingTransaction)) {
+      return false;
+    }
+
     return pendingTransaction.hasPriority()
         || pendingTransaction
             .getTransaction()

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/layered/SenderBalanceChecker.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/layered/SenderBalanceChecker.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.eth.transactions.layered;
+
+import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.datatypes.Wei;
+import org.hyperledger.besu.ethereum.ProtocolContext;
+import org.hyperledger.besu.ethereum.chain.Blockchain;
+import org.hyperledger.besu.ethereum.eth.transactions.PendingTransaction;
+import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolConfiguration;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
+import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Checks if the sender has enough balance to pay to a pending transaction. This is used by the
+ * txpool to decided what to do in case the sender hasn't enough balance.
+ */
+public interface SenderBalanceChecker {
+  boolean hasEnoughBalanceFor(final PendingTransaction pendingTransaction);
+
+  void clear();
+
+  static SenderBalanceChecker create(
+      final ProtocolSchedule protocolSchedule,
+      final ProtocolContext protocolContext,
+      final TransactionPoolConfiguration transactionPoolConfiguration) {
+    return transactionPoolConfiguration.getEnableBalanceCheck()
+        ? new SenderBalanceChecker.WorldStateChecker(protocolSchedule, protocolContext)
+        : new SenderBalanceChecker.NoOpChecker();
+  }
+
+  /**
+   * Does no check at all and always returns that sender has enough balance. It is used when the
+   * check is disabled by configuration.
+   */
+  class NoOpChecker implements SenderBalanceChecker {
+    @Override
+    public boolean hasEnoughBalanceFor(final PendingTransaction pendingTransaction) {
+      return true;
+    }
+
+    @Override
+    public void clear() {}
+  }
+
+  /**
+   * Does the check reading the balance from the chain head world state. It must be reset, calling
+   * the clear method, on every new block imported, that because the class keeps a cache of the
+   * balances, both for performance reasons, and to be able to check all the pending transactions
+   * for a sender.
+   *
+   * <p>For simplicity and performance, the check of balance, takes the assumption that the sender
+   * does not receive any new balance during the period of a block, so it is a pessimistic
+   * approximation.
+   *
+   * <p>The algorithm to check a sequence of pending transactions from the same sender works like
+   * that: for the first pending transaction of the sender, its account is read from the world
+   * state, and put in the cache, the check is done and the upfront cost is subtracted from the
+   * cached balance, so following pending transactions will found the updated balance in the cache
+   * and will subtract their upfront cost, and so on.
+   */
+  class WorldStateChecker implements SenderBalanceChecker {
+    private static final Logger LOG = LoggerFactory.getLogger(SenderBalanceChecker.class);
+    private static final Logger LOG_FOR_REPLAY = LoggerFactory.getLogger("LOG_FOR_REPLAY");
+    private final ProtocolSchedule protocolSchedule;
+    private final WorldStateArchive worldStateArchive;
+    private final Blockchain blockchain;
+    private final Map<Address, Wei> senderBalancesCache = new HashMap<>();
+
+    public WorldStateChecker(
+        final ProtocolSchedule protocolSchedule, final ProtocolContext protocolContext) {
+      this.protocolSchedule = protocolSchedule;
+      this.worldStateArchive = protocolContext.getWorldStateArchive();
+      this.blockchain = protocolContext.getBlockchain();
+    }
+
+    @Override
+    public boolean hasEnoughBalanceFor(final PendingTransaction pendingTransaction) {
+      final var tx = pendingTransaction.getTransaction();
+      final var sender = tx.getSender();
+
+      final var senderBalance = senderBalancesCache.computeIfAbsent(sender, this::getSenderBalance);
+
+      if (senderBalance.equals(Wei.ZERO)) {
+        LOG.atTrace()
+            .setMessage("Sender has zero balance for transaction {}")
+            .addArgument(pendingTransaction::toTraceLog)
+            .log();
+        return false;
+      }
+
+      final var gasCalculator =
+          protocolSchedule.getByBlockHeader(blockchain.getChainHeadHeader()).getGasCalculator();
+      final var upfrontCost = tx.getUpfrontCost(gasCalculator.blobGasCost(tx.getBlobCount()));
+
+      if (senderBalance.lessThan(upfrontCost)) {
+        LOG.atTrace()
+            .setMessage("Sender balance {} is not enough to pay upfront cost {} for transaction {}")
+            .addArgument(senderBalance::toHumanReadableString)
+            .addArgument(upfrontCost::toHumanReadableString)
+            .addArgument(pendingTransaction::toTraceLog)
+            .log();
+
+        senderBalancesCache.put(sender, Wei.ZERO);
+        return false;
+      }
+
+      senderBalancesCache.put(sender, senderBalance.subtract(upfrontCost));
+      return true;
+    }
+
+    private Wei getSenderBalance(final Address sender) {
+      final var maybeAccount = worldStateArchive.getWorldState().get(sender);
+      final var senderBalance = maybeAccount != null ? maybeAccount.getBalance() : Wei.ZERO;
+      logSenderBalance(sender, senderBalance);
+      return senderBalance;
+    }
+
+    private void logSenderBalance(final Address sender, final Wei balance) {
+      LOG_FOR_REPLAY
+          .atTrace()
+          .setMessage("SB,{},{}")
+          .addArgument(sender)
+          .addArgument(balance::toShortHexString)
+          .log();
+    }
+
+    @Override
+    public void clear() {
+      senderBalancesCache.clear();
+    }
+  }
+}

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/AbstractTransactionPoolTestBase.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/AbstractTransactionPoolTestBase.java
@@ -58,6 +58,7 @@ import org.hyperledger.besu.ethereum.eth.manager.EthProtocolManager;
 import org.hyperledger.besu.ethereum.eth.manager.EthProtocolManagerTestBuilder;
 import org.hyperledger.besu.ethereum.eth.manager.EthScheduler;
 import org.hyperledger.besu.ethereum.eth.transactions.layered.LayeredTransactionPoolBaseFeeTest;
+import org.hyperledger.besu.ethereum.eth.transactions.layered.SenderBalanceChecker;
 import org.hyperledger.besu.ethereum.eth.transactions.sorter.LegacyTransactionPoolBaseFeeTest;
 import org.hyperledger.besu.ethereum.mainnet.MainnetBlockHeaderFunctions;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
@@ -145,6 +146,7 @@ public abstract class AbstractTransactionPoolTestBase extends TrustedSetupClassL
   protected EthContext ethContext;
   protected ArgumentCaptor<Runnable> syncTaskCapture;
   protected PeerTransactionTracker peerTransactionTracker;
+  protected SenderBalanceChecker senderBalanceChecker = new SenderBalanceChecker.NoOpChecker();
   private BlobTestFixture blobTestFixture;
 
   protected abstract PendingTransactions createPendingTransactions(

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolSaveRestoreTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolSaveRestoreTest.java
@@ -104,7 +104,8 @@ public class TransactionPoolSaveRestoreTest extends AbstractTransactionPoolTestB
             transactionReplacementTester,
             FeeMarket.london(0L),
             new BlobCache(),
-            MiningConfiguration.newDefault()),
+            MiningConfiguration.newDefault(),
+            senderBalanceChecker),
         ethScheduler);
   }
 

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/layered/BaseFeePrioritizedTransactionsTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/layered/BaseFeePrioritizedTransactionsTest.java
@@ -73,7 +73,8 @@ public class BaseFeePrioritizedTransactionsTest extends AbstractPrioritizedTrans
         transactionReplacementTester,
         EIP1559_FEE_MARKET,
         new BlobCache(),
-        miningConfiguration);
+        miningConfiguration,
+        senderBalanceChecker);
   }
 
   @Override

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/layered/BaseTransactionPoolTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/layered/BaseTransactionPoolTest.java
@@ -17,6 +17,9 @@ package org.hyperledger.besu.ethereum.eth.transactions.layered;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hyperledger.besu.ethereum.core.TransactionTestFixture.createSignedCodeDelegation;
 import static org.hyperledger.besu.ethereum.eth.transactions.PendingTransaction.MAX_SCORE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.crypto.KeyPair;
 import org.hyperledger.besu.crypto.SignatureAlgorithm;
@@ -50,6 +53,7 @@ import java.util.stream.IntStream;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import org.apache.tuweni.bytes.Bytes;
+import org.junit.jupiter.api.BeforeEach;
 
 public class BaseTransactionPoolTest extends TrustedSetupClassLoaderExtension {
 
@@ -72,6 +76,12 @@ public class BaseTransactionPoolTest extends TrustedSetupClassLoaderExtension {
 
   protected final EthScheduler ethScheduler = new DeterministicEthScheduler();
   protected final StubMetricsSystem metricsSystem = new StubMetricsSystem();
+  protected final SenderBalanceChecker senderBalanceChecker = mock(SenderBalanceChecker.class);
+
+  @BeforeEach
+  public void setupSenderBalanceChecker() {
+    when(senderBalanceChecker.hasEnoughBalanceFor(any())).thenReturn(true);
+  }
 
   protected Transaction createTransaction(final long nonce) {
     return createTransaction(nonce, Wei.of(5000L), KEYS1);

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/layered/GasPricePrioritizedTransactionsTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/layered/GasPricePrioritizedTransactionsTest.java
@@ -53,7 +53,8 @@ public class GasPricePrioritizedTransactionsTest extends AbstractPrioritizedTran
         txPoolMetrics,
         transactionReplacementTester,
         new BlobCache(),
-        miningConfiguration);
+        miningConfiguration,
+        senderBalanceChecker);
   }
 
   @Override

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/layered/LayeredPendingTransactionsTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/layered/LayeredPendingTransactionsTest.java
@@ -160,7 +160,8 @@ public class LayeredPendingTransactionsTest extends BaseTransactionPoolTest {
             transactionReplacementTester,
             FeeMarket.london(0L),
             new BlobCache(),
-            MiningConfiguration.newDefault().setMinTransactionGasPrice(DEFAULT_MIN_GAS_PRICE));
+            MiningConfiguration.newDefault().setMinTransactionGasPrice(DEFAULT_MIN_GAS_PRICE),
+            senderBalanceChecker);
     return new CreatedLayers(
         prioritizedTransactions, readyTransactions, sparseTransactions, evictCollector);
   }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/layered/LayeredTransactionPoolBaseFeeTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/layered/LayeredTransactionPoolBaseFeeTest.java
@@ -49,7 +49,8 @@ public class LayeredTransactionPoolBaseFeeTest extends AbstractLayeredTransactio
         transactionReplacementTester,
         FeeMarket.london(0L),
         new BlobCache(),
-        MiningConfiguration.newDefault());
+        MiningConfiguration.newDefault(),
+        senderBalanceChecker);
   }
 
   @Override

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/layered/LayeredTransactionPoolGasPriceTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/layered/LayeredTransactionPoolGasPriceTest.java
@@ -46,7 +46,8 @@ public class LayeredTransactionPoolGasPriceTest extends AbstractLayeredTransacti
         txPoolMetrics,
         transactionReplacementTester,
         new BlobCache(),
-        MiningConfiguration.newDefault());
+        MiningConfiguration.newDefault(),
+        senderBalanceChecker);
   }
 
   @Override


### PR DESCRIPTION
## PR description

Built on top of https://github.com/hyperledger/besu/pull/9191 and https://github.com/hyperledger/besu/pull/9192
 please review them first

This PR introduces a new configuration option `tx-pool-enable-balance-check`, false by default, that when enabled, will make sure that pending transactions, which sender hasn't enough balance to pay their fee, cannot be in the prioritized layer, thus preventing them to occupy space there and potentially be selected for block production.



## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


