### PR TITLE
Add byte-level metrics for P2P message exchange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Add ability to pass a custom tracer to block simulation [#9708](https://github.com/hyperledger/besu/pull/9708)
 - Add support for `4byteTracer` in `debug_trace*` methods to collect function selectors from internal calls via PR [#9642](https://github.com/hyperledger/besu/pull/9642). Thanks to [@JukLee0ira](https://github.com/JukLee0ira).
 - Update assertj to v3.27.7 [#9710](https://github.com/hyperledger/besu/pull/9710)
+- Add byte-level metrics for P2P message exchange [#9666](https://github.com/hyperledger/besu/pull/9666)
 
 ### Bug fixes
 - Fix callTracer handling of failed CREATE operations, including correct input field extraction and proper error reporting for both soft failures and revert reasons

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/AbstractPeerConnection.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/AbstractPeerConnection.java
@@ -54,6 +54,7 @@ public abstract class AbstractPeerConnection implements PeerConnection {
   private final AtomicBoolean terminatedImmediately = new AtomicBoolean(false);
   protected final PeerConnectionEventDispatcher connectionEventDispatcher;
   private final LabelledMetric<Counter> outboundMessagesCounter;
+  private final LabelledMetric<Counter> outboundBytesCounter;
   private final long initiatedAt;
   private final boolean inboundInitiated;
   private boolean statusSent;
@@ -68,6 +69,7 @@ public abstract class AbstractPeerConnection implements PeerConnection {
       final CapabilityMultiplexer multiplexer,
       final PeerConnectionEventDispatcher connectionEventDispatcher,
       final LabelledMetric<Counter> outboundMessagesCounter,
+      final LabelledMetric<Counter> outboundBytesCounter,
       final boolean inboundInitiated) {
     this.peer = peer;
     this.peerInfo = peerInfo;
@@ -82,6 +84,7 @@ public abstract class AbstractPeerConnection implements PeerConnection {
     }
     this.connectionEventDispatcher = connectionEventDispatcher;
     this.outboundMessagesCounter = outboundMessagesCounter;
+    this.outboundBytesCounter = outboundBytesCounter;
     this.inboundInitiated = inboundInitiated;
     this.initiatedAt = System.currentTimeMillis();
 
@@ -118,6 +121,13 @@ public abstract class AbstractPeerConnection implements PeerConnection {
               subProtocol.messageName(capability.getVersion(), message.getCode()),
               Integer.toString(message.getCode()))
           .inc();
+      outboundBytesCounter
+          .labels(
+              capability.toString(),
+              subProtocol.messageName(capability.getVersion(), message.getCode()),
+              Integer.toString(message.getCode()))
+          .inc(message.getSize());
+
     } else {
       outboundMessagesCounter
           .labels(
@@ -125,6 +135,12 @@ public abstract class AbstractPeerConnection implements PeerConnection {
               WireMessageCodes.messageName(message.getCode()),
               Integer.toString(message.getCode()))
           .inc();
+      outboundBytesCounter
+          .labels(
+              "Wire",
+              WireMessageCodes.messageName(message.getCode()),
+              Integer.toString(message.getCode()))
+          .inc(message.getSize());
     }
 
     LOG.atTrace()

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/netty/DeFramer.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/netty/DeFramer.java
@@ -74,6 +74,7 @@ final class DeFramer extends ByteToMessageDecoder {
   private final PeerLookup peerLookup;
   private boolean hellosExchanged;
   private final LabelledMetric<Counter> outboundMessagesCounter;
+  private final LabelledMetric<Counter> outboundBytesCounter;
 
   DeFramer(
       final Framer framer,
@@ -98,6 +99,14 @@ final class DeFramer extends ByteToMessageDecoder {
             BesuMetricCategory.NETWORK,
             "p2p_messages_outbound",
             "Count of each P2P message sent outbound.",
+            "protocol",
+            "name",
+            "code");
+    this.outboundBytesCounter =
+        metricsSystem.createLabelledCounter(
+            BesuMetricCategory.NETWORK,
+            "p2p_bytes_outbound",
+            "Count of bytes sent outbound.",
             "protocol",
             "name",
             "code");
@@ -165,6 +174,7 @@ final class DeFramer extends ByteToMessageDecoder {
                 capabilityMultiplexer,
                 connectionEventDispatcher,
                 outboundMessagesCounter,
+                outboundBytesCounter,
                 inboundInitiated);
 
         // Check peer is who we expected

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/netty/NettyPeerConnection.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/netty/NettyPeerConnection.java
@@ -44,6 +44,7 @@ final class NettyPeerConnection extends AbstractPeerConnection {
       final CapabilityMultiplexer multiplexer,
       final PeerConnectionEventDispatcher connectionEventDispatcher,
       final LabelledMetric<Counter> outboundMessagesCounter,
+      final LabelledMetric<Counter> outboundBytesCounter,
       final boolean inboundInitiated) {
     super(
         peer,
@@ -54,6 +55,7 @@ final class NettyPeerConnection extends AbstractPeerConnection {
         multiplexer,
         connectionEventDispatcher,
         outboundMessagesCounter,
+        outboundBytesCounter,
         inboundInitiated);
 
     this.ctx = ctx;

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/NetworkRunnerTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/NetworkRunnerTest.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.p2p.network;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.hyperledger.besu.ethereum.p2p.peers.Peer;
+import org.hyperledger.besu.ethereum.p2p.rlpx.MessageCallback;
+import org.hyperledger.besu.ethereum.p2p.rlpx.connections.PeerConnection;
+import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Capability;
+import org.hyperledger.besu.ethereum.p2p.rlpx.wire.DefaultMessage;
+import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Message;
+import org.hyperledger.besu.ethereum.p2p.rlpx.wire.MessageData;
+import org.hyperledger.besu.ethereum.p2p.rlpx.wire.SubProtocol;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
+import org.hyperledger.besu.plugin.services.metrics.Counter;
+import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
+
+import java.util.List;
+import java.util.function.BiFunction;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+public class NetworkRunnerTest {
+
+  private NetworkRunner networkRunner;
+  private P2PNetwork network;
+  private LabelledMetric<Counter> inboundMessageCounter;
+  private LabelledMetric<Counter> inboundBytesCounter;
+  private Counter messageCounter;
+  private Counter bytesCounter;
+  private SubProtocol subProtocol;
+  private ProtocolManager protocolManager;
+
+  @BeforeEach
+  @SuppressWarnings("unchecked")
+  public void setUp() {
+    network = mock(P2PNetwork.class);
+    subProtocol = mock(SubProtocol.class);
+    protocolManager = mock(ProtocolManager.class);
+
+    inboundMessageCounter = mock(LabelledMetric.class);
+    inboundBytesCounter = mock(LabelledMetric.class);
+    messageCounter = mock(Counter.class);
+    bytesCounter = mock(Counter.class);
+
+    MetricsSystem metricsSystem = mock(MetricsSystem.class);
+    when(metricsSystem.createLabelledCounter(
+            any(), eq("p2p_messages_inbound"), any(), any(), any(), any()))
+        .thenReturn(inboundMessageCounter);
+    when(metricsSystem.createLabelledCounter(
+            any(), eq("p2p_bytes_inbound"), any(), any(), any(), any()))
+        .thenReturn(inboundBytesCounter);
+
+    when(inboundMessageCounter.labels(anyString(), anyString(), anyString()))
+        .thenReturn(messageCounter);
+    when(inboundBytesCounter.labels(anyString(), anyString(), anyString()))
+        .thenReturn(bytesCounter);
+
+    // Setup subProtocol to return "eth" as its name so it can be looked up
+    when(subProtocol.getName()).thenReturn("eth");
+
+    // Setup network mocks to allow start() to complete
+    when(network.isListening()).thenReturn(true);
+
+    BiFunction<Peer, Boolean, Boolean> ethPeersShouldConnect = (peer, incoming) -> true;
+
+    NetworkRunner.NetworkBuilder networkBuilder = caps -> network;
+
+    networkRunner =
+        NetworkRunner.builder()
+            .protocolManagers(List.of(protocolManager))
+            .subProtocols(subProtocol)
+            .network(networkBuilder)
+            .metricsSystem(metricsSystem)
+            .ethPeersShouldConnect(ethPeersShouldConnect)
+            .build();
+  }
+
+  @Test
+  public void shouldIncrementInboundBytesCounterWhenProcessingMessage() {
+    // Setup
+    Capability capability = Capability.create("eth", 68);
+    int messageCode = 1;
+    int messageSize = 1024;
+
+    when(subProtocol.getName()).thenReturn("eth");
+    when(subProtocol.isValidMessageCode(anyInt(), eq(messageCode))).thenReturn(true);
+    when(subProtocol.messageName(anyInt(), eq(messageCode))).thenReturn("Status");
+    when(protocolManager.getSupportedCapabilities()).thenReturn(List.of(capability));
+
+    // Start network runner to register handlers
+    networkRunner.start();
+
+    // Capture the message handler that was registered
+    ArgumentCaptor<MessageCallback> handlerCaptor = ArgumentCaptor.forClass(MessageCallback.class);
+    verify(network).subscribe(eq(capability), handlerCaptor.capture());
+
+    MessageCallback handler = handlerCaptor.getValue();
+
+    // Create test message
+    PeerConnection peerConnection = mock(PeerConnection.class);
+    MessageData messageData = mock(MessageData.class);
+    when(messageData.getSize()).thenReturn(messageSize);
+    when(messageData.getCode()).thenReturn(messageCode);
+
+    Message message = new DefaultMessage(peerConnection, messageData);
+
+    // Process message through the handler
+    handler.onMessage(capability, message);
+
+    // Verify bytes counter was incremented with correct labels and size
+    verify(inboundBytesCounter).labels(eq(capability.toString()), eq("Status"), eq("1"));
+    verify(bytesCounter).inc(messageSize);
+  }
+
+  @Test
+  public void shouldIncrementInboundBytesCounterForMultipleMessages() {
+    // Setup
+    Capability capability = Capability.create("eth", 68);
+    int messageCode1 = 1;
+    int messageCode2 = 2;
+    int messageSize1 = 512;
+    int messageSize2 = 2048;
+
+    when(subProtocol.getName()).thenReturn("eth");
+    when(subProtocol.isValidMessageCode(anyInt(), anyInt())).thenReturn(true);
+    when(subProtocol.messageName(anyInt(), eq(messageCode1))).thenReturn("Status");
+    when(subProtocol.messageName(anyInt(), eq(messageCode2))).thenReturn("GetBlockHeaders");
+    when(protocolManager.getSupportedCapabilities()).thenReturn(List.of(capability));
+
+    // Start network runner to register handlers
+    networkRunner.start();
+
+    // Capture the message handler
+    ArgumentCaptor<MessageCallback> handlerCaptor = ArgumentCaptor.forClass(MessageCallback.class);
+    verify(network).subscribe(eq(capability), handlerCaptor.capture());
+
+    MessageCallback handler = handlerCaptor.getValue();
+
+    // Create first test message
+    PeerConnection peerConnection = mock(PeerConnection.class);
+    MessageData messageData1 = mock(MessageData.class);
+    when(messageData1.getSize()).thenReturn(messageSize1);
+    when(messageData1.getCode()).thenReturn(messageCode1);
+    Message message1 = new DefaultMessage(peerConnection, messageData1);
+
+    // Create second test message
+    MessageData messageData2 = mock(MessageData.class);
+    when(messageData2.getSize()).thenReturn(messageSize2);
+    when(messageData2.getCode()).thenReturn(messageCode2);
+    Message message2 = new DefaultMessage(peerConnection, messageData2);
+
+    // Process both messages
+    handler.onMessage(capability, message1);
+    handler.onMessage(capability, message2);
+
+    // Verify bytes counter was incremented for both messages
+    verify(bytesCounter).inc(messageSize1);
+    verify(bytesCounter).inc(messageSize2);
+    verify(bytesCounter, times(2)).inc(anyLong());
+  }
+
+  @Test
+  public void shouldUseCorrectLabelsForInboundBytesCounter() {
+    // Setup
+    Capability capability = Capability.create("eth", 68);
+    int messageCode = 5;
+    int messageSize = 256;
+    String messageName = "NewBlock";
+
+    when(subProtocol.getName()).thenReturn("eth");
+    when(subProtocol.isValidMessageCode(anyInt(), eq(messageCode))).thenReturn(true);
+    when(subProtocol.messageName(anyInt(), eq(messageCode))).thenReturn(messageName);
+    when(protocolManager.getSupportedCapabilities()).thenReturn(List.of(capability));
+
+    // Start network runner to register handlers
+    networkRunner.start();
+
+    // Capture the message handler
+    ArgumentCaptor<MessageCallback> handlerCaptor = ArgumentCaptor.forClass(MessageCallback.class);
+    verify(network).subscribe(eq(capability), handlerCaptor.capture());
+
+    MessageCallback handler = handlerCaptor.getValue();
+
+    // Create test message
+    PeerConnection peerConnection = mock(PeerConnection.class);
+    MessageData messageData = mock(MessageData.class);
+    when(messageData.getSize()).thenReturn(messageSize);
+    when(messageData.getCode()).thenReturn(messageCode);
+    Message message = new DefaultMessage(peerConnection, messageData);
+
+    // Process message
+    handler.onMessage(capability, message);
+
+    // Verify correct labels were used (protocol, message name, code)
+    verify(inboundBytesCounter)
+        .labels(eq(capability.toString()), eq(messageName), eq(String.valueOf(messageCode)));
+    verify(bytesCounter).inc(messageSize);
+  }
+}

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/MockPeerConnection.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/MockPeerConnection.java
@@ -48,6 +48,7 @@ public class MockPeerConnection extends AbstractPeerConnection {
       final CapabilityMultiplexer multiplexer,
       final PeerConnectionEventDispatcher connectionEventDispatcher,
       final LabelledMetric<Counter> outboundMessagesCounter,
+      final LabelledMetric<Counter> outboundBytesCounter,
       final boolean inboundInitiated) {
     super(
         peer,
@@ -58,6 +59,7 @@ public class MockPeerConnection extends AbstractPeerConnection {
         multiplexer,
         connectionEventDispatcher,
         outboundMessagesCounter,
+        outboundBytesCounter,
         inboundInitiated);
   }
 
@@ -87,6 +89,7 @@ public class MockPeerConnection extends AbstractPeerConnection {
         Integer.toString(connectionId.incrementAndGet()),
         multiplexer,
         eventDispatcher,
+        NoOpMetricsSystem.NO_OP_LABELLED_3_COUNTER,
         NoOpMetricsSystem.NO_OP_LABELLED_3_COUNTER,
         inboundInitiated);
   }


### PR DESCRIPTION
## PR description

~~Built on top of https://github.com/hyperledger/besu/pull/9680, please review it first.~~

Introduce `besu_network_p2p_bytes_inbound` and `besu_network_p2p_bytes_outbound` metrics to track                                                                           
the number of bytes exchanged via P2P connections, providing better                                                                           
visibility into network bandwidth usage alongside existing message counts.                                                                    
                                                                                    

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


