### PR TITLE
Tune start script for OpenJDK 25 and use it in Docker image

### DIFF
--- a/app/src/main/scripts/unixStartScript.txt
+++ b/app/src/main/scripts/unixStartScript.txt
@@ -43,9 +43,6 @@ cd "\$SAVED" >/dev/null
 APP_NAME="${applicationName}"
 APP_BASE_NAME=`basename "\$0"`
 
-# Add default JVM options here. You can also use JAVA_OPTS and ${optsEnvironmentVar} to pass JVM options to this script.
-DEFAULT_JVM_OPTS=${defaultJvmOpts}
-
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD="maximum"
 
@@ -103,6 +100,18 @@ else
 
 Please set the JAVA_HOME variable in your environment to match the
 location of your Java installation."
+fi
+
+JAVA_VERSION=`"\$JAVA_HOME/bin/java" -version 2>&1 | fgrep version | cut -d' ' -f3 | tr -d '"' | cut -d. -f1`
+
+# Add default JVM options here. You can also use JAVA_OPTS and ${optsEnvironmentVar} to pass JVM options to this script.
+if [ "\$JAVA_VERSION" -ge 25 ]; then
+    DEFAULT_JVM_OPTS=@DEFAULT_JVM_OPTS_25@
+elif [ "\$JAVA_VERSION" -ge 21 ]; then
+    DEFAULT_JVM_OPTS=${defaultJvmOpts}
+else
+    echo "Java version must be at least 21"
+    exit 1
 fi
 
 # Increase the maximum file descriptors if we can.

--- a/build.gradle
+++ b/build.gradle
@@ -718,10 +718,13 @@ run {
   }
 }
 
-def tweakStartScript(createScriptTask) {
+def tweakStartScript(createScriptTask, defaultJvmOpts25) {
   def shortenWindowsClasspath = { line ->
     line.replaceAll(/^set CLASSPATH=.*$/, "set CLASSPATH=%APP_HOME%/lib/*")
   }
+
+  // this must be before the BESU_HOME replacement
+  createScriptTask.unixScript.text = createScriptTask.unixScript.text.replace('@DEFAULT_JVM_OPTS_25@', defaultJvmOpts25)
 
   createScriptTask.unixScript.text = createScriptTask.unixScript.text.replace('BESU_HOME', '\$APP_HOME')
   createScriptTask.windowsScript.text = createScriptTask.windowsScript.text.replace('BESU_HOME', '%~dp0..')
@@ -734,17 +737,28 @@ def tweakStartScript(createScriptTask) {
     .join('\r\n')
 }
 
+def defaultJvmOpts21 = application.applicationDefaultJvmArgs + [
+  "-XX:MaxHeapFreeRatio=30",
+  "-XX:MinHeapFreeRatio=10",
+  "-XX:MaxGCPauseMillis=100",
+  "-XX:StartFlightRecording,settings=default.jfc",
+  "-Xlog:jfr*=off"
+]
+
+def defaultJvmOpts25 = defaultJvmOpts21 + [
+  "-XX:+UseCompactObjectHeaders"
+]
+
+def serializeDefaultJvmOpts(opts) {
+  return "'" + opts.collect{ /"$it"/}.join(' ') + "'"
+}
+
 startScripts {
-  defaultJvmOpts = application.applicationDefaultJvmArgs + [
-    "-XX:G1ConcRefinementThreads=2",
-    "-XX:G1HeapWastePercent=15",
-    "-XX:MaxGCPauseMillis=100",
-    "-XX:StartFlightRecording,settings=default.jfc",
-    "-Xlog:jfr*=off"
-  ]
+  defaultJvmOpts = defaultJvmOpts21
   unixStartScriptGenerator.template = resources.text.fromFile("${projectDir}/app/src/main/scripts/unixStartScript.txt")
   windowsStartScriptGenerator.template = resources.text.fromFile("${projectDir}/app/src/main/scripts/windowsStartScript.txt")
-  doLast { tweakStartScript(startScripts) }
+
+  doLast { tweakStartScript(startScripts, serializeDefaultJvmOpts(defaultJvmOpts25)) }
 }
 
 task untunedStartScripts(type: CreateStartScripts) {
@@ -755,7 +769,7 @@ task untunedStartScripts(type: CreateStartScripts) {
   defaultJvmOpts = application.applicationDefaultJvmArgs
   unixStartScriptGenerator.template = resources.text.fromFile("${projectDir}/app/src/main/scripts/unixStartScript.txt")
   windowsStartScriptGenerator.template = resources.text.fromFile("${projectDir}/app/src/main/scripts/windowsStartScript.txt")
-  doLast { tweakStartScript(untunedStartScripts) }
+  doLast { tweakStartScript(untunedStartScripts, serializeDefaultJvmOpts(application.applicationDefaultJvmArgs)) }
 }
 
 task evmToolStartScripts(type: CreateStartScripts) {
@@ -768,7 +782,7 @@ task evmToolStartScripts(type: CreateStartScripts) {
   ]
   unixStartScriptGenerator.template = resources.text.fromFile("${projectDir}/app/src/main/scripts/unixStartScript.txt")
   windowsStartScriptGenerator.template = resources.text.fromFile("${projectDir}/app/src/main/scripts/windowsStartScript.txt")
-  doLast { tweakStartScript(evmToolStartScripts) }
+  doLast { tweakStartScript(evmToolStartScripts, serializeDefaultJvmOpts(defaultJvmOpts)) }
 }
 
 task autocomplete(type: JavaExec) {

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # Stage: Use Eclipse Temurin JRE
-FROM eclipse-temurin:21-jre AS java-base
+FROM eclipse-temurin:25-jre AS java-base
 
 # Stage: Final Besu image
 FROM ubuntu:24.04


### PR DESCRIPTION
## PR description

GC configuration tuning for Java25 to make it release the heap memory not used to the OS, and have pattern closer to Java21 (actually with this setup Java25 on average has less wasted heap) and base the Docker image on Java25

## Fixed Issue(s)
ref #9100 


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


