### PR TITLE
Use services executor for txpool tasks trigger by block creation

### DIFF
--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/BlockTransactionSelector.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/BlockTransactionSelector.java
@@ -387,7 +387,21 @@ public class BlockTransactionSelector implements BlockTransactionSelectionServic
     }
     ethScheduler.scheduleFutureTask(
         () -> {
-          if (!txSelectionTask.isDone()) {
+          if (txSelectionTask.isDone()) {
+            if (currTxEvaluationContext != null) {
+              LOG.atDebug()
+                  .setMessage(
+                      "Transaction {} processed within the grace time, total processing time {}ms,"
+                          + " nothing to do and no penalization applied")
+                  .addArgument(currTxEvaluationContext.getPendingTransaction()::toTraceLog)
+                  .addArgument(
+                      () ->
+                          currTxEvaluationContext
+                              .getEvaluationTimer()
+                              .elapsed(TimeUnit.MILLISECONDS))
+                  .log();
+            }
+          } else {
             if (currTxEvaluationContext != null) {
               LOG.atDebug()
                   .setMessage(

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessor.java
@@ -533,6 +533,10 @@ public class MainnetTransactionProcessor {
 
       final var cause = re.getCause();
       if (cause != null && cause instanceof InterruptedException) {
+        LOG.atDebug()
+            .setMessage("Interrupted while processing the transaction with hash {}")
+            .addArgument(transaction::getHash)
+            .log();
         return TransactionProcessingResult.invalid(
             ValidationResult.invalid(TransactionInvalidReason.EXECUTION_INTERRUPTED));
       }


### PR DESCRIPTION
Also add some more logging for penalization of interrupted pending txs


## PR description

Use services executor for txpool tasks trigger by block creation, since the transactions executor, since the former is bounded and tasks could be discarded if its queue is full, while it is mandatory that they are executed.

Also add some more logging for penalization of interrupted pending txs.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


