### PR TITLE
Fix promotion to prioritized layer for gas price fee markets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@
 - Update to log4j 2.25.3 [#9600](https://github.com/hyperledger/besu/pull/9600)
 - Add `engine_getBlobsV3` method [#9582](https://github.com/hyperledger/besu/pull/9582)
 
+### Bug fixes
+- Fix promotion to prioritized layer for gas price fee markets [#9635](https://github.com/hyperledger/besu/pull/9635)
+
 ##  25.12.0
 
 ### Breaking Changes

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/layered/GasPricePrioritizedTransactions.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/layered/GasPricePrioritizedTransactions.java
@@ -82,7 +82,7 @@ public class GasPricePrioritizedTransactions extends AbstractPrioritizedTransact
         || pendingTransaction
             .getTransaction()
             .getGasPrice()
-            .map(getAndLogMinTransactionGasPrice()::lessThan)
+            .map(getAndLogMinTransactionGasPrice()::lessOrEqualThan)
             .orElse(false);
   }
 

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/layered/AbstractPrioritizedTransactionsTestBase.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/layered/AbstractPrioritizedTransactionsTestBase.java
@@ -152,6 +152,14 @@ public abstract class AbstractPrioritizedTransactionsTestBase extends BaseTransa
   }
 
   @Test
+  public void txWithGasPriceEqualsToMineableMinGasPriceIsPrioritized() {
+    final PendingTransaction lowGasPriceTx =
+        createRemotePendingTransaction(createTransaction(0, DEFAULT_MIN_GAS_PRICE, KEYS1));
+    assertThat(prioritizeTransaction(lowGasPriceTx)).isEqualTo(ADDED);
+    assertTransactionPrioritized(lowGasPriceTx);
+  }
+
+  @Test
   public void txWithPriorityBelowCurrentMineableMinGasPriceIsPrioritized() {
     final PendingTransaction lowGasPriceTx =
         createRemotePendingTransaction(


### PR DESCRIPTION
## PR description

  This is a bug fix that corrects the gas price validation logic in the layered transaction pool. The change    
  allows transactions with gas price exactly equal to the minimum gas price to be promoted, which was           
  incorrectly rejected before.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

fixes #9598

### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


