### PR TITLE
feat: added immediate persistance for bodies and receipts

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/PersistBodiesStep.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/PersistBodiesStep.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.eth.sync;
+
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.ProtocolContext;
+import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
+import org.hyperledger.besu.ethereum.core.Block;
+
+import java.util.List;
+import java.util.function.Function;
+
+/** Persists block bodies as soon as they are downloaded. Idempotent: skips if already present. */
+public class PersistBodiesStep implements Function<List<Block>, List<Block>> {
+
+  private final MutableBlockchain blockchain;
+
+  public PersistBodiesStep(final ProtocolContext protocolContext) {
+    this.blockchain = protocolContext.getBlockchain();
+  }
+
+  @Override
+  public List<Block> apply(final List<Block> blocks) {
+    if (blocks == null || blocks.isEmpty()) {
+      return blocks;
+    }
+
+    for (final Block block : blocks) {
+      final Hash hash = block.getHash();
+      if (blockchain.getBlockBody(hash).isEmpty()) {
+        // Persist body via storage updater to avoid adding new public methods
+        final var updater =
+            ((org.hyperledger.besu.ethereum.chain.DefaultBlockchain) blockchain)
+                .getBlockchainStorage()
+                .updater();
+        updater.putBlockBody(hash, block.getBody());
+        updater.commit();
+      }
+    }
+    return blocks;
+  }
+}

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/PersistReceiptsStep.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/PersistReceiptsStep.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.eth.sync;
+
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.ProtocolContext;
+import org.hyperledger.besu.ethereum.chain.DefaultBlockchain;
+import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
+import org.hyperledger.besu.ethereum.core.SyncBlockWithReceipts;
+import org.hyperledger.besu.ethereum.core.TransactionReceipt;
+
+import java.util.List;
+import java.util.function.Function;
+
+/** Persists receipts as soon as they are downloaded. Idempotent: skips if already present. */
+public class PersistReceiptsStep implements Function<List<SyncBlockWithReceipts>, List<SyncBlockWithReceipts>> {
+
+  private final MutableBlockchain blockchain;
+
+  public PersistReceiptsStep(final ProtocolContext protocolContext) {
+    this.blockchain = protocolContext.getBlockchain();
+  }
+
+  @Override
+  public List<SyncBlockWithReceipts> apply(final List<SyncBlockWithReceipts> blocksWithReceipts) {
+    if (blocksWithReceipts == null || blocksWithReceipts.isEmpty()) {
+      return blocksWithReceipts;
+    }
+    for (final SyncBlockWithReceipts bwr : blocksWithReceipts) {
+      final Hash hash = bwr.getHash();
+      final List<TransactionReceipt> receipts = bwr.getReceipts();
+      if (blockchain.getTxReceipts(hash).isEmpty()) {
+        final var updater = ((DefaultBlockchain) blockchain).getBlockchainStorage().updater();
+        updater.putTransactionReceipts(hash, receipts);
+        updater.commit();
+      }
+    }
+    return blocksWithReceipts;
+  }
+}

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/PersistSyncBodiesStep.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/PersistSyncBodiesStep.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.eth.sync;
+
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.ProtocolContext;
+import org.hyperledger.besu.ethereum.chain.DefaultBlockchain;
+import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
+import org.hyperledger.besu.ethereum.core.SyncBlock;
+
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * Persists sync block bodies as soon as they are downloaded. Idempotent: skips if already present.
+ */
+public class PersistSyncBodiesStep implements Function<List<SyncBlock>, List<SyncBlock>> {
+
+  private final MutableBlockchain blockchain;
+
+  public PersistSyncBodiesStep(final ProtocolContext protocolContext) {
+    this.blockchain = protocolContext.getBlockchain();
+  }
+
+  @Override
+  public List<SyncBlock> apply(final List<SyncBlock> syncBlocks) {
+    if (syncBlocks == null || syncBlocks.isEmpty()) {
+      return syncBlocks;
+    }
+    for (final SyncBlock block : syncBlocks) {
+      final Hash hash = block.getHash();
+      if (blockchain.getBlockBody(hash).isEmpty()) {
+        final var updater = ((DefaultBlockchain) blockchain).getBlockchainStorage().updater();
+        updater.putSyncBlockBody(hash, block.getBody());
+        updater.commit();
+      }
+    }
+    return syncBlocks;
+  }
+}

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/PersistStepsTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/PersistStepsTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.eth.sync;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.ProtocolContext;
+import org.hyperledger.besu.ethereum.chain.BlockchainStorage;
+import org.hyperledger.besu.ethereum.chain.DefaultBlockchain;
+import org.hyperledger.besu.ethereum.core.Block;
+import org.hyperledger.besu.ethereum.core.BlockBody;
+import org.hyperledger.besu.ethereum.core.SyncBlock;
+import org.hyperledger.besu.ethereum.core.SyncBlockBody;
+import org.hyperledger.besu.ethereum.core.SyncBlockWithReceipts;
+import org.hyperledger.besu.ethereum.core.TransactionReceipt;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class PersistStepsTest {
+
+  private ProtocolContext protocolContext;
+  private DefaultBlockchain blockchain;
+  private BlockchainStorage storage;
+  private BlockchainStorage.Updater updater;
+
+  @BeforeEach
+  public void setUp() {
+    protocolContext = mock(ProtocolContext.class);
+    blockchain = mock(DefaultBlockchain.class);
+    storage = mock(BlockchainStorage.class);
+    updater = mock(BlockchainStorage.Updater.class);
+    when(protocolContext.getBlockchain()).thenReturn(blockchain);
+    when(blockchain.getBlockchainStorage()).thenReturn(storage);
+    when(storage.updater()).thenReturn(updater);
+  }
+
+  @Test
+  public void persistBodies_persists() {
+    final PersistBodiesStep step = new PersistBodiesStep(protocolContext);
+
+    final Block block = mock(Block.class);
+    final BlockBody body = mock(BlockBody.class);
+    final Hash hash = Hash.hash(Bytes.of(1));
+    when(block.getHash()).thenReturn(hash);
+    when(block.getBody()).thenReturn(body);
+    when(blockchain.getBlockBody(hash)).thenReturn(Optional.empty());
+
+    step.apply(List.of(block));
+
+    verify(updater).putBlockBody(hash, body);
+    verify(updater).commit();
+  }
+
+  @Test
+  public void persistSyncBodies_persists() {
+    final PersistSyncBodiesStep step = new PersistSyncBodiesStep(protocolContext);
+
+    final SyncBlock syncBlock = mock(SyncBlock.class);
+    final SyncBlockBody body = mock(SyncBlockBody.class);
+    final Hash hash = Hash.hash(Bytes.of(2));
+    when(syncBlock.getHash()).thenReturn(hash);
+    when(syncBlock.getBody()).thenReturn(body);
+    when(blockchain.getBlockBody(hash)).thenReturn(Optional.empty());
+
+    step.apply(List.of(syncBlock));
+
+    verify(updater).putSyncBlockBody(hash, body);
+    verify(updater).commit();
+  }
+
+  @Test
+  public void persistReceipts_persists() {
+    final PersistReceiptsStep step = new PersistReceiptsStep(protocolContext);
+
+    final SyncBlockWithReceipts bwr = mock(SyncBlockWithReceipts.class);
+    final Hash hash = Hash.hash(Bytes.of(3));
+    final List<TransactionReceipt> receipts = List.of(mock(TransactionReceipt.class));
+    when(bwr.getHash()).thenReturn(hash);
+    when(bwr.getReceipts()).thenReturn(receipts);
+    when(blockchain.getTxReceipts(hash)).thenReturn(Optional.empty());
+
+    step.apply(List.of(bwr));
+
+    verify(updater).putTransactionReceipts(hash, receipts);
+    verify(updater).commit();
+  }
+}
+
+


### PR DESCRIPTION
## PR description

Earlier we were fetching bodies ( and receipts as well) with ordered stages, and persisted only at the final import step. Because persistence happened at import and order was enforced, later-completed items waited on earlier ones, creating a bottleneck. Now, bodies and receipts are fetched unordered and persisted immediately, the final import step still sets the chain head and canonical state, but it’s no longer the sole point of persistence. Persistence steps are idempotent (skip if present), so out-of-order arrivals are safe.


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
tries to fix #9324 


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew build`
- [x] acceptance tests: `./gradlew acceptanceTest`
- [x] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


