### PR TITLE
Increase safety margin when selecting Transactions

### DIFF
--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/BlockRlpSizeTransactionSelector.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/BlockRlpSizeTransactionSelector.java
@@ -29,7 +29,9 @@ import org.slf4j.LoggerFactory;
  * it does not exceed the maximum RLP block size in EIP-7934
  */
 public class BlockRlpSizeTransactionSelector extends AbstractStatefulTransactionSelector<Long> {
-  public static final long MAX_HEADER_SIZE = 1024L;
+  // The initial size is covering us for the header size, withdrawls size, and some rlp overhead, as well as
+  // some extra space for safety.
+  public static final long INITIAL_RLP_SIZE = 256L * 1024L;
   private static final Logger LOG = LoggerFactory.getLogger(BlockRlpSizeTransactionSelector.class);
 
   public BlockRlpSizeTransactionSelector(
@@ -37,7 +39,7 @@ public class BlockRlpSizeTransactionSelector extends AbstractStatefulTransaction
     super(
         context,
         selectorsStateManager,
-        MAX_HEADER_SIZE,
+        INITIAL_RLP_SIZE,
         SelectorsStateManager.StateDuplicator::duplicateLong);
   }
 

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/BlockRlpSizeTransactionSelector.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/BlockRlpSizeTransactionSelector.java
@@ -29,8 +29,8 @@ import org.slf4j.LoggerFactory;
  * it does not exceed the maximum RLP block size in EIP-7934
  */
 public class BlockRlpSizeTransactionSelector extends AbstractStatefulTransactionSelector<Long> {
-  // The initial size is covering us for the header size, withdrawls size, and some rlp overhead, as well as
-  // some extra space for safety.
+  // The initial size is covering us for the header size, withdrawals size, and some rlp overhead,
+  // as well as some extra space for safety.
   public static final long INITIAL_RLP_SIZE = 256L * 1024L;
   private static final Logger LOG = LoggerFactory.getLogger(BlockRlpSizeTransactionSelector.class);
 

--- a/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/BlockRlpSizeTransactionSelectorTest.java
+++ b/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/BlockRlpSizeTransactionSelectorTest.java
@@ -15,7 +15,7 @@
 package org.hyperledger.besu.ethereum.blockcreation.txselection.selectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hyperledger.besu.ethereum.blockcreation.txselection.selectors.BlockRlpSizeTransactionSelector.MAX_HEADER_SIZE;
+import static org.hyperledger.besu.ethereum.blockcreation.txselection.selectors.BlockRlpSizeTransactionSelector.INITIAL_RLP_SIZE;
 import static org.hyperledger.besu.ethereum.eth.transactions.PendingTransaction.MAX_SCORE;
 import static org.hyperledger.besu.plugin.data.TransactionSelectionResult.SELECTED;
 import static org.mockito.Answers.RETURNS_DEEP_STUBS;
@@ -72,7 +72,7 @@ class BlockRlpSizeTransactionSelectorTest {
     final var tx2 = createEIP1559PendingTransaction(Bytes.random(80));
     final int maxRlpBlockSize =
         (int)
-                (MAX_HEADER_SIZE
+                (INITIAL_RLP_SIZE
                     + tx1.getTransaction().getSizeForBlockInclusion()
                     + tx2.getTransaction().getSizeForBlockInclusion())
             + 20; // ensure there's some room left
@@ -100,7 +100,7 @@ class BlockRlpSizeTransactionSelectorTest {
     final var tx3 = createEIP1559PendingTransaction(Bytes.random(20));
     final int maxRlpBlockSize =
         (int)
-            (MAX_HEADER_SIZE
+            (INITIAL_RLP_SIZE
                 + tx1.getTransaction().getSizeForBlockInclusion()
                 + tx3.getTransaction().getSizeForBlockInclusion());
     when(blockSelectionContext.maxRlpBlockSize()).thenReturn(maxRlpBlockSize);
@@ -134,7 +134,7 @@ class BlockRlpSizeTransactionSelectorTest {
     final var tx2 = createEIP1559PendingTransaction(Bytes.random(50));
     final int maxRlpBlockSize =
         (int)
-            (MAX_HEADER_SIZE
+            (INITIAL_RLP_SIZE
                 + tx1.getTransaction().getSizeForBlockInclusion()
                 + tx2.getTransaction().getSizeForBlockInclusion());
     when(blockSelectionContext.maxRlpBlockSize()).thenReturn(maxRlpBlockSize);
@@ -160,7 +160,7 @@ class BlockRlpSizeTransactionSelectorTest {
     final var tx2 = createEIP1559PendingTransaction(Bytes.random(100));
     final int maxRlpBlockSize =
         (int)
-            (MAX_HEADER_SIZE
+            (INITIAL_RLP_SIZE
                 + tx1.getTransaction().getSizeForBlockInclusion()
                 + tx2.getTransaction().getSizeForBlockInclusion());
     when(blockSelectionContext.maxRlpBlockSize()).thenReturn(maxRlpBlockSize);


### PR DESCRIPTION
## PR description
The safety margin that makes sure that the block we are building is not too big was not taking everything into account, e.g. the size of the withdrawals. This PR increases that safety margin to 256kB.



