### PR TITLE
Feature/uint256 op modulus

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -636,6 +636,7 @@ subprojects {
       description = "Usage: gradle jmh -Pincludes=MyBench -PasyncProfiler=<libPath> -PasyncProfilerOptions=<options>\n" +
         "\nRun JMH benchmarks in each of the projects. Allows for controlling JMH execution directly from the command line.\n" +
         "\t-Pincludes=<includePattern>\tInclude pattern (regular expression) for benchmarks to be executed. Defaults to including all benchmarks.\n" +
+        "\t-Pexcludes=<excludePattern>\tComma-separated exclude pattern (regular expression) for benchmarks to not be executed. Defaults to including all benchmarks.\n" +
         "\t-PasyncProfiler=<libPath>\tLibrary path to fetch the Async profiler from. Default is to disable profiling.\n" +
         "\t-PasyncProfilerOptions=<asyncProfilerOptions>\tOptions to pass on to the Async profiler separated by ';'. Default is to produce a flamegraph with all other default profiler options.\n"
     }
@@ -644,6 +645,7 @@ subprojects {
       jmhVersion = '1.37'
       fork = 3
       includes = _strListCmdArg('includes', [''])
+      excludes = _strListCmdArg('excludes', [])
       var asyncProfiler = _strCmdArg('asyncProfiler')
       var asyncProfilerOptions = _strCmdArg('asyncProfilerOptions', 'output=flamegraph')
       if (asyncProfiler != null) {
@@ -651,7 +653,7 @@ subprojects {
           'async:libPath=' + asyncProfiler + ';' + asyncProfilerOptions
         ]
       }
-      duplicateClassesStrategy = DuplicatesStrategy.WARN
+      duplicateClassesStrategy = DuplicatesStrategy.EXCLUDE
       jvmArgs = [
         '-XX:+EnableDynamicAgentLoading'
       ]

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/AddModOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/AddModOperationBenchmark.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.vm.operations;
+
+import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.operation.AddModOperation;
+import org.hyperledger.besu.evm.operation.Operation;
+
+public class AddModOperationBenchmark extends TernaryOperationBenchmark {
+
+  @Override
+  protected Operation.OperationResult invoke(final MessageFrame frame) {
+    return AddModOperation.staticOperation(frame);
+  }
+}

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/AddOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/AddOperationBenchmark.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.vm.operations;
+
+import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.operation.AddOperation;
+import org.hyperledger.besu.evm.operation.Operation;
+
+public class AddOperationBenchmark extends BinaryOperationBenchmark {
+
+  @Override
+  protected Operation.OperationResult invoke(final MessageFrame frame) {
+    return AddOperation.staticOperation(frame);
+  }
+}

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/BenchmarkHelper.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/BenchmarkHelper.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.vm.operations;
+
+import static org.mockito.Mockito.mock;
+
+import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.datatypes.Wei;
+import org.hyperledger.besu.evm.code.CodeV0;
+import org.hyperledger.besu.evm.frame.BlockValues;
+import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.worldstate.WorldUpdater;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+
+public class BenchmarkHelper {
+  public static MessageFrame createMessageFrame() {
+    return MessageFrame.builder()
+        .worldUpdater(mock(WorldUpdater.class))
+        .originator(Address.ZERO)
+        .gasPrice(Wei.ONE)
+        .blobGasPrice(Wei.ONE)
+        .blockValues(mock(BlockValues.class))
+        .miningBeneficiary(Address.ZERO)
+        .blockHashLookup((__, ___) -> Hash.ZERO)
+        .type(MessageFrame.Type.MESSAGE_CALL)
+        .initialGas(1_000_000)
+        .address(Address.ZERO)
+        .contract(Address.ZERO)
+        .inputData(Bytes32.ZERO)
+        .sender(Address.ZERO)
+        .value(Wei.ZERO)
+        .apparentValue(Wei.ZERO)
+        .code(CodeV0.EMPTY_CODE)
+        .completer(__ -> {})
+        .build();
+  }
+
+  /**
+   * Fills two arrays with random 32-byte values.
+   *
+   * @param aPool the destination array for first operands
+   * @param bPool the destination array for second operands
+   */
+  public static void fillPools(final Bytes[] aPool, final Bytes[] bPool) {
+    final ThreadLocalRandom random = ThreadLocalRandom.current();
+
+    for (int i = 0; i < aPool.length; i++) {
+      final int aSize = 1 + random.nextInt(32); // [1, 32]
+      final int bSize = 1 + random.nextInt(32);
+
+      final byte[] a = new byte[aSize];
+      final byte[] b = new byte[bSize];
+
+      random.nextBytes(a);
+      random.nextBytes(b);
+
+      aPool[i] = Bytes.wrap(a);
+      bPool[i] = Bytes.wrap(b);
+    }
+  }
+}

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/BinaryOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/BinaryOperationBenchmark.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.vm.operations;
+
+import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.operation.Operation;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+@State(Scope.Thread)
+@Warmup(iterations = 2, time = 1, timeUnit = TimeUnit.SECONDS)
+@OutputTimeUnit(value = TimeUnit.NANOSECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public abstract class BinaryOperationBenchmark {
+
+  protected static final int SAMPLE_SIZE = 30_000;
+
+  protected Bytes[] aPool;
+  protected Bytes[] bPool;
+  protected int index;
+  protected MessageFrame frame;
+
+  @Setup()
+  public void setUp() {
+    frame = BenchmarkHelper.createMessageFrame();
+    aPool = new Bytes[SAMPLE_SIZE];
+    bPool = new Bytes[SAMPLE_SIZE];
+    BenchmarkHelper.fillPools(aPool, bPool);
+    index = 0;
+  }
+
+  @Benchmark
+  public void baseline() {
+    final int idx = index;
+    index = (index + 1) % SAMPLE_SIZE;
+
+    frame.pushStackItem(bPool[idx]);
+    frame.pushStackItem(aPool[idx]);
+    frame.popStackItem();
+    frame.popStackItem();
+  }
+
+  @Benchmark
+  public void executeOperation(final Blackhole blackhole) {
+    final int i = index;
+    index = (index + 1) % SAMPLE_SIZE;
+
+    frame.pushStackItem(bPool[i]);
+    frame.pushStackItem(aPool[i]);
+
+    blackhole.consume(invoke(frame));
+
+    frame.popStackItem();
+  }
+
+  protected abstract Operation.OperationResult invoke(MessageFrame frame);
+}

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/DivOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/DivOperationBenchmark.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.vm.operations;
+
+import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.operation.DivOperation;
+import org.hyperledger.besu.evm.operation.Operation;
+
+public class DivOperationBenchmark extends BinaryOperationBenchmark {
+
+  @Override
+  protected Operation.OperationResult invoke(final MessageFrame frame) {
+    return DivOperation.staticOperation(frame);
+  }
+}

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/EqOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/EqOperationBenchmark.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.vm.operations;
+
+import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.operation.EqOperation;
+import org.hyperledger.besu.evm.operation.Operation;
+
+public class EqOperationBenchmark extends BinaryOperationBenchmark {
+
+  @Override
+  protected Operation.OperationResult invoke(final MessageFrame frame) {
+    return EqOperation.staticOperation(frame);
+  }
+}

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/ExpOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/ExpOperationBenchmark.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.vm.operations;
+
+import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
+import org.hyperledger.besu.evm.gascalculator.PragueGasCalculator;
+import org.hyperledger.besu.evm.operation.ExpOperation;
+import org.hyperledger.besu.evm.operation.Operation;
+
+public class ExpOperationBenchmark extends BinaryOperationBenchmark {
+
+  private static final GasCalculator PRAGUE_GAS_CALCULATOR = new PragueGasCalculator();
+
+  @Override
+  protected Operation.OperationResult invoke(final MessageFrame frame) {
+    return ExpOperation.staticOperation(frame, PRAGUE_GAS_CALCULATOR);
+  }
+}

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/GtOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/GtOperationBenchmark.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.vm.operations;
+
+import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.operation.GtOperation;
+import org.hyperledger.besu.evm.operation.Operation;
+
+public class GtOperationBenchmark extends BinaryOperationBenchmark {
+
+  @Override
+  protected Operation.OperationResult invoke(final MessageFrame frame) {
+    return GtOperation.staticOperation(frame);
+  }
+}

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/LtOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/LtOperationBenchmark.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.vm.operations;
+
+import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.operation.LtOperation;
+import org.hyperledger.besu.evm.operation.Operation;
+
+public class LtOperationBenchmark extends BinaryOperationBenchmark {
+
+  @Override
+  protected Operation.OperationResult invoke(final MessageFrame frame) {
+    return LtOperation.staticOperation(frame);
+  }
+}

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/ModOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/ModOperationBenchmark.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.vm.operations;
+
+import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.operation.ModOperation;
+import org.hyperledger.besu.evm.operation.Operation;
+
+public class ModOperationBenchmark extends BinaryOperationBenchmark {
+
+  @Override
+  protected Operation.OperationResult invoke(final MessageFrame frame) {
+    return ModOperation.staticOperation(frame);
+  }
+}

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/ModOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/ModOperationBenchmark.java
@@ -14,7 +14,6 @@
  */
 package org.hyperledger.besu.ethereum.vm.operations;
 
-import org.hyperledger.besu.evm.UInt256;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.operation.ModOperation;
 import org.hyperledger.besu.evm.operation.Operation;
@@ -23,11 +22,9 @@ import java.math.BigInteger;
 import java.util.concurrent.ThreadLocalRandom;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Setup;
-import org.openjdk.jmh.infra.Blackhole;
 
 public class ModOperationBenchmark extends BinaryOperationBenchmark {
   // Benches for a % b

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/ModOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/ModOperationBenchmark.java
@@ -14,11 +14,106 @@
  */
 package org.hyperledger.besu.ethereum.vm.operations;
 
+import org.hyperledger.besu.evm.UInt256;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.operation.ModOperation;
 import org.hyperledger.besu.evm.operation.Operation;
 
+import java.math.BigInteger;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.infra.Blackhole;
+
 public class ModOperationBenchmark extends BinaryOperationBenchmark {
+  // Benches for a % b
+
+  // Define available scenarios
+  public enum Case {
+    DIV1_MOD1(1, 1),
+    DIV2_MOD1(2, 1),
+    DIV2_MOD2(2, 2),
+    DIV4_MOD1(4, 1),
+    DIV4_MOD2(4, 2),
+    DIV4_MOD4(4, 4),
+    DIV6_MOD1(6, 1),
+    DIV6_MOD2(6, 2),
+    DIV6_MOD4(6, 4),
+    DIV6_MOD6(6, 6),
+    DIV8_MOD1(8, 1),
+    DIV8_MOD2(8, 2),
+    DIV8_MOD4(8, 4),
+    DIV8_MOD6(8, 6),
+    DIV8_MOD8(8, 8),
+    MOD4_LARGER_THAN_DIV2(2, 4),
+    MOD8_LARGER_THAN_DIV6(6, 8),
+    ZERO_MOD_DIV4(4, 0);
+
+    final int divSize;
+    final int modSize;
+
+    Case(final int divSize, final int modSize) {
+      this.divSize = divSize;
+      this.modSize = modSize;
+    }
+  }
+
+  @Param({
+    "DIV1_MOD1",
+    "DIV2_MOD1",
+    "DIV2_MOD2",
+    "DIV4_MOD1",
+    "DIV4_MOD2",
+    "DIV4_MOD4",
+    "DIV6_MOD1",
+    "DIV6_MOD2",
+    "DIV6_MOD4",
+    "DIV6_MOD6",
+    "DIV8_MOD1",
+    "DIV8_MOD2",
+    "DIV8_MOD4",
+    "DIV8_MOD6",
+    "DIV8_MOD8",
+    "MOD4_LARGER_THAN_DIV2",
+    "MOD8_LARGER_THAN_DIV6",
+    "ZERO_MOD_DIV4"
+  })
+  private String caseName;
+
+  @Setup(Level.Iteration)
+  @Override
+  public void setUp() {
+    frame = BenchmarkHelper.createMessageFrame();
+
+    Case scenario = Case.valueOf(caseName);
+    aPool = new Bytes[SAMPLE_SIZE];
+    bPool = new Bytes[SAMPLE_SIZE];
+
+    final ThreadLocalRandom random = ThreadLocalRandom.current();
+
+    for (int i = 0; i < SAMPLE_SIZE; i++) {
+      final byte[] a = new byte[scenario.divSize * 4];
+      final byte[] b = new byte[scenario.modSize * 4];
+      random.nextBytes(a);
+      random.nextBytes(b);
+
+      BigInteger aInt = new BigInteger(a);
+      BigInteger bInt = new BigInteger(b);
+
+      if ((scenario.divSize == scenario.modSize) && (aInt.compareTo(bInt) < 0)) {
+        aPool[i] = Bytes.wrap(b);
+        bPool[i] = Bytes.wrap(a);
+      } else {
+        aPool[i] = Bytes.wrap(a);
+        bPool[i] = Bytes.wrap(b);
+      }
+    }
+    index = 0;
+  }
 
   @Override
   protected Operation.OperationResult invoke(final MessageFrame frame) {

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/MulModOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/MulModOperationBenchmark.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.vm.operations;
+
+import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.operation.MulModOperation;
+import org.hyperledger.besu.evm.operation.Operation;
+
+public class MulModOperationBenchmark extends TernaryOperationBenchmark {
+
+  @Override
+  protected Operation.OperationResult invoke(final MessageFrame frame) {
+    return MulModOperation.staticOperation(frame);
+  }
+}

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/MulOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/MulOperationBenchmark.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.vm.operations;
+
+import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.operation.MulOperation;
+import org.hyperledger.besu.evm.operation.Operation;
+
+public class MulOperationBenchmark extends BinaryOperationBenchmark {
+
+  @Override
+  protected Operation.OperationResult invoke(final MessageFrame frame) {
+    return MulOperation.staticOperation(frame);
+  }
+}

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/SDivOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/SDivOperationBenchmark.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.hyperledger.besu.ethereum.vm.operations;
 
 import org.hyperledger.besu.evm.frame.MessageFrame;

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/SDivOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/SDivOperationBenchmark.java
@@ -1,0 +1,12 @@
+package org.hyperledger.besu.ethereum.vm.operations;
+
+import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.operation.Operation;
+import org.hyperledger.besu.evm.operation.SDivOperation;
+
+public class SDivOperationBenchmark extends BinaryOperationBenchmark {
+  @Override
+  protected Operation.OperationResult invoke(final MessageFrame frame) {
+    return SDivOperation.staticOperation(frame);
+  }
+}

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/SLtOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/SLtOperationBenchmark.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.vm.operations;
+
+import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.operation.Operation;
+import org.hyperledger.besu.evm.operation.SLtOperation;
+
+public class SLtOperationBenchmark extends BinaryOperationBenchmark {
+
+  @Override
+  protected Operation.OperationResult invoke(final MessageFrame frame) {
+    return SLtOperation.staticOperation(frame);
+  }
+}

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/SModOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/SModOperationBenchmark.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.vm.operations;
+
+import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.operation.Operation;
+import org.hyperledger.besu.evm.operation.SModOperation;
+
+public class SModOperationBenchmark extends BinaryOperationBenchmark {
+
+  @Override
+  protected Operation.OperationResult invoke(final MessageFrame frame) {
+    return SModOperation.staticOperation(frame);
+  }
+}

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/SignExtendOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/SignExtendOperationBenchmark.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.vm.operations;
+
+import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.operation.Operation;
+import org.hyperledger.besu.evm.operation.SignExtendOperation;
+
+public class SignExtendOperationBenchmark extends BinaryOperationBenchmark {
+
+  @Override
+  protected Operation.OperationResult invoke(final MessageFrame frame) {
+    return SignExtendOperation.staticOperation(frame);
+  }
+}

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/SubOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/SubOperationBenchmark.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.vm.operations;
+
+import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.operation.Operation;
+import org.hyperledger.besu.evm.operation.SubOperation;
+
+public class SubOperationBenchmark extends BinaryOperationBenchmark {
+
+  @Override
+  protected Operation.OperationResult invoke(final MessageFrame frame) {
+    return SubOperation.staticOperation(frame);
+  }
+}

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/TernaryOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/TernaryOperationBenchmark.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.vm.operations;
+
+import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.operation.Operation;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+@State(Scope.Thread)
+@Warmup(iterations = 2, time = 1, timeUnit = TimeUnit.SECONDS)
+@OutputTimeUnit(value = TimeUnit.NANOSECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public abstract class TernaryOperationBenchmark {
+
+  protected static final int SAMPLE_SIZE = 30_000;
+
+  protected Bytes[] aPool;
+  protected Bytes[] bPool;
+  protected Bytes[] cPool;
+  protected int index;
+  protected MessageFrame frame;
+
+  @Setup()
+  public void setUp() {
+    frame = BenchmarkHelper.createMessageFrame();
+    aPool = new Bytes[SAMPLE_SIZE];
+    bPool = new Bytes[SAMPLE_SIZE];
+    cPool = new Bytes[SAMPLE_SIZE];
+    BenchmarkHelper.fillPools(aPool, bPool);
+    BenchmarkHelper.fillPools(cPool, new Bytes[SAMPLE_SIZE]);
+    index = 0;
+  }
+
+  @Benchmark
+  public void baseline() {
+    final int idx = index;
+    index = (index + 1) % SAMPLE_SIZE;
+
+    frame.pushStackItem(cPool[idx]);
+    frame.pushStackItem(bPool[idx]);
+    frame.pushStackItem(aPool[idx]);
+    frame.popStackItem();
+    frame.popStackItem();
+    frame.popStackItem();
+  }
+
+  @Benchmark
+  public void executeOperation(final Blackhole blackhole) {
+    final int i = index;
+    index = (index + 1) % SAMPLE_SIZE;
+
+    frame.pushStackItem(cPool[i]);
+    frame.pushStackItem(bPool[i]);
+    frame.pushStackItem(aPool[i]);
+
+    blackhole.consume(invoke(frame));
+
+    frame.popStackItem();
+  }
+
+  protected abstract Operation.OperationResult invoke(MessageFrame frame);
+}

--- a/evm/src/main/java/org/hyperledger/besu/evm/UInt256.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/UInt256.java
@@ -1,0 +1,405 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.evm;
+
+import java.util.Arrays;
+
+/**
+ * 256-bits wide unsigned integer class.
+ *
+ * <p>This class is an optimised version of BigInteger for fixed width 8byte integers
+ */
+public final class UInt256 {
+  // Wraps a view over limbs array from 0..length.
+  // Limbs are little-endian and can perhaps have more elements than length, which are ignored.
+  private final int[] limbs;
+  private final int length;
+
+  // --- Getters for testing ---
+  int length() {
+    return length;
+  }
+
+  int[] limbs() {
+    return limbs;
+  }
+
+  // --- Preallocating small integers 0..nSmallInts ---
+  private static final int nSmallInts = 256;
+  private static final UInt256[] smallInts = new UInt256[nSmallInts];
+
+  static {
+    smallInts[0] = new UInt256(new int[] {});
+    for (int i = 1; i < nSmallInts; i++) {
+      smallInts[i] = new UInt256(new int[] {i});
+    }
+  }
+
+  /** The constant 0. */
+  public static final UInt256 ZERO = smallInts[0];
+
+  /** The constant 1. */
+  public static final UInt256 ONE = smallInts[1];
+
+  /** The constant 2. */
+  public static final UInt256 TWO = smallInts[2];
+
+  /** The constant 10. */
+  public static final UInt256 TEN = smallInts[10];
+
+  /** The constant 16. */
+  public static final UInt256 SIXTEEN = smallInts[16];
+
+  // --- Constructors ---
+
+  UInt256(final int[] limbs, final int length) {
+    this.limbs = limbs;
+    this.length = length;
+    // Unchecked length: assumes length is properly set.
+  }
+
+  UInt256(final int[] limbs) {
+    int i = Math.min(limbs.length - 1, 7);
+    while ((i >= 0) && (limbs[i] == 0)) i--;
+    this.limbs = limbs;
+    this.length = i + 1;
+  }
+
+  /**
+   * Instantiates a new UInt256 from byte[].
+   *
+   * @param bytes raw bytes in BigEndian order.
+   * @return Big-endian UInt256 represented by the bytes.
+   */
+  public static UInt256 fromBytesBE(final byte[] bytes) {
+    int offset = 0;
+    while ((offset < bytes.length) && (bytes[offset] == 0x00)) ++offset;
+    int nBytes = bytes.length - offset;
+    if (nBytes == 0) return ZERO;
+    int len = (nBytes + 3) / 4;
+    int[] limbs = new int[len];
+
+    int i;
+    int base;
+    // Up to most significant limb take 4 bytes.
+    for (i = 0, base = bytes.length - 4; i < len - 1; ++i, base = base - 4) {
+      limbs[i] =
+          (bytes[base] << 24)
+              | ((bytes[base + 1] & 0xFF) << 16)
+              | ((bytes[base + 2] & 0xFF) << 8)
+              | ((bytes[base + 3] & 0xFF));
+    }
+    // Last effective limb
+    limbs[i] =
+        switch (nBytes - i * 4) {
+          case 1 -> ((bytes[offset] & 0xFF));
+          case 2 -> (((bytes[offset] & 0xFF) << 8) | (bytes[offset + 1] & 0xFF));
+          case 3 ->
+              (((bytes[offset] & 0xFF) << 16)
+                  | ((bytes[offset + 1] & 0xFF) << 8)
+                  | (bytes[offset + 2] & 0xFF));
+          case 4 ->
+              ((bytes[offset] << 24)
+                  | ((bytes[offset + 1] & 0xFF) << 16)
+                  | ((bytes[offset + 2] & 0xFF) << 8)
+                  | (bytes[offset + 3] & 0xFF));
+          default -> throw new IllegalStateException("Unexpected value");
+        };
+    return new UInt256(limbs, len);
+  }
+
+  /**
+   * Instantiates a new UInt256 from an int.
+   *
+   * @param value int value to convert to UInt256.
+   * @return The UInt256 equivalent of value.
+   */
+  public static UInt256 fromInt(final int value) {
+    if (0 <= value && value < nSmallInts) return smallInts[value];
+    return new UInt256(new int[] {value}, 1);
+  }
+
+  /**
+   * Instantiates a new UInt256 from a long.
+   *
+   * @param value long value to convert to UInt256.
+   * @return The UInt256 equivalent of value.
+   */
+  public static UInt256 fromLong(final long value) {
+    if (0 <= value && value < nSmallInts) return smallInts[(int) value];
+    return new UInt256(new int[] {(int) value, (int) (value >>> 32)});
+  }
+
+  // ---- conversion ----
+
+  /**
+   * Convert to int.
+   *
+   * @return Value truncated to an int, possibly lossy.
+   */
+  public int intValue() {
+    return (limbs.length == 0 ? 0 : limbs[0]);
+  }
+
+  /**
+   * Convert to long.
+   *
+   * @return Value truncated to a long, possibly lossy.
+   */
+  public long longValue() {
+    switch (length) {
+      case 0 -> {
+        return 0L;
+      }
+      case 1 -> {
+        return (limbs[0] & 0xFFFFFFFFL);
+      }
+      default -> {
+        return (limbs[0] & 0xFFFFFFFFL) | ((limbs[1] & 0xFFFFFFFFL) << 32);
+      }
+    }
+  }
+
+  /**
+   * Convert to BigEndian byte array.
+   *
+   * @return Big-endian ordered bytes for this UInt256 value.
+   */
+  public byte[] toBytesBE() {
+    byte[] out = new byte[length * 4];
+    for (int i = 0; i < length; ++i) {
+      int offset = i * 4;
+      int v = limbs[length - i - 1];
+      out[offset] = (byte) (v >>> 24);
+      out[offset + 1] = (byte) (v >>> 16);
+      out[offset + 2] = (byte) (v >>> 8);
+      out[offset + 3] = (byte) v;
+    }
+    return out;
+  }
+
+  // ---- comparison ----
+
+  /**
+   * Is the value 0 ?
+   *
+   * @return true if this UInt256 value is 0.
+   */
+  public boolean isZero() {
+    if (length == 0) return true;
+    for (int i = 0; i < length; i++) {
+      if (limbs[i] != 0) return false;
+    }
+    return true;
+  }
+
+  /**
+   * Compares two UInt256.
+   *
+   * @param a left UInt256
+   * @param b right UInt256
+   * @return 0 if a == b, negative if a &lt; b and positive if a &gt; b.
+   */
+  public static int compare(final UInt256 a, final UInt256 b) {
+    int comp = Integer.compare(a.length, b.length);
+    if (comp != 0) return comp;
+    for (int i = a.length - 1; i >= 0; i--) {
+      comp = Integer.compareUnsigned(a.limbs[i], b.limbs[i]);
+      if (comp != 0) return comp;
+    }
+    return 0;
+  }
+
+  private int[] shiftLeftWithCarry(final int shift) {
+    int limbShift = shift / 32;
+    int bitShift = shift % 32;
+    if (bitShift == 0) {
+      return Arrays.copyOfRange(limbs, limbShift, length + limbShift);
+    }
+
+    int[] res = new int[length + limbShift + 1];
+    int j = limbShift;
+    int carry = 0;
+    for (int i = 0; (i < length) && (j < 8); ++i, ++j) {
+      res[j] = (limbs[i] << bitShift) | carry;
+      carry = limbs[i] >>> (32 - bitShift);
+    }
+    res[j] = carry; // last carry
+    return res;
+  }
+
+  /**
+   * Shifts value to the left.
+   *
+   * @param shift number of bits to shift. If negative, shift right instead.
+   * @return Shifted UInt256 value.
+   */
+  public UInt256 shiftLeft(final int shift) {
+    if (shift < 0) return shiftRight(-shift);
+    if (shift == 0 || isZero()) return this;
+    if (shift >= length * 32) return ZERO;
+    return new UInt256(shiftLeftWithCarry(shift));
+  }
+
+  /**
+   * Shifts value to the right.
+   *
+   * @param shift number of bits to shift. If negative, shift left instead.
+   * @return Shifted UInt256 value.
+   */
+  public UInt256 shiftRight(final int shift) {
+    if (shift < 0) return shiftLeft(-shift);
+    if (shift == 0 || isZero()) return this;
+    if (shift >= length * 32) return ZERO;
+
+    int limbShift = shift / 32;
+    int bitShift = shift % 32;
+    if (bitShift == 0) {
+      return new UInt256(Arrays.copyOfRange(limbs, limbShift, length), length - limbShift);
+    }
+
+    int[] res = new int[this.limbs.length - limbShift];
+    int j = this.limbs.length - 1 - limbShift; // res index
+    int carry = 0;
+    for (int i = this.limbs.length - 1; j >= 0; i--, j--) {
+      int r = (limbs[i] >>> bitShift) | carry;
+      res[j] = r;
+      carry = limbs[i] << (32 - bitShift);
+    }
+    return new UInt256(res);
+  }
+
+  /**
+   * Reduce modulo divisor.
+   *
+   * @param divisor The modulus of the reduction
+   * @return The remainder modulo {@code divisor}.
+   */
+  public UInt256 mod(final UInt256 divisor) {
+    if (divisor.isZero()) return ZERO;
+    int cmp = compare(this, divisor);
+    if (cmp < 0) return this;
+    if (cmp == 0) return ZERO;
+
+    int n = divisor.length;
+    if (n == 1) {
+      long d = divisor.limbs[0] & 0xFFFFFFFFL;
+      long rem = 0;
+      // Process from most significant limb downwards
+      for (int i = length - 1; i >= 0; i--) {
+        long cur = (rem << 32) | (limbs[i] & 0xFFFFFFFFL);
+        rem = Long.remainderUnsigned(cur, d);
+      }
+      return new UInt256(new int[] {(int) rem});
+    }
+
+    // --- Shortcut: divisor fits in 64 bits (2 limbs) ---
+    // if (n == 2) {
+    //   long d = ((long) divisor.limbs[1] << 32) | (divisor.limbs[0] & 0xFFFFFFFFL);
+    //  long rem = 0;
+    // Process from most significant limb downwards
+    // for (int i = length - 1; i >= 0; i--) {
+    //    long cur = (rem << 32) | (limbs[i] & 0xFFFFFFFFL);
+    //    rem = Long.remainderUnsigned(cur, d);
+    //  }
+    //  int lo = (int) rem;
+    //  int hi = (int) (rem >>> 32);
+    //  return new UInt256(new int[] {lo, hi});
+    // }
+
+    // --- Knuth Division ---
+
+    // Normalize
+    // Makes 2 copies of limbs: optim ?
+    int shift = Integer.numberOfLeadingZeros(divisor.limbs[n - 1]);
+    int[] vLimbs = divisor.shiftLeftWithCarry(shift);
+    int[] uLimbs = this.shiftLeftWithCarry(shift);
+
+    // Main division loop
+    int m = uLimbs.length - n - 1;
+    for (int j = m; j >= 0; j--) {
+      long ujn = (uLimbs[j + n] & 0xFFFFFFFFL);
+      long ujn1 = (uLimbs[j + n - 1] & 0xFFFFFFFFL);
+      long ujn2 = (uLimbs[j + n - 2] & 0xFFFFFFFFL);
+      long vn1 = vLimbs[n - 1] & 0xFFFFFFFFL;
+      long vn2 = (n > 1) ? vLimbs[n - 2] & 0xFFFFFFFFL : 0;
+
+      long dividendPart = (ujn << 32) | ujn1;
+      // Check that no need for Unsigned version of divrem.
+      long qhat = dividendPart / vn1;
+      long rhat = dividendPart % vn1;
+
+      while (qhat == 0x1_0000_0000L || (qhat * vn2) > ((rhat << 32) | ujn2)) {
+        qhat--;
+        rhat += vn1;
+        if (rhat >= 0x1_0000_0000L) break;
+      }
+
+      // Multiply-subtract qhat*v from u slice
+      long borrow = 0;
+      for (int i = 0; i < n; i++) {
+        long prod = (vLimbs[i] & 0xFFFFFFFFL) * qhat;
+        long sub = (uLimbs[i + j] & 0xFFFFFFFFL) - (prod & 0xFFFFFFFFL) - borrow;
+        uLimbs[i + j] = (int) sub;
+        borrow = (prod >>> 32) - (sub >> 63);
+      }
+      long sub = (uLimbs[j + n] & 0xFFFFFFFFL) - borrow;
+      uLimbs[j + n] = (int) sub;
+
+      if (sub < 0) {
+        // Add back
+        long carry = 0;
+        for (int i = 0; i < n; i++) {
+          long sum = (uLimbs[i + j] & 0xFFFFFFFFL) + (vLimbs[i] & 0xFFFFFFFFL) + carry;
+          uLimbs[i + j] = (int) sum;
+          carry = sum >>> 32;
+        }
+        uLimbs[j + n] = (int) (uLimbs[j + n] + carry);
+      }
+    }
+
+    // Unnormalize remainder
+    return (new UInt256(uLimbs, n)).shiftRight(shift);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder("0x");
+    for (byte b : toBytesBE()) {
+      sb.append(String.format("%02x", b));
+    }
+    return sb.toString();
+  }
+
+  @Override
+  public boolean equals(final Object obj) {
+    if (this == obj) return true;
+    if (!(obj instanceof UInt256)) return false;
+    UInt256 other = (UInt256) obj;
+
+    // Compare lengths after trimming leading zero limbs
+    int cmp = UInt256.compare(this, other);
+    return cmp == 0;
+  }
+
+  @Override
+  public int hashCode() {
+    int h = 1;
+    for (int i = 0; i < length; i++) {
+      h = 31 * h + limbs[i];
+    }
+    return h;
+  }
+}

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/ModOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/ModOperation.java
@@ -15,14 +15,11 @@
 package org.hyperledger.besu.evm.operation;
 
 import org.hyperledger.besu.evm.EVM;
+import org.hyperledger.besu.evm.UInt256;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
-import java.math.BigInteger;
-import java.util.Arrays;
-
 import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.bytes.Bytes32;
 
 /** The Mod operation. */
 public class ModOperation extends AbstractFixedCostOperation {
@@ -53,24 +50,11 @@ public class ModOperation extends AbstractFixedCostOperation {
   public static OperationResult staticOperation(final MessageFrame frame) {
     final Bytes value0 = frame.popStackItem();
     final Bytes value1 = frame.popStackItem();
-    if (value1.isZero()) {
-      frame.pushStackItem(Bytes32.ZERO);
-    } else {
-      BigInteger b1 = new BigInteger(1, value0.toArrayUnsafe());
-      BigInteger b2 = new BigInteger(1, value1.toArrayUnsafe());
-      final BigInteger result = b1.mod(b2);
-
-      Bytes resultBytes = Bytes.wrap(result.toByteArray());
-      if (resultBytes.size() > 32) {
-        resultBytes = resultBytes.slice(resultBytes.size() - 32, 32);
-      }
-
-      final byte[] padding = new byte[32 - resultBytes.size()];
-      Arrays.fill(padding, result.signum() < 0 ? (byte) 0xFF : 0x00);
-
-      frame.pushStackItem(Bytes.concatenate(Bytes.wrap(padding), resultBytes));
-    }
-
+    UInt256 b1 = UInt256.fromBytesBE(value0.toArrayUnsafe());
+    UInt256 b2 = UInt256.fromBytesBE(value1.toArrayUnsafe());
+    final UInt256 result = b1.mod(b2);
+    Bytes resultBytes = Bytes.wrap(result.toBytesBE());
+    frame.pushStackItem(resultBytes);
     return modSuccess;
   }
 }

--- a/evm/src/test/java/org/hyperledger/besu/evm/UInt256Test.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/UInt256Test.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.evm;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigInteger;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+
+public class UInt256Test {
+
+  @Test
+  public void fromInts() {
+    UInt256 result;
+
+    result = UInt256.fromInt(0);
+    assertThat(result.length()).as("Int 0 length").isEqualTo(0);
+    assertThat(result.isZero()).as("Int 0, isZero").isTrue();
+
+    int[] testInts = new int[] {130, -128, 32500};
+    for (int i : testInts) {
+      result = UInt256.fromInt(i);
+      assertThat(result.length()).as(String.format("Int %s length", i)).isEqualTo(1);
+      assertThat(result.intValue()).as(String.format("Int %s value", i)).isEqualTo(i);
+    }
+  }
+
+  @Test
+  public void fromBytesBE() {
+    byte[] input;
+    UInt256 result;
+    int[] expectedLimbs;
+
+    input = new byte[] {-128, 0, 0, 0};
+    result = UInt256.fromBytesBE(input);
+    expectedLimbs = new int[] {-2147483648};
+    assertThat(result.length()).as("4b-neg-length").isEqualTo(expectedLimbs.length);
+    assertThat(result.limbs()).as("4b-neg-limbs").isEqualTo(expectedLimbs);
+
+    input = new byte[] {0, 0, 1, 1, 1};
+    result = UInt256.fromBytesBE(input);
+    expectedLimbs = new int[] {1 + 256 + 65536};
+    assertThat(result.length()).as("3b-length").isEqualTo(expectedLimbs.length);
+    assertThat(result.limbs()).as("3b-limbs").isEqualTo(expectedLimbs);
+
+    input = new byte[] {1, 0, 0, 0, 0, 1, 1, 1};
+    result = UInt256.fromBytesBE(input);
+    expectedLimbs = new int[] {1 + 256 + 65536, 16777216};
+    assertThat(result.length()).as("8b-length").isEqualTo(expectedLimbs.length);
+    assertThat(result.limbs()).as("8b-limbs").isEqualTo(expectedLimbs);
+
+    input =
+        new byte[] {
+          1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+        };
+    result = UInt256.fromBytesBE(input);
+    expectedLimbs = new int[] {0, 0, 0, 0, 0, 0, 0, 16777216};
+    assertThat(result.length()).as("32b-length").isEqualTo(expectedLimbs.length);
+    assertThat(result.limbs()).as("32b-limbs").isEqualTo(expectedLimbs);
+
+    input =
+        new byte[] {
+          0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0,
+          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+        };
+    result = UInt256.fromBytesBE(input);
+    expectedLimbs = new int[] {0, 0, 0, 0, 0, 0, 257};
+    assertThat(result.length()).as("32b-padded-length").isEqualTo(expectedLimbs.length);
+    assertThat(result.limbs()).as("32b-padded-limbs").isEqualTo(expectedLimbs);
+  }
+
+  @Test
+  public void fromToBytesBE() {
+    byte[] input =
+        new byte[] {
+          1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+          1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
+        };
+    UInt256 asUint = UInt256.fromBytesBE(input);
+    BigInteger asBigInt = new BigInteger(1, input);
+    assertThat(asUint.toBytesBE()).isEqualTo(asBigInt.toByteArray());
+  }
+
+  @Test
+  public void smallInts() {
+    UInt256 number = UInt256.fromInt(523);
+    UInt256 modulus = UInt256.fromInt(27);
+    UInt256 remainder = number.mod(modulus);
+    UInt256 expected = UInt256.fromInt(523 % 27);
+    assertThat(remainder).isEqualTo(expected);
+  }
+
+  @Test
+  public void smallMod() {
+    byte[] num_arr =
+        new byte[] {
+          1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+          1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
+        };
+    UInt256 number = UInt256.fromBytesBE(num_arr);
+    UInt256 modulus = UInt256.fromInt(27);
+    int remainder = number.mod(modulus).intValue();
+    BigInteger big_number = new BigInteger(1, num_arr);
+    BigInteger big_modulus = BigInteger.valueOf(27L);
+    int expected = big_number.mod(big_modulus).intValue();
+    assertThat(remainder).isEqualTo(expected);
+  }
+
+  @Test
+  public void smallModFullDividend() {
+    byte[] num_arr =
+        new byte[] {
+          1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+          1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, -127
+        };
+    UInt256 number = UInt256.fromBytesBE(num_arr);
+    UInt256 modulus = UInt256.fromInt(27);
+    int remainder = number.mod(modulus).intValue();
+    BigInteger big_number = new BigInteger(1, num_arr);
+    BigInteger big_modulus = BigInteger.valueOf(27L);
+    int expected = big_number.mod(big_modulus).intValue();
+    assertThat(remainder).isEqualTo(expected);
+  }
+
+  @Test
+  public void bigMod() {
+    byte[] num_arr =
+        new byte[] {
+          1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+          1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
+        };
+    byte[] mod_arr = new byte[] {-111, 126, 78, 12};
+    UInt256 number = UInt256.fromBytesBE(num_arr);
+    UInt256 modulus = UInt256.fromBytesBE(mod_arr);
+    Bytes32 remainder = Bytes32.leftPad(Bytes.wrap(number.mod(modulus).toBytesBE()));
+    BigInteger big_number = new BigInteger(1, num_arr);
+    BigInteger big_modulus = new BigInteger(1, mod_arr);
+    Bytes32 expected = Bytes32.leftPad(Bytes.wrap(big_number.mod(big_modulus).toByteArray()));
+    assertThat(remainder).isEqualTo(expected);
+  }
+
+  @Test
+  public void bigModWithExtraCarry() {
+    byte[] num_arr =
+        new byte[] {
+          -126, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+          1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 123
+        };
+    byte[] mod_arr = new byte[] {12, 126, 78, -11};
+    UInt256 number = UInt256.fromBytesBE(num_arr);
+    UInt256 modulus = UInt256.fromBytesBE(mod_arr);
+    Bytes32 remainder = Bytes32.leftPad(Bytes.wrap(number.mod(modulus).toBytesBE()));
+    BigInteger big_number = new BigInteger(1, num_arr);
+    BigInteger big_modulus = new BigInteger(1, mod_arr);
+    Bytes32 expected = Bytes32.leftPad(Bytes.wrap(big_number.mod(big_modulus).toByteArray()));
+    assertThat(remainder).isEqualTo(expected);
+  }
+
+  @Test
+  public void modA() {
+    byte[] num_arr = new byte[] {0x00, 0x00, 0x00, 0x00, 0x67, (byte) 0xe3, 0x68, 0x64};
+    byte[] mod_arr = new byte[] {0x00, 0x1f, (byte) 0xff};
+    UInt256 number = UInt256.fromBytesBE(num_arr);
+    UInt256 modulus = UInt256.fromBytesBE(mod_arr);
+    Bytes32 remainder = Bytes32.leftPad(Bytes.wrap(number.mod(modulus).toBytesBE()));
+    BigInteger big_number = new BigInteger(1, num_arr);
+    BigInteger big_modulus = new BigInteger(1, mod_arr);
+    Bytes32 expected = Bytes32.leftPad(Bytes.wrap(big_number.mod(big_modulus).toByteArray()));
+    assertThat(remainder).isEqualTo(expected);
+  }
+
+  @Test
+  public void modB() {
+    byte[] num_arr =
+        new byte[] {0x02, 0x2b, 0x1c, (byte) 0x8c, 0x12, 0x27, (byte) 0xa0, 0x00, 0x00};
+    byte[] mod_arr =
+        new byte[] {0x03, (byte) 0x8d, 0x7e, (byte) 0xa4, (byte) 0xc6, (byte) 0x80, 0x00};
+    UInt256 number = UInt256.fromBytesBE(num_arr);
+    UInt256 modulus = UInt256.fromBytesBE(mod_arr);
+    Bytes32 remainder = Bytes32.leftPad(Bytes.wrap(number.mod(modulus).toBytesBE()));
+    BigInteger big_number = new BigInteger(1, num_arr);
+    BigInteger big_modulus = new BigInteger(1, mod_arr);
+    Bytes32 expected = Bytes32.leftPad(Bytes.wrap(big_number.mod(big_modulus).toByteArray()));
+    assertThat(remainder).isEqualTo(expected);
+  }
+}


### PR DESCRIPTION
## PR description

This PR implements the MOD operation in the EVM using a custom UInt256 class meant to replace BigInteger for optimised arithmetics.

The UInt256 class should grow to contain other arithmetic operations, but as of now contains mod, computing the remainder of a division by the modulus. It should run about 45% faster than with BigIntegers (depending on integers' sizes). More optimisations should come later as well, but this should be already useful for early release.

## Fixed Issue(s)
No issue seems to be open for this.


### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


