### PR TITLE
Extract duplicate baseline benchmarks for Binary and Ternary operations

### DIFF
--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/BinaryOperationBaselineBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/BinaryOperationBaselineBenchmark.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.vm.operations;
+
+import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.operation.Operation;
+
+public class BinaryOperationBaselineBenchmark extends BinaryOperationBenchmark {
+
+  @Override
+  protected Operation.OperationResult invoke(final MessageFrame frame) {
+    // Approximate baseline by popping the extra input and doing nothing
+    // second pop is done by the caller
+    frame.popStackItem();
+    return null;
+  }
+}

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/BinaryOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/BinaryOperationBenchmark.java
@@ -56,16 +56,6 @@ public abstract class BinaryOperationBenchmark {
   }
 
   @Benchmark
-  public void baseline() {
-    frame.pushStackItem(bPool[index]);
-    frame.pushStackItem(aPool[index]);
-    frame.popStackItem();
-    frame.popStackItem();
-
-    index = (index + 1) % SAMPLE_SIZE;
-  }
-
-  @Benchmark
   public void executeOperation(final Blackhole blackhole) {
     frame.pushStackItem(bPool[index]);
     frame.pushStackItem(aPool[index]);

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/TernaryOperationBaselineBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/TernaryOperationBaselineBenchmark.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.vm.operations;
+
+import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.operation.Operation;
+
+public class TernaryOperationBaselineBenchmark extends TernaryOperationBenchmark {
+
+  @Override
+  protected Operation.OperationResult invoke(final MessageFrame frame) {
+    // Approximate baseline by popping the two extra inputs and doing nothing
+    // third pop is done by the caller
+    frame.popStackItem();
+    frame.popStackItem();
+    return null;
+  }
+}

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/TernaryOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/TernaryOperationBenchmark.java
@@ -59,18 +59,6 @@ public abstract class TernaryOperationBenchmark {
   }
 
   @Benchmark
-  public void baseline() {
-    frame.pushStackItem(cPool[index]);
-    frame.pushStackItem(bPool[index]);
-    frame.pushStackItem(aPool[index]);
-    frame.popStackItem();
-    frame.popStackItem();
-    frame.popStackItem();
-
-    index = (index + 1) % SAMPLE_SIZE;
-  }
-
-  @Benchmark
   public void executeOperation(final Blackhole blackhole) {
     frame.pushStackItem(cPool[index]);
     frame.pushStackItem(bPool[index]);


### PR DESCRIPTION
When using JMH `@Param` this results in duplicate baseline runs, one for each Param which can add up.

The downside of this PR is you must explicitly ask for the baseline when you apply benchmark filtering:

Example run that explictly includes the Baseline benchmarks
```
./gradlew :ethereum:core:jmh -Pincludes=Add,Baseline -Pexcludes=AddMod --rerun-tasks

...
Benchmark                                           Mode  Cnt    Score   Error  Units
AddOperationBenchmark.executeOperation              avgt    5  110.220 ± 6.635  ns/op
BinaryOperationBaselineBenchmark.executeOperation   avgt    5    8.547 ± 1.634  ns/op
TernaryOperationBaselineBenchmark.executeOperation  avgt    5   14.546 ± 5.494  ns/op
```

---

Before this PR the baseline was included within each Operation...

```
./gradlew :ethereum:core:jmh -Pincludes=Add -Pexcludes=AddMod --rerun-tasks
...

Benchmark                               Mode  Cnt    Score    Error  Units
AddOperationBenchmark.baseline          avgt   15    9.241 ±  1.836  ns/op
AddOperationBenchmark.executeOperation  avgt   15  145.895 ± 13.359  ns/op
```