### PR TITLE
fix: gracefully handle timeout before any transaction evaluation

### DIFF
--- a/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockTransactionSelectorTest.java
+++ b/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockTransactionSelectorTest.java
@@ -1090,6 +1090,29 @@ public abstract class AbstractBlockTransactionSelectorTest {
         false);
   }
 
+  @Test
+  public void shouldHandleTimeoutBeforeAnyTransactionIsEvaluated() {
+    // set a very short max time for tx selection to force the timeout before evaluation of the tx
+    int txsSelectionMaxTime = 1;
+
+    final BlockTransactionSelector selector =
+        createBlockSelectorAndSetupTxPool(
+            createMiningParameters(
+                transactionSelectionService,
+                Wei.ZERO,
+                MIN_OCCUPANCY_100_PERCENT,
+                PositiveNumber.fromInt(txsSelectionMaxTime)),
+            transactionProcessor,
+            createBlock(301_000),
+            AddressHelpers.ofValue(1),
+            Wei.ZERO,
+            transactionSelectionService);
+    transactionPool.addRemoteTransactions(List.of(createTransaction(2, Wei.of(7), 100_000)));
+
+    var results = selector.buildTransactionListForBlock();
+    assertThat(results.getSelectedTransactions()).isEmpty();
+  }
+
   private void internalBlockSelectionTimeoutSimulation(
       final boolean isPoa,
       final boolean preProcessingTooLate,


### PR DESCRIPTION
## PR Description

Fixes a `NullPointerException` in `BlockTransactionSelector.cancelEvaluatingTxWithGraceTime` that occurred when the transaction selection timeout expired before any transaction had begun evaluation.

The scheduled cancellation task assumed that `currTxEvaluationContext` was always non-null.
In scenarios where the timeout expires before the first transaction is selected, `currTxEvaluationContext` is `null`, resulting in an unexpected failure during block creation.

### Changes
Instead of throwing an error and aborting block creation, the selector now cancels gracefully and emits a clear warning:
`Cancelling transaction selection before starting any evaluation`