### PR TITLE
Add event type to `AddedBlockContext`

### DIFF
--- a/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/tests/acceptance/plugins/TestBesuEventsPlugin.java
+++ b/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/tests/acceptance/plugins/TestBesuEventsPlugin.java
@@ -16,6 +16,7 @@ package org.hyperledger.besu.tests.acceptance.plugins;
 
 import org.hyperledger.besu.plugin.BesuPlugin;
 import org.hyperledger.besu.plugin.ServiceManager;
+import org.hyperledger.besu.plugin.data.AddedBlockContext;
 import org.hyperledger.besu.plugin.data.BlockHeader;
 import org.hyperledger.besu.plugin.data.PropagatedBlockContext;
 import org.hyperledger.besu.plugin.services.BesuEvents;
@@ -37,8 +38,10 @@ public class TestBesuEventsPlugin implements BesuPlugin {
 
   private ServiceManager context;
 
-  private Optional<Long> subscriptionId;
-  private final AtomicInteger blockCounter = new AtomicInteger();
+  private Optional<Long> propagationSubscriptionId;
+  private Optional<Long> addedSubscriptionId;
+  private final AtomicInteger propagatedBlockCounter = new AtomicInteger();
+  private final AtomicInteger addedBlockCounter = new AtomicInteger();
   private File callbackDir;
 
   @Override
@@ -50,26 +53,37 @@ public class TestBesuEventsPlugin implements BesuPlugin {
 
   @Override
   public void start() {
-    subscriptionId =
+    propagationSubscriptionId =
         context
             .getService(BesuEvents.class)
             .map(events -> events.addBlockPropagatedListener(this::onBlockAnnounce));
-    LOG.info("Listening with ID#" + subscriptionId);
+    LOG.info("Listening with propagation ID#" + propagationSubscriptionId);
+    addedSubscriptionId =
+        context
+            .getService(BesuEvents.class)
+            .map(events -> events.addBlockAddedListener(this::onBlockAdded));
+    LOG.info("Listening with added ID#" + addedSubscriptionId);
   }
 
   @Override
   public void stop() {
-    subscriptionId.ifPresent(
+    propagationSubscriptionId.ifPresent(
         id ->
             context
                 .getService(BesuEvents.class)
                 .ifPresent(besuEvents -> besuEvents.removeBlockPropagatedListener(id)));
-    LOG.info("No longer listening with ID#" + subscriptionId);
+    LOG.info("No longer listening propagation with ID#" + propagationSubscriptionId);
+    addedSubscriptionId.ifPresent(
+        id ->
+            context
+                .getService(BesuEvents.class)
+                .ifPresent(besuEvents -> besuEvents.removeBlockAddedListener(id)));
+    LOG.info("No longer listening added with ID#" + addedSubscriptionId);
   }
 
   private void onBlockAnnounce(final PropagatedBlockContext propagatedBlockContext) {
     final BlockHeader header = propagatedBlockContext.getBlockHeader();
-    final int blockCount = blockCounter.incrementAndGet();
+    final int blockCount = propagatedBlockCounter.incrementAndGet();
     LOG.info("I got a new block! (I've seen {}) - {}", blockCount, header);
     try {
       final File callbackFile = new File(callbackDir, "newBlock." + blockCount);
@@ -78,6 +92,29 @@ public class TestBesuEventsPlugin implements BesuPlugin {
         callbackFile.getParentFile().deleteOnExit();
       }
       Files.write(callbackFile.toPath(), Collections.singletonList(header.toString()));
+      callbackFile.deleteOnExit();
+    } catch (final IOException ioe) {
+      throw new RuntimeException(ioe);
+    }
+  }
+
+  private void onBlockAdded(final AddedBlockContext addedBlockContext) {
+    final BlockHeader header = addedBlockContext.getBlockHeader();
+    final int blockCount = addedBlockCounter.incrementAndGet();
+    LOG.info(
+        "New block added! (I've seen {}) - {}, eventType {}",
+        blockCount,
+        header,
+        addedBlockContext.getEventType());
+    try {
+      final File callbackFile = new File(callbackDir, "addedBlock." + blockCount);
+      if (!callbackFile.getParentFile().exists()) {
+        callbackFile.getParentFile().mkdirs();
+        callbackFile.getParentFile().deleteOnExit();
+      }
+      Files.write(
+          callbackFile.toPath(),
+          Collections.singletonList(addedBlockContext.getEventType().name()));
       callbackFile.deleteOnExit();
     } catch (final IOException ioe) {
       throw new RuntimeException(ioe);

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/plugins/BesuEventsPluginTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/plugins/BesuEventsPluginTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.tests.acceptance.plugins;
+
+import org.hyperledger.besu.tests.acceptance.dsl.AcceptanceTestBase;
+import org.hyperledger.besu.tests.acceptance.dsl.node.BesuNode;
+import org.hyperledger.besu.tests.acceptance.dsl.node.configuration.genesis.GenesisConfigurationFactory;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class BesuEventsPluginTest extends AcceptanceTestBase {
+  private BesuNode pluginNode;
+  private BesuNode minerNode;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    minerNode =
+        besu.createQbftNode(
+            "minerNode",
+            b ->
+                b.genesisConfigProvider(
+                    GenesisConfigurationFactory::createQbftLondonGenesisConfig));
+    pluginNode =
+        besu.createQbftPluginsNode(
+            "node1", Collections.singletonList("testPlugins"), Collections.emptyList());
+    cluster.start(pluginNode, minerNode);
+  }
+
+  @Test
+  public void blockIsAdded() {
+    waitForFile(pluginNode.homeDirectory().resolve("plugins/addedBlock.2"));
+  }
+}

--- a/app/src/main/java/org/hyperledger/besu/services/BesuEventsImpl.java
+++ b/app/src/main/java/org/hyperledger/besu/services/BesuEventsImpl.java
@@ -29,6 +29,7 @@ import org.hyperledger.besu.ethereum.eth.sync.state.SyncState;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 import org.hyperledger.besu.evm.log.LogTopic;
 import org.hyperledger.besu.plugin.data.AddedBlockContext;
+import org.hyperledger.besu.plugin.data.AddedBlockContext.EventType;
 import org.hyperledger.besu.plugin.data.BlockHeader;
 import org.hyperledger.besu.plugin.data.PropagatedBlockContext;
 import org.hyperledger.besu.plugin.services.BesuEvents;
@@ -88,6 +89,7 @@ public class BesuEventsImpl implements BesuEvents {
         event ->
             listener.onBlockAdded(
                 blockAddedContext(
+                    event.getEventType(),
                     event::getHeader,
                     () -> event.getBlock().getBody(),
                     event::getTransactionReceipts)));
@@ -104,6 +106,7 @@ public class BesuEventsImpl implements BesuEvents {
         (blockWithReceipts, chain) ->
             listener.onBlockReorg(
                 blockAddedContext(
+                    EventType.CHAIN_REORG,
                     blockWithReceipts::getHeader,
                     blockWithReceipts.getBlock()::getBody,
                     blockWithReceipts::getReceipts)));
@@ -210,6 +213,7 @@ public class BesuEventsImpl implements BesuEvents {
   }
 
   private static AddedBlockContext blockAddedContext(
+      final EventType eventType,
       final Supplier<BlockHeader> blockHeaderSupplier,
       final Supplier<BlockBody> blockBodySupplier,
       final Supplier<List<TransactionReceipt>> transactionReceiptsSupplier) {
@@ -227,6 +231,11 @@ public class BesuEventsImpl implements BesuEvents {
       @Override
       public List<TransactionReceipt> getTransactionReceipts() {
         return transactionReceiptsSupplier.get();
+      }
+
+      @Override
+      public EventType getEventType() {
+        return eventType;
       }
     };
   }

--- a/app/src/test/java/org/hyperledger/besu/services/BesuEventsImplTest.java
+++ b/app/src/test/java/org/hyperledger/besu/services/BesuEventsImplTest.java
@@ -284,6 +284,7 @@ public class BesuEventsImplTest {
     assertThat(result.get()).isNotNull();
     assertThat(result.get().getBlockHeader()).isEqualTo(block.getHeader());
     assertThat(result.get().getTransactionReceipts()).isEqualTo(transactionReceipts);
+    assertThat(result.get().getEventType()).isEqualTo(AddedBlockContext.EventType.HEAD_ADVANCED);
   }
 
   @Test

--- a/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinatorTest.java
+++ b/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinatorTest.java
@@ -48,7 +48,6 @@ import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.chain.BadBlockManager;
 import org.hyperledger.besu.ethereum.chain.BlockAddedEvent;
-import org.hyperledger.besu.ethereum.chain.BlockAddedEvent.EventType;
 import org.hyperledger.besu.ethereum.chain.BlockAddedObserver;
 import org.hyperledger.besu.ethereum.chain.GenesisState;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
@@ -80,6 +79,7 @@ import org.hyperledger.besu.ethereum.trie.MerkleTrieException;
 import org.hyperledger.besu.ethereum.trie.pathbased.bonsai.cache.CodeCache;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
 import org.hyperledger.besu.metrics.StubMetricsSystem;
+import org.hyperledger.besu.plugin.data.AddedBlockContext.EventType;
 import org.hyperledger.besu.testutil.TestClock;
 import org.hyperledger.besu.util.number.Fraction;
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/BlockAddedEvent.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/BlockAddedEvent.java
@@ -20,6 +20,7 @@ import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.LogWithMetadata;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.core.TransactionReceipt;
+import org.hyperledger.besu.plugin.data.AddedBlockContext.EventType;
 
 import java.util.Collections;
 import java.util.List;
@@ -35,13 +36,6 @@ public class BlockAddedEvent {
   private final List<LogWithMetadata> logsWithMetadata;
   private final Hash commonAncestorHash;
   private final BlockHeader header;
-
-  public enum EventType {
-    HEAD_ADVANCED,
-    FORK,
-    CHAIN_REORG,
-    STORED_ONLY
-  }
 
   private BlockAddedEvent(
       final EventType eventType,

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/BlockPropagationManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/BlockPropagationManager.java
@@ -23,7 +23,6 @@ import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.chain.BadBlockCause;
 import org.hyperledger.besu.ethereum.chain.BadBlockManager;
 import org.hyperledger.besu.ethereum.chain.BlockAddedEvent;
-import org.hyperledger.besu.ethereum.chain.BlockAddedEvent.EventType;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.Block;
@@ -52,6 +51,7 @@ import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.messages.DisconnectMessage.DisconnectReason;
 import org.hyperledger.besu.ethereum.rlp.RLPException;
+import org.hyperledger.besu.plugin.data.AddedBlockContext.EventType;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 
 import java.time.Duration;

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
@@ -53,6 +53,7 @@ import org.hyperledger.besu.ethereum.trie.MerkleTrieException;
 import org.hyperledger.besu.ethereum.trie.pathbased.bonsai.worldview.BonsaiWorldState;
 import org.hyperledger.besu.evm.account.Account;
 import org.hyperledger.besu.evm.fluent.SimpleAccount;
+import org.hyperledger.besu.plugin.data.AddedBlockContext.EventType;
 import org.hyperledger.besu.util.Subscribers;
 
 import java.io.BufferedReader;
@@ -321,8 +322,8 @@ public class TransactionPool implements BlockAddedObserver {
   @Override
   public void onBlockAdded(final BlockAddedEvent event) {
     if (isPoolEnabled.get()) {
-      if (event.getEventType().equals(BlockAddedEvent.EventType.HEAD_ADVANCED)
-          || event.getEventType().equals(BlockAddedEvent.EventType.CHAIN_REORG)) {
+      if (event.getEventType().equals(EventType.HEAD_ADVANCED)
+          || event.getEventType().equals(EventType.CHAIN_REORG)) {
 
         blockAddedEventOrderedProcessor.submit(event);
       }

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -71,7 +71,7 @@ Calculated : ${currentHash}
 tasks.register('checkAPIChanges', FileStateChecker) {
   description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
   files = sourceSets.main.allJava.files
-  knownHash = 'uxU590hrpy4uDeVfJDwFFb+CG8QXgDLYqdalgsWy9SM='
+  knownHash = 'pOyC8lju8dV896HJ//I+wDFOD07axIpgG2/HeuZbR5w='
 }
 check.dependsOn('checkAPIChanges')
 

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/data/AddedBlockContext.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/data/AddedBlockContext.java
@@ -16,8 +16,60 @@ package org.hyperledger.besu.plugin.data;
 
 import java.util.List;
 
-/** The minimum set of data for an AddedBlockContext. */
+/**
+ * Provides context information about a block that has been added to the blockchain.
+ *
+ * <p>This interface extends {@link BlockContext} to include additional metadata about how and why
+ * the block was added to the chain. It is primarily used by plugins to receive notifications about
+ * block addition events and to understand the nature of these events.
+ *
+ * @see BlockContext
+ */
 public interface AddedBlockContext extends BlockContext {
+
+  /**
+   * Defines the different types of block addition events that can occur in the blockchain.
+   *
+   * <p>These event types help distinguish between normal chain progression and exceptional
+   * scenarios like forks and reorganizations.
+   */
+  enum EventType {
+    /**
+     * Indicates that the block was added to the main chain and advanced the chain head to this
+     * block. This is the normal case for sequential block addition.
+     */
+    HEAD_ADVANCED,
+
+    /**
+     * Indicates that the block was added as part of a fork, creating an alternative chain branch
+     * that does not become the main chain.
+     */
+    FORK,
+
+    /**
+     * Indicates that the block was added as part of a chain reorganization, where the canonical
+     * chain switched to a different fork that includes this block.
+     */
+    CHAIN_REORG,
+
+    /**
+     * Indicates that the block was stored but did not affect the canonical chain. This typically
+     * occurs when importing historical blocks or when a block is stored for reference without being
+     * part of the active chain progression.
+     */
+    STORED_ONLY
+  }
+
+  /**
+   * Returns the type of event that occurred when this block was added.
+   *
+   * <p>The event type provides important context about how the block relates to the blockchain
+   * state and whether it represents normal progression, a fork, a reorganization, or just storage.
+   *
+   * @return the {@link EventType} indicating how this block was added
+   */
+  EventType getEventType();
+
   /**
    * A list of transaction receipts for the added block.
    *


### PR DESCRIPTION
## PR description

The current mechanism to notify plugins about block added to the chain is limited, since it is missing the information about the event type, since there are different reasons a block is added to the chain, and a plugin could behave differently according to the specific event, so this PR add the type of the event to the data passed to the plugin
## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


