### PR TITLE
Allow for report interval customization through CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Additions and Improvements
 - Add blockTimestamp to `eth_getLogs` result [#9278](https://github.com/hyperledger/besu/pull/9278)
+- Add `--ethstats-report-interval` CLI option to control ethstats reporting frequency instead of using hardcoded 5-second interval [#9271](https://github.com/hyperledger/besu/pull/9271)
 
 ### Bug fixes
 - Fix loss of colored output in terminal when using `--color-enabled=true` option [#8908](https://github.com/hyperledger/besu/issues/8908)

--- a/app/src/main/java/org/hyperledger/besu/RunnerBuilder.java
+++ b/app/src/main/java/org/hyperledger/besu/RunnerBuilder.java
@@ -974,7 +974,8 @@ public class RunnerBuilder {
                   EthStatsConnectOptions.fromParams(
                       ethstatsOptions.getEthstatsUrl(),
                       ethstatsOptions.getEthstatsContact(),
-                      ethstatsOptions.getEthstatsCaCert()),
+                      ethstatsOptions.getEthstatsCaCert(),
+                      ethstatsOptions.getEthstatsReportInterval()),
                   blockchainQueries,
                   besuController.getProtocolManager(),
                   transactionPool,

--- a/app/src/main/java/org/hyperledger/besu/cli/options/EthstatsOptions.java
+++ b/app/src/main/java/org/hyperledger/besu/cli/options/EthstatsOptions.java
@@ -28,6 +28,7 @@ public class EthstatsOptions implements CLIOptions<EthStatsConnectOptions> {
   private static final String ETHSTATS = "--ethstats";
   private static final String ETHSTATS_CONTACT = "--ethstats-contact";
   private static final String ETHSTATS_CACERT_FILE = "--ethstats-cacert-file";
+  private static final String ETHSTATS_REPORT_INTERVAL = "--ethstats-report-interval";
 
   @SuppressWarnings({"FieldCanBeFinal", "FieldMayBeFinal"})
   @CommandLine.Option(
@@ -52,6 +53,14 @@ public class EthstatsOptions implements CLIOptions<EthStatsConnectOptions> {
           "Specifies the path to the root CA (Certificate Authority) certificate file that has signed ethstats server certificate. This option is optional.")
   private Path ethstatsCaCert = null;
 
+  @SuppressWarnings({"FieldCanBeFinal", "FieldMayBeFinal"})
+  @CommandLine.Option(
+      names = {ETHSTATS_REPORT_INTERVAL},
+      paramLabel = "<SECONDS>",
+      description = "Interval in seconds between ethstats reports.",
+      arity = "1")
+  private Integer ethstatsReportInterval = 5;
+
   private EthstatsOptions() {}
 
   /**
@@ -65,7 +74,8 @@ public class EthstatsOptions implements CLIOptions<EthStatsConnectOptions> {
 
   @Override
   public EthStatsConnectOptions toDomainObject() {
-    return EthStatsConnectOptions.fromParams(ethstatsUrl, ethstatsContact, ethstatsCaCert);
+    return EthStatsConnectOptions.fromParams(
+        ethstatsUrl, ethstatsContact, ethstatsCaCert, ethstatsReportInterval);
   }
 
   /**
@@ -95,6 +105,15 @@ public class EthstatsOptions implements CLIOptions<EthStatsConnectOptions> {
     return ethstatsCaCert;
   }
 
+  /**
+   * Gets ethstats report interval.
+   *
+   * @return the ethstats report interval
+   */
+  public Integer getEthstatsReportInterval() {
+    return ethstatsReportInterval;
+  }
+
   @Override
   public List<String> getCLIOptions() {
     final List<String> options = new ArrayList<>();
@@ -103,6 +122,7 @@ public class EthstatsOptions implements CLIOptions<EthStatsConnectOptions> {
     if (ethstatsCaCert != null) {
       options.add(ETHSTATS_CACERT_FILE + "=" + ethstatsCaCert);
     }
+    options.add(ETHSTATS_REPORT_INTERVAL + "=" + ethstatsReportInterval);
     return options;
   }
 }

--- a/app/src/test/resources/everything_config.toml
+++ b/app/src/test/resources/everything_config.toml
@@ -216,6 +216,7 @@ auto-log-bloom-caching-enabled=true
 ethstats="nodename:secret@host:1234"
 ethstats-contact="contact@mail.n"
 ethstats-cacert-file="./root.cert"
+ethstats-report-interval=10
 
 # Data storage
 data-storage-format="BONSAI"

--- a/ethereum/ethstats/src/main/java/org/hyperledger/besu/ethstats/EthStatsService.java
+++ b/ethereum/ethstats/src/main/java/org/hyperledger/besu/ethstats/EthStatsService.java
@@ -88,7 +88,6 @@ public class EthStatsService {
 
   private static final Logger LOG = LoggerFactory.getLogger(EthStatsService.class);
 
-  private static final Duration SEND_REPORT_DELAY = Duration.ofSeconds(5);
   private static final int HISTORY_RANGE = 50;
 
   private final AtomicBoolean retryInProgress = new AtomicBoolean(false);
@@ -339,7 +338,7 @@ public class EthStatsService {
                   sendNodeStatsReport();
                 },
                 Duration.ofSeconds(0),
-                SEND_REPORT_DELAY);
+                Duration.ofSeconds(ethStatsConnectOptions.getEthStatsReportInterval()));
   }
 
   /** Sends a ping request to the ethstats server */

--- a/ethereum/ethstats/src/main/java/org/hyperledger/besu/ethstats/util/EthStatsConnectOptions.java
+++ b/ethereum/ethstats/src/main/java/org/hyperledger/besu/ethstats/util/EthStatsConnectOptions.java
@@ -81,7 +81,14 @@ public interface EthStatsConnectOptions {
   Path getCaCert();
 
   /**
-   * Creates an EthStatsConnectOptions from the given parameters.
+   * Gets the ethstats report interval.
+   *
+   * @return the ethstats report interval
+   */
+  Integer getEthStatsReportInterval();
+
+  /**
+   * Creates an EthStatsConnectOptions from the given parameters with default report interval.
    *
    * @param url the url of the connection
    * @param contact the contact of the connection
@@ -90,6 +97,23 @@ public interface EthStatsConnectOptions {
    */
   static EthStatsConnectOptions fromParams(
       final String url, final String contact, final Path caCert) {
+    return fromParams(url, contact, caCert, 5); // Default to 5 seconds
+  }
+
+  /**
+   * Creates an EthStatsConnectOptions from the given parameters.
+   *
+   * @param url the url of the connection
+   * @param contact the contact of the connection
+   * @param caCert the CA certificate of the connection
+   * @param ethStatsReportInterval the ethstats report interval
+   * @return the EthStatsConnectOptions
+   */
+  static EthStatsConnectOptions fromParams(
+      final String url,
+      final String contact,
+      final Path caCert,
+      final Integer ethStatsReportInterval) {
     try {
       checkArgument(url != null && !url.trim().isEmpty(), "Invalid empty value.");
 
@@ -130,6 +154,7 @@ public interface EthStatsConnectOptions {
           .port(uri.getPort())
           .contact(contact)
           .caCert(caCert)
+          .ethStatsReportInterval(ethStatsReportInterval)
           .build();
     } catch (IllegalArgumentException e) {
       LoggerFactory.getLogger(EthStatsConnectOptions.class).error(e.getMessage());


### PR DESCRIPTION
## PR description
This PR fixes #9270, allowing for customizable ethstats report intervals, which are needed by other blockchains like Linea to keep pace with faster block times than Ethereum Mainnet (see #9269). 

## Fixed Issue(s)
Fixes #9270

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation). (I think probably not, because the CLI contains documentation, but let me know if otherwise)
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew build`
- [x] acceptance tests: `./gradlew acceptanceTest`
- [x] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [x] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


