### PR TITLE
emeritus joshuafernandes

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -18,7 +18,6 @@
 | Gabriel Fukushima| gfukushima       | gfukushima       |
 | Justin Florentine| jflo             | RoboCopsGoneMad  |
 | Jason Frame      | jframe           | jframe           |
-| Joshua Fernandes | joshuafernandes  | joshuafernandes  |
 | Luis Pinto       | lu-pinto         | lu-pinto         |
 | Lucas Saldanha   | lucassaldanha    | lucassaldanha    |
 | Sally MacFarlane | macfarla         | macfarla         |
@@ -46,6 +45,7 @@
 | Jiri Peinlich    | gezero           | JiriPeinlich     |
 | Frank Li         | frankisawesome   | frankliawesome   |
 | Ivaylo Kirilov   | iikirilov        | iikirilov        |
+| Joshua Fernandes | joshuafernandes  | joshuafernandes  |
 | Madeline Murray  | MadelineMurray   | madelinemurray   |
 | Mark Terry       | mark-terry       | m.terry          |
 | Meredith Baxter  | mbaxter          | mbaxter          |


### PR DESCRIPTION
I propose moving @joshuafernandes to Emeritus status, pursuant to the inactivity clause, with no Besu [activity](https://github.com/hyperledger/besu/pulls?q=sort%3Aupdated-desc+is%3Apr+author%3Ajoshuafernandes+is%3Aclosed) since 2024.

We very much appreciate their contributions but moving their status to emeritus (and thus revoking PR approval privileges) is in the interest of an orderly project. If any of these maintainers express in this PR that they intend to make contributions in the next quarter, then they will not be moved to emeritus status.
I propose this vote is open until either @joshuafernandes approves this PR, or an absolute majority of active maintainers votes for the same outcome, or until two weeks has passed, after which a voting majority will determine the outcome (with a tie resulting in no change).