### PR TITLE
Treat EndOfRLPException as invalid packet in peer discovery

### DIFF
--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/discv4/VertxPeerDiscoveryAgent.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/discv4/VertxPeerDiscoveryAgent.java
@@ -62,6 +62,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.datagram.DatagramPacket;
 import io.vertx.core.datagram.DatagramSocket;
 import io.vertx.core.datagram.DatagramSocketOptions;
+import org.apache.tuweni.rlp.EndOfRLPException;
 import org.ethereum.beacon.discovery.util.DecodeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -346,7 +347,8 @@ public class VertxPeerDiscoveryAgent extends PeerDiscoveryAgentV4 {
             handleIncomingPacket(endpoint, event.result());
           } else {
             if (event.cause() instanceof PeerDiscoveryPacketDecodingException
-                || event.cause() instanceof DecodeException) {
+                || event.cause() instanceof DecodeException
+                || event.cause() instanceof EndOfRLPException) {
               LOG.debug(
                   "Discarding invalid peer discovery packet: {}, {}",
                   event.cause().getMessage(),


### PR DESCRIPTION
## PR Description

Fixes #9596

This PR updates the exception handling in `VertxPeerDiscoveryAgent` to treat `EndOfRLPException` the same way as other packet decoding exceptions (`DecodeException` and `PeerDiscoveryPacketDecodingException`).

## Problem

When processing peer discovery packets, `org.apache.tuweni.rlp.EndOfRLPException` is not caught as a packet decoding issue and is instead logged as an ERROR. This exception indicates a malformed RLP-encoded packet (specifically in ENR responses) and should be discarded quietly like other decoding exceptions.

## Changes

1. Added import for `org.apache.tuweni.rlp.EndOfRLPException`
2. Updated the exception handling in `handlePacket` method (line 345-347) to include `EndOfRLPException` in the list of exceptions that trigger packet discard with debug-level logging

## Impact

- Malformed packets that trigger `EndOfRLPException` will now be logged at DEBUG level instead of ERROR
- Reduces log pollution from invalid packets received from the network
- Consistent error handling for all RLP decoding failures

## Testing

The change follows the existing pattern for `DecodeException` handling. No new test coverage is added because:
- There are no existing tests for `VertxPeerDiscoveryAgent`'s packet exception handling
- The change is defensive and follows the exact same pattern as existing exception handling
- Testing would require significant Vertx infrastructure setup for minimal benefit

## Location

`ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/VertxPeerDiscoveryAgent.java:345-347`