### PR TITLE
Fix: handle block selection cancellation without exception

### DIFF
--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/BlockTransactionSelector.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/BlockTransactionSelector.java
@@ -21,6 +21,7 @@ import static org.hyperledger.besu.plugin.data.TransactionSelectionResult.INVALI
 import static org.hyperledger.besu.plugin.data.TransactionSelectionResult.PLUGIN_SELECTION_TIMEOUT;
 import static org.hyperledger.besu.plugin.data.TransactionSelectionResult.PLUGIN_SELECTION_TIMEOUT_INVALID_TX;
 import static org.hyperledger.besu.plugin.data.TransactionSelectionResult.SELECTED;
+import static org.hyperledger.besu.plugin.data.TransactionSelectionResult.SELECTION_CANCELLED;
 import static org.hyperledger.besu.plugin.data.TransactionSelectionResult.TX_EVALUATION_TOO_LONG;
 
 import org.hyperledger.besu.datatypes.Address;
@@ -476,19 +477,20 @@ public class BlockTransactionSelector implements BlockTransactionSelectionServic
    *
    * @param pendingTransaction The transaction to be evaluated.
    * @return The result of the transaction evaluation process.
-   * @throws CancellationException if the transaction selection process is cancelled.
    */
   @Override
   public TransactionSelectionResult evaluatePendingTransaction(
       final org.hyperledger.besu.datatypes.PendingTransaction pendingTransaction) {
-
-    checkCancellation();
 
     LOG.atTrace().setMessage("Starting evaluation of {}").addArgument(pendingTransaction).log();
 
     final TransactionEvaluationContext evaluationContext =
         createTransactionEvaluationContext(pendingTransaction);
     currTxEvaluationContext = evaluationContext;
+
+    if (isCancelled.get()) {
+      return handleTransactionNotSelected(evaluationContext, SELECTION_CANCELLED);
+    }
 
     TransactionSelectionResult selectionResult = evaluatePreProcessing(evaluationContext);
     if (!selectionResult.selected()) {
@@ -814,12 +816,6 @@ public class BlockTransactionSelector implements BlockTransactionSelectionServic
       selector.onTransactionNotSelected(evaluationContext, selectionResult);
     }
     pluginTransactionSelector.onTransactionNotSelected(evaluationContext, selectionResult);
-  }
-
-  private void checkCancellation() {
-    if (isCancelled.get()) {
-      throw new CancellationException("Cancelled during transaction selection.");
-    }
   }
 
   private long nanosToMillis(final long nanos) {

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -71,7 +71,7 @@ Calculated : ${currentHash}
 tasks.register('checkAPIChanges', FileStateChecker) {
   description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
   files = sourceSets.main.allJava.files
-  knownHash = 'lGQu0DzH2LjC7eYD2GiAwatXeT659sNCFLHCq1Gn9BU='
+  knownHash = 'wjVJLscTFe5htfLyKs6HXx0W8jTryLRejyV2ZmRQIys='
 }
 check.dependsOn('checkAPIChanges')
 

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/data/TransactionSelectionResult.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/data/TransactionSelectionResult.java
@@ -63,6 +63,7 @@ public class TransactionSelectionResult {
     BLOBS_FULL(false, false, false),
     BLOCK_OCCUPANCY_ABOVE_THRESHOLD(true, false, false),
     BLOCK_SIZE_ABOVE_THRESHOLD(true, false, false),
+    SELECTION_CANCELLED(true, false, false),
     BLOCK_SELECTION_TIMEOUT(true, false, false),
     BLOCK_SELECTION_TIMEOUT_INVALID_TX(true, true, true),
     PLUGIN_SELECTION_TIMEOUT(false, false, false),
@@ -122,6 +123,10 @@ public class TransactionSelectionResult {
   /** The block already contains the max number of allowed blobs. */
   public static final TransactionSelectionResult BLOBS_FULL =
       new TransactionSelectionResult(BaseStatus.BLOBS_FULL);
+
+  /** The block creation has been cancelled */
+  public static final TransactionSelectionResult SELECTION_CANCELLED =
+      new TransactionSelectionResult(BaseStatus.SELECTION_CANCELLED);
 
   /** There was no more time to add transaction to the block */
   public static final TransactionSelectionResult BLOCK_SELECTION_TIMEOUT =


### PR DESCRIPTION
## PR description

https://github.com/hyperledger/besu/pull/9208 introduced a regression, where a `CancellationException` is treated like an internal error, while it is not, since it is used to cancel the block creation.

In this PR I took the opportunity to fix the regression and handle the block selection cancellation without the use of exceptions, but using normal transaction selection result propagation, using the new `SELECTION_CANCELLED` result.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


