### PR TITLE
fix: addd bpos to admin_nodeInfo

### DIFF
--- a/config/src/main/java/org/hyperledger/besu/config/BlobScheduleOptions.java
+++ b/config/src/main/java/org/hyperledger/besu/config/BlobScheduleOptions.java
@@ -146,6 +146,11 @@ public class BlobScheduleOptions {
     getCancun().ifPresent(bs -> builder.put(CANCUN_KEY, bs.asMap()));
     getPrague().ifPresent(bs -> builder.put(PRAGUE_KEY, bs.asMap()));
     getOsaka().ifPresent(bs -> builder.put(OSAKA_KEY, bs.asMap()));
+    getBpo1().ifPresent(bs -> builder.put(BPO1_KEY, bs.asMap()));
+    getBpo2().ifPresent(bs -> builder.put(BPO2_KEY, bs.asMap()));
+    getBpo3().ifPresent(bs -> builder.put(BPO3_KEY, bs.asMap()));
+    getBpo4().ifPresent(bs -> builder.put(BPO4_KEY, bs.asMap()));
+    getBpo5().ifPresent(bs -> builder.put(BPO5_KEY, bs.asMap()));
     getFutureEips().ifPresent(bs -> builder.put(FUTURE_EIPS_KEY, bs.asMap()));
     return builder.build();
   }


### PR DESCRIPTION
## PR description

Add BPOs to `admin_nodeInfo`. After this PR:


```diff
public class Hello1
{
    "jsonrpc": "2.0",
    "id": 1,
    "result": {
        "enode": "enode://67144cdf5cb9d5ef4ef0301a9d38a9ceff034d09d9e51549d3cd6bfe3c88fa88a6c897e5e8a560270ed1c245fd390a814fb00eda78c41907ca42311775db7276@127.0.0.1:30303",
        "listenAddr": "127.0.0.1:30303",
        "activeFork": "BPO5",
        "ip": "127.0.0.1",
        "name": "besu/v25.10-develop-a8d3cb8/osx-aarch_64/corretto-java-21",
        "id": "67144cdf5cb9d5ef4ef0301a9d38a9ceff034d09d9e51549d3cd6bfe3c88fa88a6c897e5e8a560270ed1c245fd390a814fb00eda78c41907ca42311775db7276",
        "ports": {
            "discovery": 30303,
            "listener": 30303
        },
        "protocols": {
            "eth": {
                "config": {
                    "chainId": 7023102237,
                    "homesteadBlock": 0,
                    "eip150Block": 0,
                    "eip158Block": 0,
                    "byzantiumBlock": 0,
                    "constantinopleBlock": 0,
                    "petersburgBlock": 0,
                    "istanbulBlock": 0,
                    "berlinBlock": 0,
                    "londonBlock": 0,
                    "shanghaiTime": 0,
                    "cancunTime": 0,
                    "pragueTime": 0,
                    "osakaTime": 1753379304,
                    "bpo1Time": 1753477608,
                    "bpo2Time": 1753575912,
                    "bpo3Time": 1753674216,
                    "bpo4Time": 1753772520,
                    "bpo5Time": 1753889256,
                    "withdrawalRequestContractAddress": "0x00000961ef480eb55e80d19ad83579a64c007002",
                    "depositContractAddress": "0x00000000219ab540356cbb839cbe05303d7705fa",
                    "consolidationRequestContractAddress": "0x0000bbddc7ce488642fb579f8b00f3a590007251",
                    "ethash": {},
                    "blobSchedule": {
                        "cancun": {
                            "baseFeeUpdateFraction": 3338477,
                            "max": 6,
                            "target": 3
                        },
                        "prague": {
                            "baseFeeUpdateFraction": 5007716,
                            "max": 9,
                            "target": 6
                        },
                        "osaka": {
                            "baseFeeUpdateFraction": 5007716,
                            "max": 9,
                            "target": 6
                        },
+                        "bpo1": {
+                           "baseFeeUpdateFraction": 5007716,
+                            "max": 12,
+                           "target": 9
+                      },
+                        "bpo2": {
+                            "baseFeeUpdateFraction": 5007716,
+                            "max": 15,
+                            "target": 12
+                        },
+                        "bpo3": {
+                            "baseFeeUpdateFraction": 5007716,
+                            "max": 18,
+                            "target": 15
+                        },
+                        "bpo4": {
+                           "baseFeeUpdateFraction": 5007716,
+                            "max": 9,
+                            "target": 6
+                        },
+                        "bpo5": {
+                            "baseFeeUpdateFraction": 5007716,
+                            "max": 20,
+                            "target": 15
+                        }
                    }
                },
                "difficulty": 0,
                "genesis": "0x3a8c8cef63859865aa1d40ded77b083eef06a1702b8188d5586434b9c3adc4be",
                "head": "0x0f0b122cc8bd8f6ce9ee134439c34b8c43ab2ff7237cff112d63d3a385f620bd",
                "network": 7023102237
            }
        }
    }
}
```

