### PR TITLE
accept client or server timeout for flaky timeout test

### DIFF
--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/timeout/RpcTimeoutInterruptionIntegrationTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/timeout/RpcTimeoutInterruptionIntegrationTest.java
@@ -163,11 +163,12 @@ public class RpcTimeoutInterruptionIntegrationTest extends AbstractJsonRpcHttpSe
       // 408 can occur in resource-constrained CI environments when request processing is slow
       // 504 is the expected timeout when the method execution times out
       assertThat(response.code())
-          .as("Should receive a timeout HTTP status code (504 Gateway Timeout or 408 Request Timeout)")
+          .as(
+              "Should receive a timeout HTTP status code (504 Gateway Timeout or 408 Request Timeout)")
           .satisfiesAnyOf(
               code -> assertThat(code).isEqualTo(504), // Gateway timeout (preferred)
-              code -> assertThat(code).isEqualTo(408)  // Request timeout (acceptable in CI)
-          );
+              code -> assertThat(code).isEqualTo(408) // Request timeout (acceptable in CI)
+              );
 
       String responseBody = response.body().string();
 
@@ -187,7 +188,8 @@ public class RpcTimeoutInterruptionIntegrationTest extends AbstractJsonRpcHttpSe
     // For 408, the request might not have reached the method execution stage
     if (methodInvocations.get() > 0) {
       assertThat(methodWasInterrupted.get())
-          .as("Method execution should have been interrupted due to timeout when method was invoked")
+          .as(
+              "Method execution should have been interrupted due to timeout when method was invoked")
           .isTrue();
     }
   }


### PR DESCRIPTION
## PR description
Check for client timeout as well as server timeout

## Fixed Issue(s)
fixes #9538


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


