### PR TITLE
Parse the slot number for the genesis block

### DIFF
--- a/config/src/main/java/org/hyperledger/besu/config/GenesisConfig.java
+++ b/config/src/main/java/org/hyperledger/besu/config/GenesisConfig.java
@@ -266,6 +266,15 @@ public class GenesisConfig {
   }
 
   /**
+   * Gets slot number.
+   *
+   * @return the slot number
+   */
+  public String getSlotNumber() {
+    return JsonUtil.getValueAsString(genesisRoot, "slotnumber", "0x0");
+  }
+
+  /**
    * Gets coinbase.
    *
    * @return the coinbase

--- a/config/src/test/java/org/hyperledger/besu/config/GenesisConfigTest.java
+++ b/config/src/test/java/org/hyperledger/besu/config/GenesisConfigTest.java
@@ -302,6 +302,16 @@ class GenesisConfigTest {
   }
 
   @Test
+  void shouldGetSlotNumber() {
+    assertThat(configWithProperty("slotnumber", "0x10").getSlotNumber()).isEqualTo("0x10");
+  }
+
+  @Test
+  void shouldDefaultSlotNumberToZero() {
+    assertThat(EMPTY_CONFIG.getSlotNumber()).isEqualTo("0x0");
+  }
+
+  @Test
   void shouldGetAllocations() {
     final GenesisConfig config =
         fromConfig(

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/GenesisState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/GenesisState.java
@@ -228,6 +228,7 @@ public final class GenesisState {
             (isCancunAtGenesis(genesis) ? parseParentBeaconBlockRoot(genesis) : null))
         .requestsHash(isPragueAtGenesis(genesis) ? Hash.EMPTY_REQUESTS_HASH : null)
         .balHash(isAmsterdamAtGenesis(genesis) ? Hash.EMPTY_BAL_HASH : null)
+        .slotNumber(isAmsterdamAtGenesis(genesis) ? parseSlotNumber(genesis) : null)
         .buildBlockHeader();
   }
 
@@ -288,6 +289,11 @@ public final class GenesisState {
   private static Bytes32 parseParentBeaconBlockRoot(final GenesisConfig genesis) {
     return withNiceErrorMessage(
         "parentBeaconBlockRoot", genesis.getParentBeaconBlockRoot(), Bytes32::fromHexString);
+  }
+
+  private static long parseSlotNumber(final GenesisConfig genesis) {
+    return withNiceErrorMessage(
+        "slotNumber", genesis.getSlotNumber(), GenesisState::parseUnsignedLong);
   }
 
   private static long parseUnsignedLong(final String value) {

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/chain/GenesisStateTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/chain/GenesisStateTest.java
@@ -333,6 +333,45 @@ final class GenesisStateTest {
                 "0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"));
   }
 
+  @ParameterizedTest
+  @ArgumentsSource(GenesisStateTestArguments.class)
+  void genesisFromAmsterdam(final DataStorageConfiguration dataStorageConfiguration) {
+    final GenesisState genesisState =
+        GenesisState.fromJsonSource(
+            dataStorageConfiguration,
+            GenesisStateTest.class.getResource("genesis_amsterdam.json"),
+            ProtocolScheduleFixture.TESTING_NETWORK);
+    final BlockHeader header = genesisState.getBlock().getHeader();
+    assertThat(header.getGasLimit()).isEqualTo(0x2fefd8);
+    assertThat(header.getGasUsed()).isZero();
+    assertThat(header.getNumber()).isZero();
+    assertThat(header.getExtraData()).isEqualTo(Bytes.EMPTY);
+    assertThat(header.getParentHash()).isEqualTo(Hash.ZERO);
+
+    // Amsterdam-specific: slot number should be present
+    assertThat(header.getOptionalSlotNumber()).isPresent();
+    assertThat(header.getOptionalSlotNumber().get()).isEqualTo(0x42L);
+    assertThat(header.getSlotNumber()).isEqualTo(0x42L);
+
+    // Amsterdam-specific: BAL hash should be present
+    assertThat(header.getBalHash()).isPresent();
+    assertThat(header.getBalHash().get()).isEqualTo(Hash.EMPTY_BAL_HASH);
+  }
+
+  @ParameterizedTest
+  @ArgumentsSource(GenesisStateTestArguments.class)
+  void genesisSlotNumberNotPresentPreAmsterdam(
+      final DataStorageConfiguration dataStorageConfiguration) {
+    // Prague genesis should NOT have slot number
+    final GenesisState genesisState =
+        GenesisState.fromJsonSource(
+            dataStorageConfiguration,
+            GenesisStateTest.class.getResource("genesis_prague.json"),
+            ProtocolScheduleFixture.TESTING_NETWORK);
+    final BlockHeader header = genesisState.getBlock().getHeader();
+    assertThat(header.getOptionalSlotNumber()).isEmpty();
+  }
+
   @Test
   void dryRunDetector() {
     assertThat(true)

--- a/ethereum/core/src/test/resources/org/hyperledger/besu/ethereum/chain/genesis_amsterdam.json
+++ b/ethereum/core/src/test/resources/org/hyperledger/besu/ethereum/chain/genesis_amsterdam.json
@@ -1,0 +1,36 @@
+{
+  "config": {
+    "ethash": {},
+    "chainID": 7,
+    "homesteadBlock": 0,
+    "eip150Block": 0,
+    "eip155Block": 0,
+    "eip158Block": 0,
+    "byzantiumBlock": 0,
+    "constantinopleBlock": 0,
+    "constantinopleFixBlock": 0,
+    "istanbulBlock": 0,
+    "muirGlacierBlock": 0,
+    "berlinBlock": 0,
+    "londonBlock": 0,
+    "parisBlock": 0,
+    "terminalTotalDifficulty": 0,
+    "shanghaiTime": 0,
+    "cancunTime": 0,
+    "pragueTime": 0,
+    "amsterdamTime": 0
+  },
+  "nonce": "0x0",
+  "timestamp": "0x1234",
+  "extraData": "0x",
+  "gasLimit": "0x2fefd8",
+  "difficulty": "0x0",
+  "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "coinbase": "0x0000000000000000000000000000000000000000",
+  "slotnumber": "0x42",
+  "alloc": {
+    "fe3b557e8fb62b89f4916b721be55ceb828dbd73": {
+      "balance": "0xad78ebc5ac6200000"
+    }
+  }
+}


### PR DESCRIPTION
## PR description

The slot number is currently not parsed when reading the genesis block, leading to a wrong value when calculating the genesis block hash. This PR fixes this.

### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


