### PR TITLE
efactor(eth): remove redundant throws

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/messages/BlockRangeUpdateMessage.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/messages/BlockRangeUpdateMessage.java
@@ -41,7 +41,7 @@ public class BlockRangeUpdateMessage extends AbstractMessageData {
 
   public static BlockRangeUpdateMessage create(
       final long earliestBlockNumber, final long latestBlockNumber, final Hash blockHash)
-      throws IllegalArgumentException {
+      {
     final BlockRangeUpdateMessageData msgData =
         new BlockRangeUpdateMessageData(earliestBlockNumber, latestBlockNumber, blockHash);
     final BytesValueRLPOutput out = new BytesValueRLPOutput();


### PR DESCRIPTION
The create method does not throw IllegalArgumentException and no callers expect it. Removing the declaration aligns this API with other message create methods and reduces misleading noise in the signature.