### PR TITLE
fix: correct casing of base fee update fraction in JSON configuration

### DIFF
--- a/config/src/main/java/org/hyperledger/besu/config/BlobSchedule.java
+++ b/config/src/main/java/org/hyperledger/besu/config/BlobSchedule.java
@@ -46,7 +46,7 @@ public class BlobSchedule {
     int target = JsonUtil.getInt(blobScheduleConfigRoot, "target").orElseThrow();
     int max = JsonUtil.getInt(blobScheduleConfigRoot, "max").orElseThrow();
     int baseFeeUpdateFraction =
-        JsonUtil.getInt(blobScheduleConfigRoot, "basefeeupdatefraction").orElseThrow();
+        JsonUtil.getInt(blobScheduleConfigRoot, "baseFeeUpdateFraction").orElseThrow();
     return create(target, max, baseFeeUpdateFraction);
   }
 


### PR DESCRIPTION
## PR description
This PR corrects a JSON field name casing bug in the BlobSchedule class configuration parser.

## Code Change
Change: Single character correction on line 49 - changed the JSON field key from all lowercase to proper camelCase to match the standardized naming convention.

## Fixed Issue(s)
fixes #9418 


### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew build`
- [x] acceptance tests: `./gradlew acceptanceTest`
- [x] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


