### PR TITLE
Decreasing the ethstats report interval

### DIFF
--- a/ethereum/ethstats/src/main/java/org/hyperledger/besu/ethstats/EthStatsService.java
+++ b/ethereum/ethstats/src/main/java/org/hyperledger/besu/ethstats/EthStatsService.java
@@ -88,7 +88,7 @@ public class EthStatsService {
 
   private static final Logger LOG = LoggerFactory.getLogger(EthStatsService.class);
 
-  private static final Duration SEND_REPORT_DELAY = Duration.ofSeconds(5);
+  private static final Duration SEND_REPORT_DELAY = Duration.ofSeconds(1);
   private static final int HISTORY_RANGE = 50;
 
   private final AtomicBoolean retryInProgress = new AtomicBoolean(false);


### PR DESCRIPTION
## PR description
On Linea block time is much less than on Mainnet, so we'd like Ethstats to be updated more frequently

## Fixed Issue(s)
No issue


### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew build`
- [x] acceptance tests: `./gradlew acceptanceTest`
- [x] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [x] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


