### PR TITLE
Time limited plugin txs selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Update netty [#9156](https://github.com/hyperledger/besu/pull/9156)
 - Expose new method to query hardfork by block number Plugin API [#9115](https://github.com/hyperledger/besu/pull/9115)
 - Support loading multiple transaction selector plugins [#8743](https://github.com/hyperledger/besu/pull/9139)
+- Configurable limit for how much time plugins are allowed take, to propose transactions, during block creation [#9184](https://github.com/hyperledger/besu/pull/9184)
 
 #### Performance
 - Add jmh benchmarks for some compute-related opcodes [#9069](https://github.com/hyperledger/besu/pull/9069)

--- a/app/src/main/java/org/hyperledger/besu/cli/options/MiningOptions.java
+++ b/app/src/main/java/org/hyperledger/besu/cli/options/MiningOptions.java
@@ -18,6 +18,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.hyperledger.besu.ethereum.core.MiningConfiguration.DEFAULT_NON_POA_BLOCK_TXS_SELECTION_MAX_TIME;
+import static org.hyperledger.besu.ethereum.core.MiningConfiguration.DEFAULT_PLUGIN_BLOCK_TXS_SELECTION_MAX_TIME;
 import static org.hyperledger.besu.ethereum.core.MiningConfiguration.DEFAULT_POA_BLOCK_TXS_SELECTION_MAX_TIME;
 import static org.hyperledger.besu.ethereum.core.MiningConfiguration.MutableInitValues.DEFAULT_EXTRA_DATA;
 import static org.hyperledger.besu.ethereum.core.MiningConfiguration.MutableInitValues.DEFAULT_MIN_BLOCK_OCCUPANCY_RATIO;
@@ -124,6 +125,15 @@ public class MiningOptions implements CLIOptions<MiningConfiguration> {
               + " To be only used on PoA networks, for other networks see block-txs-selection-max-time."
               + " (default: ${DEFAULT-VALUE})")
   private PositiveNumber poaBlockTxsSelectionMaxTime = DEFAULT_POA_BLOCK_TXS_SELECTION_MAX_TIME;
+
+  @Option(
+      names = {"--plugin-block-txs-selection-max-time"},
+      converter = PositiveNumberConverter.class,
+      description =
+          "Specifies the maximum time that plugins could spent selecting transactions to be included in the block, as a percentage of the max block selection time."
+              + " (default: ${DEFAULT-VALUE})")
+  private PositiveNumber pluginBlockTxsSelectionMaxTime =
+      DEFAULT_PLUGIN_BLOCK_TXS_SELECTION_MAX_TIME;
 
   @CommandLine.ArgGroup(validate = false)
   private final Unstable unstableOptions = new Unstable();
@@ -292,6 +302,8 @@ public class MiningOptions implements CLIOptions<MiningConfiguration> {
         miningConfiguration.getNonPoaBlockTxsSelectionMaxTime();
     miningOptions.poaBlockTxsSelectionMaxTime =
         miningConfiguration.getPoaBlockTxsSelectionMaxTime();
+    miningOptions.pluginBlockTxsSelectionMaxTime =
+        miningConfiguration.getPluginBlockTxsSelectionMaxTime();
 
     miningOptions.unstableOptions.remoteSealersLimit =
         miningConfiguration.getUnstable().getRemoteSealersLimit();
@@ -337,6 +349,7 @@ public class MiningOptions implements CLIOptions<MiningConfiguration> {
         .mutableInitValues(updatableInitValuesBuilder.build())
         .nonPoaBlockTxsSelectionMaxTime(nonPoaBlockTxsSelectionMaxTime)
         .poaBlockTxsSelectionMaxTime(poaBlockTxsSelectionMaxTime)
+        .pluginBlockTxsSelectionMaxTime(pluginBlockTxsSelectionMaxTime)
         .unstable(
             ImmutableMiningConfiguration.Unstable.builder()
                 .remoteSealersLimit(unstableOptions.remoteSealersLimit)

--- a/app/src/test/java/org/hyperledger/besu/controller/AbstractBftBesuControllerBuilderTest.java
+++ b/app/src/test/java/org/hyperledger/besu/controller/AbstractBftBesuControllerBuilderTest.java
@@ -57,6 +57,7 @@ import org.hyperledger.besu.services.kvstore.InMemoryKeyValueStorage;
 import java.math.BigInteger;
 import java.nio.file.Path;
 import java.time.Clock;
+import java.time.Duration;
 import java.util.List;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -201,7 +202,8 @@ public abstract class AbstractBftBesuControllerBuilderTest {
     protocolContext.getBlockchain().appendBlock(block1, List.of());
 
     assertThat(miningConfiguration.getBlockPeriodSeconds()).isNotEmpty().hasValue(2);
-    assertThat(miningConfiguration.getBlockTxsSelectionMaxTime()).isEqualTo(2000 * 75 / 100);
+    assertThat(miningConfiguration.getBlockTxsSelectionMaxTime())
+        .isEqualTo(Duration.ofMillis(2000 * 75 / 100));
   }
 
   protected abstract BlockHeaderFunctions getBlockHeaderFunctions();

--- a/app/src/test/java/org/hyperledger/besu/controller/CliqueBesuControllerBuilderTest.java
+++ b/app/src/test/java/org/hyperledger/besu/controller/CliqueBesuControllerBuilderTest.java
@@ -60,6 +60,7 @@ import org.hyperledger.besu.services.kvstore.InMemoryKeyValueStorage;
 import java.math.BigInteger;
 import java.nio.file.Path;
 import java.time.Clock;
+import java.time.Duration;
 import java.util.List;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -231,6 +232,7 @@ public class CliqueBesuControllerBuilderTest {
     protocolContext.getBlockchain().appendBlock(block1, List.of());
 
     assertThat(miningConfiguration.getBlockPeriodSeconds()).isNotEmpty().hasValue(2);
-    assertThat(miningConfiguration.getBlockTxsSelectionMaxTime()).isEqualTo(2000 * 75 / 100);
+    assertThat(miningConfiguration.getBlockTxsSelectionMaxTime())
+        .isEqualTo(Duration.ofMillis(2000 * 75 / 100));
   }
 }

--- a/app/src/test/resources/everything_config.toml
+++ b/app/src/test/resources/everything_config.toml
@@ -164,6 +164,7 @@ min-priority-fee=0
 min-block-occupancy-ratio=0.7
 block-txs-selection-max-time=5000
 poa-block-txs-selection-max-time=75
+plugin-block-txs-selection-max-time=50
 Xminer-remote-sealers-limit=1000
 Xminer-remote-sealers-hashrate-ttl=10
 Xpos-block-creation-max-time=5

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/InterruptibleOperationTracer.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/InterruptibleOperationTracer.java
@@ -21,6 +21,7 @@ import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.log.Log;
 import org.hyperledger.besu.evm.operation.Operation;
+import org.hyperledger.besu.evm.tracing.TraceFrame;
 import org.hyperledger.besu.evm.worldstate.WorldView;
 import org.hyperledger.besu.plugin.data.BlockBody;
 import org.hyperledger.besu.plugin.data.BlockHeader;
@@ -64,6 +65,7 @@ public class InterruptibleOperationTracer implements BlockAwareOperationTracer {
 
   @Override
   public boolean isExtendedTracing() {
+    checkInterrupt();
     return delegate.isExtendedTracing();
   }
 
@@ -96,17 +98,20 @@ public class InterruptibleOperationTracer implements BlockAwareOperationTracer {
 
   @Override
   public void tracePrepareTransaction(final WorldView worldView, final Transaction transaction) {
+    checkInterrupt();
     delegate.tracePrepareTransaction(worldView, transaction);
   }
 
   @Override
   public void traceStartTransaction(final WorldView worldView, final Transaction transaction) {
+    checkInterrupt();
     delegate.traceStartTransaction(worldView, transaction);
   }
 
   @Override
   public void traceBeforeRewardTransaction(
       final WorldView worldView, final Transaction tx, final Wei miningReward) {
+    checkInterrupt();
     delegate.traceBeforeRewardTransaction(worldView, tx, miningReward);
   }
 
@@ -120,6 +125,7 @@ public class InterruptibleOperationTracer implements BlockAwareOperationTracer {
       final long gasUsed,
       final Set<Address> selfDestructs,
       final long timeNs) {
+    checkInterrupt();
     delegate.traceEndTransaction(
         worldView, tx, status, output, logs, gasUsed, selfDestructs, timeNs);
   }
@@ -140,6 +146,12 @@ public class InterruptibleOperationTracer implements BlockAwareOperationTracer {
   public void traceContextExit(final MessageFrame frame) {
     checkInterrupt();
     delegate.traceContextExit(frame);
+  }
+
+  @Override
+  public List<TraceFrame> getTraceFrames() {
+    checkInterrupt();
+    return delegate.getTraceFrames();
   }
 
   private void checkInterrupt() {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/MiningConfiguration.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/MiningConfiguration.java
@@ -179,18 +179,21 @@ public abstract class MiningConfiguration {
     };
   }
 
-  public long getBlockTxsSelectionMaxTime() {
+  public Duration getBlockTxsSelectionMaxTime() {
     final var maybeBlockPeriodSeconds = getMutableRuntimeValues().blockPeriodSeconds;
     if (maybeBlockPeriodSeconds.isPresent()) {
-      return (TimeUnit.SECONDS.toMillis(maybeBlockPeriodSeconds.getAsInt())
-              * getPoaBlockTxsSelectionMaxTime().getValue())
-          / 100;
+      return Duration.ofMillis(
+          (TimeUnit.SECONDS.toMillis(maybeBlockPeriodSeconds.getAsInt())
+                  * getPoaBlockTxsSelectionMaxTime().getValue())
+              / 100);
     }
-    return getNonPoaBlockTxsSelectionMaxTime().getValue();
+    return Duration.ofMillis(getNonPoaBlockTxsSelectionMaxTime().getValue());
   }
 
-  public long getPluginTxsSelectionMaxTime() {
-    return (getBlockTxsSelectionMaxTime() * getPluginBlockTxsSelectionMaxTime().getValue()) / 100;
+  public Duration getPluginTxsSelectionMaxTime() {
+    return Duration.ofMillis(
+        (getBlockTxsSelectionMaxTime().toMillis() * getPluginBlockTxsSelectionMaxTime().getValue())
+            / 100);
   }
 
   @Value.Default

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/MiningConfiguration.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/MiningConfiguration.java
@@ -43,6 +43,8 @@ public abstract class MiningConfiguration {
       PositiveNumber.fromInt((int) Duration.ofSeconds(5).toMillis());
   public static final PositiveNumber DEFAULT_POA_BLOCK_TXS_SELECTION_MAX_TIME =
       PositiveNumber.fromInt(75);
+  public static final PositiveNumber DEFAULT_PLUGIN_BLOCK_TXS_SELECTION_MAX_TIME =
+      PositiveNumber.fromInt(50);
   public static final MiningConfiguration MINING_DISABLED =
       ImmutableMiningConfiguration.builder()
           .mutableInitValues(
@@ -153,6 +155,11 @@ public abstract class MiningConfiguration {
   }
 
   @Value.Default
+  public PositiveNumber getPluginBlockTxsSelectionMaxTime() {
+    return DEFAULT_PLUGIN_BLOCK_TXS_SELECTION_MAX_TIME;
+  }
+
+  @Value.Default
   public TransactionSelectionService getTransactionSelectionService() {
     return new TransactionSelectionService() {
       @Override
@@ -180,6 +187,10 @@ public abstract class MiningConfiguration {
           / 100;
     }
     return getNonPoaBlockTxsSelectionMaxTime().getValue();
+  }
+
+  public long getPluginTxsSelectionMaxTime() {
+    return (getBlockTxsSelectionMaxTime() * getPluginBlockTxsSelectionMaxTime().getValue()) / 100;
   }
 
   @Value.Default

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -71,7 +71,7 @@ Calculated : ${currentHash}
 tasks.register('checkAPIChanges', FileStateChecker) {
   description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
   files = sourceSets.main.allJava.files
-  knownHash = 'HL1SB1D2nHNQZ/FUk4tobif8H1fFFrKHfHnJb7NQ00w='
+  knownHash = 'Gny42VgnqxYj6YlJ+MaWVZokueCIczj+429eMCQA11w='
 }
 check.dependsOn('checkAPIChanges')
 

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/data/TransactionSelectionResult.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/data/TransactionSelectionResult.java
@@ -65,6 +65,8 @@ public class TransactionSelectionResult {
     BLOCK_SIZE_ABOVE_THRESHOLD(true, false, false),
     BLOCK_SELECTION_TIMEOUT(true, false, false),
     BLOCK_SELECTION_TIMEOUT_INVALID_TX(true, true, true),
+    PLUGIN_SELECTION_TIMEOUT(false, false, false),
+    PLUGIN_SELECTION_TIMEOUT_INVALID_TX(false, true, true),
     TX_EVALUATION_TOO_LONG(true, false, true),
     INVALID_TX_EVALUATION_TOO_LONG(true, true, true),
     INVALID_TRANSIENT(false, false, false),
@@ -127,6 +129,17 @@ public class TransactionSelectionResult {
   /** There was no more time to add transaction to the block, and the transaction is invalid */
   public static final TransactionSelectionResult BLOCK_SELECTION_TIMEOUT_INVALID_TX =
       new TransactionSelectionResult(BaseStatus.BLOCK_SELECTION_TIMEOUT_INVALID_TX);
+
+  /** There was no more time for plugins to add transaction to the block */
+  public static final TransactionSelectionResult PLUGIN_SELECTION_TIMEOUT =
+      new TransactionSelectionResult(BaseStatus.PLUGIN_SELECTION_TIMEOUT);
+
+  /**
+   * There was no more time for plugins to add transaction to the block, and the transaction is
+   * invalid
+   */
+  public static final TransactionSelectionResult PLUGIN_SELECTION_TIMEOUT_INVALID_TX =
+      new TransactionSelectionResult(BaseStatus.PLUGIN_SELECTION_TIMEOUT_INVALID_TX);
 
   /** Transaction took too much to evaluate, but it was valid */
   public static final TransactionSelectionResult TX_EVALUATION_TOO_LONG =


### PR DESCRIPTION
## PR description

This PR gives control on how much time plugins can use to propose their own transactions during block creation.

The max time is configurable in term of percentage of the overall block creation max time, using the new configuration option `plugin-block-txs-selection-max-time` that by default is set to `50` meaning `50%` or half of the overall block creation time.



## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


