### PR TITLE
Allow transaction type 0x80 (empty string) in eth69 receipts

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/encoding/receipt/TransactionReceiptDecoder.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/encoding/receipt/TransactionReceiptDecoder.java
@@ -124,18 +124,31 @@ public class TransactionReceiptDecoder {
 
   private static TransactionReceipt decodeEth69Receipt(
       final RLPInput input, final RLPInput transactionByteRlp, final RLPInput statusOrStateRoot) {
-    byte transactionByte = transactionByteRlp.readByte();
-    final TransactionType transactionType =
-        TransactionType.fromEthSerializedType(transactionByte)
-            .orElseThrow(
-                () ->
-                    new IllegalStateException(
-                        "Invalid transaction type %x".formatted(transactionByte)));
+    final TransactionType transactionType = getTransactionType(transactionByteRlp);
     final long cumulativeGas = input.readLongScalar();
     final List<Log> logs = input.readList(logInput -> Log.readFrom(logInput, false));
     final LogsBloomFilter bloomFilter = LogsBloomFilter.builder().insertLogs(logs).build();
     return createReceipt(
         transactionType, statusOrStateRoot, cumulativeGas, logs, bloomFilter, Optional.empty());
+  }
+
+  private static TransactionType getTransactionType(final RLPInput transactionByteRlp) {
+    final TransactionType transactionType;
+    Bytes transactionBytes = transactionByteRlp.readBytes();
+    if (transactionBytes.isEmpty()) {
+      transactionType = TransactionType.FRONTIER;
+    } else if (transactionBytes.size() != 1) {
+      throw new IllegalStateException("Invalid transaction type" + transactionBytes.toHexString());
+    } else {
+      final byte typeByte = transactionBytes.get(0);
+      transactionType =
+          TransactionType.fromEthSerializedType(typeByte)
+              .orElseThrow(
+                  () ->
+                      new IllegalStateException(
+                          "Invalid transaction typeByte %x".formatted(typeByte)));
+    }
+    return transactionType;
   }
 
   private static TransactionReceipt decodeLegacyReceipt(

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/TransactionReceiptTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/TransactionReceiptTest.java
@@ -147,4 +147,19 @@ public class TransactionReceiptTest {
             true);
     assertThat(copy).isEqualTo(receipt);
   }
+
+  @Test
+  public void decodeEth69WithEmptyStringForType() {
+    String encodedReceiptWith0x00AsType =
+        "0xf85800808844e52a8ce6476327f84be494fccc2c35f0b84609e5f12c55dd85aba8d5d9bef7c08d72e5900112b81927ba5bb5f67ee594b4049bf0e4aed78db15d7bf2fc0c34e9a99de4efc08e8137ad659878f9e93df1f658367a";
+    String encodedReceiptWith0x80AsType =
+        "0xf85880808844e52a8ce6476327f84be494fccc2c35f0b84609e5f12c55dd85aba8d5d9bef7c08d72e5900112b81927ba5bb5f67ee594b4049bf0e4aed78db15d7bf2fc0c34e9a99de4efc08e8137ad659878f9e93df1f658367a";
+    final TransactionReceipt with0x00 =
+        TransactionReceiptDecoder.readFrom(
+            RLP.input(Bytes.fromHexString(encodedReceiptWith0x00AsType)), false);
+    final TransactionReceipt with0x80 =
+        TransactionReceiptDecoder.readFrom(
+            RLP.input(Bytes.fromHexString(encodedReceiptWith0x80AsType)), false);
+    assertThat(with0x00).isEqualTo(with0x80);
+  }
 }


### PR DESCRIPTION
## PR description
Eth 69 receipts contain the transaction type. Legacy Transaction type is 0, which can be Rlp encoded as 0x00 (1 byte with the value 0) or 0x80 (empty String). This PR fixes the decoding of eth 69 receipts when they contain the empty string (0x80) for the type.

## Fixed Issue(s)
#9519 


