### PR TITLE
help troubleshoot flaky test by printing error message if unexpected

### DIFF
--- a/app/src/test/java/org/hyperledger/besu/cli/options/AbstractCLIOptionsTest.java
+++ b/app/src/test/java/org/hyperledger/besu/cli/options/AbstractCLIOptionsTest.java
@@ -72,7 +72,7 @@ public abstract class AbstractCLIOptionsTest<D, T extends CLIOptions<D>>
         .ignoringFields(getNonOptionFields())
         .isEqualTo(options);
 
-    assertEmptyOutput(commandOutput.toString(UTF_8));
+    assertEmptyOutput("unexpected flaky error message: investigate me");
     assertEmptyOutput(commandErrorOutput.toString(UTF_8));
   }
 


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <macfarla.github@gmail.com>
## PR description
Print error message if it is expected to be empty but is not

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

Sometimes CLI Options tests have a [failure](https://github.com/hyperledger/besu/actions/runs/18488059153/job/52675394377?pr=9303) that looks like

```
NetworkingOptionsTest > getCLIOptions_default() FAILED
    java.lang.AssertionError at AbstractCLIOptionsTest.java:76
```

So with this PR hopefully we get something like: 
`java.lang.AssertionError: [Expected empty output but got: unexpected flaky error message: investigate me] 
`

### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


