### PR TITLE
disable bal for transaction selection when not activated

### DIFF
--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreator.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreator.java
@@ -47,6 +47,7 @@ import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
 import org.hyperledger.besu.ethereum.mainnet.ScheduleBasedBlockHeaderFunctions;
 import org.hyperledger.besu.ethereum.mainnet.WithdrawalsProcessor;
+import org.hyperledger.besu.ethereum.mainnet.block.access.list.BlockAccessListFactory;
 import org.hyperledger.besu.ethereum.mainnet.feemarket.ExcessBlobGasCalculator;
 import org.hyperledger.besu.ethereum.mainnet.requests.RequestProcessingContext;
 import org.hyperledger.besu.ethereum.mainnet.requests.RequestProcessorCoordinator;
@@ -194,7 +195,10 @@ public abstract class AbstractBlockCreator implements AsyncBlockCreator {
       final ProtocolSpec newProtocolSpec =
           protocolSchedule.getForNextBlockHeader(parentHeader, timestamp);
       final boolean includeBlockAccessList =
-          newProtocolSpec.getBlockAccessListFactory().isPresent();
+          newProtocolSpec
+              .getBlockAccessListFactory()
+              .filter(BlockAccessListFactory::isForkActivated)
+              .isPresent();
 
       final ProcessableBlockHeader processableBlockHeader =
           createPending(

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/BlockTransactionSelector.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/BlockTransactionSelector.java
@@ -166,7 +166,7 @@ public class BlockTransactionSelector implements BlockTransactionSelectionServic
     maybeBlockAccessListBuilder =
         protocolSpec
             .getBlockAccessListFactory()
-            .filter(BlockAccessListFactory::isEnabled)
+            .filter(BlockAccessListFactory::isForkActivated)
             .map(BlockAccessListFactory::newBlockAccessListBuilder);
   }
 

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/BlockTransactionSelector.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/BlockTransactionSelector.java
@@ -45,6 +45,7 @@ import org.hyperledger.besu.ethereum.mainnet.MainnetTransactionProcessor;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
 import org.hyperledger.besu.ethereum.mainnet.TransactionValidationParams;
 import org.hyperledger.besu.ethereum.mainnet.block.access.list.BlockAccessList;
+import org.hyperledger.besu.ethereum.mainnet.block.access.list.BlockAccessListFactory;
 import org.hyperledger.besu.ethereum.mainnet.block.access.list.TransactionAccessList;
 import org.hyperledger.besu.ethereum.processing.TransactionProcessingResult;
 import org.hyperledger.besu.evm.blockhash.BlockHashLookup;
@@ -115,7 +116,7 @@ public class BlockTransactionSelector implements BlockTransactionSelectionServic
   private final EthScheduler ethScheduler;
   private final AtomicBoolean isTimeout = new AtomicBoolean(false);
   private final long blockTxsSelectionMaxTime;
-  private final BlockAccessList.BlockAccessListBuilder balBuilder;
+  private final Optional<BlockAccessList.BlockAccessListBuilder> maybeBlockAccessListBuilder;
   private WorldUpdater blockWorldStateUpdater;
   private WorldUpdater txWorldStateUpdater;
   private volatile TransactionEvaluationContext currTxEvaluationContext;
@@ -161,7 +162,12 @@ public class BlockTransactionSelector implements BlockTransactionSelectionServic
     blockWorldStateUpdater = worldState.updater();
     txWorldStateUpdater = blockWorldStateUpdater.updater();
     blockTxsSelectionMaxTime = miningConfiguration.getBlockTxsSelectionMaxTime();
-    balBuilder = new BlockAccessList.BlockAccessListBuilder();
+
+    maybeBlockAccessListBuilder =
+        protocolSpec
+            .getBlockAccessListFactory()
+            .filter(BlockAccessListFactory::isEnabled)
+            .map(BlockAccessListFactory::newBlockAccessListBuilder);
   }
 
   private List<AbstractTransactionSelector> createTransactionSelectors(
@@ -192,7 +198,10 @@ public class BlockTransactionSelector implements BlockTransactionSelectionServic
         .setMessage("Transaction selection result {}")
         .addArgument(transactionSelectionResults::toTraceLog)
         .log();
-    transactionSelectionResults.setBlockAccessList(balBuilder.build());
+    maybeBlockAccessListBuilder.ifPresent(
+        blockAccessListBuilder -> {
+          transactionSelectionResults.setBlockAccessList(blockAccessListBuilder.build());
+        });
     return transactionSelectionResults;
   }
 
@@ -294,7 +303,10 @@ public class BlockTransactionSelector implements BlockTransactionSelectionServic
     transactions.forEach(
         transaction -> evaluateTransaction(new PendingTransaction.Local.Priority(transaction)));
 
-    transactionSelectionResults.setBlockAccessList(balBuilder.build());
+    maybeBlockAccessListBuilder.ifPresent(
+        blockAccessListBuilder -> {
+          transactionSelectionResults.setBlockAccessList(blockAccessListBuilder.build());
+        });
     return transactionSelectionResults;
   }
 
@@ -471,9 +483,14 @@ public class BlockTransactionSelector implements BlockTransactionSelectionServic
             TransactionValidationParams.mining(),
             blockSelectionContext.blobGasPrice(),
             Optional.of(transactionAccessList));
-    if (txWorldStateUpdater instanceof StackedUpdater<?, ?> stackedUpdater) {
-      balBuilder.addTransactionLevelAccessList(transactionAccessList, stackedUpdater);
-    }
+    maybeBlockAccessListBuilder.ifPresent(
+        blockAccessListBuilder -> {
+          if (txWorldStateUpdater instanceof StackedUpdater<?, ?> stackedUpdater) {
+            blockAccessListBuilder.addTransactionLevelAccessList(
+                transactionAccessList, stackedUpdater);
+          }
+        });
+
     return result;
   }
 

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/BlockTransactionSelector.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/BlockTransactionSelector.java
@@ -370,13 +370,13 @@ public class BlockTransactionSelector implements BlockTransactionSelectionServic
     synchronized (isTimeout) {
       isTooLate = isTimeout.get();
       if (!isTooLate) {
+        for (final var pendingAction : selectedTxPendingActions) {
+          pendingAction.run();
+        }
         selectorsStateManager.commit();
         txWorldStateUpdater.commit();
         blockWorldStateUpdater.commit();
         blockWorldStateUpdater.markTransactionBoundary();
-        for (final var pendingAction : selectedTxPendingActions) {
-          pendingAction.run();
-        }
       }
     }
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/BlockSimulator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/BlockSimulator.java
@@ -285,7 +285,7 @@ public class BlockSimulator {
     final boolean includeBlockAccessList =
         protocolSpec
             .getBlockAccessListFactory()
-            .map(BlockAccessListFactory::isEnabled)
+            .map(BlockAccessListFactory::isForkActivated)
             .orElse(false);
 
     final WorldUpdater blockUpdater = ws.updater();


### PR DESCRIPTION
## PR description

Should disable bal for transaction selection when not activated


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


