### PR TITLE
QBFT/IBFT validation refactoring

### DIFF
--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/statemachine/IbftRoundTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/statemachine/IbftRoundTest.java
@@ -81,8 +81,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 public class IbftRoundTest {
 
   private final NodeKey nodeKey = NodeKeyUtils.generate();
+  private final NodeKey nodeKey2 = NodeKeyUtils.generate();
   private final ConsensusRoundIdentifier roundIdentifier = new ConsensusRoundIdentifier(1, 0);
   private final MessageFactory messageFactory = new MessageFactory(nodeKey);
+  private final MessageFactory messageFactory2 = new MessageFactory(nodeKey2);
   private final Subscribers<MinedBlockObserver> subscribers = Subscribers.create();
   private final BftExtraDataCodec bftExtraDataCodec = new IbftExtraDataCodec();
   private ProtocolContext protocolContext;
@@ -269,7 +271,7 @@ public class IbftRoundTest {
     // Receive Commit Message
 
     round.handleCommitMessage(
-        messageFactory.createCommit(roundIdentifier, proposedBlock.getHash(), remoteCommitSeal));
+        messageFactory2.createCommit(roundIdentifier, proposedBlock.getHash(), remoteCommitSeal));
 
     // Should import block when both commit seals are available.
     final ArgumentCaptor<Block> capturedBlock = ArgumentCaptor.forClass(Block.class);
@@ -311,14 +313,14 @@ public class IbftRoundTest {
     verify(blockImporter, never()).importBlock(any(), any(), any());
 
     round.handlePrepareMessage(
-        messageFactory.createPrepare(roundIdentifier, proposedBlock.getHash()));
+        messageFactory2.createPrepare(roundIdentifier, proposedBlock.getHash()));
 
     verify(transmitter, times(1))
         .multicastCommit(roundIdentifier, proposedBlock.getHash(), localCommitSeal);
     verify(blockImporter, never()).importBlock(any(), any(), any());
 
     round.handleCommitMessage(
-        messageFactory.createCommit(roundIdentifier, proposedBlock.getHash(), remoteCommitSeal));
+        messageFactory2.createCommit(roundIdentifier, proposedBlock.getHash(), remoteCommitSeal));
     verify(blockImporter, times(1)).importBlock(any(), any(), any());
   }
 
@@ -471,6 +473,9 @@ public class IbftRoundTest {
 
     round.handleCommitMessage(
         messageFactory.createCommit(roundIdentifier, proposedBlock.getHash(), remoteCommitSeal));
+
+    round.handleCommitMessage(
+        messageFactory2.createCommit(roundIdentifier, proposedBlock.getHash(), remoteCommitSeal));
 
     round.handleProposalMessage(
         messageFactory.createProposal(roundIdentifier, proposedBlock, Optional.empty()));

--- a/consensus/qbft-core/src/main/java/org/hyperledger/besu/consensus/qbft/core/messagewrappers/QbftMessageDecoder.java
+++ b/consensus/qbft-core/src/main/java/org/hyperledger/besu/consensus/qbft/core/messagewrappers/QbftMessageDecoder.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.consensus.qbft.core.messagewrappers;
+
+import org.hyperledger.besu.consensus.common.bft.messagewrappers.BftMessage;
+import org.hyperledger.besu.consensus.qbft.core.messagedata.CommitMessageData;
+import org.hyperledger.besu.consensus.qbft.core.messagedata.PrepareMessageData;
+import org.hyperledger.besu.consensus.qbft.core.messagedata.ProposalMessageData;
+import org.hyperledger.besu.consensus.qbft.core.messagedata.QbftV1;
+import org.hyperledger.besu.consensus.qbft.core.messagedata.RoundChangeMessageData;
+import org.hyperledger.besu.consensus.qbft.core.types.QbftBlockCodec;
+import org.hyperledger.besu.consensus.qbft.core.types.QbftMessage;
+import org.hyperledger.besu.ethereum.p2p.rlpx.wire.MessageData;
+
+/** The QbftMessageDecoder decodes a QbftMessage into a BftMessage. */
+public class QbftMessageDecoder {
+
+  /** Instantiates a new Qbft message decoder. */
+  public QbftMessageDecoder() {}
+
+  /**
+   * Decode a QbftMessage into a BftMessage.
+   *
+   * @param message the QbftMessage to decode
+   * @param blockCodec the block codec for decoding block data in Proposal and RoundChange messages
+   * @return the decoded BftMessage
+   * @throws IllegalArgumentException if the message code is not recognized
+   */
+  public BftMessage<?> decode(final QbftMessage message, final QbftBlockCodec blockCodec) {
+    final MessageData messageData = message.getData();
+
+    return switch (messageData.getCode()) {
+      case QbftV1.PROPOSAL -> ProposalMessageData.fromMessageData(messageData).decode(blockCodec);
+      case QbftV1.PREPARE -> PrepareMessageData.fromMessageData(messageData).decode();
+      case QbftV1.COMMIT -> CommitMessageData.fromMessageData(messageData).decode();
+      case QbftV1.ROUND_CHANGE ->
+          RoundChangeMessageData.fromMessageData(messageData).decode(blockCodec);
+      default ->
+          throw new IllegalArgumentException(
+              String.format(
+                  "Received message with messageCode=%d does not conform to any recognised QBFT message structure",
+                  message.getData().getCode()));
+    };
+  }
+}

--- a/consensus/qbft-core/src/main/java/org/hyperledger/besu/consensus/qbft/core/statemachine/BaseQbftBlockHeightManager.java
+++ b/consensus/qbft-core/src/main/java/org/hyperledger/besu/consensus/qbft/core/statemachine/BaseQbftBlockHeightManager.java
@@ -22,6 +22,8 @@ import org.hyperledger.besu.consensus.qbft.core.messagewrappers.Proposal;
 import org.hyperledger.besu.consensus.qbft.core.messagewrappers.RoundChange;
 import org.hyperledger.besu.consensus.qbft.core.types.QbftBlockHeader;
 
+import java.util.Optional;
+
 /** The interface Base qbft block height manager. */
 public interface BaseQbftBlockHeightManager {
   /**
@@ -79,4 +81,18 @@ public interface BaseQbftBlockHeightManager {
    * @param roundChange the round change payload
    */
   void handleRoundChangePayload(RoundChange roundChange);
+
+  /**
+   * Gets the current round.
+   *
+   * @return the current round, or empty if no round is active
+   */
+  Optional<QbftRound> getCurrentRound();
+
+  /**
+   * Gets the round change manager.
+   *
+   * @return the round change manager, or empty if not available
+   */
+  Optional<RoundChangeManager> getRoundChangeManager();
 }

--- a/consensus/qbft-core/src/main/java/org/hyperledger/besu/consensus/qbft/core/statemachine/NoOpBlockHeightManager.java
+++ b/consensus/qbft-core/src/main/java/org/hyperledger/besu/consensus/qbft/core/statemachine/NoOpBlockHeightManager.java
@@ -22,6 +22,8 @@ import org.hyperledger.besu.consensus.qbft.core.messagewrappers.Proposal;
 import org.hyperledger.besu.consensus.qbft.core.messagewrappers.RoundChange;
 import org.hyperledger.besu.consensus.qbft.core.types.QbftBlockHeader;
 
+import java.util.Optional;
+
 /** The type NoOp block height manager. */
 public class NoOpBlockHeightManager implements BaseQbftBlockHeightManager {
 
@@ -62,5 +64,15 @@ public class NoOpBlockHeightManager implements BaseQbftBlockHeightManager {
   @Override
   public QbftBlockHeader getParentBlockHeader() {
     return parentHeader;
+  }
+
+  @Override
+  public Optional<QbftRound> getCurrentRound() {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<RoundChangeManager> getRoundChangeManager() {
+    return Optional.empty();
   }
 }

--- a/consensus/qbft-core/src/main/java/org/hyperledger/besu/consensus/qbft/core/statemachine/QbftBlockHeightManager.java
+++ b/consensus/qbft-core/src/main/java/org/hyperledger/besu/consensus/qbft/core/statemachine/QbftBlockHeightManager.java
@@ -478,6 +478,16 @@ public class QbftBlockHeightManager implements BaseQbftBlockHeightManager {
     return MessageAge.PRIOR_ROUND;
   }
 
+  @Override
+  public Optional<QbftRound> getCurrentRound() {
+    return currentRound;
+  }
+
+  @Override
+  public Optional<RoundChangeManager> getRoundChangeManager() {
+    return Optional.of(roundChangeManager);
+  }
+
   /** The enum Message age. */
   public enum MessageAge {
     /** Prior round message age. */

--- a/consensus/qbft-core/src/main/java/org/hyperledger/besu/consensus/qbft/core/statemachine/QbftRound.java
+++ b/consensus/qbft-core/src/main/java/org/hyperledger/besu/consensus/qbft/core/statemachine/QbftRound.java
@@ -122,6 +122,15 @@ public class QbftRound {
   }
 
   /**
+   * Gets round state.
+   *
+   * @return the round state
+   */
+  public RoundState getRoundState() {
+    return roundState;
+  }
+
+  /**
    * Create a block
    *
    * @param headerTimeStampSeconds of the block

--- a/consensus/qbft-core/src/main/java/org/hyperledger/besu/consensus/qbft/core/statemachine/RoundChangeManager.java
+++ b/consensus/qbft-core/src/main/java/org/hyperledger/besu/consensus/qbft/core/statemachine/RoundChangeManager.java
@@ -259,4 +259,13 @@ public class RoundChangeManager {
       final ConsensusRoundIdentifier left, final ConsensusRoundIdentifier right) {
     return left.getRoundNumber() > right.getRoundNumber();
   }
+
+  /**
+   * Gets the round change message validator.
+   *
+   * @return the round change message validator
+   */
+  public RoundChangeMessageValidator getRoundChangeMessageValidator() {
+    return roundChangeMessageValidator;
+  }
 }

--- a/consensus/qbft-core/src/main/java/org/hyperledger/besu/consensus/qbft/core/validation/MessageValidator.java
+++ b/consensus/qbft-core/src/main/java/org/hyperledger/besu/consensus/qbft/core/validation/MessageValidator.java
@@ -118,12 +118,29 @@ public class MessageValidator {
    * @return the boolean
    */
   public boolean validateProposal(final Proposal msg) {
+    return validateProposal(msg, true);
+  }
+
+  /**
+   * Validate proposal payload without block validation.
+   *
+   * @param msg the Proposal payload msg
+   * @return whether the proposal is valid
+   */
+  public boolean validateProposalWithoutBlockValidation(final Proposal msg) {
+    return validateProposal(msg, false);
+  }
+
+  private boolean validateProposal(final Proposal msg, final boolean validateBlock) {
     if (subsequentMessageValidator.isPresent()) {
       LOG.info("Received subsequent Proposal for current round, discarding.");
       return false;
     }
 
-    final boolean result = proposalValidator.validate(msg);
+    final boolean result =
+        validateBlock
+            ? proposalValidator.validate(msg)
+            : proposalValidator.validateWithoutBlockValidation(msg);
     if (result) {
       subsequentMessageValidator =
           Optional.of(subsequentMessageValidatorFactory.create(msg.getBlock()));

--- a/consensus/qbft-core/src/main/java/org/hyperledger/besu/consensus/qbft/core/validation/ProposalPayloadValidator.java
+++ b/consensus/qbft-core/src/main/java/org/hyperledger/besu/consensus/qbft/core/validation/ProposalPayloadValidator.java
@@ -61,6 +61,28 @@ public class ProposalPayloadValidator {
    * @return the boolean
    */
   public boolean validate(final SignedData<ProposalPayload> signedPayload) {
+    return validate(signedPayload, true);
+  }
+
+  /**
+   * Validate without block validation.
+   *
+   * @param signedPayload the signed Proposal payload
+   * @return the boolean
+   */
+  public boolean validateWithoutBlockValidation(final SignedData<ProposalPayload> signedPayload) {
+    return validate(signedPayload, false);
+  }
+
+  /**
+   * Validate with optional block validation.
+   *
+   * @param signedPayload the signed Proposal payload
+   * @param validateBlock whether to validate the block
+   * @return the boolean
+   */
+  private boolean validate(
+      final SignedData<ProposalPayload> signedPayload, final boolean validateBlock) {
 
     if (!signedPayload.getAuthor().equals(expectedProposer)) {
       LOG.info("{}: proposal created by non-proposer", ERROR_PREFIX);
@@ -75,7 +97,7 @@ public class ProposalPayloadValidator {
     }
 
     final QbftBlock block = payload.getProposedBlock();
-    if (!validateBlock(block)) {
+    if (validateBlock && !validateBlock(block)) {
       return false;
     }
 

--- a/consensus/qbft-core/src/main/java/org/hyperledger/besu/consensus/qbft/core/validation/ProposalValidator.java
+++ b/consensus/qbft-core/src/main/java/org/hyperledger/besu/consensus/qbft/core/validation/ProposalValidator.java
@@ -85,6 +85,27 @@ public class ProposalValidator {
    * @return the boolean
    */
   public boolean validate(final Proposal msg) {
+    return validate(msg, true);
+  }
+
+  /**
+   * Validate without block validation.
+   *
+   * @param msg the Proposal msg
+   * @return the boolean
+   */
+  public boolean validateWithoutBlockValidation(final Proposal msg) {
+    return validate(msg, false);
+  }
+
+  /**
+   * Validate with optional block validation.
+   *
+   * @param msg the Proposal msg
+   * @param validateBlock whether to validate the block
+   * @return the boolean
+   */
+  private boolean validate(final Proposal msg, final boolean validateBlock) {
     final QbftBlockValidator blockValidator =
         protocolSchedule.getBlockValidator(msg.getBlock().getHeader());
 
@@ -92,7 +113,12 @@ public class ProposalValidator {
     final ProposalPayloadValidator payloadValidator =
         new ProposalPayloadValidator(expectedProposer, roundIdentifier, blockValidator);
 
-    if (!payloadValidator.validate(msg.getSignedPayload())) {
+    final boolean payloadValid =
+        validateBlock
+            ? payloadValidator.validate(msg.getSignedPayload())
+            : payloadValidator.validateWithoutBlockValidation(msg.getSignedPayload());
+
+    if (!payloadValid) {
       LOG.info("{}: invalid proposal payload in proposal message", ERROR_PREFIX);
       return false;
     }

--- a/consensus/qbft-core/src/main/java/org/hyperledger/besu/consensus/qbft/core/validation/ValidatorUtil.java
+++ b/consensus/qbft-core/src/main/java/org/hyperledger/besu/consensus/qbft/core/validation/ValidatorUtil.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.consensus.qbft.core.validation;
+
+import org.hyperledger.besu.consensus.common.bft.ConsensusRoundIdentifier;
+import org.hyperledger.besu.consensus.common.bft.messagewrappers.BftMessage;
+import org.hyperledger.besu.datatypes.Address;
+
+import java.util.Collection;
+
+/** Utility class for validating QBFT messages. */
+public class ValidatorUtil {
+
+  /** Default constructor. */
+  private ValidatorUtil() {
+    // Utility class
+  }
+
+  /**
+   * Check if a message is from a known validator.
+   *
+   * @param msg the BFT message
+   * @param validators the collection of validator addresses
+   * @return true if the message author is a known validator
+   */
+  public static boolean isMsgFromKnownValidator(
+      final BftMessage<?> msg, final Collection<Address> validators) {
+    return validators.contains(msg.getAuthor());
+  }
+
+  /**
+   * Check if a message is for the current chain height.
+   *
+   * @param bftMessage the BFT message
+   * @param currentChainHeight the current chain height
+   * @return true if the message is for the current chain height
+   */
+  public static boolean isMsgForCurrentHeight(
+      final BftMessage<?> bftMessage, final long currentChainHeight) {
+    return isMsgForCurrentHeight(bftMessage.getRoundIdentifier(), currentChainHeight);
+  }
+
+  /**
+   * Check if a round identifier is for the current chain height.
+   *
+   * @param roundIdentifier the consensus round identifier
+   * @param currentChainHeight the current chain height
+   * @return true if the round identifier is for the current chain height
+   */
+  public static boolean isMsgForCurrentHeight(
+      final ConsensusRoundIdentifier roundIdentifier, final long currentChainHeight) {
+    return roundIdentifier.getSequenceNumber() == currentChainHeight;
+  }
+
+  /**
+   * Check if a message is for a future chain height.
+   *
+   * @param bftMessage the BFT message
+   * @param currentChainHeight the current chain height
+   * @return true if the message is for a future chain height
+   */
+  public static boolean isMsgForFutureChainHeight(
+      final BftMessage<?> bftMessage, final long currentChainHeight) {
+    return bftMessage.getRoundIdentifier().getSequenceNumber() > currentChainHeight;
+  }
+}

--- a/consensus/qbft-core/src/test/java/org/hyperledger/besu/consensus/qbft/core/statemachine/QbftRoundTest.java
+++ b/consensus/qbft-core/src/test/java/org/hyperledger/besu/consensus/qbft/core/statemachine/QbftRoundTest.java
@@ -324,6 +324,10 @@ public class QbftRoundTest {
         messageFactory.createCommit(roundIdentifier, proposedBlock.getHash(), remoteCommitSeal));
     verify(blockImporter, never()).importBlock(any());
 
+    round.handleCommitMessage(
+        messageFactory2.createCommit(roundIdentifier, proposedBlock.getHash(), remoteCommitSeal));
+    verify(blockImporter, never()).importBlock(any());
+
     round.handleProposalMessage(
         messageFactory.createProposal(
             roundIdentifier, proposedBlock, Collections.emptyList(), Collections.emptyList()));


### PR DESCRIPTION
## PR description
QBFT/IBFT validation refactoring and cleanup. And also allow use of message validation outside of Besu for other projects.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


