### PR TITLE
Revert "include javadoc jar in plugins publish (#9611)"

### DIFF
--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -14,14 +14,6 @@
 import java.security.MessageDigest
 
 apply plugin: 'java-library'
-
-java {
-  withJavadocJar()
-}
-
-javadocJar {
-  archiveBaseName = calculateArtifactId(project)
-}
 jar {
   archiveBaseName = calculateArtifactId(project)
   manifest {


### PR DESCRIPTION
This reverts commit 61b6c2b82161de6937b9f2bf4a9e0909da63157e.


## PR description

Reverts #9611 since it makes publication to fail

```
./gradlew -Prelease.releaseVersion=26.1-local -Pversion=26.1-local distTar publishToMavenLocal

> Task :generateArtifactsCatalog
Artifacts catalog written to:
JSON: /home/fdifabio/repo/besu/build/reports/dependencies/besu-artifacts-catalog.json

> Task :plugin-api:publishMavenJavaPublicationToMavenLocal FAILED

[Incubating] Problems report is available at: file:///home/fdifabio/repo/besu/build/reports/problems/problems-report.html

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':plugin-api:publishMavenJavaPublicationToMavenLocal'.
> Failed to publish publication 'mavenJava' to repository 'mavenLocal'
> Invalid publication 'mavenJava': multiple artifacts with the identical extension and classifier ('jar', 'javadoc').
```

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


