### PR TITLE
Improve FCU performance in case of non finality issues

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/storage/keyvalue/KeyValueStoragePrefixedKeyBlockchainStorage.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/storage/keyvalue/KeyValueStoragePrefixedKeyBlockchainStorage.java
@@ -100,7 +100,7 @@ public class KeyValueStoragePrefixedKeyBlockchainStorage implements BlockchainSt
   @Override
   public Optional<BlockHeader> getBlockHeader(final Hash blockHash) {
     return get(BLOCK_HEADER_PREFIX, blockHash)
-        .map(b -> BlockHeader.readFrom(RLP.input(b), blockHeaderFunctions));
+        .map(b -> BlockHeader.readFrom(RLP.input(b), blockHeaderFunctions, blockHash));
   }
 
   @Override


### PR DESCRIPTION
## PR description
In case of non finality issues, there is a bigger gap between the new head and the finalized block. In the current implementation, when besu checks that the new head is a descendant of the finalized block, it recalculates the hash of each single block, where this is not needed.
This PR includes a new RLP method that build the block header without recalculating the hash.
Below the CPU profiling with the non finality issue 

<img width="1351" height="620" alt="image" src="https://github.com/user-attachments/assets/473905cf-a1ef-4ddb-9e24-0d84baf13db5" />


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


