### PR TITLE
fix: use timestamp from head to validate fork for getBlobs

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV1.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV1.java
@@ -38,7 +38,6 @@ import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
 import io.vertx.core.Vertx;
@@ -71,20 +70,17 @@ public class EngineGetBlobsV1 extends ExecutionEngineJsonRpcMethod {
   private final TransactionPool transactionPool;
   private final Optional<Long> cancunMilestone;
   private final Optional<Long> osakaMilestone;
-  private final Supplier<Long> timestampProvider;
 
   public EngineGetBlobsV1(
       final Vertx vertx,
       final ProtocolContext protocolContext,
       final ProtocolSchedule protocolSchedule,
       final EngineCallListener engineCallListener,
-      final TransactionPool transactionPool,
-      final Supplier<Long> timestampProvider) {
+      final TransactionPool transactionPool) {
     super(vertx, protocolContext, engineCallListener);
     this.transactionPool = transactionPool;
     this.cancunMilestone = protocolSchedule.milestoneFor(CANCUN);
     this.osakaMilestone = protocolSchedule.milestoneFor(OSAKA);
-    this.timestampProvider = timestampProvider;
   }
 
   @Override
@@ -94,8 +90,8 @@ public class EngineGetBlobsV1 extends ExecutionEngineJsonRpcMethod {
 
   @Override
   public JsonRpcResponse syncResponse(final JsonRpcRequestContext requestContext) {
-    ValidationResult<RpcErrorType> forkValidationResult =
-        validateForkSupported(timestampProvider.get());
+    long timestamp = protocolContext.getBlockchain().getChainHeadHeader().getTimestamp();
+    ValidationResult<RpcErrorType> forkValidationResult = validateForkSupported(timestamp);
     if (!forkValidationResult.isValid()) {
       return new JsonRpcErrorResponse(requestContext.getRequest().getId(), forkValidationResult);
     }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/ExecutionEngineJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/ExecutionEngineJsonRpcMethods.java
@@ -180,8 +180,7 @@ public class ExecutionEngineJsonRpcMethods extends ApiGroupJsonRpcMethods {
                   protocolContext,
                   protocolSchedule,
                   engineQosTimer,
-                  transactionPool,
-                  System::currentTimeMillis)));
+                  transactionPool)));
       if (protocolSchedule.milestoneFor(CANCUN).isPresent()) {
         executionEngineApisSupported.add(
             new EngineGetPayloadV3(
@@ -230,8 +229,7 @@ public class ExecutionEngineJsonRpcMethods extends ApiGroupJsonRpcMethods {
                 protocolSchedule,
                 engineQosTimer,
                 transactionPool,
-                metricsSystem,
-                System::currentTimeMillis));
+                metricsSystem));
       }
 
       return mapOf(executionEngineApisSupported);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV1Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV1Test.java
@@ -38,6 +38,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.BlobAndProofV1;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.BlobTestFixture;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.core.TransactionTestFixture;
 import org.hyperledger.besu.ethereum.core.kzg.BlobsWithCommitments;
@@ -83,29 +84,21 @@ public class EngineGetBlobsV1Test extends AbstractScheduledApiTest {
   @Mock private EngineCallListener engineCallListener;
   @Mock private MutableBlockchain blockchain;
   @Mock private TransactionPool transactionPool;
+  @Mock private BlockHeader blockHeader;
 
   private EngineGetBlobsV1 method;
 
   private static final Vertx vertx = Vertx.vertx();
 
-  private Long timestamp = cancunHardfork.milestone();
-
-  private Long timestampProvider() {
-    return timestamp;
-  }
-
   @BeforeEach
   public void beforeEach() {
     when(protocolContext.getBlockchain()).thenReturn(blockchain);
+    when(blockHeader.getTimestamp()).thenReturn(cancunHardfork.milestone());
+    when(blockchain.getChainHeadHeader()).thenReturn(blockHeader);
     this.method =
         spy(
             new EngineGetBlobsV1(
-                vertx,
-                protocolContext,
-                protocolSchedule,
-                engineCallListener,
-                transactionPool,
-                this::timestampProvider));
+                vertx, protocolContext, protocolSchedule, engineCallListener, transactionPool));
   }
 
   @Test
@@ -234,7 +227,7 @@ public class EngineGetBlobsV1Test extends AbstractScheduledApiTest {
 
   @Test
   void shouldFailWhenCancunNotActive() {
-    timestamp = cancunHardfork.milestone() - 1;
+    when(blockHeader.getTimestamp()).thenReturn(cancunHardfork.milestone() - 1);
     var response = resp(new VersionedHash[] {VERSIONED_HASH_ZERO});
     assertThat(fromErrorResp(response).getCode())
         .isEqualTo(RpcErrorType.UNSUPPORTED_FORK.getCode());
@@ -242,21 +235,21 @@ public class EngineGetBlobsV1Test extends AbstractScheduledApiTest {
 
   @Test
   void shouldSucceedWhenCancunActive() {
-    timestamp = cancunHardfork.milestone();
+    when(blockHeader.getTimestamp()).thenReturn(cancunHardfork.milestone());
     var response = resp(new VersionedHash[] {VERSIONED_HASH_ZERO});
     assertThat(response.getType()).isEqualTo(RpcResponseType.SUCCESS);
   }
 
   @Test
   void shouldSucceedWhenOsakaNotActive() {
-    timestamp = osakaHardfork.milestone() - 1;
+    when(blockHeader.getTimestamp()).thenReturn(osakaHardfork.milestone() - 1);
     var response = resp(new VersionedHash[] {VERSIONED_HASH_ZERO});
     assertThat(response.getType()).isEqualTo(RpcResponseType.SUCCESS);
   }
 
   @Test
   void shouldFailWhenOsakaActive() {
-    timestamp = osakaHardfork.milestone();
+    when(blockHeader.getTimestamp()).thenReturn(osakaHardfork.milestone());
     var response = resp(new VersionedHash[] {VERSIONED_HASH_ZERO});
     assertThat(fromErrorResp(response).getCode())
         .isEqualTo(RpcErrorType.UNSUPPORTED_FORK.getCode());


### PR DESCRIPTION
## PR description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


