### PR TITLE
PoW removal: unused methods from MiningCoordinator

### DIFF
--- a/app/src/main/java/org/hyperledger/besu/controller/MainnetBesuControllerBuilder.java
+++ b/app/src/main/java/org/hyperledger/besu/controller/MainnetBesuControllerBuilder.java
@@ -64,12 +64,7 @@ public class MainnetBesuControllerBuilder extends BesuControllerBuilder {
             ethProtocolManager.ethContext().getScheduler());
 
     final PoWMiningCoordinator miningCoordinator =
-        new PoWMiningCoordinator(
-            protocolContext.getBlockchain(),
-            executor,
-            syncState,
-            miningConfiguration.getUnstable().getRemoteSealersLimit(),
-            miningConfiguration.getUnstable().getRemoteSealersTimeToLive());
+        new PoWMiningCoordinator(protocolContext.getBlockchain(), executor, syncState);
     miningCoordinator.addMinedBlockObserver(ethProtocolManager);
     if (miningConfiguration.isMiningEnabled()) {
       miningCoordinator.enable();

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/MiningCoordinator.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/MiningCoordinator.java
@@ -20,8 +20,6 @@ import org.hyperledger.besu.ethereum.chain.PoWObserver;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Transaction;
-import org.hyperledger.besu.ethereum.mainnet.PoWSolution;
-import org.hyperledger.besu.ethereum.mainnet.PoWSolverInputs;
 
 import java.util.List;
 import java.util.Optional;
@@ -66,31 +64,6 @@ public interface MiningCoordinator {
   }
 
   Optional<Address> getCoinbase();
-
-  default Optional<Long> hashesPerSecond() {
-    return Optional.empty();
-  }
-
-  default Optional<PoWSolverInputs> getWorkDefinition() {
-    throw new UnsupportedOperationException(
-        "Current consensus mechanism prevents querying work definition.");
-  }
-
-  default boolean submitWork(final PoWSolution solution) {
-    throw new UnsupportedOperationException(
-        "Current consensus mechanism prevents submission of work solutions.");
-  }
-
-  /**
-   * Allows to submit the hashrate of a sealer with a specific id
-   *
-   * @param id of the sealer
-   * @param hashrate of the sealer
-   * @return true if the hashrate has been added otherwise false
-   */
-  default boolean submitHashRate(final String id, final Long hashrate) {
-    return false;
-  }
 
   /**
    * Creates a block if possible, otherwise return an empty result

--- a/ethereum/ethstats/src/main/java/org/hyperledger/besu/ethstats/EthStatsService.java
+++ b/ethereum/ethstats/src/main/java/org/hyperledger/besu/ethstats/EthStatsService.java
@@ -423,7 +423,6 @@ public class EthStatsService {
     }
     final boolean isSyncing = syncState.isInSync();
     final long gasPrice = suggestGasPrice(blockchainQueries.getBlockchain().getChainHeadBlock());
-    final long hashrate = miningCoordinator.hashesPerSecond().orElse(0L);
     // safe to cast to int since it isn't realistic to have more than max int peers
     final int peersNumber =
         (int) protocolManager.ethContext().getEthPeers().streamAvailablePeers().count();
@@ -431,7 +430,7 @@ public class EthStatsService {
     final NodeStatsReport nodeStatsReport =
         ImmutableNodeStatsReport.builder()
             .id(enodeURL.getNodeId().toHexString())
-            .stats(true, isMiningEnabled, hashrate, peersNumber, gasPrice, isSyncing, 100)
+            .stats(true, isMiningEnabled, 0L, peersNumber, gasPrice, isSyncing, 100)
             .build();
     sendMessage(webSocket, new EthStatsRequest(STATS, nodeStatsReport));
   }


### PR DESCRIPTION
## PR description
Removed unused methods for hashrate and workDefinition from MiningCoordinator

## Fixed Issue(s)
refs #9457


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [x] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


