### PR TITLE
engine_getBlobsV2 parallel serialization of blob data and proofs

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV2.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV2.java
@@ -146,7 +146,7 @@ public class EngineGetBlobsV2 extends ExecutionEngineJsonRpcMethod {
     }
 
     final List<BlobAndProofV2> results =
-        validBundles.stream().map(this::createBlobAndProofV2).toList();
+        validBundles.parallelStream().map(this::createBlobAndProofV2).toList();
 
     hitCounter.inc();
     return new JsonRpcSuccessResponse(requestContext.getRequest().getId(), results);
@@ -166,7 +166,7 @@ public class EngineGetBlobsV2 extends ExecutionEngineJsonRpcMethod {
   private BlobAndProofV2 createBlobAndProofV2(final BlobProofBundle blobProofBundle) {
     return new BlobAndProofV2(
         HexUtils.toFastHex(blobProofBundle.getBlob().getData(), true),
-        blobProofBundle.getKzgProof().stream()
+        blobProofBundle.getKzgProof().parallelStream()
             .map(proof -> HexUtils.toFastHex(proof.getData(), true))
             .toList());
   }


### PR DESCRIPTION
Mitigates scalability issues since converting blob data and proof data toHexString is O(n)

Testing this out alongside https://github.com/hyperledger/besu/pull/9413