### PR TITLE
Include generated BALs in `debug_getBadBlocks` response

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugGetBadBlocks.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugGetBadBlocks.java
@@ -45,7 +45,14 @@ public class DebugGetBadBlocks implements JsonRpcMethod {
   public JsonRpcResponse response(final JsonRpcRequestContext requestContext) {
     final List<BadBlockResult> response =
         protocolContext.getBadBlockManager().getBadBlocks().stream()
-            .map(block -> BadBlockResult.from(blockResultFactory.transactionComplete(block), block))
+            .map(
+                block ->
+                    BadBlockResult.from(
+                        blockResultFactory.transactionComplete(block),
+                        block,
+                        protocolContext
+                            .getBadBlockManager()
+                            .getGeneratedBlockAccessList(block.getHash())))
             .collect(Collectors.toList());
     return new JsonRpcSuccessResponse(requestContext.getRequest().getId(), response);
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/BadBlockResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/BadBlockResult.java
@@ -15,6 +15,9 @@
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.results;
 
 import org.hyperledger.besu.ethereum.core.Block;
+import org.hyperledger.besu.ethereum.mainnet.block.access.list.BlockAccessList;
+
+import java.util.Optional;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
@@ -26,7 +29,7 @@ import org.immutables.value.Value;
 @Value.Style(allParameters = true)
 @JsonSerialize(as = ImmutableBadBlockResult.class)
 @JsonDeserialize(as = ImmutableBadBlockResult.class)
-@JsonPropertyOrder({"block", "hash", "rlp"})
+@JsonPropertyOrder({"block", "hash", "rlp", "generatedBlockAccessList"})
 public interface BadBlockResult {
 
   @JsonProperty("block")
@@ -38,8 +41,17 @@ public interface BadBlockResult {
   @JsonProperty("rlp")
   String getRlp();
 
-  static BadBlockResult from(final BlockResult blockResult, final Block block) {
+  @JsonProperty("generatedBlockAccessList")
+  Optional<BlockAccessListResult> getGeneratedBlockAccessList();
+
+  static BadBlockResult from(
+      final BlockResult blockResult,
+      final Block block,
+      final Optional<BlockAccessList> generatedBlockAccessList) {
     return ImmutableBadBlockResult.of(
-        blockResult, block.getHash().toHexString(), block.toRlp().toHexString());
+        blockResult,
+        block.getHash().toHexString(),
+        block.toRlp().toHexString(),
+        generatedBlockAccessList.map(BlockAccessListResult::fromBlockAccessList));
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/BlockProcessingResult.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/BlockProcessingResult.java
@@ -16,6 +16,7 @@ package org.hyperledger.besu.ethereum;
 
 import org.hyperledger.besu.ethereum.core.Request;
 import org.hyperledger.besu.ethereum.core.TransactionReceipt;
+import org.hyperledger.besu.ethereum.mainnet.block.access.list.BlockAccessList;
 
 import java.util.List;
 import java.util.Optional;
@@ -26,6 +27,7 @@ public class BlockProcessingResult extends BlockValidationResult {
   private final Optional<BlockProcessingOutputs> yield;
   private final boolean isPartial;
   private Optional<Integer> nbParallelizedTransactions = Optional.empty();
+  private final Optional<BlockAccessList> maybeGeneratedBlockAccessList;
 
   /** A result indicating that processing failed. */
   public static final BlockProcessingResult FAILED = new BlockProcessingResult("processing failed");
@@ -63,6 +65,7 @@ public class BlockProcessingResult extends BlockValidationResult {
       final Optional<BlockProcessingOutputs> yield, final boolean isPartial) {
     this.yield = yield;
     this.isPartial = isPartial;
+    this.maybeGeneratedBlockAccessList = Optional.empty();
   }
 
   /**
@@ -87,6 +90,7 @@ public class BlockProcessingResult extends BlockValidationResult {
     super(cause.getLocalizedMessage(), cause);
     this.yield = yield;
     this.isPartial = false;
+    this.maybeGeneratedBlockAccessList = Optional.empty();
   }
 
   /**
@@ -100,9 +104,26 @@ public class BlockProcessingResult extends BlockValidationResult {
       final Optional<BlockProcessingOutputs> yield,
       final String errorMessage,
       final boolean isPartial) {
+    this(yield, errorMessage, isPartial, Optional.empty());
+  }
+
+  /**
+   * A result indicating that processing was successful but incomplete.
+   *
+   * @param yield the outputs of processing a block
+   * @param errorMessage the error message if any
+   * @param isPartial whether the processing was incomplete
+   * @param generatedBlockAccessList the generated block access list, if available
+   */
+  public BlockProcessingResult(
+      final Optional<BlockProcessingOutputs> yield,
+      final String errorMessage,
+      final boolean isPartial,
+      final Optional<BlockAccessList> generatedBlockAccessList) {
     super(errorMessage);
     this.yield = yield;
     this.isPartial = isPartial;
+    this.maybeGeneratedBlockAccessList = generatedBlockAccessList;
   }
 
   /**
@@ -114,6 +135,7 @@ public class BlockProcessingResult extends BlockValidationResult {
     super(errorMessage);
     this.isPartial = false;
     this.yield = Optional.empty();
+    this.maybeGeneratedBlockAccessList = Optional.empty();
   }
 
   /**
@@ -159,5 +181,14 @@ public class BlockProcessingResult extends BlockValidationResult {
    */
   public Optional<Integer> getNbParallelizedTransactions() {
     return nbParallelizedTransactions;
+  }
+
+  /**
+   * Returns the generated block access list produced during processing, when available.
+   *
+   * @return the generated block access list
+   */
+  public Optional<BlockAccessList> getGeneratedBlockAccessList() {
+    return maybeGeneratedBlockAccessList;
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/MainnetBlockValidator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/MainnetBlockValidator.java
@@ -281,7 +281,11 @@ public class MainnetBlockValidator implements BlockValidator {
         // Result.errorMessage should not be empty on failure, but add a default to be safe
         String description = result.errorMessage.orElse("Unknown cause");
         final BadBlockCause cause = BadBlockCause.fromValidationFailure(description);
-        context.getBadBlockManager().addBadBlock(failedBlock, cause);
+        final Optional<BlockAccessList> generatedBlockAccessList =
+            result instanceof BlockProcessingResult
+                ? ((BlockProcessingResult) result).getGeneratedBlockAccessList()
+                : Optional.empty();
+        context.getBadBlockManager().addBadBlock(failedBlock, cause, generatedBlockAccessList);
       } else {
         LOG.debug("Invalid block {} not added to badBlockManager ", failedBlock.toLogString());
       }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/AbstractBlockProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/AbstractBlockProcessor.java
@@ -393,7 +393,8 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
             if (worldState instanceof BonsaiWorldState) {
               ((BonsaiWorldStateUpdateAccumulator) worldState.updater()).reset();
             }
-            return new BlockProcessingResult(Optional.empty(), errorMessage);
+            return new BlockProcessingResult(
+                Optional.empty(), errorMessage, false, Optional.of(bal));
           }
         }
         maybeBlockAccessList = Optional.of(bal);


### PR DESCRIPTION
Including generated BALs in `debug_getBadBlocks` response simplifies debugging protocol issues during BAL testing by making it easier to compare expected and actual BALs in case of a mismatch.

The generated BAL is propagated from `AbstractBlockProcessor` through `BlockProcessingResult` to `MainnetBlockValidator`, which stores it in the `BadBlockManager`, from where it can be served in `debug_getBadBlocks` response as `generatedBlockAccessList` field.