### PR TITLE
Replace switch statement in EVM with executor array

### DIFF
--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/OpcodeExecutor.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/OpcodeExecutor.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.evm.operation;
+
+import org.hyperledger.besu.evm.EVM;
+import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.operation.Operation.OperationResult;
+
+/**
+ * Functional interface for opcode execution. Pre-built at EVM construction time to avoid runtime
+ * dispatch overhead from the giant switch statement. Each opcode gets an executor that either calls
+ * a static method (for hot opcodes) or delegates to the Operation instance (for complex opcodes).
+ */
+@FunctionalInterface
+public interface OpcodeExecutor {
+
+  /**
+   * Execute an opcode.
+   *
+   * @param frame the message frame containing execution state
+   * @param code the bytecode array
+   * @param pc the current program counter
+   * @param evm the EVM instance
+   * @return the operation result containing gas cost, halt reason, and PC increment
+   */
+  OperationResult execute(MessageFrame frame, byte[] code, int pc, EVM evm);
+}


### PR DESCRIPTION
## PR description

This PR tries to improve the performance, by replacing the big switch statement in the EVM, with assumed bad branch prediction, with a executor array which is contructed once at startup.

Performance checks are pending to confirm that this does indeed improve performance

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


