### PR TITLE
Make the log of the block creation results more compact

### DIFF
--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/TransactionSelectionResults.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/TransactionSelectionResults.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.ethereum.blockcreation.txselection;
 
+import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.TransactionType;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.core.TransactionReceipt;
@@ -152,11 +153,18 @@ public class TransactionSelectionResults {
         + cumulativeGasUsed
         + ", selectedTransactions="
         + selectedTransactions.stream()
-            .map(Transaction::toTraceLog)
-            .collect(Collectors.joining("; "))
+            .map(Transaction::getHash)
+            .map(Hash::toHexString)
+            .collect(Collectors.joining(", "))
         + ", notSelectedTransactions="
         + notSelectedTransactions.entrySet().stream()
-            .map(e -> e.getValue() + ":" + e.getKey().toTraceLog())
-            .collect(Collectors.joining(";"));
+            .collect(
+                Collectors.groupingBy(
+                    Map.Entry::getValue,
+                    Collectors.mapping(e -> e.getKey().getHash(), Collectors.toList())))
+            .entrySet()
+            .stream()
+            .map(e -> e.getKey() + ":" + e.getValue())
+            .collect(Collectors.joining(", "));
   }
 }


### PR DESCRIPTION
## PR description

The log of the block creation results are useful for debugging, it is only logged when TRACE is enable, but in case of a very large amount of txs evaluated, the log line can be too long for some log aggregation systems that reject it.

This PR make the log more compact only logging the hash of the tx, and grouping not selected txs by reason, so the line is much shorted than before, and having the hash is always possible to get txs details from previous log lines when the single tx is processed and logged.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


