### PR TITLE
Refactor: uniform the way genesis config options are passed to protocol specs

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/components/ProtocolScheduleModule.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/components/ProtocolScheduleModule.java
@@ -93,7 +93,7 @@ public class ProtocolScheduleModule {
       final ProtocolScheduleBuilder builder, final GenesisConfigOptions config) {
     final Optional<BigInteger> chainId = config.getChainId().or(builder::getDefaultChainId);
     DefaultProtocolSchedule protocolSchedule = new DefaultProtocolSchedule(chainId);
-    builder.initSchedule(protocolSchedule, chainId);
+    builder.initSchedule(protocolSchedule);
     return protocolSchedule;
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/components/ProtocolSpecModule.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/components/ProtocolSpecModule.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.ethereum.components;
 
+import org.hyperledger.besu.config.GenesisConfigOptions;
 import org.hyperledger.besu.ethereum.mainnet.MainnetProtocolSpecs;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSpecBuilder;
 import org.hyperledger.besu.evm.internal.EvmConfiguration;
@@ -34,8 +35,9 @@ public class ProtocolSpecModule {
   /**
    * Provides the protocol spec for the frontier network fork.
    *
+   * @param genesisConfigOptions the genesis config options
    * @param evmConfiguration the EVM configuration
-   * @param isParalleltxEnabled whether parallel tx processing is enabled
+   * @param isParallelTxEnabled whether parallel tx processing is enabled
    * @param metricsSystem the metrics system
    * @param isBlockAccessListEnabled whether block-level access lists are enabled
    * @return the protocol spec for the frontier network fork
@@ -43,11 +45,16 @@ public class ProtocolSpecModule {
   @Provides
   @Named("frontier")
   public ProtocolSpecBuilder frontierProtocolSpec(
+      final GenesisConfigOptions genesisConfigOptions,
       final EvmConfiguration evmConfiguration,
-      final boolean isParalleltxEnabled,
+      final boolean isParallelTxEnabled,
       final boolean isBlockAccessListEnabled,
       final MetricsSystem metricsSystem) {
     return MainnetProtocolSpecs.frontierDefinition(
-        evmConfiguration, isParalleltxEnabled, isBlockAccessListEnabled, metricsSystem);
+        genesisConfigOptions,
+        evmConfiguration,
+        isParallelTxEnabled,
+        isBlockAccessListEnabled,
+        metricsSystem);
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ClassicProtocolSpecs.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ClassicProtocolSpecs.java
@@ -28,6 +28,7 @@ import static org.hyperledger.besu.datatypes.HardforkId.ClassicHardforkId.SPIRAL
 import static org.hyperledger.besu.datatypes.HardforkId.ClassicHardforkId.THANOS;
 import static org.hyperledger.besu.ethereum.mainnet.MainnetProtocolSpecs.powHasher;
 
+import org.hyperledger.besu.config.GenesisConfigOptions;
 import org.hyperledger.besu.config.PowAlgorithm;
 import org.hyperledger.besu.datatypes.TransactionType;
 import org.hyperledger.besu.datatypes.Wei;
@@ -53,7 +54,6 @@ import java.math.BigInteger;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.OptionalLong;
 import java.util.Set;
 
 public class ClassicProtocolSpecs {
@@ -64,11 +64,13 @@ public class ClassicProtocolSpecs {
   }
 
   public static ProtocolSpecBuilder classicRecoveryInitDefinition(
+      final GenesisConfigOptions genesisConfigOptions,
       final EvmConfiguration evmConfiguration,
       final boolean isParallelTxProcessingEnabled,
       final boolean isBlockAccessListEnabled,
       final MetricsSystem metricsSystem) {
     return MainnetProtocolSpecs.homesteadDefinition(
+            genesisConfigOptions,
             evmConfiguration,
             isParallelTxProcessingEnabled,
             isBlockAccessListEnabled,
@@ -81,11 +83,13 @@ public class ClassicProtocolSpecs {
 
   public static ProtocolSpecBuilder tangerineWhistleDefinition(
       final Optional<BigInteger> chainId,
+      final GenesisConfigOptions genesisConfigOptions,
       final EvmConfiguration evmConfiguration,
       final boolean isParallelTxProcessingEnabled,
       final boolean isBlockAccessListEnabled,
       final MetricsSystem metricsSystem) {
     return MainnetProtocolSpecs.homesteadDefinition(
+            genesisConfigOptions,
             evmConfiguration,
             isParallelTxProcessingEnabled,
             isBlockAccessListEnabled,
@@ -101,12 +105,14 @@ public class ClassicProtocolSpecs {
 
   public static ProtocolSpecBuilder dieHardDefinition(
       final Optional<BigInteger> chainId,
+      final GenesisConfigOptions genesisConfigOptions,
       final EvmConfiguration evmConfiguration,
       final boolean isParallelTxProcessingEnabled,
       final boolean isBlockAccessListEnabled,
       final MetricsSystem metricsSystem) {
     return tangerineWhistleDefinition(
             chainId,
+            genesisConfigOptions,
             evmConfiguration,
             isParallelTxProcessingEnabled,
             isBlockAccessListEnabled,
@@ -118,13 +124,14 @@ public class ClassicProtocolSpecs {
 
   public static ProtocolSpecBuilder gothamDefinition(
       final Optional<BigInteger> chainId,
-      final OptionalLong ecip1017EraRounds,
+      final GenesisConfigOptions genesisConfigOptions,
       final EvmConfiguration evmConfiguration,
       final boolean isParallelTxProcessingEnabled,
       final boolean isBlockAccessListEnabled,
       final MetricsSystem metricsSystem) {
     return dieHardDefinition(
             chainId,
+            genesisConfigOptions,
             evmConfiguration,
             isParallelTxProcessingEnabled,
             isBlockAccessListEnabled,
@@ -144,21 +151,21 @@ public class ClassicProtocolSpecs {
                     blockReward,
                     miningBeneficiaryCalculator,
                     skipZeroBlockRewards,
-                    ecip1017EraRounds,
+                    genesisConfigOptions.getEcip1017EraRounds(),
                     protocolSchedule))
         .hardforkId(GOTHAM);
   }
 
   public static ProtocolSpecBuilder defuseDifficultyBombDefinition(
       final Optional<BigInteger> chainId,
-      final OptionalLong ecip1017EraRounds,
+      final GenesisConfigOptions genesisConfigOptions,
       final EvmConfiguration evmConfiguration,
       final boolean isParallelTxProcessingEnabled,
       final boolean isBlockAccessListEnabled,
       final MetricsSystem metricsSystem) {
     return gothamDefinition(
             chainId,
-            ecip1017EraRounds,
+            genesisConfigOptions,
             evmConfiguration,
             isParallelTxProcessingEnabled,
             isBlockAccessListEnabled,
@@ -174,14 +181,14 @@ public class ClassicProtocolSpecs {
   public static ProtocolSpecBuilder atlantisDefinition(
       final Optional<BigInteger> chainId,
       final boolean enableRevertReason,
-      final OptionalLong ecip1017EraRounds,
+      final GenesisConfigOptions genesisConfigOptions,
       final EvmConfiguration evmConfiguration,
       final boolean isParallelTxProcessingEnabled,
       final boolean isBlockAccessListEnabled,
       final MetricsSystem metricsSystem) {
     return gothamDefinition(
             chainId,
-            ecip1017EraRounds,
+            genesisConfigOptions,
             evmConfiguration,
             isParallelTxProcessingEnabled,
             isBlockAccessListEnabled,
@@ -222,7 +229,7 @@ public class ClassicProtocolSpecs {
   public static ProtocolSpecBuilder aghartaDefinition(
       final Optional<BigInteger> chainId,
       final boolean enableRevertReason,
-      final OptionalLong ecip1017EraRounds,
+      final GenesisConfigOptions genesisConfigOptions,
       final EvmConfiguration evmConfiguration,
       final boolean isParallelTxProcessingEnabled,
       final boolean isBlockAccessListEnabled,
@@ -230,7 +237,7 @@ public class ClassicProtocolSpecs {
     return atlantisDefinition(
             chainId,
             enableRevertReason,
-            ecip1017EraRounds,
+            genesisConfigOptions,
             evmConfiguration,
             isParallelTxProcessingEnabled,
             isBlockAccessListEnabled,
@@ -245,7 +252,7 @@ public class ClassicProtocolSpecs {
   public static ProtocolSpecBuilder phoenixDefinition(
       final Optional<BigInteger> chainId,
       final boolean enableRevertReason,
-      final OptionalLong ecip1017EraRounds,
+      final GenesisConfigOptions genesisConfigOptions,
       final EvmConfiguration evmConfiguration,
       final boolean isParallelTxProcessingEnabled,
       final boolean isBlockAccessListEnabled,
@@ -253,7 +260,7 @@ public class ClassicProtocolSpecs {
     return aghartaDefinition(
             chainId,
             enableRevertReason,
-            ecip1017EraRounds,
+            genesisConfigOptions,
             evmConfiguration,
             isParallelTxProcessingEnabled,
             isBlockAccessListEnabled,
@@ -270,7 +277,7 @@ public class ClassicProtocolSpecs {
   public static ProtocolSpecBuilder thanosDefinition(
       final Optional<BigInteger> chainId,
       final boolean enableRevertReason,
-      final OptionalLong ecip1017EraRounds,
+      final GenesisConfigOptions genesisConfigOptions,
       final EvmConfiguration evmConfiguration,
       final boolean isParallelTxProcessingEnabled,
       final boolean isBlockAccessListEnabled,
@@ -278,7 +285,7 @@ public class ClassicProtocolSpecs {
     return phoenixDefinition(
             chainId,
             enableRevertReason,
-            ecip1017EraRounds,
+            genesisConfigOptions,
             evmConfiguration,
             isParallelTxProcessingEnabled,
             isBlockAccessListEnabled,
@@ -297,7 +304,7 @@ public class ClassicProtocolSpecs {
   public static ProtocolSpecBuilder magnetoDefinition(
       final Optional<BigInteger> chainId,
       final boolean enableRevertReason,
-      final OptionalLong ecip1017EraRounds,
+      final GenesisConfigOptions genesisConfigOptions,
       final EvmConfiguration evmConfiguration,
       final boolean isParallelTxProcessingEnabled,
       final boolean isBlockAccessListEnabled,
@@ -305,7 +312,7 @@ public class ClassicProtocolSpecs {
     return thanosDefinition(
             chainId,
             enableRevertReason,
-            ecip1017EraRounds,
+            genesisConfigOptions,
             evmConfiguration,
             isParallelTxProcessingEnabled,
             isBlockAccessListEnabled,
@@ -327,7 +334,7 @@ public class ClassicProtocolSpecs {
   public static ProtocolSpecBuilder mystiqueDefinition(
       final Optional<BigInteger> chainId,
       final boolean enableRevertReason,
-      final OptionalLong ecip1017EraRounds,
+      final GenesisConfigOptions genesisConfigOptions,
       final EvmConfiguration evmConfiguration,
       final boolean isParallelTxProcessingEnabled,
       final boolean isBlockAccessListEnabled,
@@ -335,7 +342,7 @@ public class ClassicProtocolSpecs {
     return magnetoDefinition(
             chainId,
             enableRevertReason,
-            ecip1017EraRounds,
+            genesisConfigOptions,
             evmConfiguration,
             isParallelTxProcessingEnabled,
             isBlockAccessListEnabled,
@@ -351,7 +358,7 @@ public class ClassicProtocolSpecs {
   public static ProtocolSpecBuilder spiralDefinition(
       final Optional<BigInteger> chainId,
       final boolean enableRevertReason,
-      final OptionalLong ecip1017EraRounds,
+      final GenesisConfigOptions genesisConfigOptions,
       final EvmConfiguration evmConfiguration,
       final boolean isParallelTxProcessingEnabled,
       final boolean isBlockAccessListEnabled,
@@ -359,7 +366,7 @@ public class ClassicProtocolSpecs {
     return mystiqueDefinition(
             chainId,
             enableRevertReason,
-            ecip1017EraRounds,
+            genesisConfigOptions,
             evmConfiguration,
             isParallelTxProcessingEnabled,
             isBlockAccessListEnabled,

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetProtocolSpecFactory.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetProtocolSpecFactory.java
@@ -21,13 +21,12 @@ import org.hyperledger.besu.plugin.services.MetricsSystem;
 
 import java.math.BigInteger;
 import java.util.Optional;
-import java.util.OptionalLong;
 
 public class MainnetProtocolSpecFactory {
 
   private final Optional<BigInteger> chainId;
   private final boolean isRevertReasonEnabled;
-  private final OptionalLong ecip1017EraRounds;
+  private final GenesisConfigOptions genesisConfigOptions;
   private final EvmConfiguration evmConfiguration;
   private final MiningConfiguration miningConfiguration;
   private final boolean isParallelTxProcessingEnabled;
@@ -37,7 +36,7 @@ public class MainnetProtocolSpecFactory {
   public MainnetProtocolSpecFactory(
       final Optional<BigInteger> chainId,
       final boolean isRevertReasonEnabled,
-      final OptionalLong ecip1017EraRounds,
+      final GenesisConfigOptions genesisConfigOptions,
       final EvmConfiguration evmConfiguration,
       final MiningConfiguration miningConfiguration,
       final boolean isParallelTxProcessingEnabled,
@@ -45,7 +44,7 @@ public class MainnetProtocolSpecFactory {
       final MetricsSystem metricsSystem) {
     this.chainId = chainId;
     this.isRevertReasonEnabled = isRevertReasonEnabled;
-    this.ecip1017EraRounds = ecip1017EraRounds;
+    this.genesisConfigOptions = genesisConfigOptions;
     this.evmConfiguration = evmConfiguration;
     this.miningConfiguration = miningConfiguration;
     this.isParallelTxProcessingEnabled = isParallelTxProcessingEnabled;
@@ -55,32 +54,53 @@ public class MainnetProtocolSpecFactory {
 
   public ProtocolSpecBuilder frontierDefinition() {
     return MainnetProtocolSpecs.frontierDefinition(
-        evmConfiguration, isParallelTxProcessingEnabled, isBlockAccessListEnabled, metricsSystem);
+        genesisConfigOptions,
+        evmConfiguration,
+        isParallelTxProcessingEnabled,
+        isBlockAccessListEnabled,
+        metricsSystem);
   }
 
   public ProtocolSpecBuilder homesteadDefinition() {
     return MainnetProtocolSpecs.homesteadDefinition(
-        evmConfiguration, isParallelTxProcessingEnabled, isBlockAccessListEnabled, metricsSystem);
+        genesisConfigOptions,
+        evmConfiguration,
+        isParallelTxProcessingEnabled,
+        isBlockAccessListEnabled,
+        metricsSystem);
   }
 
   public ProtocolSpecBuilder daoRecoveryInitDefinition() {
     return MainnetProtocolSpecs.daoRecoveryInitDefinition(
-        evmConfiguration, isParallelTxProcessingEnabled, isBlockAccessListEnabled, metricsSystem);
+        genesisConfigOptions,
+        evmConfiguration,
+        isParallelTxProcessingEnabled,
+        isBlockAccessListEnabled,
+        metricsSystem);
   }
 
   public ProtocolSpecBuilder daoRecoveryTransitionDefinition() {
     return MainnetProtocolSpecs.daoRecoveryTransitionDefinition(
-        evmConfiguration, isParallelTxProcessingEnabled, isBlockAccessListEnabled, metricsSystem);
+        genesisConfigOptions,
+        evmConfiguration,
+        isParallelTxProcessingEnabled,
+        isBlockAccessListEnabled,
+        metricsSystem);
   }
 
   public ProtocolSpecBuilder tangerineWhistleDefinition() {
     return MainnetProtocolSpecs.tangerineWhistleDefinition(
-        evmConfiguration, isParallelTxProcessingEnabled, isBlockAccessListEnabled, metricsSystem);
+        genesisConfigOptions,
+        evmConfiguration,
+        isParallelTxProcessingEnabled,
+        isBlockAccessListEnabled,
+        metricsSystem);
   }
 
   public ProtocolSpecBuilder spuriousDragonDefinition() {
     return MainnetProtocolSpecs.spuriousDragonDefinition(
         chainId,
+        genesisConfigOptions,
         evmConfiguration,
         isParallelTxProcessingEnabled,
         isBlockAccessListEnabled,
@@ -91,6 +111,7 @@ public class MainnetProtocolSpecFactory {
     return MainnetProtocolSpecs.byzantiumDefinition(
         chainId,
         isRevertReasonEnabled,
+        genesisConfigOptions,
         evmConfiguration,
         isParallelTxProcessingEnabled,
         isBlockAccessListEnabled,
@@ -101,6 +122,7 @@ public class MainnetProtocolSpecFactory {
     return MainnetProtocolSpecs.constantinopleDefinition(
         chainId,
         isRevertReasonEnabled,
+        genesisConfigOptions,
         evmConfiguration,
         isParallelTxProcessingEnabled,
         isBlockAccessListEnabled,
@@ -111,6 +133,7 @@ public class MainnetProtocolSpecFactory {
     return MainnetProtocolSpecs.petersburgDefinition(
         chainId,
         isRevertReasonEnabled,
+        genesisConfigOptions,
         evmConfiguration,
         isParallelTxProcessingEnabled,
         isBlockAccessListEnabled,
@@ -121,6 +144,7 @@ public class MainnetProtocolSpecFactory {
     return MainnetProtocolSpecs.istanbulDefinition(
         chainId,
         isRevertReasonEnabled,
+        genesisConfigOptions,
         evmConfiguration,
         isParallelTxProcessingEnabled,
         isBlockAccessListEnabled,
@@ -131,6 +155,7 @@ public class MainnetProtocolSpecFactory {
     return MainnetProtocolSpecs.muirGlacierDefinition(
         chainId,
         isRevertReasonEnabled,
+        genesisConfigOptions,
         evmConfiguration,
         isParallelTxProcessingEnabled,
         isBlockAccessListEnabled,
@@ -141,13 +166,14 @@ public class MainnetProtocolSpecFactory {
     return MainnetProtocolSpecs.berlinDefinition(
         chainId,
         isRevertReasonEnabled,
+        genesisConfigOptions,
         evmConfiguration,
         isParallelTxProcessingEnabled,
         isBlockAccessListEnabled,
         metricsSystem);
   }
 
-  public ProtocolSpecBuilder londonDefinition(final GenesisConfigOptions genesisConfigOptions) {
+  public ProtocolSpecBuilder londonDefinition() {
     return MainnetProtocolSpecs.londonDefinition(
         chainId,
         isRevertReasonEnabled,
@@ -159,8 +185,7 @@ public class MainnetProtocolSpecFactory {
         metricsSystem);
   }
 
-  public ProtocolSpecBuilder arrowGlacierDefinition(
-      final GenesisConfigOptions genesisConfigOptions) {
+  public ProtocolSpecBuilder arrowGlacierDefinition() {
     return MainnetProtocolSpecs.arrowGlacierDefinition(
         chainId,
         isRevertReasonEnabled,
@@ -172,8 +197,7 @@ public class MainnetProtocolSpecFactory {
         metricsSystem);
   }
 
-  public ProtocolSpecBuilder grayGlacierDefinition(
-      final GenesisConfigOptions genesisConfigOptions) {
+  public ProtocolSpecBuilder grayGlacierDefinition() {
     return MainnetProtocolSpecs.grayGlacierDefinition(
         chainId,
         isRevertReasonEnabled,
@@ -185,7 +209,7 @@ public class MainnetProtocolSpecFactory {
         metricsSystem);
   }
 
-  public ProtocolSpecBuilder parisDefinition(final GenesisConfigOptions genesisConfigOptions) {
+  public ProtocolSpecBuilder parisDefinition() {
     return MainnetProtocolSpecs.parisDefinition(
         chainId,
         isRevertReasonEnabled,
@@ -197,7 +221,7 @@ public class MainnetProtocolSpecFactory {
         metricsSystem);
   }
 
-  public ProtocolSpecBuilder shanghaiDefinition(final GenesisConfigOptions genesisConfigOptions) {
+  public ProtocolSpecBuilder shanghaiDefinition() {
     return MainnetProtocolSpecs.shanghaiDefinition(
         chainId,
         isRevertReasonEnabled,
@@ -209,7 +233,7 @@ public class MainnetProtocolSpecFactory {
         metricsSystem);
   }
 
-  public ProtocolSpecBuilder cancunDefinition(final GenesisConfigOptions genesisConfigOptions) {
+  public ProtocolSpecBuilder cancunDefinition() {
     return MainnetProtocolSpecs.cancunDefinition(
         chainId,
         isRevertReasonEnabled,
@@ -221,7 +245,7 @@ public class MainnetProtocolSpecFactory {
         metricsSystem);
   }
 
-  public ProtocolSpecBuilder cancunEOFDefinition(final GenesisConfigOptions genesisConfigOptions) {
+  public ProtocolSpecBuilder cancunEOFDefinition() {
     return MainnetProtocolSpecs.cancunEOFDefinition(
         chainId,
         isRevertReasonEnabled,
@@ -233,7 +257,7 @@ public class MainnetProtocolSpecFactory {
         metricsSystem);
   }
 
-  public ProtocolSpecBuilder pragueDefinition(final GenesisConfigOptions genesisConfigOptions) {
+  public ProtocolSpecBuilder pragueDefinition() {
     return MainnetProtocolSpecs.pragueDefinition(
         chainId,
         isRevertReasonEnabled,
@@ -245,7 +269,7 @@ public class MainnetProtocolSpecFactory {
         metricsSystem);
   }
 
-  public ProtocolSpecBuilder osakaDefinition(final GenesisConfigOptions genesisConfigOptions) {
+  public ProtocolSpecBuilder osakaDefinition() {
     return MainnetProtocolSpecs.osakaDefinition(
         chainId,
         isRevertReasonEnabled,
@@ -257,7 +281,7 @@ public class MainnetProtocolSpecFactory {
         metricsSystem);
   }
 
-  public ProtocolSpecBuilder bpo1Definition(final GenesisConfigOptions genesisConfigOptions) {
+  public ProtocolSpecBuilder bpo1Definition() {
     return MainnetProtocolSpecs.bpo1Definition(
         chainId,
         isRevertReasonEnabled,
@@ -269,7 +293,7 @@ public class MainnetProtocolSpecFactory {
         metricsSystem);
   }
 
-  public ProtocolSpecBuilder bpo2Definition(final GenesisConfigOptions genesisConfigOptions) {
+  public ProtocolSpecBuilder bpo2Definition() {
     return MainnetProtocolSpecs.bpo2Definition(
         chainId,
         isRevertReasonEnabled,
@@ -281,7 +305,7 @@ public class MainnetProtocolSpecFactory {
         metricsSystem);
   }
 
-  public ProtocolSpecBuilder bpo3Definition(final GenesisConfigOptions genesisConfigOptions) {
+  public ProtocolSpecBuilder bpo3Definition() {
     return MainnetProtocolSpecs.bpo3Definition(
         chainId,
         isRevertReasonEnabled,
@@ -293,7 +317,7 @@ public class MainnetProtocolSpecFactory {
         metricsSystem);
   }
 
-  public ProtocolSpecBuilder bpo4Definition(final GenesisConfigOptions genesisConfigOptions) {
+  public ProtocolSpecBuilder bpo4Definition() {
     return MainnetProtocolSpecs.bpo4Definition(
         chainId,
         isRevertReasonEnabled,
@@ -305,7 +329,7 @@ public class MainnetProtocolSpecFactory {
         metricsSystem);
   }
 
-  public ProtocolSpecBuilder bpo5Definition(final GenesisConfigOptions genesisConfigOptions) {
+  public ProtocolSpecBuilder bpo5Definition() {
     return MainnetProtocolSpecs.bpo5Definition(
         chainId,
         isRevertReasonEnabled,
@@ -325,10 +349,9 @@ public class MainnetProtocolSpecFactory {
    * <p>There is no guarantee of the contents of this fork across Besu releases and should be
    * considered unstable.
    *
-   * @param genesisConfigOptions the chain options from the genesis config
    * @return a protocol spec for the "Future" fork.
    */
-  public ProtocolSpecBuilder futureEipsDefinition(final GenesisConfigOptions genesisConfigOptions) {
+  public ProtocolSpecBuilder futureEipsDefinition() {
     return MainnetProtocolSpecs.futureEipsDefinition(
         chainId,
         isRevertReasonEnabled,
@@ -347,11 +370,9 @@ public class MainnetProtocolSpecFactory {
    * <p>There is no guarantee of the contents of this fork across Besu releases and should be
    * considered unstable.
    *
-   * @param genesisConfigOptions the chain options from the genesis config
    * @return a protocol spec for the "Experimental" fork.
    */
-  public ProtocolSpecBuilder experimentalEipsDefinition(
-      final GenesisConfigOptions genesisConfigOptions) {
+  public ProtocolSpecBuilder experimentalEipsDefinition() {
     return MainnetProtocolSpecs.experimentalEipsDefinition(
         chainId,
         isRevertReasonEnabled,
@@ -369,6 +390,7 @@ public class MainnetProtocolSpecFactory {
   public ProtocolSpecBuilder dieHardDefinition() {
     return ClassicProtocolSpecs.dieHardDefinition(
         chainId,
+        genesisConfigOptions,
         evmConfiguration,
         isParallelTxProcessingEnabled,
         isBlockAccessListEnabled,
@@ -378,7 +400,7 @@ public class MainnetProtocolSpecFactory {
   public ProtocolSpecBuilder gothamDefinition() {
     return ClassicProtocolSpecs.gothamDefinition(
         chainId,
-        ecip1017EraRounds,
+        genesisConfigOptions,
         evmConfiguration,
         isParallelTxProcessingEnabled,
         isBlockAccessListEnabled,
@@ -388,7 +410,7 @@ public class MainnetProtocolSpecFactory {
   public ProtocolSpecBuilder defuseDifficultyBombDefinition() {
     return ClassicProtocolSpecs.defuseDifficultyBombDefinition(
         chainId,
-        ecip1017EraRounds,
+        genesisConfigOptions,
         evmConfiguration,
         isParallelTxProcessingEnabled,
         isBlockAccessListEnabled,
@@ -399,7 +421,7 @@ public class MainnetProtocolSpecFactory {
     return ClassicProtocolSpecs.atlantisDefinition(
         chainId,
         isRevertReasonEnabled,
-        ecip1017EraRounds,
+        genesisConfigOptions,
         evmConfiguration,
         isParallelTxProcessingEnabled,
         isBlockAccessListEnabled,
@@ -410,7 +432,7 @@ public class MainnetProtocolSpecFactory {
     return ClassicProtocolSpecs.aghartaDefinition(
         chainId,
         isRevertReasonEnabled,
-        ecip1017EraRounds,
+        genesisConfigOptions,
         evmConfiguration,
         isParallelTxProcessingEnabled,
         isBlockAccessListEnabled,
@@ -421,7 +443,7 @@ public class MainnetProtocolSpecFactory {
     return ClassicProtocolSpecs.phoenixDefinition(
         chainId,
         isRevertReasonEnabled,
-        ecip1017EraRounds,
+        genesisConfigOptions,
         evmConfiguration,
         isParallelTxProcessingEnabled,
         isBlockAccessListEnabled,
@@ -432,7 +454,7 @@ public class MainnetProtocolSpecFactory {
     return ClassicProtocolSpecs.thanosDefinition(
         chainId,
         isRevertReasonEnabled,
-        ecip1017EraRounds,
+        genesisConfigOptions,
         evmConfiguration,
         isParallelTxProcessingEnabled,
         isBlockAccessListEnabled,
@@ -443,7 +465,7 @@ public class MainnetProtocolSpecFactory {
     return ClassicProtocolSpecs.magnetoDefinition(
         chainId,
         isRevertReasonEnabled,
-        ecip1017EraRounds,
+        genesisConfigOptions,
         evmConfiguration,
         isParallelTxProcessingEnabled,
         isBlockAccessListEnabled,
@@ -454,7 +476,7 @@ public class MainnetProtocolSpecFactory {
     return ClassicProtocolSpecs.mystiqueDefinition(
         chainId,
         isRevertReasonEnabled,
-        ecip1017EraRounds,
+        genesisConfigOptions,
         evmConfiguration,
         isParallelTxProcessingEnabled,
         isBlockAccessListEnabled,
@@ -465,7 +487,7 @@ public class MainnetProtocolSpecFactory {
     return ClassicProtocolSpecs.spiralDefinition(
         chainId,
         isRevertReasonEnabled,
-        ecip1017EraRounds,
+        genesisConfigOptions,
         evmConfiguration,
         isParallelTxProcessingEnabled,
         isBlockAccessListEnabled,

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetProtocolSpecs.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetProtocolSpecs.java
@@ -150,6 +150,7 @@ public abstract class MainnetProtocolSpecs {
   private MainnetProtocolSpecs() {}
 
   public static ProtocolSpecBuilder frontierDefinition(
+      final GenesisConfigOptions genesisConfigOptions,
       final EvmConfiguration evmConfiguration,
       final boolean isParallelTxProcessingEnabled,
       final boolean isBlockAccessListEnabled,
@@ -218,11 +219,13 @@ public abstract class MainnetProtocolSpecs {
   }
 
   public static ProtocolSpecBuilder homesteadDefinition(
+      final GenesisConfigOptions genesisConfigOptions,
       final EvmConfiguration evmConfiguration,
       final boolean isParallelTxProcessingEnabled,
       final boolean isBlockAccessListEnabled,
       final MetricsSystem metricsSystem) {
     return frontierDefinition(
+            genesisConfigOptions,
             evmConfiguration,
             isParallelTxProcessingEnabled,
             isBlockAccessListEnabled,
@@ -242,11 +245,13 @@ public abstract class MainnetProtocolSpecs {
   }
 
   public static ProtocolSpecBuilder daoRecoveryInitDefinition(
+      final GenesisConfigOptions genesisConfigOptions,
       final EvmConfiguration evmConfiguration,
       final boolean isParallelTxProcessingEnabled,
       final boolean isBlockAccessListEnabled,
       final MetricsSystem metricsSystem) {
     return homesteadDefinition(
+            genesisConfigOptions,
             evmConfiguration,
             isParallelTxProcessingEnabled,
             isBlockAccessListEnabled,
@@ -282,11 +287,13 @@ public abstract class MainnetProtocolSpecs {
   }
 
   public static ProtocolSpecBuilder daoRecoveryTransitionDefinition(
+      final GenesisConfigOptions genesisConfigOptions,
       final EvmConfiguration evmConfiguration,
       final boolean isParallelTxProcessingEnabled,
       final boolean isBlockAccessListEnabled,
       final MetricsSystem metricsSystem) {
     return daoRecoveryInitDefinition(
+            genesisConfigOptions,
             evmConfiguration,
             isParallelTxProcessingEnabled,
             isBlockAccessListEnabled,
@@ -299,11 +306,13 @@ public abstract class MainnetProtocolSpecs {
   }
 
   public static ProtocolSpecBuilder tangerineWhistleDefinition(
+      final GenesisConfigOptions genesisConfigOptions,
       final EvmConfiguration evmConfiguration,
       final boolean isParallelTxProcessingEnabled,
       final boolean isBlockAccessListEnabled,
       final MetricsSystem metricsSystem) {
     return homesteadDefinition(
+            genesisConfigOptions,
             evmConfiguration,
             isParallelTxProcessingEnabled,
             isBlockAccessListEnabled,
@@ -314,11 +323,13 @@ public abstract class MainnetProtocolSpecs {
 
   public static ProtocolSpecBuilder spuriousDragonDefinition(
       final Optional<BigInteger> chainId,
+      final GenesisConfigOptions genesisConfigOptions,
       final EvmConfiguration evmConfiguration,
       final boolean isParallelTxProcessingEnabled,
       final boolean isBlockAccessListEnabled,
       final MetricsSystem metricsSystem) {
     return tangerineWhistleDefinition(
+            genesisConfigOptions,
             evmConfiguration,
             isParallelTxProcessingEnabled,
             isBlockAccessListEnabled,
@@ -367,12 +378,14 @@ public abstract class MainnetProtocolSpecs {
   public static ProtocolSpecBuilder byzantiumDefinition(
       final Optional<BigInteger> chainId,
       final boolean enableRevertReason,
+      final GenesisConfigOptions genesisConfigOptions,
       final EvmConfiguration evmConfiguration,
       final boolean isParallelTxProcessingEnabled,
       final boolean isBlockAccessListEnabled,
       final MetricsSystem metricsSystem) {
     return spuriousDragonDefinition(
             chainId,
+            genesisConfigOptions,
             evmConfiguration,
             isParallelTxProcessingEnabled,
             isBlockAccessListEnabled,
@@ -389,6 +402,7 @@ public abstract class MainnetProtocolSpecs {
   public static ProtocolSpecBuilder constantinopleDefinition(
       final Optional<BigInteger> chainId,
       final boolean enableRevertReason,
+      final GenesisConfigOptions genesisConfigOptions,
       final EvmConfiguration evmConfiguration,
       final boolean isParallelTxProcessingEnabled,
       final boolean isBlockAccessListEnabled,
@@ -396,6 +410,7 @@ public abstract class MainnetProtocolSpecs {
     return byzantiumDefinition(
             chainId,
             enableRevertReason,
+            genesisConfigOptions,
             evmConfiguration,
             isParallelTxProcessingEnabled,
             isBlockAccessListEnabled,
@@ -410,6 +425,7 @@ public abstract class MainnetProtocolSpecs {
   public static ProtocolSpecBuilder petersburgDefinition(
       final Optional<BigInteger> chainId,
       final boolean enableRevertReason,
+      final GenesisConfigOptions genesisConfigOptions,
       final EvmConfiguration evmConfiguration,
       final boolean isParallelTxProcessingEnabled,
       final boolean isBlockAccessListEnabled,
@@ -417,6 +433,7 @@ public abstract class MainnetProtocolSpecs {
     return constantinopleDefinition(
             chainId,
             enableRevertReason,
+            genesisConfigOptions,
             evmConfiguration,
             isParallelTxProcessingEnabled,
             isBlockAccessListEnabled,
@@ -428,6 +445,7 @@ public abstract class MainnetProtocolSpecs {
   public static ProtocolSpecBuilder istanbulDefinition(
       final Optional<BigInteger> chainId,
       final boolean enableRevertReason,
+      final GenesisConfigOptions genesisConfigOptions,
       final EvmConfiguration evmConfiguration,
       final boolean isParallelTxProcessingEnabled,
       final boolean isBlockAccessListEnabled,
@@ -435,6 +453,7 @@ public abstract class MainnetProtocolSpecs {
     return petersburgDefinition(
             chainId,
             enableRevertReason,
+            genesisConfigOptions,
             evmConfiguration,
             isParallelTxProcessingEnabled,
             isBlockAccessListEnabled,
@@ -459,6 +478,7 @@ public abstract class MainnetProtocolSpecs {
   static ProtocolSpecBuilder muirGlacierDefinition(
       final Optional<BigInteger> chainId,
       final boolean enableRevertReason,
+      final GenesisConfigOptions genesisConfigOptions,
       final EvmConfiguration evmConfiguration,
       final boolean isParallelTxProcessingEnabled,
       final boolean isBlockAccessListEnabled,
@@ -466,6 +486,7 @@ public abstract class MainnetProtocolSpecs {
     return istanbulDefinition(
             chainId,
             enableRevertReason,
+            genesisConfigOptions,
             evmConfiguration,
             isParallelTxProcessingEnabled,
             isBlockAccessListEnabled,
@@ -477,6 +498,7 @@ public abstract class MainnetProtocolSpecs {
   static ProtocolSpecBuilder berlinDefinition(
       final Optional<BigInteger> chainId,
       final boolean enableRevertReason,
+      final GenesisConfigOptions genesisConfigOptions,
       final EvmConfiguration evmConfiguration,
       final boolean isParallelTxProcessingEnabled,
       final boolean isBlockAccessListEnabled,
@@ -484,6 +506,7 @@ public abstract class MainnetProtocolSpecs {
     return muirGlacierDefinition(
             chainId,
             enableRevertReason,
+            genesisConfigOptions,
             evmConfiguration,
             isParallelTxProcessingEnabled,
             isBlockAccessListEnabled,
@@ -515,6 +538,7 @@ public abstract class MainnetProtocolSpecs {
     return berlinDefinition(
             chainId,
             enableRevertReason,
+            genesisConfigOptions,
             evmConfiguration,
             isParallelTxProcessingEnabled,
             isBlockAccessListEnabled,

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ProtocolScheduleBuilder.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ProtocolScheduleBuilder.java
@@ -79,18 +79,17 @@ public class ProtocolScheduleBuilder {
   public ProtocolSchedule createProtocolSchedule() {
     final Optional<BigInteger> chainId = config.getChainId().or(() -> defaultChainId);
     DefaultProtocolSchedule protocolSchedule = new DefaultProtocolSchedule(chainId);
-    initSchedule(protocolSchedule, chainId);
+    initSchedule(protocolSchedule);
     return protocolSchedule;
   }
 
-  public void initSchedule(
-      final ProtocolSchedule protocolSchedule, final Optional<BigInteger> chainId) {
+  public void initSchedule(final ProtocolSchedule protocolSchedule) {
 
     final MainnetProtocolSpecFactory specFactory =
         new MainnetProtocolSpecFactory(
-            chainId,
+            protocolSchedule.getChainId(),
             isRevertReasonEnabled,
-            config.getEcip1017EraRounds(),
+            config,
             evmConfiguration.overrides(
                 config.getContractSizeLimit(), OptionalInt.empty(), config.getEvmStackSize()),
             miningConfiguration,
@@ -105,8 +104,7 @@ public class ProtocolScheduleBuilder {
     final NavigableMap<Long, BuilderMapEntry> builders = buildFlattenedMilestoneMap(mileStones);
 
     // At this stage, all milestones are flagged with the correct modifier, but ProtocolSpecs must
-    // be
-    // inserted _AT_ the modifier block entry.
+    // be inserted _AT_ the modifier block entry.
     if (!builders.isEmpty()) {
       protocolSpecAdapters.stream()
           .forEach(
@@ -185,6 +183,7 @@ public class ProtocolScheduleBuilder {
                   MilestoneType.BLOCK_NUMBER,
                   classicBlockNumber,
                   ClassicProtocolSpecs.classicRecoveryInitDefinition(
+                      config,
                       evmConfiguration,
                       isParallelTxProcessingEnabled,
                       isBlockAccessListEnabled,

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/milestones/MilestoneDefinitions.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/milestones/MilestoneDefinitions.java
@@ -157,21 +157,19 @@ public class MilestoneDefinitions {
         createBlockNumberMilestone(
             MainnetHardforkId.BERLIN, config.getBerlinBlockNumber(), specFactory::berlinDefinition),
         createBlockNumberMilestone(
-            MainnetHardforkId.LONDON,
-            config.getLondonBlockNumber(),
-            () -> specFactory.londonDefinition(config)),
+            MainnetHardforkId.LONDON, config.getLondonBlockNumber(), specFactory::londonDefinition),
         createBlockNumberMilestone(
             MainnetHardforkId.ARROW_GLACIER,
             config.getArrowGlacierBlockNumber(),
-            () -> specFactory.arrowGlacierDefinition(config)),
+            specFactory::arrowGlacierDefinition),
         createBlockNumberMilestone(
             MainnetHardforkId.GRAY_GLACIER,
             config.getGrayGlacierBlockNumber(),
-            () -> specFactory.grayGlacierDefinition(config)),
+            specFactory::grayGlacierDefinition),
         createBlockNumberMilestone(
             MainnetHardforkId.PARIS,
             config.getMergeNetSplitBlockNumber(),
-            () -> specFactory.parisDefinition(config)));
+            specFactory::parisDefinition));
   }
 
   /**
@@ -185,42 +183,34 @@ public class MilestoneDefinitions {
       final MainnetProtocolSpecFactory specFactory, final GenesisConfigOptions config) {
     return List.of(
         createTimestampMilestone(
-            MainnetHardforkId.SHANGHAI,
-            config.getShanghaiTime(),
-            () -> specFactory.shanghaiDefinition(config)),
+            MainnetHardforkId.SHANGHAI, config.getShanghaiTime(), specFactory::shanghaiDefinition),
         createTimestampMilestone(
-            MainnetHardforkId.CANCUN,
-            config.getCancunTime(),
-            () -> specFactory.cancunDefinition(config)),
+            MainnetHardforkId.CANCUN, config.getCancunTime(), specFactory::cancunDefinition),
         createTimestampMilestone(
             MainnetHardforkId.CANCUN_EOF,
             config.getCancunEOFTime(),
-            () -> specFactory.cancunEOFDefinition(config)),
+            specFactory::cancunEOFDefinition),
         createTimestampMilestone(
-            MainnetHardforkId.PRAGUE,
-            config.getPragueTime(),
-            () -> specFactory.pragueDefinition(config)),
+            MainnetHardforkId.PRAGUE, config.getPragueTime(), specFactory::pragueDefinition),
         createTimestampMilestone(
-            MainnetHardforkId.OSAKA,
-            config.getOsakaTime(),
-            () -> specFactory.osakaDefinition(config)),
+            MainnetHardforkId.OSAKA, config.getOsakaTime(), specFactory::osakaDefinition),
         createTimestampMilestone(
-            MainnetHardforkId.BPO1, config.getBpo1Time(), () -> specFactory.bpo1Definition(config)),
+            MainnetHardforkId.BPO1, config.getBpo1Time(), specFactory::bpo1Definition),
         createTimestampMilestone(
-            MainnetHardforkId.BPO2, config.getBpo2Time(), () -> specFactory.bpo2Definition(config)),
+            MainnetHardforkId.BPO2, config.getBpo2Time(), specFactory::bpo2Definition),
         createTimestampMilestone(
-            MainnetHardforkId.BPO3, config.getBpo3Time(), () -> specFactory.bpo3Definition(config)),
+            MainnetHardforkId.BPO3, config.getBpo3Time(), specFactory::bpo3Definition),
         createTimestampMilestone(
-            MainnetHardforkId.BPO4, config.getBpo4Time(), () -> specFactory.bpo4Definition(config)),
+            MainnetHardforkId.BPO4, config.getBpo4Time(), specFactory::bpo4Definition),
         createTimestampMilestone(
-            MainnetHardforkId.BPO5, config.getBpo5Time(), () -> specFactory.bpo5Definition(config)),
+            MainnetHardforkId.BPO5, config.getBpo5Time(), specFactory::bpo5Definition),
         createTimestampMilestone(
             MainnetHardforkId.FUTURE_EIPS,
             config.getFutureEipsTime(),
-            () -> specFactory.futureEipsDefinition(config)),
+            specFactory::futureEipsDefinition),
         createTimestampMilestone(
             MainnetHardforkId.EXPERIMENTAL_EIPS,
             config.getExperimentalEipsTime(),
-            () -> specFactory.experimentalEipsDefinition(config)));
+            specFactory::experimentalEipsDefinition));
   }
 }


### PR DESCRIPTION
## PR description

Just a refactor PR to uniform the way genesis config options are passed to protocol specs, no functional changes expected. This refactor will make the next PR https://github.com/hyperledger/besu/pull/9257 much easier to read.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


