### PR TITLE
Fix: Ensure deterministic sub-protocol registration in ConsensusSchedule

### DIFF
--- a/app/src/main/java/org/hyperledger/besu/controller/ConsensusScheduleBesuControllerBuilder.java
+++ b/app/src/main/java/org/hyperledger/besu/controller/ConsensusScheduleBesuControllerBuilder.java
@@ -49,6 +49,8 @@ import org.hyperledger.besu.ethereum.forkid.ForkIdManager;
 import org.hyperledger.besu.ethereum.mainnet.BalConfiguration;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.p2p.config.SubProtocolConfiguration;
+import org.hyperledger.besu.ethereum.p2p.network.ProtocolManager;
+import org.hyperledger.besu.ethereum.p2p.rlpx.wire.SubProtocol;
 import org.hyperledger.besu.ethereum.storage.StorageProvider;
 import org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
@@ -225,9 +227,37 @@ public class ConsensusScheduleBesuControllerBuilder extends BesuControllerBuilde
   protected SubProtocolConfiguration createSubProtocolConfiguration(
       final EthProtocolManager ethProtocolManager,
       final Optional<SnapProtocolManager> maybeSnapProtocolManager) {
-    return besuControllerBuilderSchedule
-        .get(besuControllerBuilderSchedule.keySet().stream().skip(1).findFirst().orElseThrow())
-        .createSubProtocolConfiguration(ethProtocolManager, maybeSnapProtocolManager);
+    // During consensus migration, we need BOTH wire protocols registered.
+    // This allows nodes to communicate before AND after the migration block.
+    // Previously used .skip(1) which was non-deterministic with HashMap ordering.
+    //
+    // We merge all sub-protocol configurations, which registers both:
+    // - IBF/1 (IBFT2) for pre-migration communication
+    // - istanbul/100 (QBFT) for post-migration communication
+    final SubProtocolConfiguration mergedConfig = new SubProtocolConfiguration();
+    final java.util.Set<String> addedProtocolNames = new java.util.HashSet<>();
+
+    // Add sub-protocols from each consensus builder (sorted by block number for determinism)
+    besuControllerBuilderSchedule.entrySet().stream()
+        .sorted(Map.Entry.comparingByKey())
+        .forEach(
+            entry -> {
+              final SubProtocolConfiguration builderConfig =
+                  entry.getValue().createSubProtocolConfiguration(ethProtocolManager, maybeSnapProtocolManager);
+              final List<SubProtocol> subProtocols = builderConfig.getSubProtocols();
+              final List<ProtocolManager> protocolManagers = builderConfig.getProtocolManagers();
+              for (int i = 0; i < subProtocols.size(); i++) {
+                final SubProtocol subProtocol = subProtocols.get(i);
+                final ProtocolManager protocolManager = protocolManagers.get(i);
+                // Only add if not already present (avoid duplicates like EthProtocol)
+                if (!addedProtocolNames.contains(subProtocol.getName())) {
+                  mergedConfig.withSubProtocol(subProtocol, protocolManager);
+                  addedProtocolNames.add(subProtocol.getName());
+                }
+              }
+            });
+
+    return mergedConfig;
   }
 
   @Override


### PR DESCRIPTION
  This PR fixes a critical bug that prevents successful **IBFT2 →
    QBFT consensus migration** in Besu. During migration, nodes
   would stall and fail to produce blocks because they could only
   speak one BFT wire protocol instead of both.

   ## Problem

   When running a consensus migration from IBFT2 to QBFT using a
   `transitions` configuration in genesis, the network would stall
    before reaching the fork block. Nodes could not exchange IBFT2
    messages even though they were still running IBFT2 consensus
   pre-fork.

   ### Root Cause

   In `ConsensusScheduleBesuControllerBuilder.createSubProtocolCon
   figuration()`, the original code was:

   ```java
   return besuControllerBuilderSchedule
       .get(besuControllerBuilderSchedule.keySet().stream().skip(1
   ).findFirst().orElseThrow())
       .createSubProtocolConfiguration(ethProtocolManager,
   maybeSnapProtocolManager);
   ```

   **Issues with this approach:**

   1. **Non-deterministic ordering**:
   `besuControllerBuilderSchedule` is a `Map` (HashMap), so
   `keySet().stream().skip(1)` produces unpredictable results
   depending on hash ordering
   2. **Only one protocol registered**: Only the sub-protocol
   configuration from ONE consensus mechanism was registered,
   meaning nodes could only speak QBFT on the wire while still
   needing IBFT2 consensus pre-fork
   3. **Peer communication failure**: Nodes couldn't exchange
   IBFT2 messages → block production stalls before fork height

   ## Solution

   The fix registers **all BFT sub-protocols** from all scheduled
   consensus mechanisms:

   - **IBF/1** (IBFT2) - for pre-migration communication
   - **istanbul/100** (QBFT) - for post-migration communication

   This allows nodes to communicate using both protocols during
   the transition period. The fix:

   1. Iterates through all consensus builders (sorted by block
   number for determinism)
   2. Merges their sub-protocol configurations
   3. Avoids duplicates (e.g., EthProtocol which is common to
   both)

   ## Testing

   ### Migration Test Performed

   1. **Started IBFT2 network** - 4 validator nodes producing
   blocks under IBFT2 consensus
   2. **Verified IBFT2 active** - Logs showed
   `IbftBesuControllerBuilder` for blocks #0-49
   3. **Stopped network** at block ~46 (before fork block 50)
   4. **Restarted with migration genesis** containing both IBFT2
   and QBFT config with `startBlock: 50`
   5. **Verified seamless transition**:
      - Blocks #47-49: `IbftBesuControllerBuilder` (IBFT2)
      - Block #50+: `QbftBesuControllerBuilder` (QBFT)
   6. **Confirmed continuous operation** - Network continued
   producing blocks past #100 under QBFT

   ### Log Evidence

   ```
   # Pre-fork (IBFT2)
   IbftBesuControllerBuilder | Produced #49 / 0 tx / ...

   # Fork block (QBFT takes over)
   QbftBesuControllerBuilder | Imported empty block #50 / 0 tx /
   ...

   # Post-fork (QBFT continues)
   QbftBesuControllerBuilder | Produced empty block #73 / 0 tx /
   ...
   ```

   ## Genesis Configuration Used

   ```json
   {
     "config": {
       "ibft2": {
         "blockperiodseconds": 1,
         "epochlength": 30000,
         "requesttimeoutseconds": 2
       },
       "qbft": {
         "blockperiodseconds": 1,
         "epochlength": 30000,
         "requesttimeoutseconds": 2,
         "startBlock": 50
       }
     }
   }
   ```

   ## Fixed Issue(s)

   Fixes consensus migration failures when transitioning from
   IBFT2 to QBFT using scheduled transitions.

   ## Checklist

   - [x] Checked out [contribution guidelines](https://github.com/
   hyperledger/besu/blob/main/CONTRIBUTING.md)
   - [x] Considered documentation - `doc-change-required` may be
   needed to clarify migration requirements
   - [x] Considered changelog - This is a bug fix for consensus
   migration
   - [x] No database changes

   ## Local Tests

   - [x] Manual migration test (IBFT2 → QBFT) - **PASSED**
   - [ ] spotless: `./gradlew spotlessApply`
   - [ ] unit tests: `./gradlew build`
   - [ ] acceptance tests: `./gradlew acceptanceTest`
   - [ ] integration tests: `./gradlew integrationTest`