### PR TITLE
Statically initialise SignatureAlgorithm default instance

### DIFF
--- a/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/ReferenceTestProtocolSchedules.java
+++ b/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/ReferenceTestProtocolSchedules.java
@@ -16,6 +16,7 @@ package org.hyperledger.besu.ethereum.referencetests;
 
 import org.hyperledger.besu.config.GenesisConfigOptions;
 import org.hyperledger.besu.config.StubGenesisConfigOptions;
+import org.hyperledger.besu.crypto.SignatureAlgorithmFactory;
 import org.hyperledger.besu.ethereum.chain.BadBlockManager;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
@@ -39,6 +40,10 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class ReferenceTestProtocolSchedules {
+
+  static {
+    SignatureAlgorithmFactory.setDefaultInstance();
+  }
 
   private static final BigInteger CHAIN_ID = BigInteger.ONE;
 


### PR DESCRIPTION
The reference tests repeatedly initialise BouncyCastleProvider redundantly

<img width="2997" height="1198" alt="Screenshot 2025-10-14 at 11 43 17 am" src="https://github.com/user-attachments/assets/dbbc4689-7ebe-4b00-8149-cf8075c62014" />
