### PR TITLE
Fix setting additional properties on TransitionProtocolSchedule

### DIFF
--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/TransitionProtocolSchedule.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/TransitionProtocolSchedule.java
@@ -35,8 +35,10 @@ import org.slf4j.LoggerFactory;
 
 /** The Transition protocol schedule. */
 public class TransitionProtocolSchedule implements ProtocolSchedule {
-  private final TransitionUtils<ProtocolSchedule> transitionUtils;
   private static final Logger LOG = LoggerFactory.getLogger(TransitionProtocolSchedule.class);
+  private final TransitionUtils<ProtocolSchedule> transitionUtils;
+  private final ProtocolSchedule preMergeProtocolSchedule;
+  private final ProtocolSchedule postMergeProtocolSchedule;
   private final MergeContext mergeContext;
   private ProtocolContext protocolContext;
 
@@ -51,6 +53,8 @@ public class TransitionProtocolSchedule implements ProtocolSchedule {
       final ProtocolSchedule preMergeProtocolSchedule,
       final ProtocolSchedule postMergeProtocolSchedule,
       final MergeContext mergeContext) {
+    this.preMergeProtocolSchedule = preMergeProtocolSchedule;
+    this.postMergeProtocolSchedule = postMergeProtocolSchedule;
     this.mergeContext = mergeContext;
     transitionUtils =
         new TransitionUtils<>(preMergeProtocolSchedule, postMergeProtocolSchedule, mergeContext);
@@ -219,17 +223,15 @@ public class TransitionProtocolSchedule implements ProtocolSchedule {
   @Override
   public void setPermissionTransactionFilter(
       final PermissionTransactionFilter permissionTransactionFilter) {
-    transitionUtils.dispatchConsumerAccordingToMergeState(
-        protocolSchedule ->
-            protocolSchedule.setPermissionTransactionFilter(permissionTransactionFilter));
+    preMergeProtocolSchedule.setPermissionTransactionFilter(permissionTransactionFilter);
+    postMergeProtocolSchedule.setPermissionTransactionFilter(permissionTransactionFilter);
   }
 
   @Override
   public void setAdditionalValidationRules(
       final List<TransactionValidationRule> additionalValidationRules) {
-    transitionUtils.dispatchConsumerAccordingToMergeState(
-        protocolSchedule ->
-            protocolSchedule.setAdditionalValidationRules(additionalValidationRules));
+    preMergeProtocolSchedule.setAdditionalValidationRules(additionalValidationRules);
+    postMergeProtocolSchedule.setAdditionalValidationRules(additionalValidationRules);
   }
 
   /**


### PR DESCRIPTION
## PR description

When setting additional properties on the `TransitionProtocolSchedule` these needs to be set on pre and post protocol schedules, while now they where only set on the protocol schedule active at initialization time.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


