### PR TITLE
emeritus gfukushima

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -42,9 +42,9 @@
 | David Mechler    | davemec          | davemec          |
 | Edward Evans     | EdJoJob          | EdJoJob          |
 | Edward Mack      | edwardmack       | mackcom          | 
+| Frank Li         | frankisawesome   | frankliawesome   |
 | Jiri Peinlich    | gezero           | JiriPeinlich     |
 | Gabriel Fukushima| gfukushima       | gfukushima       |
-| Frank Li         | frankisawesome   | frankliawesome   |
 | Ivaylo Kirilov   | iikirilov        | iikirilov        |
 | Madeline Murray  | MadelineMurray   | madelinemurray   |
 | Mark Terry       | mark-terry       | m.terry          |


### PR DESCRIPTION
I propose moving @gfukushima  to Emeritus status, pursuant to the inactivity clause, with no Besu [activity](https://github.com/hyperledger/besu/pulls?q=sort%3Aupdated-desc+is%3Apr+author%3Agfukushima+is%3Aclosed) since 2024.

We very much appreciate their contributions but moving their status to emeritus (and thus revoking PR approval privileges) is in the interest of an orderly project. If any of these maintainers express in this PR that they intend to make contributions in the next quarter, then they will not be moved to emeritus status.
I propose this vote is open until either @gfukushima approves this PR, or an absolute majority of active maintainers votes for the same outcome, or until two weeks has passed, after which a voting majority will determine the outcome (with a tie resulting in no change).