### PR TITLE
remove osaka from blob schedule for testnets

### DIFF
--- a/config/src/main/resources/holesky.json
+++ b/config/src/main/resources/holesky.json
@@ -30,11 +30,6 @@
         "max": 9,
         "baseFeeUpdateFraction": 5007716
       },
-      "osaka": {
-        "target": 6,
-        "max": 9,
-        "baseFeeUpdateFraction": 5007716
-      },
       "bpo1": {
         "target": 10,
         "max": 15,

--- a/config/src/main/resources/hoodi.json
+++ b/config/src/main/resources/hoodi.json
@@ -34,11 +34,6 @@
         "max": 9,
         "baseFeeUpdateFraction": 5007716
       },
-      "osaka": {
-        "target": 6,
-        "max": 9,
-        "baseFeeUpdateFraction": 5007716
-      },
       "bpo1": {
         "target": 10,
         "max": 15,

--- a/config/src/main/resources/sepolia.json
+++ b/config/src/main/resources/sepolia.json
@@ -30,11 +30,6 @@
         "max": 9,
         "baseFeeUpdateFraction": 5007716
       },
-      "osaka": {
-        "target": 6,
-        "max": 9,
-        "baseFeeUpdateFraction": 5007716
-      },
       "bpo1": {
         "target": 10,
         "max": 15,


### PR DESCRIPTION
## PR description
This is never used and osaka has same values as cancun. Discussion in discord 

also related

https://github.com/ethpandaops/ethereum-genesis-generator/pull/245
https://github.com/eth-clients/hoodi/pull/22
https://github.com/eth-clients/sepolia/pull/116
https://github.com/eth-clients/holesky/pull/134
[eth-clients/mainnet@`9dac422` (#11)](https://github.com/eth-clients/mainnet/pull/11/commits/9dac4227015859458c06b81552bf93c555d0feeb)

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


