### PR TITLE
Change `plugins_reloadPluginConfig` RPC method to return the result of the reload

### DIFF
--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/condition/net/NetConditions.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/condition/net/NetConditions.java
@@ -59,8 +59,4 @@ public class NetConditions {
   public Condition netVersionUnauthorized() {
     return new ExpectUnauthorized(transactions.netVersion());
   }
-
-  public Condition rpcIsListening() {
-    return new AwaitNetPeerCount(transactions.peerCount(), BigInteger.ZERO);
-  }
 }

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/transaction/plugins/ReloadPluginConfig.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/transaction/plugins/ReloadPluginConfig.java
@@ -42,7 +42,9 @@ public class ReloadPluginConfig implements Transaction<String> {
       final Response<String> resp =
           node.plugins().reloadConfiguration(Optional.ofNullable(pluginName)).send();
       assertThat(resp).isNotNull();
-      assertThat(resp.hasError()).isFalse();
+      if (resp.hasError()) {
+        throw new RuntimeException(resp.getError().getMessage());
+      }
       return resp.getResult();
     } catch (final IOException e) {
       throw new RuntimeException(e);

--- a/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/tests/acceptance/plugins/TestReloadConfigurationPlugin1.java
+++ b/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/tests/acceptance/plugins/TestReloadConfigurationPlugin1.java
@@ -17,11 +17,20 @@ package org.hyperledger.besu.tests.acceptance.plugins;
 import org.hyperledger.besu.plugin.BesuPlugin;
 
 import com.google.auto.service.AutoService;
+import picocli.CommandLine;
 
 @AutoService(BesuPlugin.class)
 public class TestReloadConfigurationPlugin1 extends AbstractTestReloadConfigurationPlugin {
 
+  @CommandLine.Option(names = "--plugin-reload-conf1-fail")
+  boolean fail = false;
+
   public TestReloadConfigurationPlugin1() {
     super(1);
+  }
+
+  @Override
+  protected boolean shouldFail() {
+    return fail;
   }
 }

--- a/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/tests/acceptance/plugins/TestReloadConfigurationPlugin2.java
+++ b/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/tests/acceptance/plugins/TestReloadConfigurationPlugin2.java
@@ -17,11 +17,20 @@ package org.hyperledger.besu.tests.acceptance.plugins;
 import org.hyperledger.besu.plugin.BesuPlugin;
 
 import com.google.auto.service.AutoService;
+import picocli.CommandLine;
 
 @AutoService(BesuPlugin.class)
 public class TestReloadConfigurationPlugin2 extends AbstractTestReloadConfigurationPlugin {
 
+  @CommandLine.Option(names = "--plugin-reload-conf2-fail")
+  boolean fail = false;
+
   public TestReloadConfigurationPlugin2() {
     super(2);
+  }
+
+  @Override
+  protected boolean shouldFail() {
+    return fail;
   }
 }

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/plugins/PluginConfigurationReloadTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/plugins/PluginConfigurationReloadTest.java
@@ -15,28 +15,27 @@
 package org.hyperledger.besu.tests.acceptance.plugins;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.hyperledger.besu.tests.acceptance.dsl.AcceptanceTestBase;
 import org.hyperledger.besu.tests.acceptance.dsl.node.BesuNode;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class PluginConfigurationReloadTest extends AcceptanceTestBase {
   private BesuNode pluginNode;
 
-  @BeforeEach
-  public void setUp() throws Exception {
+  private void setupNode(final int... failingIds) throws IOException {
     pluginNode =
         besu.createQbftPluginsNode(
             "pluginNode",
             Collections.singletonList("testPlugins"),
-            Collections.emptyList(),
+            Arrays.stream(failingIds).mapToObj("--plugin-reload-conf%d-fail"::formatted).toList(),
             "PLUGINS");
 
     cluster.start(pluginNode);
@@ -45,7 +44,8 @@ public class PluginConfigurationReloadTest extends AcceptanceTestBase {
   }
 
   @Test
-  public void reloadSinglePluginConfiguration() {
+  public void reloadSinglePluginConfigurationSuccessful() throws IOException {
+    setupNode();
 
     final var reloadConfTx =
         plugins.reloadConfiguration(TestReloadConfigurationPlugin1.class.getName());
@@ -53,21 +53,64 @@ public class PluginConfigurationReloadTest extends AcceptanceTestBase {
     final var response = pluginNode.execute(reloadConfTx);
 
     assertThat(response).isEqualTo("Success");
-    assertConfigReloadForPlugins(1);
+    assertConfigReloadCalledForPlugins(1);
   }
 
   @Test
-  public void reloadAllPluginConfigurations() {
+  public void reloadSinglePluginConfigurationFailure() throws IOException {
+    setupNode(1);
+
+    final var reloadConfTx =
+        plugins.reloadConfiguration(TestReloadConfigurationPlugin1.class.getName());
+
+    assertThatThrownBy(() -> pluginNode.execute(reloadConfTx))
+        .hasMessage(
+            "org.hyperledger.besu.tests.acceptance.plugins.TestReloadConfigurationPlugin1:failure(Failed to reload configuration)");
+
+    assertConfigReloadCalledForPlugins(1);
+  }
+
+  @Test
+  public void reloadAllPluginConfigurationsSuccessful() throws IOException {
+    setupNode();
 
     final var reloadConfTx = plugins.reloadConfiguration();
 
     final var response = pluginNode.execute(reloadConfTx);
 
     assertThat(response).isEqualTo("Success");
-    assertConfigReloadForPlugins(1, 2);
+    assertConfigReloadCalledForPlugins(1, 2);
   }
 
-  public void assertConfigReloadForPlugins(final int... pluginIds) {
+  @Test
+  public void reloadAllPluginConfigurationsOneFails() throws IOException {
+    setupNode(1);
+
+    final var reloadConfTx = plugins.reloadConfiguration();
+
+    assertThatThrownBy(() -> pluginNode.execute(reloadConfTx))
+        .hasMessageContainingAll(
+            "org.hyperledger.besu.tests.acceptance.plugins.TestReloadConfigurationPlugin1:failure(Failed to reload configuration)",
+            "org.hyperledger.besu.tests.acceptance.plugins.TestReloadConfigurationPlugin2:success");
+
+    assertConfigReloadCalledForPlugins(1, 2);
+  }
+
+  @Test
+  public void reloadAllPluginConfigurationsAllFail() throws IOException {
+    setupNode(1, 2);
+
+    final var reloadConfTx = plugins.reloadConfiguration();
+
+    assertThatThrownBy(() -> pluginNode.execute(reloadConfTx))
+        .hasMessageContainingAll(
+            "org.hyperledger.besu.tests.acceptance.plugins.TestReloadConfigurationPlugin1:failure(Failed to reload configuration)",
+            "org.hyperledger.besu.tests.acceptance.plugins.TestReloadConfigurationPlugin2:failure(Failed to reload configuration)");
+
+    assertConfigReloadCalledForPlugins(1, 2);
+  }
+
+  private void assertConfigReloadCalledForPlugins(final int... pluginIds) {
     final var reloadConfFiles =
         pluginNode
             .homeDirectory()
@@ -75,7 +118,7 @@ public class PluginConfigurationReloadTest extends AcceptanceTestBase {
             .toFile()
             .listFiles((dir, name) -> name.startsWith("reloadConfiguration."));
 
-    assertThat(reloadConfFiles).hasSize(pluginIds.length);
+    assertThat(reloadConfFiles).isNotNull().hasSize(pluginIds.length);
 
     final var foundFilenames = Arrays.stream(reloadConfFiles).map(File::getName).toList();
     assertThat(foundFilenames)

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/PluginsReloadConfiguration.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/PluginsReloadConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright ConsenSys AG.
+ * Copyright contributors to Besu.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -17,16 +17,18 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter.JsonRpcParameterException;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.plugin.BesuPlugin;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,22 +52,41 @@ public class PluginsReloadConfiguration implements JsonRpcMethod {
     try {
       final var maybePluginName = requestContext.getOptionalParameter(0, String.class);
 
-      final Collection<BesuPlugin> reloadPlugins;
+      final Map<String, BesuPlugin> reloadPluginsByName;
       if (maybePluginName.isPresent()) {
         final var pluginName = maybePluginName.get();
         if (!namedPlugins.containsKey(pluginName)) {
           LOG.error(
-              "Plugin cannot be reloaded because no plugin has been registered with specified name: {}.",
+              "Plugin cannot be reloaded because no plugin has been registered with specified name: {}",
               pluginName);
           return new JsonRpcErrorResponse(
               requestContext.getRequest().getId(), RpcErrorType.PLUGIN_NOT_FOUND);
         }
-        reloadPlugins = Collections.singleton(namedPlugins.get(pluginName));
+        reloadPluginsByName = Collections.singletonMap(pluginName, namedPlugins.get(pluginName));
       } else {
-        reloadPlugins = namedPlugins.values();
+        reloadPluginsByName = namedPlugins;
       }
 
-      reloadPlugins.forEach(this::reloadPluginConfig);
+      final var asyncReloads =
+          reloadPluginsByName.entrySet().stream()
+              .collect(
+                  Collectors.toMap(
+                      Map.Entry::getKey, e -> asyncReloadPluginConfig(e.getKey(), e.getValue())));
+
+      try {
+        CompletableFuture.allOf(
+                asyncReloads.values().toArray(new CompletableFuture<?>[asyncReloads.size()]))
+            .get();
+      } catch (InterruptedException | ExecutionException e) {
+        // fill a detailed error message with the result of each plugin
+        final String errMsg =
+            asyncReloads.entrySet().stream()
+                .map(this::resultToString)
+                .collect(Collectors.joining(","));
+        return new JsonRpcErrorResponse(
+            requestContext.getRequest().getId(), new JsonRpcError(-32000, errMsg, null));
+      }
+
       return new JsonRpcSuccessResponse(requestContext.getRequest().getId());
     } catch (JsonRpcParameterException e) {
       return new JsonRpcErrorResponse(
@@ -73,17 +94,34 @@ public class PluginsReloadConfiguration implements JsonRpcMethod {
     }
   }
 
-  private void reloadPluginConfig(final BesuPlugin plugin) {
-    final String name = plugin.getName();
-    LOG.info("Reloading plugin configuration: {}.", name);
-    final CompletableFuture<Void> future = plugin.reloadConfiguration();
-    future.whenComplete(
-        (unused, throwable) -> {
-          if (throwable != null) {
-            LOG.error("Failed to reload plugin {}", name, throwable);
-          } else {
-            LOG.info("Plugin {} has been reloaded.", name);
-          }
-        });
+  private CompletableFuture<Void> asyncReloadPluginConfig(
+      final String pluginName, final BesuPlugin plugin) {
+    LOG.info("Reloading plugin configuration: {}", pluginName);
+    return plugin
+        .reloadConfiguration()
+        .whenComplete(
+            (unused, throwable) -> {
+              if (throwable != null) {
+                LOG.error("Failed to reload plugin {}", pluginName, throwable);
+              } else {
+                LOG.info("Plugin {} has been reloaded successfully", pluginName);
+              }
+            });
+  }
+
+  private String resultToString(final Map.Entry<String, CompletableFuture<Void>> entry) {
+    final var pluginName = entry.getKey();
+    final var result = entry.getValue();
+    if (result.isCompletedExceptionally()) {
+      try {
+        result.get();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return pluginName + ":failure(interrupted)";
+      } catch (ExecutionException e) {
+        return pluginName + ":failure(" + e.getCause().getMessage() + ")";
+      }
+    }
+    return pluginName + ":success";
   }
 }


### PR DESCRIPTION
## PR description

~~Built on top of https://github.com/hyperledger/besu/pull/9563, please review it first.~~

Calls to `plugins_reloadPluginConfig` RPC method always return success because they just trigger the reload of the plugin configuration, without waiting for the result, but this results in a bad UX for the caller, since he has no clue about the success or not of the operation, unless it looks in the logs.

Since reloading plugin configurations should be a fast operation, no more that few seconds in the worst cases, it makes sense to wait for the reloads to complete and return the result of the operations to the caller, so that if one or more reload operations fail, an error is returned, with a detailed error message, that specify which plugins have failed and the reason, and which plugin instead have reloaded their config successfully.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


