### PR TITLE
Enhance payload selection with tx count and creation time tiebreakers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 ### Bug fixes
 - Fix promotion to prioritized layer for gas price fee markets [#9635](https://github.com/hyperledger/besu/pull/9635)
 - Fix callTracer to properly capture nested calls and populate revertReason field when transactions revert [#9651](https://github.com/hyperledger/besu/pull/9651)
+- Enhance payload selection with tx count and creation time tiebreakers [#9657](https://github.com/hyperledger/besu/pull/9657)
 
 ##  25.12.0
 

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/PayloadWrapper.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/PayloadWrapper.java
@@ -26,10 +26,11 @@ import java.util.List;
 import java.util.Optional;
 
 /** Wrapper for payload plus extra info. */
-public class PayloadWrapper {
+public class PayloadWrapper implements Comparable<PayloadWrapper> {
   private final PayloadIdentifier payloadIdentifier;
   private final BlockWithReceipts blockWithReceipts;
   private final Wei blockValue;
+  private final int txCount;
   private final Optional<List<Request>> requests;
   private final BlockCreationTiming blockCreationTimings;
   private final Optional<BlockAccessList> blockAccessList;
@@ -51,6 +52,7 @@ public class PayloadWrapper {
     this.payloadIdentifier = payloadIdentifier;
     this.blockValue = BlockValueCalculator.calculateBlockValue(blockWithReceipts);
     this.blockAccessList = blockAccessList;
+    this.txCount = blockWithReceipts.getBlock().getBody().getTransactions().size();
     this.requests = requests;
     this.blockCreationTimings = blockCreationTimings;
   }
@@ -62,6 +64,15 @@ public class PayloadWrapper {
    */
   public Wei blockValue() {
     return blockValue;
+  }
+
+  /**
+   * Get the number of transactions in the block
+   *
+   * @return the number of transactions
+   */
+  public int transactionCount() {
+    return txCount;
   }
 
   /**
@@ -102,5 +113,37 @@ public class PayloadWrapper {
    */
   public BlockCreationTiming getBlockCreationTimings() {
     return blockCreationTimings;
+  }
+
+  /**
+   * Compares this PayloadWrapper with another for ordering.
+   *
+   * <p>Comparison is performed in three stages:
+   *
+   * <ol>
+   *   <li>Primary: Compare by block value (Wei). Higher value is considered greater.
+   *   <li>Secondary: If block values are equal, compare by transaction count. Higher transaction
+   *       count is considered greater.
+   *   <li>Tertiary: If transaction counts are also equals, compare by starting time. Payload build
+   *       before are considered greater.
+   * </ol>
+   *
+   * @param o the PayloadWrapper to compare with
+   * @return a negative integer, zero, or a positive integer as this PayloadWrapper is less than,
+   *     equal to, or greater than the specified PayloadWrapper
+   */
+  @Override
+  public int compareTo(final PayloadWrapper o) {
+    final var cmpValue = blockValue().compareTo(o.blockValue());
+    if (cmpValue == 0) {
+      final var cmpTxCount = Integer.compare(transactionCount(), o.transactionCount());
+      if (cmpTxCount == 0) {
+        return -getBlockCreationTimings()
+            .startedAt()
+            .compareTo(o.getBlockCreationTimings().startedAt());
+      }
+      return cmpTxCount;
+    }
+    return cmpValue;
   }
 }

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/BlockCreationTiming.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/BlockCreationTiming.java
@@ -58,6 +58,10 @@ public class BlockCreationTiming {
     return elapsed;
   }
 
+  public Instant startedAt() {
+    return startedAt;
+  }
+
   @Override
   public String toString() {
     final var sb = new StringBuilder("started at " + startedAt + ", ");


### PR DESCRIPTION
## PR description

Use transaction count as tiebreaker for equal-value payload selection                                                                                                
                                                                                                                                                                       
  When multiple payloads have the same block value, prefer the one with                                                                                                
  more transactions. If both value and transaction count are equal, prefer                                                                                             
  the payload that started building earlier for deterministic selection.      

This is particularly useful on PoS gas free networks, where the block value is always zero despite the number of txs included in the block.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


