### PR TITLE
Remove unnecessary BlockValues dependency from ethereum/core project

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/ProcessableBlockHeader.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/ProcessableBlockHeader.java
@@ -17,16 +17,14 @@ package org.hyperledger.besu.ethereum.core;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.Wei;
-import org.hyperledger.besu.evm.frame.BlockValues;
 
 import java.util.Optional;
 
-import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 
 /** A block header capable of being processed. */
 public class ProcessableBlockHeader
-    implements BlockValues, org.hyperledger.besu.plugin.data.ProcessableBlockHeader {
+    implements org.hyperledger.besu.plugin.data.ProcessableBlockHeader {
 
   protected final Hash parentHash;
 
@@ -99,16 +97,6 @@ public class ProcessableBlockHeader
   }
 
   /**
-   * Returns the block difficulty.
-   *
-   * @return the block difficulty
-   */
-  @Override
-  public Bytes getDifficultyBytes() {
-    return difficulty.getAsBytes32();
-  }
-
-  /**
    * Returns the block number.
    *
    * @return the block number
@@ -146,16 +134,6 @@ public class ProcessableBlockHeader
   @Override
   public Optional<Wei> getBaseFee() {
     return Optional.ofNullable(baseFee);
-  }
-
-  /**
-   * Returns the mixHash before merge, and the prevRandao value after
-   *
-   * @return the mixHash before merge, and the prevRandao value after
-   */
-  @Override
-  public Bytes32 getMixHashOrPrevRandao() {
-    return mixHashOrPrevRandao;
   }
 
   /**

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/T8nExecutor.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/T8nExecutor.java
@@ -594,8 +594,8 @@ public class T8nExecutor {
 
     resultObject.put(
         "currentDifficulty",
-        !blockHeader.getDifficultyBytes().trimLeadingZeros().isEmpty()
-            ? blockHeader.getDifficultyBytes().toShortHexString()
+        !blockHeader.getDifficulty().getAsBytes32().trimLeadingZeros().isEmpty()
+            ? blockHeader.getDifficulty().getAsBytes32().toShortHexString()
             : null);
     resultObject.put("gasUsed", Bytes.ofUnsignedLong(gasUsed).toQuantityHexString());
     blockHeader

--- a/ethereum/referencetests/src/reference-test/java/org/hyperledger/besu/ethereum/vm/BlockchainReferenceTestTools.java
+++ b/ethereum/referencetests/src/reference-test/java/org/hyperledger/besu/ethereum/vm/BlockchainReferenceTestTools.java
@@ -228,7 +228,7 @@ public class BlockchainReferenceTestTools {
         ethScheduler,
         Optional.of(transactions),
         Optional.of(ommers),
-        blockFromReference.getHeader().getMixHashOrPrevRandao(),
+        blockFromReference.getHeader().getPrevRandao().orElseThrow(),
         blockFromReference.getHeader().getTimestamp(),
         withdrawals,
         blockFromReference.getHeader().getParentBeaconBlockRoot());


### PR DESCRIPTION
## PR description
Remove dependency from BlockValues in ProcessableBlockHeader as it's not required downstream at the interface level and complicates other changes.



### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


