### PR TITLE
fix: `fromHexString` usage with explicit length

### DIFF
--- a/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/CliqueExtraDataTest.java
+++ b/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/CliqueExtraDataTest.java
@@ -50,7 +50,7 @@ public class CliqueExtraDataTest {
     final List<Address> validators =
         Arrays.asList(
             AddressHelpers.ofValue(1), AddressHelpers.ofValue(2), AddressHelpers.ofValue(3));
-    final Bytes vanityData = Bytes.fromHexString("11223344", 32);
+    final Bytes vanityData = Bytes vanityData = Bytes.fromHexString("11223344").leftPad(32);
 
     final CliqueExtraData extraData =
         new CliqueExtraData(


### PR DESCRIPTION
`Bytes.fromHexString` only accepts a single string argument, so the previous usage with two arguments doesn’t work.

updated the code to pad the result to the desired length using `.leftPad(32)`:

```java
Bytes vanityData = Bytes.fromHexString("11223344").leftPad(32);
```
the byte array has the correct length without changing the library.
3 альтернативных варианта формулировок, чтобы выбрать самый «живой» и человечный. Хочешь?
