### PR TITLE
Removing the memoize from the signature algorithm

### DIFF
--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/account/Account.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/account/Account.java
@@ -32,8 +32,6 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Optional;
 
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import org.apache.tuweni.bytes.Bytes32;
 import org.web3j.crypto.Credentials;
 import org.web3j.utils.Convert.Unit;
@@ -47,8 +45,8 @@ public class Account {
   private final Address address;
   private long nonce = 0;
 
-  private static final Supplier<SignatureAlgorithm> SIGNATURE_ALGORITHM =
-      Suppliers.memoize(SignatureAlgorithmFactory::getInstance);
+  private static final SignatureAlgorithm SIGNATURE_ALGORITHM =
+      SignatureAlgorithmFactory.getInstance();
 
   private Account(
       final EthTransactions eth,
@@ -75,7 +73,7 @@ public class Account {
   }
 
   public static Account create(final EthTransactions eth, final String name) {
-    return new Account(eth, name, SIGNATURE_ALGORITHM.get().generateKeyPair());
+    return new Account(eth, name, SIGNATURE_ALGORITHM.generateKeyPair());
   }
 
   public static Account fromPrivateKey(
@@ -83,10 +81,8 @@ public class Account {
     return new Account(
         eth,
         name,
-        SIGNATURE_ALGORITHM
-            .get()
-            .createKeyPair(
-                SIGNATURE_ALGORITHM.get().createPrivateKey(Bytes32.fromHexString(privateKey))));
+        SIGNATURE_ALGORITHM.createKeyPair(
+            SIGNATURE_ALGORITHM.createPrivateKey(Bytes32.fromHexString(privateKey))));
   }
 
   public Optional<Credentials> web3jCredentials() {

--- a/app/src/main/java/org/hyperledger/besu/chainimport/internal/TransactionData.java
+++ b/app/src/main/java/org/hyperledger/besu/chainimport/internal/TransactionData.java
@@ -27,8 +27,6 @@ import java.util.Optional;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
@@ -44,8 +42,8 @@ public class TransactionData {
   private final Optional<Address> to;
   private final SECPPrivateKey privateKey;
 
-  private static final Supplier<SignatureAlgorithm> SIGNATURE_ALGORITHM =
-      Suppliers.memoize(SignatureAlgorithmFactory::getInstance);
+  private static final SignatureAlgorithm SIGNATURE_ALGORITHM =
+      SignatureAlgorithmFactory.getInstance();
 
   /**
    * Instantiates a new Transaction data.
@@ -70,7 +68,7 @@ public class TransactionData {
     this.data = data.map(Bytes::fromHexString).orElse(Bytes.EMPTY);
     this.value = value.map(Wei::fromHexString).orElse(Wei.ZERO);
     this.to = to.map(Address::fromHexString);
-    this.privateKey = SIGNATURE_ALGORITHM.get().createPrivateKey(Bytes32.fromHexString(secretKey));
+    this.privateKey = SIGNATURE_ALGORITHM.createPrivateKey(Bytes32.fromHexString(secretKey));
   }
 
   /**
@@ -80,7 +78,7 @@ public class TransactionData {
    * @return the signed transaction
    */
   public Transaction getSignedTransaction(final NonceProvider nonceProvider) {
-    final KeyPair keyPair = SIGNATURE_ALGORITHM.get().createKeyPair(privateKey);
+    final KeyPair keyPair = SIGNATURE_ALGORITHM.createKeyPair(privateKey);
 
     final Address fromAddress = Address.extract(keyPair.getPublicKey());
     final long nonce = nonceProvider.get(fromAddress);

--- a/app/src/main/java/org/hyperledger/besu/cli/subcommands/operator/GenerateBlockchainConfig.java
+++ b/app/src/main/java/org/hyperledger/besu/cli/subcommands/operator/GenerateBlockchainConfig.java
@@ -49,8 +49,6 @@ import java.util.stream.IntStream;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import com.google.common.io.Resources;
 import jakarta.validation.constraints.NotBlank;
 import org.apache.tuweni.bytes.Bytes;
@@ -68,8 +66,7 @@ import picocli.CommandLine.ParentCommand;
 class GenerateBlockchainConfig implements Runnable {
   private static final Logger LOG = LoggerFactory.getLogger(GenerateBlockchainConfig.class);
 
-  private final Supplier<SignatureAlgorithm> SIGNATURE_ALGORITHM =
-      Suppliers.memoize(SignatureAlgorithmFactory::getInstance);
+  private final SignatureAlgorithm SIGNATURE_ALGORITHM = SignatureAlgorithmFactory.getInstance();
 
   @NotBlank
   @Option(
@@ -177,13 +174,13 @@ class GenerateBlockchainConfig implements Runnable {
 
     try {
       final SECPPublicKey publicKey =
-          SIGNATURE_ALGORITHM.get().createPublicKey(Bytes.fromHexString(publicKeyText));
+          SIGNATURE_ALGORITHM.createPublicKey(Bytes.fromHexString(publicKeyText));
 
-      if (!SIGNATURE_ALGORITHM.get().isValidPublicKey(publicKey)) {
+      if (!SIGNATURE_ALGORITHM.isValidPublicKey(publicKey)) {
         throw new IllegalArgumentException(
             publicKeyText
                 + " is not a valid public key for elliptic curve "
-                + SIGNATURE_ALGORITHM.get().getCurveName());
+                + SIGNATURE_ALGORITHM.getCurveName());
       }
 
       writeKeypair(publicKey, null);
@@ -208,7 +205,7 @@ class GenerateBlockchainConfig implements Runnable {
   private void generateNodeKeypair(final int node) {
     try {
       LOG.info("Generating keypair for node {}.", node);
-      final KeyPair keyPair = SIGNATURE_ALGORITHM.get().generateKeyPair();
+      final KeyPair keyPair = SIGNATURE_ALGORITHM.generateKeyPair();
       writeKeypair(keyPair.getPublicKey(), keyPair.getPrivateKey());
 
     } catch (final IOException e) {

--- a/app/src/main/java/org/hyperledger/besu/services/BlockSimulatorServiceImpl.java
+++ b/app/src/main/java/org/hyperledger/besu/services/BlockSimulatorServiceImpl.java
@@ -39,9 +39,6 @@ import org.hyperledger.besu.plugin.data.TransactionSimulationResult;
 import org.hyperledger.besu.plugin.services.BlockSimulationService;
 
 import java.util.List;
-import java.util.function.Supplier;
-
-import com.google.common.base.Suppliers;
 
 /** This class is a service that simulates the processing of a block */
 public class BlockSimulatorServiceImpl implements BlockSimulationService {
@@ -49,16 +46,14 @@ public class BlockSimulatorServiceImpl implements BlockSimulationService {
   private final WorldStateArchive worldStateArchive;
   private final Blockchain blockchain;
 
-  private static final Supplier<SignatureAlgorithm> SIGNATURE_ALGORITHM =
-      Suppliers.memoize(SignatureAlgorithmFactory::getInstance);
+  private static final SignatureAlgorithm SIGNATURE_ALGORITHM =
+      SignatureAlgorithmFactory.getInstance();
   // Dummy signature for transactions to not fail being processed.
   private static final SECPSignature FAKE_SIGNATURE =
-      SIGNATURE_ALGORITHM
-          .get()
-          .createSignature(
-              SIGNATURE_ALGORITHM.get().getHalfCurveOrder(),
-              SIGNATURE_ALGORITHM.get().getHalfCurveOrder(),
-              (byte) 0);
+      SIGNATURE_ALGORITHM.createSignature(
+          SIGNATURE_ALGORITHM.getHalfCurveOrder(),
+          SIGNATURE_ALGORITHM.getHalfCurveOrder(),
+          (byte) 0);
 
   /**
    * This constructor creates a BlockSimulatorServiceImpl object

--- a/app/src/test/java/org/hyperledger/besu/services/BesuEventsImplTest.java
+++ b/app/src/test/java/org/hyperledger/besu/services/BesuEventsImplTest.java
@@ -79,8 +79,6 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -92,9 +90,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public class BesuEventsImplTest {
 
-  private static final Supplier<SignatureAlgorithm> SIGNATURE_ALGORITHM =
-      Suppliers.memoize(SignatureAlgorithmFactory::getInstance);
-  private static final KeyPair KEY_PAIR1 = SIGNATURE_ALGORITHM.get().generateKeyPair();
+  private static final SignatureAlgorithm SIGNATURE_ALGORITHM =
+      SignatureAlgorithmFactory.getInstance();
+  private static final KeyPair KEY_PAIR1 = SIGNATURE_ALGORITHM.generateKeyPair();
   private static final org.hyperledger.besu.ethereum.core.Transaction TX1 = createTransaction(0);
   private static final org.hyperledger.besu.ethereum.core.Transaction TX2 = createTransaction(1);
 

--- a/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/CliqueExtraDataTest.java
+++ b/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/CliqueExtraDataTest.java
@@ -32,21 +32,19 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import com.google.common.collect.Lists;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
 
 public class CliqueExtraDataTest {
 
-  private static final Supplier<SignatureAlgorithm> SIGNATURE_ALGORITHM =
-      Suppliers.memoize(SignatureAlgorithmFactory::getInstance);
+  private static final SignatureAlgorithm SIGNATURE_ALGORITHM =
+      SignatureAlgorithmFactory.getInstance();
 
   @Test
   public void encodeAndDecodingDoNotAlterData() {
     final SECPSignature proposerSeal =
-        SIGNATURE_ALGORITHM.get().createSignature(BigInteger.ONE, BigInteger.ONE, (byte) 0);
+        SIGNATURE_ALGORITHM.createSignature(BigInteger.ONE, BigInteger.ONE, (byte) 0);
     final List<Address> validators =
         Arrays.asList(
             AddressHelpers.ofValue(1), AddressHelpers.ofValue(2), AddressHelpers.ofValue(3));
@@ -97,7 +95,7 @@ public class CliqueExtraDataTest {
   public void addressToExtraDataString() {
     final List<KeyPair> nodeKeys = Lists.newArrayList();
     for (int i = 0; i < 4; i++) {
-      nodeKeys.add(SIGNATURE_ALGORITHM.get().generateKeyPair());
+      nodeKeys.add(SIGNATURE_ALGORITHM.generateKeyPair());
     }
 
     final List<Address> addresses =

--- a/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/blockcreation/CliqueMiningCoordinatorTest.java
+++ b/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/blockcreation/CliqueMiningCoordinatorTest.java
@@ -47,8 +47,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -61,11 +59,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @SuppressWarnings("DirectInvocationOnMock")
 public class CliqueMiningCoordinatorTest {
 
-  private static final Supplier<SignatureAlgorithm> SIGNATURE_ALGORITHM =
-      Suppliers.memoize(SignatureAlgorithmFactory::getInstance);
+  private static final SignatureAlgorithm SIGNATURE_ALGORITHM =
+      SignatureAlgorithmFactory.getInstance();
 
-  private final KeyPair proposerKeys = SIGNATURE_ALGORITHM.get().generateKeyPair();
-  private final KeyPair validatorKeys = SIGNATURE_ALGORITHM.get().generateKeyPair();
+  private final KeyPair proposerKeys = SIGNATURE_ALGORITHM.generateKeyPair();
+  private final KeyPair validatorKeys = SIGNATURE_ALGORITHM.generateKeyPair();
   private final Address proposerAddress = Util.publicKeyToAddress(proposerKeys.getPublicKey());
   private final Address validatorAddress = Util.publicKeyToAddress(validatorKeys.getPublicKey());
 

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/IbftExtraDataRLPEncoderTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/IbftExtraDataRLPEncoderTest.java
@@ -34,17 +34,15 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
-import java.util.function.Supplier;
 
-import com.google.common.base.Suppliers;
 import com.google.common.collect.Lists;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
 
 public class IbftExtraDataRLPEncoderTest {
 
-  private static final Supplier<SignatureAlgorithm> SIGNATURE_ALGORITHM =
-      Suppliers.memoize(SignatureAlgorithmFactory::getInstance);
+  private static final SignatureAlgorithm SIGNATURE_ALGORITHM =
+      SignatureAlgorithmFactory.getInstance();
 
   private final String RAW_HEX_ENCODING_STRING =
       "f8f1a00102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20ea9400000000000000000000000000000000000"
@@ -64,8 +62,8 @@ public class IbftExtraDataRLPEncoderTest {
     final int round = 0x00FEDCBA;
     final List<SECPSignature> committerSeals =
         Arrays.asList(
-            SIGNATURE_ALGORITHM.get().createSignature(BigInteger.ONE, BigInteger.TEN, (byte) 0),
-            SIGNATURE_ALGORITHM.get().createSignature(BigInteger.TEN, BigInteger.ONE, (byte) 0));
+            SIGNATURE_ALGORITHM.createSignature(BigInteger.ONE, BigInteger.TEN, (byte) 0),
+            SIGNATURE_ALGORITHM.createSignature(BigInteger.TEN, BigInteger.ONE, (byte) 0));
 
     // Create a byte buffer with no data.
     final byte[] vanity_bytes = createNonEmptyVanityData();
@@ -265,8 +263,8 @@ public class IbftExtraDataRLPEncoderTest {
     final int round = 0x00FEDCBA;
     final List<SECPSignature> committerSeals =
         Arrays.asList(
-            SIGNATURE_ALGORITHM.get().createSignature(BigInteger.ONE, BigInteger.TEN, (byte) 0),
-            SIGNATURE_ALGORITHM.get().createSignature(BigInteger.TEN, BigInteger.ONE, (byte) 0));
+            SIGNATURE_ALGORITHM.createSignature(BigInteger.ONE, BigInteger.TEN, (byte) 0),
+            SIGNATURE_ALGORITHM.createSignature(BigInteger.TEN, BigInteger.ONE, (byte) 0));
 
     // Create randomised vanity data.
     final byte[] vanity_bytes = createNonEmptyVanityData();
@@ -308,8 +306,8 @@ public class IbftExtraDataRLPEncoderTest {
     final int round = 0x00FEDCBA;
     final List<SECPSignature> committerSeals =
         Arrays.asList(
-            SIGNATURE_ALGORITHM.get().createSignature(BigInteger.ONE, BigInteger.TEN, (byte) 0),
-            SIGNATURE_ALGORITHM.get().createSignature(BigInteger.TEN, BigInteger.ONE, (byte) 0));
+            SIGNATURE_ALGORITHM.createSignature(BigInteger.ONE, BigInteger.TEN, (byte) 0),
+            SIGNATURE_ALGORITHM.createSignature(BigInteger.TEN, BigInteger.ONE, (byte) 0));
 
     // Create a byte buffer with no data.
     final byte[] vanity_bytes = createNonEmptyVanityData();
@@ -351,8 +349,8 @@ public class IbftExtraDataRLPEncoderTest {
     final int round = 0x00FEDCBA;
     final List<SECPSignature> committerSeals =
         Arrays.asList(
-            SIGNATURE_ALGORITHM.get().createSignature(BigInteger.ONE, BigInteger.TEN, (byte) 0),
-            SIGNATURE_ALGORITHM.get().createSignature(BigInteger.TEN, BigInteger.ONE, (byte) 0));
+            SIGNATURE_ALGORITHM.createSignature(BigInteger.ONE, BigInteger.TEN, (byte) 0),
+            SIGNATURE_ALGORITHM.createSignature(BigInteger.TEN, BigInteger.ONE, (byte) 0));
 
     // Create a byte buffer with no data.
     final byte[] vanity_bytes = createNonEmptyVanityData();
@@ -389,8 +387,8 @@ public class IbftExtraDataRLPEncoderTest {
     final int round = 0x00FEDCBA;
     final List<SECPSignature> committerSeals =
         Arrays.asList(
-            SIGNATURE_ALGORITHM.get().createSignature(BigInteger.ONE, BigInteger.TEN, (byte) 0),
-            SIGNATURE_ALGORITHM.get().createSignature(BigInteger.TEN, BigInteger.ONE, (byte) 0));
+            SIGNATURE_ALGORITHM.createSignature(BigInteger.ONE, BigInteger.TEN, (byte) 0),
+            SIGNATURE_ALGORITHM.createSignature(BigInteger.TEN, BigInteger.ONE, (byte) 0));
 
     // Create a byte buffer with no data.
     final byte[] vanity_bytes = createNonEmptyVanityData();
@@ -459,8 +457,8 @@ public class IbftExtraDataRLPEncoderTest {
     final int round = 0x00FEDCBA;
     final List<SECPSignature> committerSeals =
         Arrays.asList(
-            SIGNATURE_ALGORITHM.get().createSignature(BigInteger.ONE, BigInteger.TEN, (byte) 0),
-            SIGNATURE_ALGORITHM.get().createSignature(BigInteger.TEN, BigInteger.ONE, (byte) 0));
+            SIGNATURE_ALGORITHM.createSignature(BigInteger.ONE, BigInteger.TEN, (byte) 0),
+            SIGNATURE_ALGORITHM.createSignature(BigInteger.TEN, BigInteger.ONE, (byte) 0));
 
     // Create a byte buffer with no data.
     final byte[] vanity_bytes = new byte[32];

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/payload/PreparedCertificateTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/payload/PreparedCertificateTest.java
@@ -34,8 +34,6 @@ import java.math.BigInteger;
 import java.util.Collections;
 import java.util.List;
 
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.Test;
 
@@ -44,8 +42,8 @@ public class PreparedCertificateTest {
   private static final ConsensusRoundIdentifier ROUND_IDENTIFIER =
       new ConsensusRoundIdentifier(0x1234567890ABCDEFL, 0xFEDCBA98);
 
-  private static final Supplier<SignatureAlgorithm> SIGNATURE_ALGORITHM =
-      Suppliers.memoize(SignatureAlgorithmFactory::getInstance);
+  private static final SignatureAlgorithm SIGNATURE_ALGORITHM =
+      SignatureAlgorithmFactory.getInstance();
 
   @Test
   public void roundTripRlpWithNoPreparePayloads() {
@@ -71,7 +69,7 @@ public class PreparedCertificateTest {
     final PreparePayload preparePayload =
         new PreparePayload(ROUND_IDENTIFIER, Hash.fromHexStringLenient("0x8523ba6e7c5f59ae87"));
     final SECPSignature signature =
-        SIGNATURE_ALGORITHM.get().createSignature(BigInteger.ONE, BigInteger.TEN, (byte) 0);
+        SIGNATURE_ALGORITHM.createSignature(BigInteger.ONE, BigInteger.TEN, (byte) 0);
     final SignedData<PreparePayload> signedPrepare =
         PayloadDeserializers.from(preparePayload, signature);
 
@@ -94,7 +92,7 @@ public class PreparedCertificateTest {
             singletonList(AddressHelpers.ofValue(1)), ROUND_IDENTIFIER);
     final ProposalPayload proposalPayload = new ProposalPayload(ROUND_IDENTIFIER, block.getHash());
     final SECPSignature signature =
-        SIGNATURE_ALGORITHM.get().createSignature(BigInteger.ONE, BigInteger.TEN, (byte) 0);
+        SIGNATURE_ALGORITHM.createSignature(BigInteger.ONE, BigInteger.TEN, (byte) 0);
     return PayloadDeserializers.from(proposalPayload, signature);
   }
 }

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/payload/RoundChangePayloadTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/payload/RoundChangePayloadTest.java
@@ -36,8 +36,6 @@ import java.math.BigInteger;
 import java.util.Collections;
 import java.util.Optional;
 
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.Test;
 
@@ -45,10 +43,10 @@ public class RoundChangePayloadTest {
 
   private static final ConsensusRoundIdentifier ROUND_IDENTIFIER =
       new ConsensusRoundIdentifier(0x1234567890ABCDEFL, 0xFEDCBA98);
-  private static final Supplier<SignatureAlgorithm> SIGNATURE_ALGORITHM =
-      Suppliers.memoize(SignatureAlgorithmFactory::getInstance);
+  private static final SignatureAlgorithm SIGNATURE_ALGORITHM =
+      SignatureAlgorithmFactory.getInstance();
   private static final SECPSignature SIGNATURE =
-      SIGNATURE_ALGORITHM.get().createSignature(BigInteger.ONE, BigInteger.TEN, (byte) 0);
+      SIGNATURE_ALGORITHM.createSignature(BigInteger.ONE, BigInteger.TEN, (byte) 0);
 
   @Test
   public void roundTripRlpWithNoPreparedCertificate() {
@@ -113,7 +111,7 @@ public class RoundChangePayloadTest {
             singletonList(AddressHelpers.ofValue(1)), ROUND_IDENTIFIER);
     final ProposalPayload proposalPayload = new ProposalPayload(ROUND_IDENTIFIER, block.getHash());
     final SECPSignature signature =
-        SIGNATURE_ALGORITHM.get().createSignature(BigInteger.ONE, BigInteger.TEN, (byte) 0);
+        SIGNATURE_ALGORITHM.createSignature(BigInteger.ONE, BigInteger.TEN, (byte) 0);
     return PayloadDeserializers.from(proposalPayload, signature);
   }
 }

--- a/consensus/ibftlegacy/src/main/java/org/hyperledger/besu/consensus/ibftlegacy/IbftExtraDataCodec.java
+++ b/consensus/ibftlegacy/src/main/java/org/hyperledger/besu/consensus/ibftlegacy/IbftExtraDataCodec.java
@@ -28,8 +28,6 @@ import org.hyperledger.besu.ethereum.rlp.RLPInput;
 
 import java.util.Collection;
 
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import org.apache.tuweni.bytes.Bytes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,8 +41,8 @@ public class IbftExtraDataCodec extends BftExtraDataCodec {
   /** The constant EXTRA_VANITY_LENGTH. */
   public static final int EXTRA_VANITY_LENGTH = 32;
 
-  private static final Supplier<SignatureAlgorithm> SIGNATURE_ALGORITHM =
-      Suppliers.memoize(SignatureAlgorithmFactory::getInstance);
+  private static final SignatureAlgorithm SIGNATURE_ALGORITHM =
+      SignatureAlgorithmFactory.getInstance();
 
   private static final Logger LOG = LoggerFactory.getLogger(IbftExtraDataCodec.class);
 
@@ -90,7 +88,7 @@ public class IbftExtraDataCodec extends BftExtraDataCodec {
     final Collection<Address> validators = rlpInput.readList(Address::readFrom);
     final SECPSignature proposerSeal = parseProposerSeal(rlpInput);
     final Collection<SECPSignature> seals =
-        rlpInput.readList(rlp -> SIGNATURE_ALGORITHM.get().decodeSignature(rlp.readBytes()));
+        rlpInput.readList(rlp -> SIGNATURE_ALGORITHM.decodeSignature(rlp.readBytes()));
     rlpInput.leaveList();
 
     return new IbftLegacyExtraData(vanityData, seals, proposerSeal, validators);
@@ -98,7 +96,7 @@ public class IbftExtraDataCodec extends BftExtraDataCodec {
 
   private static SECPSignature parseProposerSeal(final RLPInput rlpInput) {
     final Bytes data = rlpInput.readBytes();
-    return data.isZero() ? null : SIGNATURE_ALGORITHM.get().decodeSignature(data);
+    return data.isZero() ? null : SIGNATURE_ALGORITHM.decodeSignature(data);
   }
 
   /**

--- a/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinatorTest.java
+++ b/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinatorTest.java
@@ -97,7 +97,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
-import com.google.common.base.Suppliers;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
@@ -120,18 +119,16 @@ import org.slf4j.LoggerFactory;
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
 
-  private static final com.google.common.base.Supplier<SignatureAlgorithm> SIGNATURE_ALGORITHM =
-      Suppliers.memoize(SignatureAlgorithmFactory::getInstance);
+  private static final SignatureAlgorithm SIGNATURE_ALGORITHM =
+      SignatureAlgorithmFactory.getInstance();
 
   private static final Logger LOG = LoggerFactory.getLogger(MergeCoordinatorTest.class);
   private static final SECPPrivateKey PRIVATE_KEY1 =
-      SIGNATURE_ALGORITHM
-          .get()
-          .createPrivateKey(
-              Bytes32.fromHexString(
-                  "ae6ae8e5ccbfb04590405997ee2d52d2b330726137b875053c36d94e974d162f"));
+      SIGNATURE_ALGORITHM.createPrivateKey(
+          Bytes32.fromHexString(
+              "ae6ae8e5ccbfb04590405997ee2d52d2b330726137b875053c36d94e974d162f"));
   private static final KeyPair KEYS1 =
-      new KeyPair(PRIVATE_KEY1, SIGNATURE_ALGORITHM.get().createPublicKey(PRIVATE_KEY1));
+      new KeyPair(PRIVATE_KEY1, SIGNATURE_ALGORITHM.createPublicKey(PRIVATE_KEY1));
 
   private static final long REPETITION_MIN_DURATION = 100;
 

--- a/consensus/qbft-core/src/test/java/org/hyperledger/besu/consensus/qbft/core/statemachine/RoundStateTest.java
+++ b/consensus/qbft-core/src/test/java/org/hyperledger/besu/consensus/qbft/core/statemachine/RoundStateTest.java
@@ -44,8 +44,6 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import com.google.common.collect.Lists;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -56,8 +54,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public class RoundStateTest {
 
-  private static final Supplier<SignatureAlgorithm> SIGNATURE_ALGORITHM =
-      Suppliers.memoize(SignatureAlgorithmFactory::getInstance);
+  private static final SignatureAlgorithm SIGNATURE_ALGORITHM =
+      SignatureAlgorithmFactory.getInstance();
 
   private final List<MessageFactory> validatorMessageFactories = Lists.newArrayList();
   private final ConsensusRoundIdentifier roundIdentifier = new ConsensusRoundIdentifier(1, 1);
@@ -124,9 +122,7 @@ public class RoundStateTest {
             .createCommit(
                 roundIdentifier,
                 blockHash,
-                SIGNATURE_ALGORITHM
-                    .get()
-                    .createSignature(BigInteger.ONE, BigInteger.ONE, (byte) 1));
+                SIGNATURE_ALGORITHM.createSignature(BigInteger.ONE, BigInteger.ONE, (byte) 1));
 
     roundState.addCommitMessage(commit);
     assertThat(roundState.isPrepared()).isFalse();
@@ -258,9 +254,7 @@ public class RoundStateTest {
             .createCommit(
                 roundIdentifier,
                 blockHash,
-                SIGNATURE_ALGORITHM
-                    .get()
-                    .createSignature(BigInteger.ONE, BigInteger.TEN, (byte) 1));
+                SIGNATURE_ALGORITHM.createSignature(BigInteger.ONE, BigInteger.TEN, (byte) 1));
 
     final Commit secondCommit =
         validatorMessageFactories
@@ -268,9 +262,7 @@ public class RoundStateTest {
             .createCommit(
                 roundIdentifier,
                 blockHash,
-                SIGNATURE_ALGORITHM
-                    .get()
-                    .createSignature(BigInteger.TEN, BigInteger.TEN, (byte) 1));
+                SIGNATURE_ALGORITHM.createSignature(BigInteger.TEN, BigInteger.TEN, (byte) 1));
 
     final Proposal proposal =
         validatorMessageFactories

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/QbftExtraDataCodecTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/QbftExtraDataCodecTest.java
@@ -35,17 +35,15 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
-import java.util.function.Supplier;
 
-import com.google.common.base.Suppliers;
 import com.google.common.collect.Lists;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
 
 public class QbftExtraDataCodecTest {
 
-  private static final Supplier<SignatureAlgorithm> SIGNATURE_ALGORITHM =
-      Suppliers.memoize(SignatureAlgorithmFactory::getInstance);
+  private static final SignatureAlgorithm SIGNATURE_ALGORITHM =
+      SignatureAlgorithmFactory.getInstance();
 
   private final String RAW_HEX_ENCODING_STRING =
       "0xf8f0a00102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20ea940000000000000000"
@@ -66,8 +64,8 @@ public class QbftExtraDataCodecTest {
     final int round = 0x00FEDCBA;
     final List<SECPSignature> committerSeals =
         Arrays.asList(
-            SIGNATURE_ALGORITHM.get().createSignature(BigInteger.ONE, BigInteger.TEN, (byte) 0),
-            SIGNATURE_ALGORITHM.get().createSignature(BigInteger.TEN, BigInteger.ONE, (byte) 0));
+            SIGNATURE_ALGORITHM.createSignature(BigInteger.ONE, BigInteger.TEN, (byte) 0),
+            SIGNATURE_ALGORITHM.createSignature(BigInteger.TEN, BigInteger.ONE, (byte) 0));
 
     // Create a byte buffer with no data.
     final byte[] vanity_bytes = createNonEmptyVanityData();
@@ -265,8 +263,8 @@ public class QbftExtraDataCodecTest {
     final int round = 0x00FEDCBA;
     final List<SECPSignature> committerSeals =
         Arrays.asList(
-            SIGNATURE_ALGORITHM.get().createSignature(BigInteger.ONE, BigInteger.TEN, (byte) 0),
-            SIGNATURE_ALGORITHM.get().createSignature(BigInteger.TEN, BigInteger.ONE, (byte) 0));
+            SIGNATURE_ALGORITHM.createSignature(BigInteger.ONE, BigInteger.TEN, (byte) 0),
+            SIGNATURE_ALGORITHM.createSignature(BigInteger.TEN, BigInteger.ONE, (byte) 0));
 
     // Create randomised vanity data.
     final byte[] vanity_bytes = createNonEmptyVanityData();
@@ -308,8 +306,8 @@ public class QbftExtraDataCodecTest {
     final int round = 0x00FEDCBA;
     final List<SECPSignature> committerSeals =
         Arrays.asList(
-            SIGNATURE_ALGORITHM.get().createSignature(BigInteger.ONE, BigInteger.TEN, (byte) 0),
-            SIGNATURE_ALGORITHM.get().createSignature(BigInteger.TEN, BigInteger.ONE, (byte) 0));
+            SIGNATURE_ALGORITHM.createSignature(BigInteger.ONE, BigInteger.TEN, (byte) 0),
+            SIGNATURE_ALGORITHM.createSignature(BigInteger.TEN, BigInteger.ONE, (byte) 0));
 
     // Create a byte buffer with no data.
     final byte[] vanity_bytes = createNonEmptyVanityData();
@@ -349,8 +347,8 @@ public class QbftExtraDataCodecTest {
     final int round = 0x00FEDCBA;
     final List<SECPSignature> committerSeals =
         Arrays.asList(
-            SIGNATURE_ALGORITHM.get().createSignature(BigInteger.ONE, BigInteger.TEN, (byte) 0),
-            SIGNATURE_ALGORITHM.get().createSignature(BigInteger.TEN, BigInteger.ONE, (byte) 0));
+            SIGNATURE_ALGORITHM.createSignature(BigInteger.ONE, BigInteger.TEN, (byte) 0),
+            SIGNATURE_ALGORITHM.createSignature(BigInteger.TEN, BigInteger.ONE, (byte) 0));
 
     // Create a byte buffer with no data.
     final byte[] vanity_bytes = createNonEmptyVanityData();
@@ -390,8 +388,8 @@ public class QbftExtraDataCodecTest {
     final int round = 0x00FEDCBA;
     final List<SECPSignature> committerSeals =
         Arrays.asList(
-            SIGNATURE_ALGORITHM.get().createSignature(BigInteger.ONE, BigInteger.TEN, (byte) 0),
-            SIGNATURE_ALGORITHM.get().createSignature(BigInteger.TEN, BigInteger.ONE, (byte) 0));
+            SIGNATURE_ALGORITHM.createSignature(BigInteger.ONE, BigInteger.TEN, (byte) 0),
+            SIGNATURE_ALGORITHM.createSignature(BigInteger.TEN, BigInteger.ONE, (byte) 0));
 
     // Create a byte buffer with no data.
     final byte[] vanity_bytes = createNonEmptyVanityData();
@@ -463,8 +461,8 @@ public class QbftExtraDataCodecTest {
     final int round = 0x00FEDCBA;
     final List<SECPSignature> committerSeals =
         Arrays.asList(
-            SIGNATURE_ALGORITHM.get().createSignature(BigInteger.ONE, BigInteger.TEN, (byte) 0),
-            SIGNATURE_ALGORITHM.get().createSignature(BigInteger.TEN, BigInteger.ONE, (byte) 0));
+            SIGNATURE_ALGORITHM.createSignature(BigInteger.ONE, BigInteger.TEN, (byte) 0),
+            SIGNATURE_ALGORITHM.createSignature(BigInteger.TEN, BigInteger.ONE, (byte) 0));
 
     // Create a byte buffer with no data.
     final byte[] vanity_bytes = new byte[32];

--- a/crypto/algorithms/src/main/java/org/hyperledger/besu/crypto/KeyPairUtil.java
+++ b/crypto/algorithms/src/main/java/org/hyperledger/besu/crypto/KeyPairUtil.java
@@ -25,8 +25,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import com.google.common.io.Resources;
 import org.apache.tuweni.bytes.Bytes32;
 import org.slf4j.Logger;
@@ -35,8 +33,8 @@ import org.slf4j.LoggerFactory;
 /** The Key pair util. */
 public class KeyPairUtil {
   private static final Logger LOG = LoggerFactory.getLogger(KeyPairUtil.class);
-  private static final Supplier<SignatureAlgorithm> SIGNATURE_ALGORITHM =
-      Suppliers.memoize(SignatureAlgorithmFactory::getInstance);
+  private static final SignatureAlgorithm SIGNATURE_ALGORITHM =
+      SignatureAlgorithmFactory.getInstance();
 
   /** Default constructor */
   private KeyPairUtil() {}
@@ -69,8 +67,8 @@ public class KeyPairUtil {
       throw new IllegalArgumentException("Unable to load resource: " + resourcePath);
     }
     SECPPrivateKey privateKey =
-        SIGNATURE_ALGORITHM.get().createPrivateKey(Bytes32.fromHexString((keyData)));
-    keyPair = SIGNATURE_ALGORITHM.get().createKeyPair(privateKey);
+        SIGNATURE_ALGORITHM.createPrivateKey(Bytes32.fromHexString((keyData)));
+    keyPair = SIGNATURE_ALGORITHM.createKeyPair(privateKey);
 
     LOG.info("Loaded keyPair {} from {}", keyPair.getPublicKey().toString(), resourcePath);
     return keyPair;
@@ -92,13 +90,12 @@ public class KeyPairUtil {
       LOG.info(
           "Loaded public key {} from {}", key.getPublicKey().toString(), keyFile.getAbsolutePath());
     } else {
-      final SignatureAlgorithm signatureAlgorithm = SIGNATURE_ALGORITHM.get();
-      key = signatureAlgorithm.generateKeyPair();
+      key = SIGNATURE_ALGORITHM.generateKeyPair();
       storeKeyFile(key, keyFile.getParentFile().toPath());
 
       LOG.info(
           "Generated new {} public key {} and stored it to {}",
-          signatureAlgorithm.getCurveName(),
+          SIGNATURE_ALGORITHM.getCurveName(),
           key.getPublicKey().toString(),
           keyFile.getAbsolutePath());
     }
@@ -146,7 +143,7 @@ public class KeyPairUtil {
    * @return the key pair
    */
   public static KeyPair load(final File file) {
-    return SIGNATURE_ALGORITHM.get().createKeyPair(loadPrivateKey(file));
+    return SIGNATURE_ALGORITHM.createKeyPair(loadPrivateKey(file));
   }
 
   /**
@@ -161,7 +158,7 @@ public class KeyPairUtil {
       if (info.size() != 1) {
         throw new IllegalArgumentException("Supplied file does not contain valid keyPair pair.");
       }
-      return SIGNATURE_ALGORITHM.get().createPrivateKey(Bytes32.fromHexString((info.get(0))));
+      return SIGNATURE_ALGORITHM.createPrivateKey(Bytes32.fromHexString((info.get(0))));
     } catch (IOException ex) {
       throw new IllegalArgumentException("Supplied file does not contain valid keyPair pair.");
     }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineGetPayloadTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineGetPayloadTest.java
@@ -42,9 +42,7 @@ import org.hyperledger.besu.ethereum.core.BlockWithReceipts;
 
 import java.util.Collections;
 import java.util.Optional;
-import java.util.function.Supplier;
 
-import com.google.common.base.Suppliers;
 import io.vertx.core.Vertx;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
@@ -57,9 +55,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public abstract class AbstractEngineGetPayloadTest extends AbstractScheduledApiTest {
 
-  private static final Supplier<SignatureAlgorithm> SIGNATURE_ALGORITHM =
-      Suppliers.memoize(SignatureAlgorithmFactory::getInstance);
-  protected static final KeyPair senderKeys = SIGNATURE_ALGORITHM.get().generateKeyPair();
+  private static final SignatureAlgorithm SIGNATURE_ALGORITHM =
+      SignatureAlgorithmFactory.getInstance();
+  protected static final KeyPair senderKeys = SIGNATURE_ALGORITHM.generateKeyPair();
 
   @FunctionalInterface
   interface MethodFactory {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV1Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV1Test.java
@@ -50,9 +50,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Supplier;
 
-import com.google.common.base.Suppliers;
 import io.vertx.core.Vertx;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
@@ -68,16 +66,14 @@ import org.mockito.quality.Strictness;
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class EngineGetBlobsV1Test extends TrustedSetupClassLoaderExtension {
 
-  private static final Supplier<SignatureAlgorithm> SIGNATURE_ALGORITHM =
-      Suppliers.memoize(SignatureAlgorithmFactory::getInstance);
+  private static final SignatureAlgorithm SIGNATURE_ALGORITHM =
+      SignatureAlgorithmFactory.getInstance();
   private static final SECPPrivateKey PRIVATE_KEY1 =
-      SIGNATURE_ALGORITHM
-          .get()
-          .createPrivateKey(
-              Bytes32.fromHexString(
-                  "8f2a55949038a9610f50fb23b5883af3b4ecb3c3bb792cbcefbd1542c692be63"));
+      SIGNATURE_ALGORITHM.createPrivateKey(
+          Bytes32.fromHexString(
+              "8f2a55949038a9610f50fb23b5883af3b4ecb3c3bb792cbcefbd1542c692be63"));
   private static final KeyPair KEYS1 =
-      new KeyPair(PRIVATE_KEY1, SIGNATURE_ALGORITHM.get().createPublicKey(PRIVATE_KEY1));
+      new KeyPair(PRIVATE_KEY1, SIGNATURE_ALGORITHM.createPublicKey(PRIVATE_KEY1));
   public static final VersionedHash VERSIONED_HASH_ZERO = new VersionedHash((byte) 1, Hash.ZERO);
 
   @Mock private ProtocolContext protocolContext;

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV3Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV3Test.java
@@ -64,9 +64,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
-import java.util.function.Supplier;
 
-import com.google.common.base.Suppliers;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
@@ -76,9 +74,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith({MockitoExtension.class})
 public class EngineNewPayloadV3Test extends EngineNewPayloadV2Test {
-  private static final Supplier<SignatureAlgorithm> SIGNATURE_ALGORITHM =
-      Suppliers.memoize(SignatureAlgorithmFactory::getInstance);
-  protected static final KeyPair senderKeys = SIGNATURE_ALGORITHM.get().generateKeyPair();
+  private static final SignatureAlgorithm SIGNATURE_ALGORITHM =
+      SignatureAlgorithmFactory.getInstance();
+  protected static final KeyPair senderKeys = SIGNATURE_ALGORITHM.generateKeyPair();
 
   public EngineNewPayloadV3Test() {}
 

--- a/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreatorTest.java
+++ b/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreatorTest.java
@@ -95,7 +95,6 @@ import java.time.Clock;
 import java.util.List;
 import java.util.Optional;
 
-import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
@@ -107,16 +106,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith({MockitoExtension.class})
 class AbstractBlockCreatorTest extends TrustedSetupClassLoaderExtension {
-  private static final Supplier<SignatureAlgorithm> SIGNATURE_ALGORITHM =
-      Suppliers.memoize(SignatureAlgorithmFactory::getInstance);
+  private static final SignatureAlgorithm SIGNATURE_ALGORITHM =
+      SignatureAlgorithmFactory.getInstance();
   private static final SECPPrivateKey PRIVATE_KEY1 =
-      SIGNATURE_ALGORITHM
-          .get()
-          .createPrivateKey(
-              Bytes32.fromHexString(
-                  "8f2a55949038a9610f50fb23b5883af3b4ecb3c3bb792cbcefbd1542c692be63"));
+      SIGNATURE_ALGORITHM.createPrivateKey(
+          Bytes32.fromHexString(
+              "8f2a55949038a9610f50fb23b5883af3b4ecb3c3bb792cbcefbd1542c692be63"));
   private static final KeyPair KEYS1 =
-      new KeyPair(PRIVATE_KEY1, SIGNATURE_ALGORITHM.get().createPublicKey(PRIVATE_KEY1));
+      new KeyPair(PRIVATE_KEY1, SIGNATURE_ALGORITHM.createPublicKey(PRIVATE_KEY1));
 
   @Mock private WithdrawalsProcessor withdrawalsProcessor;
   protected EthScheduler ethScheduler = new DeterministicEthScheduler();

--- a/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/BlobSizeTransactionSelectorTest.java
+++ b/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/BlobSizeTransactionSelectorTest.java
@@ -50,8 +50,6 @@ import org.hyperledger.besu.plugin.services.txselection.SelectorsStateManager;
 import java.util.Optional;
 import java.util.stream.IntStream;
 
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes48;
 import org.junit.jupiter.api.BeforeEach;
@@ -62,9 +60,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class BlobSizeTransactionSelectorTest {
-  private static final Supplier<SignatureAlgorithm> SIGNATURE_ALGORITHM =
-      Suppliers.memoize(SignatureAlgorithmFactory::getInstance);
-  private static final KeyPair KEYS = SIGNATURE_ALGORITHM.get().generateKeyPair();
+  private static final SignatureAlgorithm SIGNATURE_ALGORITHM =
+      SignatureAlgorithmFactory.getInstance();
+  private static final KeyPair KEYS = SIGNATURE_ALGORITHM.generateKeyPair();
 
   private static final long BLOB_GAS_PER_BLOB = new CancunGasCalculator().getBlobGasPerBlob();
   private static final int MAX_BLOBS = 6;

--- a/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/BlockRlpSizeTransactionSelectorTest.java
+++ b/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/BlockRlpSizeTransactionSelectorTest.java
@@ -37,8 +37,6 @@ import org.hyperledger.besu.plugin.services.txselection.SelectorsStateManager;
 
 import java.util.Optional;
 
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -48,9 +46,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class BlockRlpSizeTransactionSelectorTest {
-  private static final Supplier<SignatureAlgorithm> SIGNATURE_ALGORITHM =
-      Suppliers.memoize(SignatureAlgorithmFactory::getInstance);
-  private static final KeyPair KEYS = SIGNATURE_ALGORITHM.get().generateKeyPair();
+  private static final SignatureAlgorithm SIGNATURE_ALGORITHM =
+      SignatureAlgorithmFactory.getInstance();
+  private static final KeyPair KEYS = SIGNATURE_ALGORITHM.generateKeyPair();
 
   @Mock(answer = RETURNS_DEEP_STUBS)
   BlockSelectionContext blockSelectionContext;

--- a/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/BlockSizeTransactionSelectorTest.java
+++ b/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/BlockSizeTransactionSelectorTest.java
@@ -43,8 +43,6 @@ import org.hyperledger.besu.plugin.services.txselection.SelectorsStateManager;
 import java.util.Optional;
 import java.util.stream.IntStream;
 
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -53,9 +51,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class BlockSizeTransactionSelectorTest {
-  private static final Supplier<SignatureAlgorithm> SIGNATURE_ALGORITHM =
-      Suppliers.memoize(SignatureAlgorithmFactory::getInstance);
-  private static final KeyPair KEYS = SIGNATURE_ALGORITHM.get().generateKeyPair();
+  private static final SignatureAlgorithm SIGNATURE_ALGORITHM =
+      SignatureAlgorithmFactory.getInstance();
+  private static final KeyPair KEYS = SIGNATURE_ALGORITHM.generateKeyPair();
   private static final long TRANSFER_GAS_LIMIT = 21_000L;
   private static final long BLOCK_GAS_LIMIT = 1_000_000L;
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/CodeDelegation.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/CodeDelegation.java
@@ -38,8 +38,8 @@ import org.apache.tuweni.bytes.Bytes;
 // ignore `signer` field used in execution-spec-tests
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CodeDelegation implements org.hyperledger.besu.datatypes.CodeDelegation {
-  private static final Supplier<SignatureAlgorithm> SIGNATURE_ALGORITHM =
-      Suppliers.memoize(SignatureAlgorithmFactory::getInstance);
+  private static final SignatureAlgorithm SIGNATURE_ALGORITHM =
+      SignatureAlgorithmFactory.getInstance();
 
   public static final Bytes MAGIC = Bytes.fromHexString("05");
 
@@ -93,12 +93,10 @@ public class CodeDelegation implements org.hyperledger.besu.datatypes.CodeDelega
         chainId,
         address,
         Bytes.fromHexStringLenient(nonce).toLong(),
-        SIGNATURE_ALGORITHM
-            .get()
-            .createCodeDelegationSignature(
-                Bytes.fromHexStringLenient(r).toUnsignedBigInteger(),
-                Bytes.fromHexStringLenient(s).toUnsignedBigInteger(),
-                Bytes.fromHexStringLenient(v).get(0)));
+        SIGNATURE_ALGORITHM.createCodeDelegationSignature(
+            Bytes.fromHexStringLenient(r).toUnsignedBigInteger(),
+            Bytes.fromHexStringLenient(s).toUnsignedBigInteger(),
+            Bytes.fromHexStringLenient(v).get(0)));
   }
 
   @JsonProperty("chainId")
@@ -162,10 +160,7 @@ public class CodeDelegation implements org.hyperledger.besu.datatypes.CodeDelega
     Optional<Address> authorityAddress;
     try {
       authorityAddress =
-          SIGNATURE_ALGORITHM
-              .get()
-              .recoverPublicKeyFromSignature(hash, signature)
-              .map(Address::extract);
+          SIGNATURE_ALGORITHM.recoverPublicKeyFromSignature(hash, signature).map(Address::extract);
     } catch (final IllegalArgumentException e) {
       authorityAddress = Optional.empty();
     }
@@ -251,9 +246,7 @@ public class CodeDelegation implements org.hyperledger.besu.datatypes.CodeDelega
       output.endList();
 
       signature(
-          SIGNATURE_ALGORITHM
-              .get()
-              .sign(Hash.hash(Bytes.concatenate(MAGIC, output.encoded())), keyPair));
+          SIGNATURE_ALGORITHM.sign(Hash.hash(Bytes.concatenate(MAGIC, output.encoded())), keyPair));
       return build();
     }
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/encoding/AccessListTransactionDecoder.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/encoding/AccessListTransactionDecoder.java
@@ -26,14 +26,12 @@ import org.hyperledger.besu.ethereum.rlp.RLP;
 import org.hyperledger.besu.ethereum.rlp.RLPInput;
 
 import java.math.BigInteger;
-import java.util.function.Supplier;
 
-import com.google.common.base.Suppliers;
 import org.apache.tuweni.bytes.Bytes;
 
 class AccessListTransactionDecoder {
-  private static final Supplier<SignatureAlgorithm> SIGNATURE_ALGORITHM =
-      Suppliers.memoize(SignatureAlgorithmFactory::getInstance);
+  private static final SignatureAlgorithm SIGNATURE_ALGORITHM =
+      SignatureAlgorithmFactory.getInstance();
 
   private AccessListTransactionDecoder() {
     // private constructor
@@ -73,12 +71,10 @@ class AccessListTransactionDecoder {
     final Transaction transaction =
         preSignatureTransactionBuilder
             .signature(
-                SIGNATURE_ALGORITHM
-                    .get()
-                    .createSignature(
-                        txRlp.readUInt256Scalar().toUnsignedBigInteger(),
-                        txRlp.readUInt256Scalar().toUnsignedBigInteger(),
-                        recId))
+                SIGNATURE_ALGORITHM.createSignature(
+                    txRlp.readUInt256Scalar().toUnsignedBigInteger(),
+                    txRlp.readUInt256Scalar().toUnsignedBigInteger(),
+                    recId))
             .build();
     txRlp.leaveList();
     return transaction;

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/encoding/BlobTransactionDecoder.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/encoding/BlobTransactionDecoder.java
@@ -26,14 +26,11 @@ import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.rlp.RLP;
 import org.hyperledger.besu.ethereum.rlp.RLPInput;
 
-import java.util.function.Supplier;
-
-import com.google.common.base.Suppliers;
 import org.apache.tuweni.bytes.Bytes;
 
 public class BlobTransactionDecoder {
-  private static final Supplier<SignatureAlgorithm> SIGNATURE_ALGORITHM =
-      Suppliers.memoize(SignatureAlgorithmFactory::getInstance);
+  private static final SignatureAlgorithm SIGNATURE_ALGORITHM =
+      SignatureAlgorithmFactory.getInstance();
 
   private BlobTransactionDecoder() {
     // private constructor
@@ -98,12 +95,10 @@ public class BlobTransactionDecoder {
 
     final byte recId = (byte) input.readUnsignedByteScalar();
     builder.signature(
-        SIGNATURE_ALGORITHM
-            .get()
-            .createSignature(
-                input.readUInt256Scalar().toUnsignedBigInteger(),
-                input.readUInt256Scalar().toUnsignedBigInteger(),
-                recId));
+        SIGNATURE_ALGORITHM.createSignature(
+            input.readUInt256Scalar().toUnsignedBigInteger(),
+            input.readUInt256Scalar().toUnsignedBigInteger(),
+            recId));
     input.leaveList();
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/encoding/CodeDelegationTransactionDecoder.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/encoding/CodeDelegationTransactionDecoder.java
@@ -28,14 +28,12 @@ import org.hyperledger.besu.ethereum.rlp.RLP;
 import org.hyperledger.besu.ethereum.rlp.RLPInput;
 
 import java.math.BigInteger;
-import java.util.function.Supplier;
 
-import com.google.common.base.Suppliers;
 import org.apache.tuweni.bytes.Bytes;
 
 public class CodeDelegationTransactionDecoder {
-  private static final Supplier<SignatureAlgorithm> SIGNATURE_ALGORITHM =
-      Suppliers.memoize(SignatureAlgorithmFactory::getInstance);
+  private static final SignatureAlgorithm SIGNATURE_ALGORITHM =
+      SignatureAlgorithmFactory.getInstance();
 
   private CodeDelegationTransactionDecoder() {
     // private constructor
@@ -79,7 +77,7 @@ public class CodeDelegationTransactionDecoder {
 
     txRlp.leaveList();
 
-    return builder.signature(SIGNATURE_ALGORITHM.get().createSignature(r, s, recId)).build();
+    return builder.signature(SIGNATURE_ALGORITHM.createSignature(r, s, recId)).build();
   }
 
   public static CodeDelegation decodeInnerPayload(final RLPInput input) {
@@ -96,7 +94,7 @@ public class CodeDelegationTransactionDecoder {
     input.leaveList();
 
     final SECPSignature signature =
-        SIGNATURE_ALGORITHM.get().createCodeDelegationSignature(r, s, yParity);
+        SIGNATURE_ALGORITHM.createCodeDelegationSignature(r, s, yParity);
 
     return new org.hyperledger.besu.ethereum.core.CodeDelegation(
         chainId, address, nonce, signature);

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/encoding/EIP1559TransactionDecoder.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/encoding/EIP1559TransactionDecoder.java
@@ -26,14 +26,12 @@ import org.hyperledger.besu.ethereum.rlp.RLP;
 import org.hyperledger.besu.ethereum.rlp.RLPInput;
 
 import java.math.BigInteger;
-import java.util.function.Supplier;
 
-import com.google.common.base.Suppliers;
 import org.apache.tuweni.bytes.Bytes;
 
 public class EIP1559TransactionDecoder {
-  private static final Supplier<SignatureAlgorithm> SIGNATURE_ALGORITHM =
-      Suppliers.memoize(SignatureAlgorithmFactory::getInstance);
+  private static final SignatureAlgorithm SIGNATURE_ALGORITHM =
+      SignatureAlgorithmFactory.getInstance();
 
   private EIP1559TransactionDecoder() {
     // private constructor
@@ -73,12 +71,10 @@ public class EIP1559TransactionDecoder {
     final Transaction transaction =
         builder
             .signature(
-                SIGNATURE_ALGORITHM
-                    .get()
-                    .createSignature(
-                        txRlp.readUInt256Scalar().toUnsignedBigInteger(),
-                        txRlp.readUInt256Scalar().toUnsignedBigInteger(),
-                        recId))
+                SIGNATURE_ALGORITHM.createSignature(
+                    txRlp.readUInt256Scalar().toUnsignedBigInteger(),
+                    txRlp.readUInt256Scalar().toUnsignedBigInteger(),
+                    recId))
             .build();
     txRlp.leaveList();
     return transaction;

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/encoding/FrontierTransactionDecoder.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/encoding/FrontierTransactionDecoder.java
@@ -32,14 +32,11 @@ import org.hyperledger.besu.ethereum.rlp.RLPInput;
 
 import java.math.BigInteger;
 import java.util.Optional;
-import java.util.function.Supplier;
-
-import com.google.common.base.Suppliers;
 
 public class FrontierTransactionDecoder {
   // Supplier for the signature algorithm
-  private static final Supplier<SignatureAlgorithm> SIGNATURE_ALGORITHM =
-      Suppliers.memoize(SignatureAlgorithmFactory::getInstance);
+  private static final SignatureAlgorithm SIGNATURE_ALGORITHM =
+      SignatureAlgorithmFactory.getInstance();
 
   public static Transaction decode(final RLPInput input) {
     RLPInput transactionRlp = input.readAsRlp();
@@ -73,7 +70,7 @@ public class FrontierTransactionDecoder {
     }
     final BigInteger r = transactionRlp.readUInt256Scalar().toUnsignedBigInteger();
     final BigInteger s = transactionRlp.readUInt256Scalar().toUnsignedBigInteger();
-    final SECPSignature signature = SIGNATURE_ALGORITHM.get().createSignature(r, s, recId);
+    final SECPSignature signature = SIGNATURE_ALGORITHM.createSignature(r, s, recId);
 
     transactionRlp.leaveList();
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetProtocolSpecs.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetProtocolSpecs.java
@@ -117,8 +117,6 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.IntStream;
 
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import com.google.common.io.Resources;
 import io.vertx.core.json.JsonArray;
 import org.slf4j.Logger;
@@ -130,8 +128,8 @@ public abstract class MainnetProtocolSpecs {
   private static final Address RIPEMD160_PRECOMPILE =
       Address.fromHexString("0x0000000000000000000000000000000000000003");
 
-  private static final Supplier<SignatureAlgorithm> SIGNATURE_ALGORITHM =
-      Suppliers.memoize(SignatureAlgorithmFactory::getInstance);
+  private static final SignatureAlgorithm SIGNATURE_ALGORITHM =
+      SignatureAlgorithmFactory.getInstance();
 
   // A consensus bug at Ethereum mainnet transaction 0xcf416c53
   // deleted an empty account even when the message execution scope
@@ -912,7 +910,7 @@ public abstract class MainnetProtocolSpecs {
                         .codeDelegationProcessor(
                             new CodeDelegationProcessor(
                                 chainId,
-                                SIGNATURE_ALGORITHM.get().getHalfCurveOrder(),
+                                SIGNATURE_ALGORITHM.getHalfCurveOrder(),
                                 new CodeDelegationService()))
                         .build())
             // EIP-2935 Blockhash processor

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/TransactionSimulator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/TransactionSimulator.java
@@ -59,7 +59,6 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Suppliers;
 import jakarta.validation.constraints.NotNull;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
@@ -74,17 +73,15 @@ import org.slf4j.LoggerFactory;
  */
 public class TransactionSimulator {
   private static final Logger LOG = LoggerFactory.getLogger(TransactionSimulator.class);
-  private static final Supplier<SignatureAlgorithm> SIGNATURE_ALGORITHM =
-      Suppliers.memoize(SignatureAlgorithmFactory::getInstance);
+  private static final SignatureAlgorithm SIGNATURE_ALGORITHM =
+      SignatureAlgorithmFactory.getInstance();
 
   // Dummy signature for transactions to not fail being processed.
   private static final SECPSignature FAKE_SIGNATURE =
-      SIGNATURE_ALGORITHM
-          .get()
-          .createSignature(
-              SIGNATURE_ALGORITHM.get().getHalfCurveOrder(),
-              SIGNATURE_ALGORITHM.get().getHalfCurveOrder(),
-              (byte) 0);
+      SIGNATURE_ALGORITHM.createSignature(
+          SIGNATURE_ALGORITHM.getHalfCurveOrder(),
+          SIGNATURE_ALGORITHM.getHalfCurveOrder(),
+          (byte) 0);
 
   // TODO: Identify a better default from account to use, such as the registered
   // coinbase or an account currently unlocked by the client.

--- a/ethereum/core/src/test-support/java/org/hyperledger/besu/ethereum/core/TransactionTestFixture.java
+++ b/ethereum/core/src/test-support/java/org/hyperledger/besu/ethereum/core/TransactionTestFixture.java
@@ -32,14 +32,12 @@ import java.math.BigInteger;
 import java.util.List;
 import java.util.Optional;
 
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import org.apache.tuweni.bytes.Bytes;
 
 public class TransactionTestFixture {
-  private static final Supplier<SignatureAlgorithm> SIGNATURE_ALGORITHM =
-      Suppliers.memoize(SignatureAlgorithmFactory::getInstance);
-  private static final KeyPair KEY_PAIR = SIGNATURE_ALGORITHM.get().generateKeyPair();
+  private static final SignatureAlgorithm SIGNATURE_ALGORITHM =
+      SignatureAlgorithmFactory.getInstance();
+  private static final KeyPair KEY_PAIR = SIGNATURE_ALGORITHM.generateKeyPair();
   private static final org.hyperledger.besu.datatypes.CodeDelegation CODE_DELEGATION =
       createSignedCodeDelegation(BigInteger.ZERO, Address.ZERO, 0, KEY_PAIR);
 
@@ -222,7 +220,7 @@ public class TransactionTestFixture {
             Bytes.concatenate(
                 org.hyperledger.besu.ethereum.core.CodeDelegation.MAGIC, rlpOutput.encoded()));
 
-    final var signature = SIGNATURE_ALGORITHM.get().sign(hash, keys);
+    final var signature = SIGNATURE_ALGORITHM.sign(hash, keys);
 
     return new org.hyperledger.besu.ethereum.core.CodeDelegation(
         chainId,

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/TransactionBuilderTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/TransactionBuilderTest.java
@@ -32,16 +32,14 @@ import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
 import java.math.BigInteger;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import com.google.common.base.Suppliers;
 import org.junit.jupiter.api.Test;
 
 class TransactionBuilderTest {
-  private static final Supplier<SignatureAlgorithm> SIGNATURE_ALGORITHM =
-      Suppliers.memoize(SignatureAlgorithmFactory::getInstance);
-  private static final KeyPair senderKeys = SIGNATURE_ALGORITHM.get().generateKeyPair();
+  private static final SignatureAlgorithm SIGNATURE_ALGORITHM =
+      SignatureAlgorithmFactory.getInstance();
+  private static final KeyPair senderKeys = SIGNATURE_ALGORITHM.generateKeyPair();
 
   @Test
   void guessTypeCanGuessAllTypes() {

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/TransactionIntegrationTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/TransactionIntegrationTest.java
@@ -28,16 +28,14 @@ import org.hyperledger.besu.ethereum.rlp.RLPInput;
 
 import java.math.BigInteger;
 import java.util.Optional;
-import java.util.function.Supplier;
 
-import com.google.common.base.Suppliers;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
 
 public class TransactionIntegrationTest {
-  private static final Supplier<SignatureAlgorithm> SIGNATURE_ALGORITHM =
-      Suppliers.memoize(SignatureAlgorithmFactory::getInstance);
-  private static final KeyPair senderKeys = SIGNATURE_ALGORITHM.get().generateKeyPair();
+  private static final SignatureAlgorithm SIGNATURE_ALGORITHM =
+      SignatureAlgorithmFactory.getInstance();
+  private static final KeyPair senderKeys = SIGNATURE_ALGORITHM.generateKeyPair();
 
   @Test
   public void

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/TransactionSizeAndHashTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/TransactionSizeAndHashTest.java
@@ -36,9 +36,7 @@ import org.hyperledger.besu.ethereum.core.kzg.KZGProof;
 
 import java.math.BigInteger;
 import java.util.List;
-import java.util.function.Supplier;
 
-import com.google.common.base.Suppliers;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.bytes.Bytes48;
@@ -46,17 +44,15 @@ import org.junit.jupiter.api.Test;
 
 public class TransactionSizeAndHashTest {
 
-  private static final Supplier<SignatureAlgorithm> SIGNATURE_ALGORITHM =
-      Suppliers.memoize(SignatureAlgorithmFactory::getInstance);
+  private static final SignatureAlgorithm SIGNATURE_ALGORITHM =
+      SignatureAlgorithmFactory.getInstance();
 
   // Fake signature for transactions to not fail being processed.
   private static final SECPSignature FAKE_SIGNATURE =
-      SIGNATURE_ALGORITHM
-          .get()
-          .createSignature(
-              SIGNATURE_ALGORITHM.get().getHalfCurveOrder(),
-              SIGNATURE_ALGORITHM.get().getHalfCurveOrder(),
-              (byte) 0);
+      SIGNATURE_ALGORITHM.createSignature(
+          SIGNATURE_ALGORITHM.getHalfCurveOrder(),
+          SIGNATURE_ALGORITHM.getHalfCurveOrder(),
+          (byte) 0);
 
   @Test
   public void returnsRightSizeForFrontierTx() {

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/encoding/CodeDelegationTransactionEncoderTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/encoding/CodeDelegationTransactionEncoderTest.java
@@ -23,16 +23,14 @@ import org.hyperledger.besu.ethereum.core.CodeDelegation;
 import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
 
 import java.math.BigInteger;
-import java.util.function.Supplier;
 
-import com.google.common.base.Suppliers;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class CodeDelegationTransactionEncoderTest {
-  private static final Supplier<SignatureAlgorithm> SIGNATURE_ALGORITHM =
-      Suppliers.memoize(SignatureAlgorithmFactory::getInstance);
+  private static final SignatureAlgorithm SIGNATURE_ALGORITHM =
+      SignatureAlgorithmFactory.getInstance();
 
   BytesValueRLPOutput output;
 
@@ -50,14 +48,12 @@ class CodeDelegationTransactionEncoderTest {
             BigInteger.ONE,
             Address.fromHexString("0x633688abc3cCf8B0C03088D2d1C6ae4958c2fA56"),
             42,
-            SIGNATURE_ALGORITHM
-                .get()
-                .createSignature(
-                    new BigInteger(
-                        "840798fa67118e034c1eb7e42fe89e28d7cd5006dc813d5729e5f75b0d1a7ec5", 16),
-                    new BigInteger(
-                        "3b1dbace38ceb862a65bf2eac0637693b5c3493bcb2a022dd614c0a74cce0b99", 16),
-                    (byte) 0));
+            SIGNATURE_ALGORITHM.createSignature(
+                new BigInteger(
+                    "840798fa67118e034c1eb7e42fe89e28d7cd5006dc813d5729e5f75b0d1a7ec5", 16),
+                new BigInteger(
+                    "3b1dbace38ceb862a65bf2eac0637693b5c3493bcb2a022dd614c0a74cce0b99", 16),
+                (byte) 0));
 
     CodeDelegationTransactionEncoder.encodeSingleCodeDelegation(authorization, output);
 
@@ -76,14 +72,12 @@ class CodeDelegationTransactionEncoderTest {
             BigInteger.ONE,
             Address.fromHexString("0x633688abc3cCf8B0C03088D2d1C6ae4958c2fA56"),
             0,
-            SIGNATURE_ALGORITHM
-                .get()
-                .createSignature(
-                    new BigInteger(
-                        "dd6b24048be1b7d7fe5bbbb73ffc37eb2ce1997ecb4ae5b6096532ef19363148", 16),
-                    new BigInteger(
-                        "25b58a1ff8ad00bddbbfa1d5c2411961cbb6d08dcdc8ae88303db3c6cf983031", 16),
-                    (byte) 1));
+            SIGNATURE_ALGORITHM.createSignature(
+                new BigInteger(
+                    "dd6b24048be1b7d7fe5bbbb73ffc37eb2ce1997ecb4ae5b6096532ef19363148", 16),
+                new BigInteger(
+                    "25b58a1ff8ad00bddbbfa1d5c2411961cbb6d08dcdc8ae88303db3c6cf983031", 16),
+                (byte) 1));
 
     CodeDelegationTransactionEncoder.encodeSingleCodeDelegation(authorization, output);
 
@@ -102,14 +96,12 @@ class CodeDelegationTransactionEncoderTest {
             BigInteger.ZERO,
             Address.fromHexString("0x633688abc3cCf8B0C03088D2d1C6ae4958c2fA56"),
             5,
-            SIGNATURE_ALGORITHM
-                .get()
-                .createSignature(
-                    new BigInteger(
-                        "25c1240d7ffec0daeedb752d3357aff2e3cd58468f0c2d43ee0ee999e02ace2", 16),
-                    new BigInteger(
-                        "3c8a25b2becd6e666f69803d1ae3322f2e137b7745c2c7f19da80f993ffde4df", 16),
-                    (byte) 1));
+            SIGNATURE_ALGORITHM.createSignature(
+                new BigInteger(
+                    "25c1240d7ffec0daeedb752d3357aff2e3cd58468f0c2d43ee0ee999e02ace2", 16),
+                new BigInteger(
+                    "3c8a25b2becd6e666f69803d1ae3322f2e137b7745c2c7f19da80f993ffde4df", 16),
+                (byte) 1));
 
     CodeDelegationTransactionEncoder.encodeSingleCodeDelegation(authorization, output);
 

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionValidatorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionValidatorTest.java
@@ -56,10 +56,8 @@ import java.math.BigInteger;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import com.google.common.base.Suppliers;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes48;
 import org.junit.jupiter.api.Test;
@@ -76,9 +74,9 @@ import org.mockito.quality.Strictness;
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class MainnetTransactionValidatorTest extends TrustedSetupClassLoaderExtension {
 
-  private static final Supplier<SignatureAlgorithm> SIGNATURE_ALGORITHM =
-      Suppliers.memoize(SignatureAlgorithmFactory::getInstance);
-  protected static final KeyPair senderKeys = SIGNATURE_ALGORITHM.get().generateKeyPair();
+  private static final SignatureAlgorithm SIGNATURE_ALGORITHM =
+      SignatureAlgorithmFactory.getInstance();
+  protected static final KeyPair senderKeys = SIGNATURE_ALGORITHM.generateKeyPair();
 
   private static final TransactionValidationParams transactionProcessingParams =
       processingBlockParams;
@@ -258,7 +256,7 @@ public class MainnetTransactionValidatorTest extends TrustedSetupClassLoaderExte
             gasCalculator, GasLimitCalculator.constant(), false, Optional.of(BigInteger.ONE));
 
     final TransactionTestFixture builder = new TransactionTestFixture();
-    final KeyPair senderKeyPair = SIGNATURE_ALGORITHM.get().generateKeyPair();
+    final KeyPair senderKeyPair = SIGNATURE_ALGORITHM.generateKeyPair();
     final Address arbitrarySender = Address.fromHexString("1");
     builder.gasPrice(Wei.ZERO).nonce(0).sender(arbitrarySender).value(Wei.ZERO);
 

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/PermissionTransactionValidatorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/PermissionTransactionValidatorTest.java
@@ -35,9 +35,7 @@ import org.hyperledger.besu.evm.account.Account;
 
 import java.math.BigInteger;
 import java.util.Optional;
-import java.util.function.Supplier;
 
-import com.google.common.base.Suppliers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -45,9 +43,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public class PermissionTransactionValidatorTest extends MainnetTransactionValidatorTest {
 
-  private static final Supplier<SignatureAlgorithm> SIGNATURE_ALGORITHM =
-      Suppliers.memoize(SignatureAlgorithmFactory::getInstance);
-  private static final KeyPair senderKeys = SIGNATURE_ALGORITHM.get().generateKeyPair();
+  private static final SignatureAlgorithm SIGNATURE_ALGORITHM =
+      SignatureAlgorithmFactory.getInstance();
+  private static final KeyPair senderKeys = SIGNATURE_ALGORITHM.generateKeyPair();
 
   private final Transaction basicTransaction =
       new TransactionTestFixture()

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/transaction/TransactionSimulatorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/transaction/TransactionSimulatorTest.java
@@ -70,8 +70,6 @@ import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.stream.Stream;
 
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.junit.jupiter.api.BeforeEach;
@@ -90,11 +88,11 @@ import org.mockito.quality.Strictness;
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class TransactionSimulatorTest extends TrustedSetupClassLoaderExtension {
 
-  private static final Supplier<SignatureAlgorithm> SIGNATURE_ALGORITHM =
-      Suppliers.memoize(SignatureAlgorithmFactory::getInstance);
-  private static final BigInteger HALF_CURVE_ORDER = SIGNATURE_ALGORITHM.get().getHalfCurveOrder();
+  private static final SignatureAlgorithm SIGNATURE_ALGORITHM =
+      SignatureAlgorithmFactory.getInstance();
+  private static final BigInteger HALF_CURVE_ORDER = SIGNATURE_ALGORITHM.getHalfCurveOrder();
   private static final SECPSignature FAKE_SIGNATURE =
-      SIGNATURE_ALGORITHM.get().createSignature(HALF_CURVE_ORDER, HALF_CURVE_ORDER, (byte) 0);
+      SIGNATURE_ALGORITHM.createSignature(HALF_CURVE_ORDER, HALF_CURVE_ORDER, (byte) 0);
 
   private static final Address DEFAULT_FROM =
       Address.fromHexString("0x0000000000000000000000000000000000000000");

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/layered/AbstractPrioritizedTransactionsTestBase.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/layered/AbstractPrioritizedTransactionsTestBase.java
@@ -105,7 +105,7 @@ public abstract class AbstractPrioritizedTransactionsTestBase extends BaseTransa
               createTransaction(
                   0,
                   Wei.of(DEFAULT_MIN_GAS_PRICE.multiply(2).toBigInteger().pow(i + 1)),
-                  SIGNATURE_ALGORITHM.get().generateKeyPair()));
+                  SIGNATURE_ALGORITHM.generateKeyPair()));
       remoteTxs.add(highValueRemoteTx);
       prioritizeResult = prioritizeTransaction(highValueRemoteTx);
       assertThat(prioritizeResult).isEqualTo(ADDED);

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/layered/BaseFeePrioritizedTransactionsTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/layered/BaseFeePrioritizedTransactionsTest.java
@@ -142,7 +142,7 @@ public class BaseFeePrioritizedTransactionsTest extends AbstractPrioritizedTrans
                         createTransaction(
                             0,
                             DEFAULT_MIN_GAS_PRICE.add(1),
-                            SIGNATURE_ALGORITHM.get().generateKeyPair())))
+                            SIGNATURE_ALGORITHM.generateKeyPair())))
             .collect(Collectors.toUnmodifiableList());
 
     final var lowestPriorityFee =
@@ -226,7 +226,7 @@ public class BaseFeePrioritizedTransactionsTest extends AbstractPrioritizedTrans
                             DEFAULT_MIN_GAS_PRICE.add(1).multiply(20),
                             0,
                             null,
-                            SIGNATURE_ALGORITHM.get().generateKeyPair())))
+                            SIGNATURE_ALGORITHM.generateKeyPair())))
             .collect(Collectors.toUnmodifiableList());
 
     shouldPrioritizeValueThenTimeAddedToPool(
@@ -249,7 +249,7 @@ public class BaseFeePrioritizedTransactionsTest extends AbstractPrioritizedTrans
               1,
               BlobType.KZG_PROOF,
               null,
-              SIGNATURE_ALGORITHM.get().generateKeyPair());
+              SIGNATURE_ALGORITHM.generateKeyPair());
       addedTxs.add(tx);
       assertThat(prioritizeTransaction(tx)).isEqualTo(ADDED);
     }
@@ -264,7 +264,7 @@ public class BaseFeePrioritizedTransactionsTest extends AbstractPrioritizedTrans
             1,
             BlobType.KZG_PROOF,
             null,
-            SIGNATURE_ALGORITHM.get().generateKeyPair());
+            SIGNATURE_ALGORITHM.generateKeyPair());
     assertThat(prioritizeTransaction(overflowTx)).isEqualTo(DROPPED);
 
     addedTxs.forEach(this::assertTransactionPrioritized);

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/layered/BaseTransactionPoolTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/layered/BaseTransactionPoolTest.java
@@ -47,16 +47,14 @@ import java.util.Optional;
 import java.util.Random;
 import java.util.stream.IntStream;
 
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import org.apache.tuweni.bytes.Bytes;
 
 public class BaseTransactionPoolTest extends TrustedSetupClassLoaderExtension {
 
-  protected static final Supplier<SignatureAlgorithm> SIGNATURE_ALGORITHM =
-      Suppliers.memoize(SignatureAlgorithmFactory::getInstance);
-  protected static final KeyPair KEYS1 = SIGNATURE_ALGORITHM.get().generateKeyPair();
-  protected static final KeyPair KEYS2 = SIGNATURE_ALGORITHM.get().generateKeyPair();
+  protected static final SignatureAlgorithm SIGNATURE_ALGORITHM =
+      SignatureAlgorithmFactory.getInstance();
+  protected static final KeyPair KEYS1 = SIGNATURE_ALGORITHM.generateKeyPair();
+  protected static final KeyPair KEYS2 = SIGNATURE_ALGORITHM.generateKeyPair();
   protected static final Address SENDER1 = Util.publicKeyToAddress(KEYS1.getPublicKey());
   protected static final Address SENDER2 = Util.publicKeyToAddress(KEYS2.getPublicKey());
   protected static final CodeDelegation CODE_DELEGATION_SENDER_1 =

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/layered/GasPricePrioritizedTransactionsTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/layered/GasPricePrioritizedTransactionsTest.java
@@ -90,7 +90,7 @@ public class GasPricePrioritizedTransactionsTest extends AbstractPrioritizedTran
                         createTransaction(
                             0,
                             DEFAULT_MIN_GAS_PRICE.add(1),
-                            SIGNATURE_ALGORITHM.get().generateKeyPair())))
+                            SIGNATURE_ALGORITHM.generateKeyPair())))
             .toList();
 
     final PendingTransaction highGasPriceTransaction =

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/layered/LayeredPendingTransactionsTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/layered/LayeredPendingTransactionsTest.java
@@ -248,7 +248,7 @@ public class LayeredPendingTransactionsTest extends BaseTransactionPoolTest {
               i,
               DEFAULT_BASE_FEE.add(i),
               (int) smallPoolConfig.getPendingTransactionsLayerMaxCapacityBytes() + 1,
-              SIGNATURE_ALGORITHM.get().generateKeyPair());
+              SIGNATURE_ALGORITHM.generateKeyPair());
       smallPendingTransactions.addTransaction(
           createRemotePendingTransaction(tx), Optional.of(sender));
       firstTxs.add(tx);
@@ -262,7 +262,7 @@ public class LayeredPendingTransactionsTest extends BaseTransactionPoolTest {
             0,
             DEFAULT_MIN_GAS_PRICE.multiply(1000),
             (int) smallPoolConfig.getPendingTransactionsLayerMaxCapacityBytes(),
-            SIGNATURE_ALGORITHM.get().generateKeyPair());
+            SIGNATURE_ALGORITHM.generateKeyPair());
     final Account lastSender = mock(Account.class);
     when(lastSender.getNonce()).thenReturn(0L);
     smallPendingTransactions.addTransaction(
@@ -296,8 +296,7 @@ public class LayeredPendingTransactionsTest extends BaseTransactionPoolTest {
       final Account sender = mock(Account.class);
       when(sender.getNonce()).thenReturn((long) i);
       final var tx =
-          createTransaction(
-              i, DEFAULT_BASE_FEE.add(i), SIGNATURE_ALGORITHM.get().generateKeyPair());
+          createTransaction(i, DEFAULT_BASE_FEE.add(i), SIGNATURE_ALGORITHM.generateKeyPair());
       pendingTransactions.addTransaction(createRemotePendingTransaction(tx), Optional.of(sender));
       txs.add(tx);
       assertTransactionPending(pendingTransactions, tx);

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/layered/LayersTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/layered/LayersTest.java
@@ -2043,7 +2043,7 @@ public class LayersTest extends BaseTransactionPoolTest {
     final boolean hasPriority;
 
     Sender(final boolean hasPriority, final int gasFeeMultiplier) {
-      this.key = SIGNATURE_ALGORITHM.get().generateKeyPair();
+      this.key = SIGNATURE_ALGORITHM.generateKeyPair();
       this.address = Util.publicKeyToAddress(key.getPublicKey());
       this.gasFeeMultiplier = gasFeeMultiplier;
       this.hasPriority = hasPriority;

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/sorter/AbstractPendingTransactionsTestBase.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/sorter/AbstractPendingTransactionsTestBase.java
@@ -62,8 +62,6 @@ import java.util.OptionalLong;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import com.google.common.collect.Lists;
 import org.junit.jupiter.api.Test;
 
@@ -72,10 +70,10 @@ public abstract class AbstractPendingTransactionsTestBase {
   protected static final int MAX_TRANSACTIONS = 5;
   protected static final int MAX_TRANSACTIONS_LARGE_POOL = 15;
   private static final float LIMITED_TRANSACTIONS_BY_SENDER_PERCENTAGE = 0.8f;
-  protected static final Supplier<SignatureAlgorithm> SIGNATURE_ALGORITHM =
-      Suppliers.memoize(SignatureAlgorithmFactory::getInstance);
-  protected static final KeyPair KEYS1 = SIGNATURE_ALGORITHM.get().generateKeyPair();
-  protected static final KeyPair KEYS2 = SIGNATURE_ALGORITHM.get().generateKeyPair();
+  protected static final SignatureAlgorithm SIGNATURE_ALGORITHM =
+      SignatureAlgorithmFactory.getInstance();
+  protected static final KeyPair KEYS1 = SIGNATURE_ALGORITHM.generateKeyPair();
+  protected static final KeyPair KEYS2 = SIGNATURE_ALGORITHM.generateKeyPair();
   protected static final String ADDED_COUNTER = "transactions_added_total";
   protected static final String REMOVED_COUNTER = "transactions_removed_total";
   protected static final String REMOTE = "remote";
@@ -170,7 +168,7 @@ public abstract class AbstractPendingTransactionsTestBase {
   @Test
   public void shouldDropOldestTransactionWhenLimitExceeded() {
     final Transaction oldestTransaction =
-        transactionWithNonceSenderAndGasPrice(0, SIGNATURE_ALGORITHM.get().generateKeyPair(), 10L);
+        transactionWithNonceSenderAndGasPrice(0, SIGNATURE_ALGORITHM.generateKeyPair(), 10L);
     final Account oldestSender = mock(Account.class);
     when(oldestSender.getNonce()).thenReturn(0L);
     senderLimitedTransactions.addTransaction(
@@ -180,8 +178,7 @@ public abstract class AbstractPendingTransactionsTestBase {
       when(sender.getNonce()).thenReturn((long) i);
       senderLimitedTransactions.addTransaction(
           createRemotePendingTransaction(
-              transactionWithNonceSenderAndGasPrice(
-                  i, SIGNATURE_ALGORITHM.get().generateKeyPair(), 10L)),
+              transactionWithNonceSenderAndGasPrice(i, SIGNATURE_ALGORITHM.generateKeyPair(), 10L)),
           Optional.of(sender));
     }
     assertThat(senderLimitedTransactions.size()).isEqualTo(MAX_TRANSACTIONS);
@@ -968,7 +965,7 @@ public abstract class AbstractPendingTransactionsTestBase {
                   final Account randomSender = mock(Account.class);
                   final Transaction lowPriceTx =
                       transactionWithNonceSenderAndGasPrice(
-                          0, SIGNATURE_ALGORITHM.get().generateKeyPair(), 10);
+                          0, SIGNATURE_ALGORITHM.generateKeyPair(), 10);
                   transactions.addTransaction(
                       createRemotePendingTransaction(lowPriceTx), Optional.of(randomSender));
                   return lowPriceTx;

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgent.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgent.java
@@ -51,7 +51,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Suppliers;
 import com.google.common.net.InetAddresses;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt64;
@@ -68,8 +67,8 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class PeerDiscoveryAgent {
   private static final Logger LOG = LoggerFactory.getLogger(PeerDiscoveryAgent.class);
-  private static final com.google.common.base.Supplier<SignatureAlgorithm> SIGNATURE_ALGORITHM =
-      Suppliers.memoize(SignatureAlgorithmFactory::getInstance);
+  private static final SignatureAlgorithm SIGNATURE_ALGORITHM =
+      SignatureAlgorithmFactory.getInstance();
 
   // The devp2p specification says only accept packets up to 1280, but some
   // clients ignore that, so we add in a little extra padding.
@@ -220,11 +219,9 @@ public abstract class PeerDiscoveryAgent {
                           sequenceNumber,
                           new EnrField(EnrField.ID, IdentitySchema.V4),
                           new EnrField(
-                              SIGNATURE_ALGORITHM.get().getCurveName(),
-                              SIGNATURE_ALGORITHM
-                                  .get()
-                                  .compressPublicKey(
-                                      SIGNATURE_ALGORITHM.get().createPublicKey(id))),
+                              SIGNATURE_ALGORITHM.getCurveName(),
+                              SIGNATURE_ALGORITHM.compressPublicKey(
+                                  SIGNATURE_ALGORITHM.createPublicKey(id))),
                           new EnrField(EnrField.IP_V4, addressBytes),
                           new EnrField(EnrField.TCP, listeningPort),
                           new EnrField(EnrField.UDP, discoveryPort),

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/EncryptedMessage.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/EncryptedMessage.java
@@ -23,8 +23,6 @@ import org.hyperledger.besu.cryptoservices.NodeKey;
 import java.nio.ByteBuffer;
 import java.security.SecureRandom;
 
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.MutableBytes;
 import org.bouncycastle.crypto.InvalidCipherTextException;
@@ -34,8 +32,8 @@ final class EncryptedMessage {
   private static final int IV_SIZE = 16;
 
   private static final SecureRandom RANDOM = SecureRandomProvider.createSecureRandom();
-  private static final Supplier<SignatureAlgorithm> SIGNATURE_ALGORITHM =
-      Suppliers.memoize(SignatureAlgorithmFactory::getInstance);
+  private static final SignatureAlgorithm SIGNATURE_ALGORITHM =
+      SignatureAlgorithmFactory.getInstance();
 
   private EncryptedMessage() {
     // Utility Class
@@ -54,8 +52,7 @@ final class EncryptedMessage {
 
     // Extract the ephemeral public key, stripping off the first byte (0x04), which designates it's
     // an uncompressed key.
-    final SECPPublicKey ephPubKey =
-        SIGNATURE_ALGORITHM.get().createPublicKey(msgBytes.slice(1, 64));
+    final SECPPublicKey ephPubKey = SIGNATURE_ALGORITHM.createPublicKey(msgBytes.slice(1, 64));
 
     // Strip off the IV to use.
     final Bytes iv = msgBytes.slice(65, IV_SIZE);
@@ -79,8 +76,7 @@ final class EncryptedMessage {
    */
   public static Bytes decryptMsgEIP8(final Bytes msgBytes, final NodeKey nodeKey)
       throws InvalidCipherTextException {
-    final SECPPublicKey ephPubKey =
-        SIGNATURE_ALGORITHM.get().createPublicKey(msgBytes.slice(3, 64));
+    final SECPPublicKey ephPubKey = SIGNATURE_ALGORITHM.createPublicKey(msgBytes.slice(3, 64));
 
     // Strip off the IV to use.
     final Bytes iv = msgBytes.slice(3 + 64, IV_SIZE);

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgentTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgentTest.java
@@ -54,8 +54,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt64;
@@ -66,8 +64,8 @@ import org.junit.jupiter.api.Test;
 public class PeerDiscoveryAgentTest {
 
   private static final int BROADCAST_TCP_PORT = 30303;
-  private static final Supplier<SignatureAlgorithm> SIGNATURE_ALGORITHM =
-      Suppliers.memoize(SignatureAlgorithmFactory::getInstance);
+  private static final SignatureAlgorithm SIGNATURE_ALGORITHM =
+      SignatureAlgorithmFactory.getInstance();
   private PeerDiscoveryTestHelper helper;
   private PacketPackage packetPackage;
 
@@ -97,14 +95,10 @@ public class PeerDiscoveryAgentTest {
   @Test
   public void testNodeRecordCreated() {
     final KeyPair keyPair =
-        SIGNATURE_ALGORITHM
-            .get()
-            .createKeyPair(
-                SIGNATURE_ALGORITHM
-                    .get()
-                    .createPrivateKey(
-                        Bytes32.fromHexString(
-                            "0xb71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")));
+        SIGNATURE_ALGORITHM.createKeyPair(
+            SIGNATURE_ALGORITHM.createPrivateKey(
+                Bytes32.fromHexString(
+                    "0xb71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")));
     final MockPeerDiscoveryAgent agent =
         helper.startDiscoveryAgent(
             helper
@@ -131,14 +125,10 @@ public class PeerDiscoveryAgentTest {
   @Test
   public void testNodeRecordCreatedUpdatesDiscoveryPeer() {
     final KeyPair keyPair =
-        SIGNATURE_ALGORITHM
-            .get()
-            .createKeyPair(
-                SIGNATURE_ALGORITHM
-                    .get()
-                    .createPrivateKey(
-                        Bytes32.fromHexString(
-                            "0xb71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")));
+        SIGNATURE_ALGORITHM.createKeyPair(
+            SIGNATURE_ALGORITHM.createPrivateKey(
+                Bytes32.fromHexString(
+                    "0xb71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")));
     final MockPeerDiscoveryAgent agent =
         helper.startDiscoveryAgent(
             helper
@@ -156,14 +146,10 @@ public class PeerDiscoveryAgentTest {
   @Test
   public void testNodeRecordNotUpdatedIfNoPeerDiscovery() {
     final KeyPair keyPair =
-        SIGNATURE_ALGORITHM
-            .get()
-            .createKeyPair(
-                SIGNATURE_ALGORITHM
-                    .get()
-                    .createPrivateKey(
-                        Bytes32.fromHexString(
-                            "0xb71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")));
+        SIGNATURE_ALGORITHM.createKeyPair(
+            SIGNATURE_ALGORITHM.createPrivateKey(
+                Bytes32.fromHexString(
+                    "0xb71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")));
     final MockPeerDiscoveryAgent agent =
         helper.startDiscoveryAgent(
             helper

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PeerTableTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PeerTableTest.java
@@ -30,15 +30,13 @@ import org.hyperledger.besu.ethereum.p2p.peers.Peer;
 import java.util.List;
 import java.util.Optional;
 
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
 
 public class PeerTableTest {
 
-  private static final Supplier<SignatureAlgorithm> SIGNATURE_ALGORITHM =
-      Suppliers.memoize(SignatureAlgorithmFactory::getInstance);
+  private static final SignatureAlgorithm SIGNATURE_ALGORITHM =
+      SignatureAlgorithmFactory.getInstance();
   private final PeerDiscoveryTestHelper helper = new PeerDiscoveryTestHelper();
 
   @Test
@@ -88,8 +86,7 @@ public class PeerTableTest {
   @Test
   public void peerExists_withDifferentIp() {
     final PeerTable table = new PeerTable(Peer.randomId());
-    final Bytes peerId =
-        SIGNATURE_ALGORITHM.get().generateKeyPair().getPublicKey().getEncodedBytes();
+    final Bytes peerId = SIGNATURE_ALGORITHM.generateKeyPair().getPublicKey().getEncodedBytes();
     final DiscoveryPeer peer =
         DiscoveryPeer.fromIdAndEndpoint(peerId, new Endpoint("1.1.1.1", 30303, Optional.empty()));
 
@@ -108,8 +105,7 @@ public class PeerTableTest {
   @Test
   public void peerExists_withDifferentUdpPort() {
     final PeerTable table = new PeerTable(Peer.randomId());
-    final Bytes peerId =
-        SIGNATURE_ALGORITHM.get().generateKeyPair().getPublicKey().getEncodedBytes();
+    final Bytes peerId = SIGNATURE_ALGORITHM.generateKeyPair().getPublicKey().getEncodedBytes();
     final DiscoveryPeer peer =
         DiscoveryPeer.fromIdAndEndpoint(peerId, new Endpoint("1.1.1.1", 30303, Optional.empty()));
 
@@ -128,8 +124,7 @@ public class PeerTableTest {
   @Test
   public void peerExists_withDifferentIdAndUdpPort() {
     final PeerTable table = new PeerTable(Peer.randomId());
-    final Bytes peerId =
-        SIGNATURE_ALGORITHM.get().generateKeyPair().getPublicKey().getEncodedBytes();
+    final Bytes peerId = SIGNATURE_ALGORITHM.generateKeyPair().getPublicKey().getEncodedBytes();
     final DiscoveryPeer peer =
         DiscoveryPeer.fromIdAndEndpoint(peerId, new Endpoint("1.1.1.1", 30303, Optional.empty()));
 

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/ECIESHandshakeTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/ECIESHandshakeTest.java
@@ -24,8 +24,6 @@ import org.hyperledger.besu.ethereum.p2p.rlpx.handshake.Handshaker.HandshakeStat
 
 import java.util.Optional;
 
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import org.apache.tuweni.bytes.Bytes;
@@ -38,42 +36,25 @@ public class ECIESHandshakeTest {
   // Input data.
   private static class Input {
 
-    static final Supplier<SignatureAlgorithm> SIGNATURE_ALGORITHM =
-        Suppliers.memoize(SignatureAlgorithmFactory::getInstance);
+    static final SignatureAlgorithm SIGNATURE_ALGORITHM = SignatureAlgorithmFactory.getInstance();
 
     // Keys.
     private static final KeyPair initiatorKeyPair =
-        SIGNATURE_ALGORITHM
-            .get()
-            .createKeyPair(
-                SIGNATURE_ALGORITHM
-                    .get()
-                    .createPrivateKey(
-                        h32("0x5e173f6ac3c669587538e7727cf19b782a4f2fda07c1eaa662c593e5e85e3051")));
+        SIGNATURE_ALGORITHM.createKeyPair(
+            SIGNATURE_ALGORITHM.createPrivateKey(
+                h32("0x5e173f6ac3c669587538e7727cf19b782a4f2fda07c1eaa662c593e5e85e3051")));
     private static final KeyPair initiatorEphKeyPair =
-        SIGNATURE_ALGORITHM
-            .get()
-            .createKeyPair(
-                SIGNATURE_ALGORITHM
-                    .get()
-                    .createPrivateKey(
-                        h32("0x19c2185f4f40634926ebed3af09070ca9e029f2edd5fae6253074896205f5f6c")));
+        SIGNATURE_ALGORITHM.createKeyPair(
+            SIGNATURE_ALGORITHM.createPrivateKey(
+                h32("0x19c2185f4f40634926ebed3af09070ca9e029f2edd5fae6253074896205f5f6c")));
     private static final KeyPair responderKeyPair =
-        SIGNATURE_ALGORITHM
-            .get()
-            .createKeyPair(
-                SIGNATURE_ALGORITHM
-                    .get()
-                    .createPrivateKey(
-                        h32("0xc45f950382d542169ea207959ee0220ec1491755abe405cd7498d6b16adb6df8")));
+        SIGNATURE_ALGORITHM.createKeyPair(
+            SIGNATURE_ALGORITHM.createPrivateKey(
+                h32("0xc45f950382d542169ea207959ee0220ec1491755abe405cd7498d6b16adb6df8")));
     private static final KeyPair responderEphKeyPair =
-        SIGNATURE_ALGORITHM
-            .get()
-            .createKeyPair(
-                SIGNATURE_ALGORITHM
-                    .get()
-                    .createPrivateKey(
-                        h32("0xd25688cf0ab10afa1a0e2dba7853ed5f1e5bf1c631757ed4e103b593ff3f5620")));
+        SIGNATURE_ALGORITHM.createKeyPair(
+            SIGNATURE_ALGORITHM.createPrivateKey(
+                h32("0xd25688cf0ab10afa1a0e2dba7853ed5f1e5bf1c631757ed4e103b593ff3f5620")));
 
     // Nonces.
     private static final Bytes32 initiatorNonce =


### PR DESCRIPTION
## PR description
This PR tries to avoid the use of Memoize when getting the SignatureAlgorithm, since it is already a singleton that can be obtained through the SignatureAlgorithmFactory class.
But, after removing this Memoize use, when executing the tests I could check that Memoize was being used, not only to cache the SignatureAlgorithm, but also for not loading the SignatureAlgorithm in the class using it until it was required. Right now, without Memoize, and loading the SignatureAlgorithm in most classes in this way

`  private final SignatureAlgorithm SIGNATURE_ALGORITHM = SignatureAlgorithmFactory.getInstance();`
  
The SignatureAlgorithm is loaded at building time, so it gets the default value:

```
 public static SignatureAlgorithm getInstance() {
    return instance != null
        ? instance
        : SignatureAlgorithmType.DEFAULT_SIGNATURE_ALGORITHM_TYPE.get();
  }  

```

What happens in tests is that the SignatureAlgorithm gets the default value instead of the value existing in the json genesis files, so I'm a bit afraid that this also happens in production environments, so I would like that someone could check whether this is the correct.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


