### PR TITLE
Assign background transaction futures to the tracking array so they can be cancelled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Update to tuweni 2.7.2 [#9338](https://github.com/hyperledger/besu/pull/9338)
 
 ### Bug fixes
+- Performance: Fix CompletableFuture tracking to correctly cancel parallel txs threads [#9360](https://github.com/hyperledger/besu/pull/9360)
 
 ## 25.10.0
 This is a recommended update for Hoodi users for the Fusaka hardfork.

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/parallelization/ParallelizedConcurrentTransactionProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/parallelization/ParallelizedConcurrentTransactionProcessor.java
@@ -116,18 +116,19 @@ public class ParallelizedConcurrentTransactionProcessor {
       /*
        * All transactions are executed in the background by copying the world state of the block on which the transactions need to be executed, ensuring that each one has its own accumulator.
        */
-      CompletableFuture.runAsync(
-          () ->
-              runTransaction(
-                  protocolContext,
-                  blockHeader,
-                  transactionLocation,
-                  transaction,
-                  miningBeneficiary,
-                  blockHashLookup,
-                  blobGasPrice,
-                  blockAccessListBuilder),
-          executor);
+      completableFuturesForBackgroundTransactions[i] =
+          CompletableFuture.runAsync(
+              () ->
+                  runTransaction(
+                      protocolContext,
+                      blockHeader,
+                      transactionLocation,
+                      transaction,
+                      miningBeneficiary,
+                      blockHashLookup,
+                      blobGasPrice,
+                      blockAccessListBuilder),
+              executor);
     }
   }
 


### PR DESCRIPTION
This could improve performance in the cases where sequential execution beats parallel, particularly when dealing with a large transaction such as a XEN contract: if sequential processing catches up, cancel the parallel tx future and process the tx once sequentially instead of leaving the parallel tx future to complete in the background.

## Testing 

Test was run over 2.5 days, ~18K blocks.

Full analysis report: https://hackmd.io/@siladu/HypqnrhCxl

Analysis shows no regression and perhaps some limited improvements to specific blocks, though comparing to all our running nodes' block times, I think this is likely noise.
One outlier result for block 23647133 skews the report quite a lot.

Files used in analysis

Besu Logs
* [control-besu.log](https://github.com/user-attachments/files/23155170/control-besu.log)
* [test-cancellation-besu.log](https://github.com/user-attachments/files/23155181/test-cancellation-besu.log)

Analysis tool (usage in the hackmd report)
* [compare_besu_exec.py](https://github.com/user-attachments/files/23155180/compare_besu_exec.py)

XEN contract transaction lists
* [export-0xc3c7b049678d84081dfd0ba21a6c7fdcc31c226f_XEN_Minter.csv](https://github.com/user-attachments/files/23155176/export-0xc3c7b049678d84081dfd0ba21a6c7fdcc31c226f_XEN_Minter.csv)
* [export-0x0de8bf93da2f7eecb3d9169422413a9bef4ef628_CoinTool_XEN_Batch_Minter.csv](https://github.com/user-attachments/files/23155177/export-0x0de8bf93da2f7eecb3d9169422413a9bef4ef628_CoinTool_XEN_Batch_Minter.csv)
* [0x2f848984984d6c3c036174ce627703edaf780479_MCT-XEN_Batch_Minter_export-transaction-list-1761523431099.csv](https://github.com/user-attachments/files/23155178/0x2f848984984d6c3c036174ce627703edaf780479_MCT-XEN_Batch_Minter_export-transaction-list-1761523431099.csv)
* [0x0000000000771a79d0fc7f3b7fe270eb4498f20b_MCT_MXENFT_Token_export-transaction-list.csv](https://github.com/user-attachments/files/23155179/0x0000000000771a79d0fc7f3b7fe270eb4498f20b_MCT_MXENFT_Token_export-transaction-list.csv)


More testing ongoing...
