### PR TITLE
Activate Amsterdam after BPO5 on bal-devnet-0

### DIFF
--- a/config/src/main/java/org/hyperledger/besu/config/JsonGenesisConfigOptions.java
+++ b/config/src/main/java/org/hyperledger/besu/config/JsonGenesisConfigOptions.java
@@ -538,12 +538,12 @@ public class JsonGenesisConfigOptions implements GenesisConfigOptions {
     getCancunEOFTime().ifPresent(l -> builder.put("cancunEOFTime", l));
     getPragueTime().ifPresent(l -> builder.put("pragueTime", l));
     getOsakaTime().ifPresent(l -> builder.put("osakaTime", l));
-    getAmsterdamTime().ifPresent(l -> builder.put("amsterdamTime", l));
     getBpo1Time().ifPresent(l -> builder.put("bpo1Time", l));
     getBpo2Time().ifPresent(l -> builder.put("bpo2Time", l));
     getBpo3Time().ifPresent(l -> builder.put("bpo3Time", l));
     getBpo4Time().ifPresent(l -> builder.put("bpo4Time", l));
     getBpo5Time().ifPresent(l -> builder.put("bpo5Time", l));
+    getAmsterdamTime().ifPresent(l -> builder.put("amsterdamTime", l));
     getTerminalBlockNumber().ifPresent(l -> builder.put("terminalBlockNumber", l));
     getTerminalBlockHash().ifPresent(h -> builder.put("terminalBlockHash", h.toHexString()));
     getFutureEipsTime().ifPresent(l -> builder.put("futureEipsTime", l));
@@ -705,12 +705,12 @@ public class JsonGenesisConfigOptions implements GenesisConfigOptions {
             getCancunEOFTime(),
             getPragueTime(),
             getOsakaTime(),
-            getAmsterdamTime(),
             getBpo1Time(),
             getBpo2Time(),
             getBpo3Time(),
             getBpo4Time(),
             getBpo5Time(),
+            getAmsterdamTime(),
             getFutureEipsTime(),
             getExperimentalEipsTime());
     // when adding forks add an entry to ${REPO_ROOT}/config/src/test/resources/all_forks.json

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetProtocolSpecs.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetProtocolSpecs.java
@@ -988,28 +988,6 @@ public abstract class MainnetProtocolSpecs {
         .hardforkId(OSAKA);
   }
 
-  static ProtocolSpecBuilder amsterdamDefinition(
-      final Optional<BigInteger> chainId,
-      final boolean enableRevertReason,
-      final GenesisConfigOptions genesisConfigOptions,
-      final EvmConfiguration evmConfiguration,
-      final MiningConfiguration miningConfiguration,
-      final boolean isParallelTxProcessingEnabled,
-      final boolean isBlockAccessListEnabled,
-      final MetricsSystem metricsSystem) {
-    return osakaDefinition(
-            chainId,
-            enableRevertReason,
-            genesisConfigOptions,
-            evmConfiguration,
-            miningConfiguration,
-            isParallelTxProcessingEnabled,
-            isBlockAccessListEnabled,
-            metricsSystem)
-        .blockAccessListFactory(new BlockAccessListFactory(isBlockAccessListEnabled, true))
-        .hardforkId(AMSTERDAM);
-  }
-
   static ProtocolSpecBuilder bpo1Definition(
       final Optional<BigInteger> chainId,
       final boolean enableRevertReason,
@@ -1118,6 +1096,28 @@ public abstract class MainnetProtocolSpecs {
             isBlockAccessListEnabled,
             metricsSystem);
     return applyBlobSchedule(builder, genesisConfigOptions, BlobScheduleOptions::getBpo5, BPO5);
+  }
+
+  static ProtocolSpecBuilder amsterdamDefinition(
+      final Optional<BigInteger> chainId,
+      final boolean enableRevertReason,
+      final GenesisConfigOptions genesisConfigOptions,
+      final EvmConfiguration evmConfiguration,
+      final MiningConfiguration miningConfiguration,
+      final boolean isParallelTxProcessingEnabled,
+      final boolean isBlockAccessListEnabled,
+      final MetricsSystem metricsSystem) {
+    return bpo5Definition(
+            chainId,
+            enableRevertReason,
+            genesisConfigOptions,
+            evmConfiguration,
+            miningConfiguration,
+            isParallelTxProcessingEnabled,
+            isBlockAccessListEnabled,
+            metricsSystem)
+        .blockAccessListFactory(new BlockAccessListFactory(isBlockAccessListEnabled, true))
+        .hardforkId(AMSTERDAM);
   }
 
   private static ProtocolSpecBuilder applyBlobSchedule(

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/milestones/MilestoneDefinitions.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/milestones/MilestoneDefinitions.java
@@ -205,10 +205,6 @@ public class MilestoneDefinitions {
             config.getOsakaTime(),
             () -> specFactory.osakaDefinition(config)),
         createTimestampMilestone(
-            MainnetHardforkId.AMSTERDAM,
-            config.getAmsterdamTime(),
-            () -> specFactory.amsterdamDefinition(config)),
-        createTimestampMilestone(
             MainnetHardforkId.BPO1, config.getBpo1Time(), () -> specFactory.bpo1Definition(config)),
         createTimestampMilestone(
             MainnetHardforkId.BPO2, config.getBpo2Time(), () -> specFactory.bpo2Definition(config)),
@@ -218,6 +214,10 @@ public class MilestoneDefinitions {
             MainnetHardforkId.BPO4, config.getBpo4Time(), () -> specFactory.bpo4Definition(config)),
         createTimestampMilestone(
             MainnetHardforkId.BPO5, config.getBpo5Time(), () -> specFactory.bpo5Definition(config)),
+        createTimestampMilestone(
+            MainnetHardforkId.AMSTERDAM,
+            config.getAmsterdamTime(),
+            () -> specFactory.amsterdamDefinition(config)),
         createTimestampMilestone(
             MainnetHardforkId.FUTURE_EIPS,
             config.getFutureEipsTime(),


### PR DESCRIPTION
Currently, Amsterdam is incorrectly assumed to activate following Osaka, and BPO5 definition doesn't extend Amsterdam. Consequently, BPO5 activation "overrides" Amsterdam activation, and if both are activated at the same timestamp, BPO5 activation is "prioritized".

The changes in the PR make Amsterdam follow BPO5 by making Amsterdam definition extend BPO5 definition and by creating Amsterdam timestamp milestone after BPO5 milestone.