### PR TITLE
EIP-7843: Add slotNumber to block header + EIP-7778: Fix gas accounting

### DIFF
--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/BlockUtils.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/BlockUtils.java
@@ -60,6 +60,7 @@ public class BlockUtils {
         null,
         null,
         null,
+        null, // slotNumber
         blockHeaderFunctions);
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayload.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayload.java
@@ -290,6 +290,7 @@ public abstract class AbstractEngineNewPayload extends ExecutionEngineJsonRpcMet
             maybeParentBeaconBlockRoot.orElse(null),
             maybeRequests.map(BodyValidation::requestsHash).orElse(null),
             maybeBlockAccessList.map(BodyValidation::balHash).orElse(null),
+            blockParam.getSlotNumber(),
             headerFunctions);
 
     // ensure the block hash matches the blockParam hash

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/EnginePayloadAttributesParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/EnginePayloadAttributesParameter.java
@@ -31,6 +31,7 @@ public class EnginePayloadAttributesParameter {
   final Address suggestedFeeRecipient;
   final List<WithdrawalParameter> withdrawals;
   private final Bytes32 parentBeaconBlockRoot;
+  private final Long slotNumber;
 
   @JsonCreator
   public EnginePayloadAttributesParameter(
@@ -38,13 +39,15 @@ public class EnginePayloadAttributesParameter {
       @JsonProperty("prevRandao") final String prevRandao,
       @JsonProperty("suggestedFeeRecipient") final String suggestedFeeRecipient,
       @JsonProperty("withdrawals") final List<WithdrawalParameter> withdrawals,
-      @JsonProperty("parentBeaconBlockRoot") final String parentBeaconBlockRoot) {
+      @JsonProperty("parentBeaconBlockRoot") final String parentBeaconBlockRoot,
+      @JsonProperty("slotNumber") final String slotNumber) {
     this.timestamp = Long.decode(timestamp);
     this.prevRandao = Bytes32.fromHexString(prevRandao);
     this.suggestedFeeRecipient = Address.fromHexString(suggestedFeeRecipient);
     this.withdrawals = withdrawals;
     this.parentBeaconBlockRoot =
         parentBeaconBlockRoot == null ? null : Bytes32.fromHexString(parentBeaconBlockRoot);
+    this.slotNumber = slotNumber == null ? null : Long.decode(slotNumber);
   }
 
   public Long getTimestamp() {
@@ -65,6 +68,10 @@ public class EnginePayloadAttributesParameter {
 
   public List<WithdrawalParameter> getWithdrawals() {
     return withdrawals;
+  }
+
+  public Long getSlotNumber() {
+    return slotNumber;
   }
 
   public String serialize() {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/EnginePayloadParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/EnginePayloadParameter.java
@@ -45,6 +45,7 @@ public class EnginePayloadParameter {
   private final Long blobGasUsed;
   private final String excessBlobGas;
   private final String blockAccessList;
+  private final Long slotNumber;
 
   /**
    * Creates an instance of EnginePayloadParameter.
@@ -66,6 +67,8 @@ public class EnginePayloadParameter {
    * @param withdrawals Array of Withdrawal
    * @param blobGasUsed QUANTITY, 64 Bits
    * @param excessBlobGas QUANTITY, 64 Bits
+   * @param blockAccessList DATA, RLP encoded block access list
+   * @param slotNumber QUANTITY, 64 Bits
    */
   @JsonCreator
   public EnginePayloadParameter(
@@ -86,7 +89,8 @@ public class EnginePayloadParameter {
       @JsonProperty("withdrawals") final List<WithdrawalParameter> withdrawals,
       @JsonProperty("blobGasUsed") final UnsignedLongParameter blobGasUsed,
       @JsonProperty("excessBlobGas") final String excessBlobGas,
-      @JsonProperty("blockAccessList") final String blockAccessList) {
+      @JsonProperty("blockAccessList") final String blockAccessList,
+      @JsonProperty("slotNumber") final UnsignedLongParameter slotNumber) {
     this.blockHash = blockHash;
     this.parentHash = parentHash;
     this.feeRecipient = feeRecipient;
@@ -105,6 +109,7 @@ public class EnginePayloadParameter {
     this.blobGasUsed = blobGasUsed == null ? null : blobGasUsed.getValue();
     this.excessBlobGas = excessBlobGas;
     this.blockAccessList = blockAccessList;
+    this.slotNumber = slotNumber == null ? null : slotNumber.getValue();
   }
 
   public Hash getBlockHash() {
@@ -177,5 +182,9 @@ public class EnginePayloadParameter {
 
   public String getBlockAccessList() {
     return blockAccessList;
+  }
+
+  public Long getSlotNumber() {
+    return slotNumber;
   }
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdatedTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdatedTest.java
@@ -244,6 +244,7 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
             Bytes32.fromHexStringLenient("0xDEADBEEF").toHexString(),
             Address.ECREC.toString(),
             null,
+            null,
             null);
     var mockPayloadId =
         PayloadIdentifier.forPayloadParams(
@@ -433,6 +434,7 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
             Bytes32.fromHexStringLenient("0xDEADBEEF").toHexString(),
             Address.ECREC.toString(),
             null,
+            null,
             null);
 
     var resp =
@@ -470,6 +472,7 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
             Bytes32.fromHexStringLenient("0xDEADBEEF").toHexString(),
             Address.ECREC.toString(),
             emptyList(),
+            null,
             null);
 
     var resp =
@@ -495,6 +498,7 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
             Bytes32.fromHexStringLenient("0xDEADBEEF").toHexString(),
             Address.ECREC.toString(),
             emptyList(),
+            null,
             null);
 
     var resp =
@@ -519,6 +523,7 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
             String.valueOf(mockHeader.getTimestamp() + 1),
             Bytes32.fromHexStringLenient("0xDEADBEEF").toHexString(),
             Address.ECREC.toString(),
+            null,
             null,
             null);
 
@@ -564,6 +569,7 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
             Bytes32.fromHexStringLenient("0xDEADBEEF").toHexString(),
             Address.ECREC.toString(),
             null,
+            null,
             null);
 
     var resp =
@@ -600,6 +606,7 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
             Bytes32.fromHexStringLenient("0xDEADBEEF").toHexString(),
             Address.ECREC.toString(),
             withdrawalParameters,
+            null,
             null);
 
     final Optional<List<Withdrawal>> withdrawals =
@@ -648,6 +655,7 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
             String.valueOf(mockHeader.getTimestamp() + 1),
             Bytes32.fromHexStringLenient("0xDEADBEEF").toHexString(),
             Address.ECREC.toString(),
+            null,
             null,
             null);
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayloadTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayloadTest.java
@@ -407,7 +407,8 @@ public abstract class AbstractEngineNewPayloadTest extends AbstractScheduledApiT
         withdrawals,
         header.getBlobGasUsed().map(UnsignedLongParameter::new).orElse(null),
         header.getExcessBlobGas().map(BlobGas::toHexString).orElse(null),
-        blockAccessList);
+        blockAccessList,
+        null);
   }
 
   protected BlockHeader setupValidPayload(

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV2Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV2Test.java
@@ -73,6 +73,7 @@ public class EngineForkchoiceUpdatedV2Test extends AbstractEngineForkchoiceUpdat
             Bytes32.fromHexStringLenient("0xDEADBEEF").toHexString(),
             Address.ECREC.toString(),
             null,
+            null,
             null);
 
     final JsonRpcResponse resp = resp(param, Optional.of(payloadParams));

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/EnginePayloadAttributesParameterTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/EnginePayloadAttributesParameterTest.java
@@ -98,13 +98,13 @@ public class EnginePayloadAttributesParameterTest {
 
   private EnginePayloadAttributesParameter parameterWithdrawalsOmitted() {
     return new EnginePayloadAttributesParameter(
-        TIMESTAMP, PREV_RANDAO, SUGGESTED_FEE_RECIPIENT_ADDRESS, null, null);
+        TIMESTAMP, PREV_RANDAO, SUGGESTED_FEE_RECIPIENT_ADDRESS, null, null, null);
   }
 
   private EnginePayloadAttributesParameter parameterWithdrawalsPresent() {
     final List<WithdrawalParameter> withdrawals = List.of(WITHDRAWAL_PARAM_1, WITHDRAWAL_PARAM_2);
     return new EnginePayloadAttributesParameter(
-        TIMESTAMP, PREV_RANDAO, SUGGESTED_FEE_RECIPIENT_ADDRESS, withdrawals, null);
+        TIMESTAMP, PREV_RANDAO, SUGGESTED_FEE_RECIPIENT_ADDRESS, withdrawals, null, null);
   }
 
   // TODO: add a parent beacon block root test here

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/BlockHeader.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/BlockHeader.java
@@ -69,6 +69,7 @@ public class BlockHeader extends SealableBlockHeader
       final Bytes32 parentBeaconBlockRoot,
       final Hash requestsHash,
       final Hash balHash,
+      final Long slotNumber,
       final BlockHeaderFunctions blockHeaderFunctions) {
     this(
         parentHash,
@@ -93,6 +94,7 @@ public class BlockHeader extends SealableBlockHeader
         parentBeaconBlockRoot,
         requestsHash,
         balHash,
+        slotNumber,
         blockHeaderFunctions,
         Optional.empty());
   }
@@ -120,6 +122,7 @@ public class BlockHeader extends SealableBlockHeader
       final Bytes32 parentBeaconBlockRoot,
       final Hash requestsHash,
       final Hash balHash,
+      final Long slotNumber,
       final BlockHeaderFunctions blockHeaderFunctions,
       final Optional<Bytes> rawRlp) {
     super(
@@ -143,7 +146,8 @@ public class BlockHeader extends SealableBlockHeader
         excessBlobGas,
         parentBeaconBlockRoot,
         requestsHash,
-        balHash);
+        balHash,
+        slotNumber);
     this.nonce = nonce;
     this.hash = Suppliers.memoize(() -> blockHeaderFunctions.hash(this));
     this.parsedExtraData = Suppliers.memoize(() -> blockHeaderFunctions.parseExtraData(this));
@@ -173,6 +177,7 @@ public class BlockHeader extends SealableBlockHeader
       final Bytes32 parentBeaconBlockRoot,
       final Hash requestsHash,
       final Hash balHash,
+      final Long slotNumber,
       final Hash blockHeaderHash,
       final BlockHeaderFunctions blockHeaderFunctions,
       final Optional<Bytes> rawRlp) {
@@ -197,7 +202,8 @@ public class BlockHeader extends SealableBlockHeader
         excessBlobGas,
         parentBeaconBlockRoot,
         requestsHash,
-        balHash);
+        balHash,
+        slotNumber);
     this.nonce = nonce;
     this.hash = Suppliers.memoize(() -> blockHeaderHash);
     this.parsedExtraData = Suppliers.memoize(() -> blockHeaderFunctions.parseExtraData(this));
@@ -305,6 +311,9 @@ public class BlockHeader extends SealableBlockHeader
 
             if (blockAccessListHash == null) break;
             out.writeBytes(blockAccessListHash.getBytes());
+
+            if (slotNumber == null) break;
+            out.writeLongScalar(slotNumber);
           } while (false);
           out.endList();
         });
@@ -347,6 +356,8 @@ public class BlockHeader extends SealableBlockHeader
         !headerRlp.isEndOfCurrentList() ? Hash.wrap(headerRlp.readBytes32()) : null;
     final Hash balHash =
         !headerRlp.isEndOfCurrentList() ? Hash.wrap(headerRlp.readBytes32()) : null;
+    final Long slotNum =
+        !headerRlp.isEndOfCurrentList() ? headerRlp.readLongScalar() : null;
     headerRlp.leaveList();
     return new BlockHeader(
         parentHash,
@@ -371,6 +382,7 @@ public class BlockHeader extends SealableBlockHeader
         parentBeaconBlockRoot,
         requestsHash,
         balHash,
+        slotNum,
         blockHeaderFunctions,
         Optional.of(headerRlp.raw()));
   }
@@ -412,6 +424,8 @@ public class BlockHeader extends SealableBlockHeader
         !headerRlp.isEndOfCurrentList() ? Hash.wrap(headerRlp.readBytes32()) : null;
     final Hash balHash =
         !headerRlp.isEndOfCurrentList() ? Hash.wrap(headerRlp.readBytes32()) : null;
+    final Long slotNum =
+        !headerRlp.isEndOfCurrentList() ? headerRlp.readLongScalar() : null;
     headerRlp.leaveList();
     return new BlockHeader(
         parentHash,
@@ -436,6 +450,7 @@ public class BlockHeader extends SealableBlockHeader
         parentBeaconBlockRoot,
         requestsHash,
         balHash,
+        slotNum,
         knownHash,
         blockHeaderFunctions,
         Optional.of(headerRlp.raw()));
@@ -492,7 +507,10 @@ public class BlockHeader extends SealableBlockHeader
       sb.append("requestsHash=").append(requestsHash).append(", ");
     }
     if (blockAccessListHash != null) {
-      sb.append("blockAccessListHash=").append(blockAccessListHash);
+      sb.append("blockAccessListHash=").append(blockAccessListHash).append(", ");
+    }
+    if (slotNumber != null) {
+      sb.append("slotNumber=").append(slotNumber);
     }
     return sb.append("}").toString();
   }
@@ -532,6 +550,7 @@ public class BlockHeader extends SealableBlockHeader
             .getBalHash()
             .map(h -> Hash.fromHexString(h.getBytes().toHexString()))
             .orElse(null),
+        null,
         blockHeaderFunctions);
   }
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/BlockHeaderBuilder.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/BlockHeaderBuilder.java
@@ -86,6 +86,8 @@ public class BlockHeaderBuilder {
   private BlobGas excessBlobGas = null;
   private Bytes32 parentBeaconBlockRoot = null;
 
+  private Long slotNumber = null;
+
   public static BlockHeaderBuilder create() {
     return new BlockHeaderBuilder();
   }
@@ -136,7 +138,8 @@ public class BlockHeaderBuilder {
         .excessBlobGas(header.getExcessBlobGas().orElse(null))
         .parentBeaconBlockRoot(header.getParentBeaconBlockRoot().orElse(null))
         .requestsHash(header.getRequestsHash().orElse(null))
-        .balHash(header.getBalHash().orElse(null));
+        .balHash(header.getBalHash().orElse(null))
+        .slotNumber(header.getSlotNumber().orElse(null));
   }
 
   public static BlockHeaderBuilder fromHeader(
@@ -191,6 +194,7 @@ public class BlockHeaderBuilder {
             .parentBeaconBlockRoot(fromBuilder.parentBeaconBlockRoot)
             .requestsHash(fromBuilder.requestsHash)
             .balHash(fromBuilder.balHash)
+            .slotNumber(fromBuilder.slotNumber)
             .blockHeaderFunctions(fromBuilder.blockHeaderFunctions);
     toBuilder.nonce = fromBuilder.nonce;
     return toBuilder;
@@ -275,6 +279,7 @@ public class BlockHeaderBuilder {
         parentBeaconBlockRoot,
         requestsHash,
         balHash,
+        slotNumber,
         blockHeaderFunctions);
   }
 
@@ -317,7 +322,8 @@ public class BlockHeaderBuilder {
         excessBlobGas,
         parentBeaconBlockRoot,
         requestsHash,
-        balHash);
+        balHash,
+        slotNumber);
   }
 
   private void validateBlockHeader() {
@@ -383,6 +389,7 @@ public class BlockHeaderBuilder {
     sealableBlockHeader.getParentBeaconBlockRoot().ifPresent(this::parentBeaconBlockRoot);
     requestsHash(sealableBlockHeader.getRequestsHash().orElse(null));
     balHash(sealableBlockHeader.getBalHash().orElse(null));
+    slotNumber(sealableBlockHeader.getSlotNumber().orElse(null));
     return this;
   }
 
@@ -505,6 +512,11 @@ public class BlockHeaderBuilder {
 
   public BlockHeaderBuilder balHash(final Hash hash) {
     this.balHash = hash;
+    return this;
+  }
+
+  public BlockHeaderBuilder slotNumber(final Long slotNumber) {
+    this.slotNumber = slotNumber;
     return this;
   }
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/SealableBlockHeader.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/SealableBlockHeader.java
@@ -47,6 +47,8 @@ public class SealableBlockHeader extends ProcessableBlockHeader {
 
   protected final Hash blockAccessListHash;
 
+  protected final Long slotNumber;
+
   protected final Long blobGasUsed;
 
   protected final BlobGas excessBlobGas;
@@ -72,7 +74,8 @@ public class SealableBlockHeader extends ProcessableBlockHeader {
       final BlobGas excessBlobGas,
       final Bytes32 parentBeaconBlockRoot,
       final Hash requestsHash,
-      final Hash blockAccessListHash) {
+      final Hash blockAccessListHash,
+      final Long slotNumber) {
     super(
         parentHash,
         coinbase,
@@ -90,6 +93,7 @@ public class SealableBlockHeader extends ProcessableBlockHeader {
     this.receiptsRoot = receiptsRoot;
     this.requestsHash = requestsHash;
     this.blockAccessListHash = blockAccessListHash;
+    this.slotNumber = slotNumber;
     this.logsBloom = logsBloom;
     this.gasUsed = gasUsed;
     this.extraData = extraData;
@@ -185,6 +189,15 @@ public class SealableBlockHeader extends ProcessableBlockHeader {
    */
   public Optional<Hash> getBalHash() {
     return Optional.ofNullable(blockAccessListHash);
+  }
+
+  /**
+   * Returns the slot number if available.
+   *
+   * @return the slot number if available.
+   */
+  public Optional<Long> getSlotNumber() {
+    return Optional.ofNullable(slotNumber);
   }
 
   /**

--- a/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/BlockchainReferenceTestCaseSpec.java
+++ b/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/BlockchainReferenceTestCaseSpec.java
@@ -221,6 +221,7 @@ public class BlockchainReferenceTestCaseSpec {
           parentBeaconBlockRoot != null ? Bytes32.fromHexString(parentBeaconBlockRoot) : null,
           requestsHash != null ? Hash.fromHexString(requestsHash) : null,
           blockAccessListHash != null ? Hash.fromHexString(blockAccessListHash) : null,
+          null, // slotNumber
           new BlockHeaderFunctions() {
             @Override
             public Hash hash(final BlockHeader header) {

--- a/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/ReferenceTestEnv.java
+++ b/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/ReferenceTestEnv.java
@@ -146,7 +146,8 @@ public class ReferenceTestEnv extends BlockHeader {
         currentExcessBlobGas == null ? null : BlobGas.of(Long.decode(currentExcessBlobGas)),
         beaconRoot == null ? null : Bytes32.fromHexString(beaconRoot),
         null, // requestsHash
-        null,
+        null, // balHash
+        null, // slotNumber
         new MainnetBlockHeaderFunctions());
     this.parentDifficulty = parentDifficulty;
     this.parentBaseFee = parentBaseFee;


### PR DESCRIPTION
Three fixes for bal-devnet-2 compatibility:

1. EIP-7843 (SLOTNUM): Add slotNumber field to block header hierarchy (SealableBlockHeader, BlockHeader, BlockHeaderBuilder), RLP encoding/ decoding, and engine API parameters (EnginePayloadParameter, EnginePayloadAttributesParameter). Without this, engine_newPayloadV5 fails with HTTP 400 when CL sends slotNumber.

2. EIP-7843: Wire slotNumber from engine API payload into BlockHeader construction in AbstractEngineNewPayload.

3. EIP-7778: Post-Amsterdam block gas accounting uses gas before refunds (getEstimateGasUsedByTransaction) instead of gas after refunds. This fixes receipts root mismatch with Geth.