### PR TITLE
Improve the accuracy of mgas/s number in the logs

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayload.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayload.java
@@ -652,15 +652,19 @@ public abstract class AbstractEngineNewPayload extends ExecutionEngineJsonRpcMet
     }
     double mgasPerSec = (timeInNs != 0) ? (double) (block.getHeader().getGasUsed() * 1_000) / timeInNs : 0;
     double timeInMs = (double)  timeInNs/1_000_000;
-    message.append(
-        "| %2d blobs| %s bfee| %,11d (%5.1f%%) gas used| %03.1fms exec| %6.2f Mgas/s| %2d peers");
+    boolean timeOverOrEq1second = timeInMs >= 1_000;
+    if (timeOverOrEq1second) {
+      message.append("| %2d blobs| %s bfee| %,11d (%5.1f%%) gas used| %01.3fs exec| %6.2f Mgas/s| %2d peers");
+    } else {
+      message.append("| %2d blobs| %s bfee| %,11d (%5.1f%%) gas used| %03.1fms exec| %6.2f Mgas/s| %2d peers");
+    }
     messageArgs.addAll(
         List.of(
             blobCount,
             block.getHeader().getBaseFee().map(Wei::toHumanReadablePaddedString).orElse("N/A"),
             block.getHeader().getGasUsed(),
             (block.getHeader().getGasUsed() * 100.0) / block.getHeader().getGasLimit(),
-                timeInMs  ,
+                timeOverOrEq1second ? timeInMs / 1_000 :  timeInMs  ,
             mgasPerSec,
             ethPeers.peerCount()));
     LOG.info(String.format(message.toString(), messageArgs.toArray()));

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayload.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayload.java
@@ -650,13 +650,16 @@ public abstract class AbstractEngineNewPayload extends ExecutionEngineJsonRpcMet
       message.append("| %2d ws");
       messageArgs.add(block.getBody().getWithdrawals().get().size());
     }
-    double mgasPerSec = (timeInNs != 0) ? (double) (block.getHeader().getGasUsed() * 1_000) / timeInNs : 0;
-    double timeInMs = (double)  timeInNs/1_000_000;
+    double mgasPerSec =
+        (timeInNs != 0) ? (double) (block.getHeader().getGasUsed() * 1_000) / timeInNs : 0;
+    double timeInMs = (double) timeInNs / 1_000_000;
     boolean timeOverOrEq1second = timeInMs >= 1_000;
     if (timeOverOrEq1second) {
-      message.append("| %2d blobs| %s bfee| %,11d (%5.1f%%) gas used| %01.3fs exec| %6.2f Mgas/s| %2d peers");
+      message.append(
+          "| %2d blobs| %s bfee| %,11d (%5.1f%%) gas used| %01.3fs exec| %6.2f Mgas/s| %2d peers");
     } else {
-      message.append("| %2d blobs| %s bfee| %,11d (%5.1f%%) gas used| %03.1fms exec| %6.2f Mgas/s| %2d peers");
+      message.append(
+          "| %2d blobs| %s bfee| %,11d (%5.1f%%) gas used| %03.1fms exec| %6.2f Mgas/s| %2d peers");
     }
     messageArgs.addAll(
         List.of(
@@ -664,7 +667,7 @@ public abstract class AbstractEngineNewPayload extends ExecutionEngineJsonRpcMet
             block.getHeader().getBaseFee().map(Wei::toHumanReadablePaddedString).orElse("N/A"),
             block.getHeader().getGasUsed(),
             (block.getHeader().getGasUsed() * 100.0) / block.getHeader().getGasLimit(),
-                timeOverOrEq1second ? timeInMs / 1_000 :  timeInMs  ,
+            timeOverOrEq1second ? timeInMs / 1_000 : timeInMs,
             mgasPerSec,
             ethPeers.peerCount()));
     LOG.info(String.format(message.toString(), messageArgs.toArray()));

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayload.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayload.java
@@ -651,6 +651,7 @@ public abstract class AbstractEngineNewPayload extends ExecutionEngineJsonRpcMet
       messageArgs.add(block.getBody().getWithdrawals().get().size());
     }
     double mgasPerSec = (timeInNs != 0) ? (double) (block.getHeader().getGasUsed() * 1_000) / timeInNs : 0;
+    double timeInMs = (double)  timeInNs/1_000_000;
     message.append(
         "| %2d blobs| %s bfee| %,11d (%5.1f%%) gas used| %03.1fms exec| %6.2f Mgas/s| %2d peers");
     messageArgs.addAll(
@@ -659,7 +660,7 @@ public abstract class AbstractEngineNewPayload extends ExecutionEngineJsonRpcMet
             block.getHeader().getBaseFee().map(Wei::toHumanReadablePaddedString).orElse("N/A"),
             block.getHeader().getGasUsed(),
             (block.getHeader().getGasUsed() * 100.0) / block.getHeader().getGasLimit(),
-                timeInNs/1_000_000,
+                timeInMs  ,
             mgasPerSec,
             ethPeers.peerCount()));
     LOG.info(String.format(message.toString(), messageArgs.toArray()));


### PR DESCRIPTION
## PR description
This PR improves mgas/s number accuracy in the logs.
I have noticed in some devnets logs like 
```
2025-09-29 09:19:06.027+0000 | vert.x-worker-thread-0 | INFO  | AbstractEngineNewPayload | Imported #18,812,701  (98032.....b127b)|    2 tx|  0 blobs|      7 wei bfee|      42,000 (  0.0%) gas used| 0.000s exec|   0.00 Mgas/s| 25 peers
```
We can see that Mgas/s is 0 in the log. This is happening because executing the 2 transfers is taking less than 1 ms, which make the execution time 0 s because the time in seconds is displayed only with 3 decimals.

In this PR, we use also System.nanoTime()  instead of System.currentTimeMillis(), because  System.nanoTime() is less dependant on the OS changes. We also use the time in nanoseconds to calculate mgas/s, so if there is any transaction, mgas/s should not be empty.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


