### PR TITLE
add rpc http timeout to the plugin api

### DIFF
--- a/app/src/main/java/org/hyperledger/besu/services/BesuConfigurationImpl.java
+++ b/app/src/main/java/org/hyperledger/besu/services/BesuConfigurationImpl.java
@@ -35,6 +35,7 @@ public class BesuConfigurationImpl implements BesuConfiguration {
   private MiningConfiguration miningConfiguration;
   private String rpcHttpHost = JsonRpcConfiguration.DEFAULT_JSON_RPC_HOST;
   private Integer rpcHttpPort = JsonRpcConfiguration.DEFAULT_JSON_RPC_PORT;
+  private long rpcHttpTimeoutSec = JsonRpcConfiguration.DEFAULT_HTTP_TIMEOUT_SEC;
 
   /** Default Constructor. */
   public BesuConfigurationImpl() {}
@@ -77,6 +78,7 @@ public class BesuConfigurationImpl implements BesuConfiguration {
   public BesuConfigurationImpl withJsonRpcHttpOptions(final JsonRpcHttpOptions rpcHttpOptions) {
     this.rpcHttpHost = rpcHttpOptions.getRpcHttpHost();
     this.rpcHttpPort = rpcHttpOptions.getRpcHttpPort();
+    this.rpcHttpTimeoutSec = rpcHttpOptions.jsonRpcConfiguration().getHttpTimeoutSec();
     return this;
   }
 
@@ -100,6 +102,11 @@ public class BesuConfigurationImpl implements BesuConfiguration {
   @Override
   public Integer getConfiguredRpcHttpPort() {
     return rpcHttpPort;
+  }
+
+  @Override
+  public long getConfiguredRpcHttpTimeoutSec() {
+    return rpcHttpTimeoutSec;
   }
 
   @Override

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcConfiguration.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcConfiguration.java
@@ -37,6 +37,8 @@ public class JsonRpcConfiguration {
   public static final int DEFAULT_ENGINE_JSON_RPC_PORT = 8551;
   public static final int DEFAULT_MAX_ACTIVE_CONNECTIONS = 80;
   public static final int DEFAULT_MAX_BATCH_SIZE = 1024;
+  public static final long DEFAULT_HTTP_TIMEOUT_SEC =
+      TimeoutOptions.defaultOptions().getTimeoutSeconds();
   public static final long DEFAULT_MAX_REQUEST_CONTENT_LENGTH = 128 * 1024 * 1024; // 128MB
   public static final boolean DEFAULT_PRETTY_JSON_ENABLED = false;
 
@@ -52,7 +54,7 @@ public class JsonRpcConfiguration {
   private JwtAlgorithm authenticationAlgorithm = JwtAlgorithm.RS256;
   private File authenticationPublicKeyFile;
   private Optional<TlsConfiguration> tlsConfiguration = Optional.empty();
-  private long httpTimeoutSec = TimeoutOptions.defaultOptions().getTimeoutSeconds();
+  private long httpTimeoutSec = DEFAULT_HTTP_TIMEOUT_SEC;
   private int maxActiveConnections;
   private int maxBatchSize;
   private long maxRequestContentLength;

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/AbstractIsolationTests.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/AbstractIsolationTests.java
@@ -237,6 +237,11 @@ public abstract class AbstractIsolationTests {
               }
 
               @Override
+              public long getConfiguredRpcHttpTimeoutSec() {
+                return 0;
+              }
+
+              @Override
               public Path getStoragePath() {
                 return tempData.resolve("database");
               }

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -71,7 +71,7 @@ Calculated : ${currentHash}
 tasks.register('checkAPIChanges', FileStateChecker) {
   description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
   files = sourceSets.main.allJava.files
-  knownHash = '2CHCfej+ocWs4OIHSYm4gA4T121uBxYoILBGqZshgDo='
+  knownHash = 'HL1SB1D2nHNQZ/FUk4tobif8H1fFFrKHfHnJb7NQ00w='
 }
 check.dependsOn('checkAPIChanges')
 

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/BesuConfiguration.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/BesuConfiguration.java
@@ -49,6 +49,13 @@ public interface BesuConfiguration extends BesuService {
   String getConfiguredRpcHttpHost();
 
   /**
+   * Get the configured RPC http timeout in second.
+   *
+   * @return the configured RPC http timeout in second.
+   */
+  long getConfiguredRpcHttpTimeoutSec();
+
+  /**
    * Get the configured RPC http port.
    *
    * @return the configured RPC http port.


### PR DESCRIPTION
## PR description

add rpc http timeout to the plugin api

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


