### PR TITLE
Conditionally include empty BAL in genesis state

### DIFF
--- a/datatypes/src/main/java/org/hyperledger/besu/datatypes/Hash.java
+++ b/datatypes/src/main/java/org/hyperledger/besu/datatypes/Hash.java
@@ -56,6 +56,10 @@ public class Hash extends DelegatingBytes32 {
    */
   public static final Hash EMPTY_REQUESTS_HASH = Hash.wrap(sha256(Bytes.EMPTY));
 
+  /** Hash of empty block access list or
+   * "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347" */
+  public static final Hash EMPTY_BAL_HASH = EMPTY_LIST_HASH;
+
   /**
    * Instantiates a new Hash.
    *

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/GenesisState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/GenesisState.java
@@ -33,6 +33,7 @@ import org.hyperledger.besu.ethereum.core.MutableWorldState;
 import org.hyperledger.besu.ethereum.core.Withdrawal;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ScheduleBasedBlockHeaderFunctions;
+import org.hyperledger.besu.ethereum.mainnet.block.access.list.BlockAccessList;
 import org.hyperledger.besu.ethereum.trie.pathbased.bonsai.cache.CodeCache;
 import org.hyperledger.besu.ethereum.trie.pathbased.common.worldview.PathBasedWorldState;
 import org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration;
@@ -157,7 +158,12 @@ public final class GenesisState {
     final Optional<List<Withdrawal>> withdrawals =
         isShanghaiAtGenesis(config) ? Optional.of(emptyList()) : Optional.empty();
 
-    return new BlockBody(emptyList(), emptyList(), withdrawals);
+    final Optional<BlockAccessList> blockAccessList =
+        isAmsterdamAtGenesis(config)
+            ? Optional.of(BlockAccessList.builder().build())
+            : Optional.empty();
+
+    return new BlockBody(emptyList(), emptyList(), withdrawals, blockAccessList);
   }
 
   public Block getBlock() {
@@ -253,6 +259,7 @@ public final class GenesisState {
         .parentBeaconBlockRoot(
             (isCancunAtGenesis(genesis) ? parseParentBeaconBlockRoot(genesis) : null))
         .requestsHash(isPragueAtGenesis(genesis) ? Hash.EMPTY_REQUESTS_HASH : null)
+        .balHash(isAmsterdamAtGenesis(genesis) ? Hash.EMPTY_BAL_HASH : null)
         .buildBlockHeader();
   }
 


### PR DESCRIPTION
Include a BAL in the genesis state if Amsterdam is active on genesis. This BAL is always empty since there are no transactions in the genesis block.