### PR TITLE
When simulating a tx, always set the gas price to base fee if not provided

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/TransactionSimulator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/TransactionSimulator.java
@@ -592,8 +592,8 @@ public class TransactionSimulator {
       maxPriorityFeePerGas = Wei.ZERO;
       maxFeePerBlobGas = Wei.ZERO;
     } else {
-      if (noPricingParametersPresent && !transactionValidationParams.allowUnderpriced()) {
-        // in case there are gas price parameters and underpriced txs are not allowed,
+      if (noPricingParametersPresent) {
+        // in case there are no gas price parameters,
         // then set the gas price to the min necessary to process the tx.
         gasPrice = processableHeader.getBaseFee().orElse(Wei.ZERO);
       } else {


### PR DESCRIPTION
## PR description

PR https://github.com/hyperledger/besu/pull/9530 extended the support for estimating the gas for underpriced txs to be in line with Hive tests, doing [the check in the tx validator](https://github.com/hyperledger/besu/pull/9530/changes#diff-b687d725d48c7858ace60a62773adcf6bf06bc9ec42c61063c59cbb0746726d1L301), so the previous strategy to forcing the gasPrice to be zero to allow underpriced txs is not correct anymore and needs to be removed, so that if the gasPrice is not specified, it must be set to the baseFee.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


