### PR TITLE
engine_getBlobsV2 parallel serialization of blob data

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV2.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV2.java
@@ -146,7 +146,7 @@ public class EngineGetBlobsV2 extends ExecutionEngineJsonRpcMethod {
     }
 
     final List<BlobAndProofV2> results =
-        validBundles.stream().map(this::createBlobAndProofV2).toList();
+        validBundles.parallelStream().map(this::createBlobAndProofV2).toList();
 
     hitCounter.inc();
     return new JsonRpcSuccessResponse(requestContext.getRequest().getId(), results);


### PR DESCRIPTION
Mitigates scalability issues since converting blob data toHexString is O(n).

Blob proofs are still processed in serial stream within each blob processing thread. The proofs contain less data so probably aren't the bottleneck and parallelising this may add more overhead than it's worth.

Testing this out alongside the parallel proof version: https://github.com/hyperledger/besu/pull/9414

