### PR TITLE
Allow specifying blobSchedule for Amsterdam

### DIFF
--- a/config/src/main/java/org/hyperledger/besu/config/BlobScheduleOptions.java
+++ b/config/src/main/java/org/hyperledger/besu/config/BlobScheduleOptions.java
@@ -32,6 +32,7 @@ public class BlobScheduleOptions {
   private static final String BPO3_KEY = "bpo3";
   private static final String BPO4_KEY = "bpo4";
   private static final String BPO5_KEY = "bpo5";
+  private static final String AMSTERDAM_KEY = "amsterdam";
 
   /**
    * Instantiates a new Blob Schedule config options.
@@ -106,6 +107,15 @@ public class BlobScheduleOptions {
   }
 
   /**
+   * Gets amsterdam blob schedule.
+   *
+   * @return the amsterdam blob schedule
+   */
+  public Optional<BlobSchedule> getAmsterdam() {
+    return getBlobSchedule(AMSTERDAM_KEY);
+  }
+
+  /**
    * Gets blob schedule by key.
    *
    * @param key the key for the blob schedule
@@ -129,6 +139,7 @@ public class BlobScheduleOptions {
     getBpo3().ifPresent(bs -> builder.put(BPO3_KEY, bs.asMap()));
     getBpo4().ifPresent(bs -> builder.put(BPO4_KEY, bs.asMap()));
     getBpo5().ifPresent(bs -> builder.put(BPO5_KEY, bs.asMap()));
+    getAmsterdam().ifPresent(bs -> builder.put(AMSTERDAM_KEY, bs.asMap()));
     return builder.build();
   }
 }

--- a/config/src/test/java/org/hyperledger/besu/config/BlobScheduleOptionsTest.java
+++ b/config/src/test/java/org/hyperledger/besu/config/BlobScheduleOptionsTest.java
@@ -44,6 +44,7 @@ public class BlobScheduleOptionsTest {
     assertParsed(options::getBpo3, 31, 32, 5007716);
     assertParsed(options::getBpo4, 41, 42, 5007716);
     assertParsed(options::getBpo5, 51, 52, 5007716);
+    assertParsed(options::getAmsterdam, 8, 11, 6000000);
   }
 
   @Test

--- a/config/src/test/resources/mainnet_with_blob_schedule.json
+++ b/config/src/test/resources/mainnet_with_blob_schedule.json
@@ -27,6 +27,11 @@
         "max": 10,
         "baseFeeUpdateFraction": 5007716
       },
+      "amsterdam": {
+        "target": 8,
+        "max": 11,
+        "baseFeeUpdateFraction": 6000000
+      },
       "bpo1": {
         "target": 11,
         "max": 12,

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetProtocolSpecs.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetProtocolSpecs.java
@@ -1163,19 +1163,21 @@ public abstract class MainnetProtocolSpecs {
       final boolean isParallelTxProcessingEnabled,
       final BalConfiguration balConfiguration,
       final MetricsSystem metricsSystem) {
-    return bpo5Definition(
-            chainId,
-            enableRevertReason,
-            genesisConfigOptions,
-            evmConfiguration,
-            miningConfiguration,
-            isParallelTxProcessingEnabled,
-            balConfiguration,
-            metricsSystem)
-        .blockAccessListFactory(
-            new BlockAccessListFactory(balConfiguration.isBalApiEnabled(), true))
-        .stateRootCommitterFactory(new StateRootCommitterFactoryBal(balConfiguration))
-        .hardforkId(AMSTERDAM);
+    final ProtocolSpecBuilder builder =
+        bpo5Definition(
+                chainId,
+                enableRevertReason,
+                genesisConfigOptions,
+                evmConfiguration,
+                miningConfiguration,
+                isParallelTxProcessingEnabled,
+                balConfiguration,
+                metricsSystem)
+            .blockAccessListFactory(
+                new BlockAccessListFactory(balConfiguration.isBalApiEnabled(), true))
+            .stateRootCommitterFactory(new StateRootCommitterFactoryBal(balConfiguration));
+    return applyBlobSchedule(
+        builder, genesisConfigOptions, BlobScheduleOptions::getAmsterdam, AMSTERDAM);
   }
 
   private static ProtocolSpecBuilder applyBlobSchedule(


### PR DESCRIPTION
Adds `amsterdam` as a key to `BlobScheduleOptions` to allow defining Amsterdam blob schedule in the genesis config options:
```
{
  "config": {
    ...
    "blobSchedule": {
      ...
      "amsterdam": {
        "target": 8,
        "max": 11,
        "baseFeeUpdateFraction": 6000000
      },
     ...
    },
    ...
  }
}
```

Applies the schedule from `BlobScheduleOptions` in `MainnetProtocolSpecs#amsterdamDefinition` the same way it is done for BPO forks currently.

This is a hotfix for [a class of BAL hive test failures](https://hive.ethpandaops.io/#/logs/bal/1762223578-c0a6696a4b8d4edec97a0bbb7b62281a/besu_default%2Fclient-24c585d4fb5f95c7f493dc5eebf9b2acb4ab133959ea52db7e335e67fc233a57.log).