### PR TITLE
feat: implement performance-based peer selection for snap sync (#9722)

### DIFF
--- a/app/src/main/java/org/hyperledger/besu/cli/options/EthProtocolOptions.java
+++ b/app/src/main/java/org/hyperledger/besu/cli/options/EthProtocolOptions.java
@@ -35,6 +35,7 @@ public class EthProtocolOptions implements CLIOptions<EthProtocolConfiguration> 
   private static final String MAX_GET_POOLED_TRANSACTIONS = "--Xewp-max-get-pooled-transactions";
   private static final String MAX_CAPABILITY = "--Xeth-capability-max";
   private static final String MIN_CAPABILITY = "--Xeth-capability-min";
+  private static final String PEER_PERFORMANCE_EMA_ALPHA = "--Xeth-peer-performance-ema-alpha";
 
   @CommandLine.Option(
       hidden = true,
@@ -113,6 +114,15 @@ public class EthProtocolOptions implements CLIOptions<EthProtocolConfiguration> 
       description = "Min protocol version to support")
   private int minEthCapability = EthProtocolConfiguration.DEFAULT_MIN_CAPABILITY;
 
+  @CommandLine.Option(
+      hidden = true,
+      names = {PEER_PERFORMANCE_EMA_ALPHA},
+      paramLabel = "<DOUBLE>",
+      description =
+          "The alpha value for the peer performance exponential moving average (EMA) (default: ${DEFAULT-VALUE})")
+  private double peerPerformanceEmaAlpha =
+      EthProtocolConfiguration.DEFAULT_PEER_PERFORMANCE_EMA_ALPHA;
+
   private EthProtocolOptions() {}
 
   /**
@@ -142,6 +152,7 @@ public class EthProtocolOptions implements CLIOptions<EthProtocolConfiguration> 
     options.maxGetPooledTransactions = PositiveNumber.fromInt(config.getMaxGetPooledTransactions());
     options.maxEthCapability = config.getMaxEthCapability();
     options.minEthCapability = config.getMinEthCapability();
+    options.peerPerformanceEmaAlpha = config.getPeerPerformanceEmaAlpha();
     return options;
   }
 
@@ -157,6 +168,7 @@ public class EthProtocolOptions implements CLIOptions<EthProtocolConfiguration> 
         .maxGetPooledTransactions(maxGetPooledTransactions.getValue())
         .maxEthCapability(maxEthCapability)
         .minEthCapability(minEthCapability)
+        .peerPerformanceEmaAlpha(peerPerformanceEmaAlpha)
         .build();
   }
 

--- a/app/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
+++ b/app/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
@@ -721,7 +721,8 @@ public abstract class BesuControllerBuilder implements MiningConfigurationOverri
             maxRemotelyInitiatedPeers,
             randomPeerPriority,
             syncConfig.getSyncMode(),
-            forkIdManager);
+            forkIdManager,
+            ethereumWireProtocolConfiguration.getPeerPerformanceEmaAlpha());
 
     final EthMessages ethMessages = new EthMessages();
     final EthMessages snapMessages = new EthMessages();

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/AdminJsonRpcHttpServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/AdminJsonRpcHttpServiceTest.java
@@ -80,7 +80,10 @@ public class AdminJsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
             EthProtocolConfiguration.DEFAULT_MAX_MESSAGE_SIZE,
             TestClock.fixed(),
             Collections.emptyList(),
-            Bytes.random(64)));
+            Bytes.random(64),
+            0.1,
+            v -> {},
+            v -> {}));
     peerList.add(
         new EthPeer(
             MockPeerConnection.create(info2, addr30301, addr60302),
@@ -89,7 +92,10 @@ public class AdminJsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
             EthProtocolConfiguration.DEFAULT_MAX_MESSAGE_SIZE,
             TestClock.fixed(),
             Collections.emptyList(),
-            Bytes.random(64)));
+            Bytes.random(64),
+            0.1,
+            v -> {},
+            v -> {}));
     peerList.add(
         new EthPeer(
             MockPeerConnection.create(info3, addr30301, addr60303),
@@ -98,7 +104,10 @@ public class AdminJsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
             EthProtocolConfiguration.DEFAULT_MAX_MESSAGE_SIZE,
             TestClock.fixed(),
             Collections.emptyList(),
-            Bytes.random(64)));
+            Bytes.random(64),
+            0.1,
+            v -> {},
+            v -> {}));
 
     when(ethPeersMock.streamAllPeers())
         .thenReturn(peerList.stream().map(EthPeerImmutableAttributes::from));

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminPeersTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminPeersTest.java
@@ -127,7 +127,10 @@ public class AdminPeersTest {
             EthProtocolConfiguration.DEFAULT_MAX_MESSAGE_SIZE,
             TestClock.fixed(),
             Collections.emptyList(),
-            Bytes.random(64));
+            Bytes.random(64),
+            0.1,
+            v -> {},
+            v -> {});
     return Lists.newArrayList(ethPeer);
   }
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/EthProtocolConfiguration.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/EthProtocolConfiguration.java
@@ -29,6 +29,7 @@ public interface EthProtocolConfiguration {
   int DEFAULT_MAX_GET_POOLED_TRANSACTIONS = 256;
   int DEFAULT_MAX_CAPABILITY = Integer.MAX_VALUE;
   int DEFAULT_MIN_CAPABILITY = 0;
+  double DEFAULT_PEER_PERFORMANCE_EMA_ALPHA = 0.1;
 
   EthProtocolConfiguration DEFAULT = ImmutableEthProtocolConfiguration.builder().build();
 
@@ -75,5 +76,10 @@ public interface EthProtocolConfiguration {
   @Value.Default
   default int getMinEthCapability() {
     return DEFAULT_MIN_CAPABILITY;
+  }
+
+  @Value.Default
+  default double getPeerPerformanceEmaAlpha() {
+    return DEFAULT_PEER_PERFORMANCE_EMA_ALPHA;
   }
 }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeerImmutableAttributes.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeerImmutableAttributes.java
@@ -28,6 +28,8 @@ public record EthPeerImmutableAttributes(
     boolean isServingSnap,
     boolean hasAvailableRequestCapacity,
     boolean isInboundInitiated,
+    double averageLatencyMs,
+    double averageThroughputBytesPerSecond,
     EthPeer ethPeer) {
 
   public static EthPeerImmutableAttributes from(final EthPeer peer) {
@@ -43,6 +45,8 @@ public record EthPeerImmutableAttributes(
         peer.isServingSnap(),
         peer.hasAvailableRequestCapacity(),
         peer.getConnection().inboundInitiated(),
+        peer.getAverageLatencyMs(),
+        peer.getAverageThroughputBytesPerSecond(),
         peer);
   }
 }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeers.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeers.java
@@ -85,6 +85,16 @@ public class EthPeers implements PeerSelector {
   public static final Comparator<EthPeerImmutableAttributes> LEAST_TO_MOST_BUSY =
       Comparator.comparing(EthPeerImmutableAttributes::outstandingRequests)
           .thenComparing(EthPeerImmutableAttributes::lastRequestTimestamp);
+
+  public static final Comparator<EthPeerImmutableAttributes> BY_LOW_LATENCY =
+      Comparator.comparing(
+              (final EthPeerImmutableAttributes p) ->
+                  p.averageLatencyMs() < 0 ? Double.MAX_VALUE : p.averageLatencyMs())
+          .reversed();
+
+  public static final Comparator<EthPeerImmutableAttributes> BY_HIGH_THROUGHPUT =
+      Comparator.comparing(EthPeerImmutableAttributes::averageThroughputBytesPerSecond);
+
   public static final int NODE_ID_LENGTH = 64;
   public static final int USEFULL_PEER_SCORE_THRESHOLD = 102;
 
@@ -373,9 +383,14 @@ public class EthPeers implements PeerSelector {
   }
 
   public Stream<EthPeerImmutableAttributes> streamBestPeers() {
+    return streamBestPeers(getBestPeerComparator());
+  }
+
+  public Stream<EthPeerImmutableAttributes> streamBestPeers(
+      final Comparator<EthPeerImmutableAttributes> comparator) {
     return streamAvailablePeers()
         .filter(EthPeerImmutableAttributes::isFullyValidated)
-        .sorted(getBestPeerComparator().reversed());
+        .sorted(comparator.reversed());
   }
 
   public Optional<EthPeer> bestPeer() {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeers.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeers.java
@@ -72,37 +72,115 @@ import org.slf4j.LoggerFactory;
 public class EthPeers implements PeerSelector {
   private static final Logger LOG = LoggerFactory.getLogger(EthPeers.class);
   public static final Comparator<EthPeerImmutableAttributes> TOTAL_DIFFICULTY =
-      Comparator.comparing((final EthPeerImmutableAttributes p) -> p.estimatedTotalDifficulty());
+      new Comparator<EthPeerImmutableAttributes>() {
+        @Override
+        public int compare(
+            final EthPeerImmutableAttributes p1, final EthPeerImmutableAttributes p2) {
+          return p1.estimatedTotalDifficulty().compareTo(p2.estimatedTotalDifficulty());
+        }
+
+        @Override
+        public String toString() {
+          return "TOTAL_DIFFICULTY";
+        }
+      };
 
   public static final Comparator<EthPeerImmutableAttributes> CHAIN_HEIGHT =
-      Comparator.comparing((final EthPeerImmutableAttributes p) -> p.estimatedChainHeight());
+      new Comparator<EthPeerImmutableAttributes>() {
+        @Override
+        public int compare(
+            final EthPeerImmutableAttributes p1, final EthPeerImmutableAttributes p2) {
+          return Long.compare(p1.estimatedChainHeight(), p2.estimatedChainHeight());
+        }
+
+        @Override
+        public String toString() {
+          return "CHAIN_HEIGHT";
+        }
+      };
 
   public static final Comparator<EthPeerImmutableAttributes> MOST_USEFUL_PEER =
-      Comparator.comparing((final EthPeerImmutableAttributes p) -> p.reputationScore())
-          .thenComparing(CHAIN_HEIGHT);
+      new Comparator<EthPeerImmutableAttributes>() {
+        @Override
+        public int compare(
+            final EthPeerImmutableAttributes p1, final EthPeerImmutableAttributes p2) {
+          final int reputationCompare = Integer.compare(p1.reputationScore(), p2.reputationScore());
+          if (reputationCompare != 0) {
+            return reputationCompare;
+          }
+          return CHAIN_HEIGHT.compare(p1, p2);
+        }
+
+        @Override
+        public String toString() {
+          return "MOST_USEFUL_PEER";
+        }
+      };
 
   public static final Comparator<EthPeerImmutableAttributes> TOTAL_DIFFICULTY_THEN_HEIGHT =
-      TOTAL_DIFFICULTY.thenComparing(CHAIN_HEIGHT);
+      new Comparator<EthPeerImmutableAttributes>() {
+        @Override
+        public int compare(
+            final EthPeerImmutableAttributes p1, final EthPeerImmutableAttributes p2) {
+          final int difficultyCompare = TOTAL_DIFFICULTY.compare(p1, p2);
+          if (difficultyCompare != 0) {
+            return difficultyCompare;
+          }
+          return CHAIN_HEIGHT.compare(p1, p2);
+        }
+
+        @Override
+        public String toString() {
+          return "TOTAL_DIFFICULTY_THEN_HEIGHT";
+        }
+      };
 
   public static final Comparator<EthPeerImmutableAttributes> LEAST_TO_MOST_BUSY =
-      Comparator.comparing(EthPeerImmutableAttributes::outstandingRequests)
-          .thenComparing(EthPeerImmutableAttributes::lastRequestTimestamp);
+      new Comparator<EthPeerImmutableAttributes>() {
+        @Override
+        public int compare(
+            final EthPeerImmutableAttributes p1, final EthPeerImmutableAttributes p2) {
+          final int outstandingCompare =
+              Integer.compare(p1.outstandingRequests(), p2.outstandingRequests());
+          if (outstandingCompare != 0) {
+            return outstandingCompare;
+          }
+          return Long.compare(p1.lastRequestTimestamp(), p2.lastRequestTimestamp());
+        }
+
+        @Override
+        public String toString() {
+          return "LEAST_TO_MOST_BUSY";
+        }
+      };
 
   /**
    * Comparator that sorts peers by their average latency (EMA).
    *
    * <p>Selects peers with lower latency values, as measured by exponential moving average. Peers
-   * without latency data are treated as worst-case (0.0).
+   * without latency data are treated as neutral (0.0) and effectively deprioritized once real
+   * measurements exist.
    *
    * <p>Note: In mainnet testing, the impact of latency-based selection was within noise margins.
    * Future improvements could integrate peer scoring and other multi-criteria selection methods to
    * achieve more measurable performance gains.
    */
   public static final Comparator<EthPeerImmutableAttributes> BY_LOW_LATENCY =
-      Comparator.comparing(
-              (final EthPeerImmutableAttributes p) ->
-                  p.averageLatencyMs() < 0 ? 0.0 : p.averageLatencyMs())
-          .reversed();
+      new Comparator<EthPeerImmutableAttributes>() {
+        @Override
+        public int compare(
+            final EthPeerImmutableAttributes p1, final EthPeerImmutableAttributes p2) {
+          final double l1 = p1.averageLatencyMs() < 0 ? 0.0 : p1.averageLatencyMs();
+          final double l2 = p2.averageLatencyMs() < 0 ? 0.0 : p2.averageLatencyMs();
+          return Double.compare(
+              l2, l1); // Reversed to put low latency (high values in reversed) first
+        }
+
+        @Override
+        public String toString() {
+          return "BY_LOW_LATENCY";
+        }
+      };
 
   /**
    * Comparator that sorts peers by their average throughput (EMA).
@@ -115,11 +193,26 @@ public class EthPeers implements PeerSelector {
    * achieve more measurable performance gains.
    */
   public static final Comparator<EthPeerImmutableAttributes> BY_HIGH_THROUGHPUT =
-      Comparator.comparing(
-          (final EthPeerImmutableAttributes p) ->
-              p.averageThroughputBytesPerSecond() < 0
+      new Comparator<EthPeerImmutableAttributes>() {
+        @Override
+        public int compare(
+            final EthPeerImmutableAttributes p1, final EthPeerImmutableAttributes p2) {
+          final double t1 =
+              p1.averageThroughputBytesPerSecond() < 0
                   ? Double.MAX_VALUE
-                  : p.averageThroughputBytesPerSecond());
+                  : p1.averageThroughputBytesPerSecond();
+          final double t2 =
+              p2.averageThroughputBytesPerSecond() < 0
+                  ? Double.MAX_VALUE
+                  : p2.averageThroughputBytesPerSecond();
+          return Double.compare(t1, t2);
+        }
+
+        @Override
+        public String toString() {
+          return "BY_HIGH_THROUGHPUT";
+        }
+      };
 
   public static final int NODE_ID_LENGTH = 64;
   public static final int USEFULL_PEER_SCORE_THRESHOLD = 102;

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractPeerRequestTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractPeerRequestTask.java
@@ -111,19 +111,27 @@ public abstract class AbstractPeerRequestTask<R> extends AbstractPeerTask<R> {
       result.ifPresent(
           r -> {
             final double durationMs = (System.nanoTime() - startTimeNanos) / 1_000_000.0;
-            peer.recordLatency(durationMs);
-            peer.recordThroughput(message.getSize(), durationMs);
+            if (peer != null) {
+              peer.recordLatency(durationMs);
+              if (message != null) {
+                peer.recordThroughput(message.getSize(), durationMs);
+              }
+              peer.recordUsefulResponse();
+            }
             promise.complete(r);
-            peer.recordUsefulResponse();
           });
     } catch (final RLPException e) {
       // Peer sent us malformed data - disconnect
       LOG.debug(
-          "Disconnecting with BREACH_OF_PROTOCOL due to malformed message: {}",
-          peer.getLoggableId(),
+          "Disconnecting with BREACH_OF_PROTOCOL due to malformed message from peer: {}",
+          (peer == null) ? "unknown" : peer.getLoggableId(),
           e);
-      LOG.trace("Peer {} Malformed message data: {}", peer, message.getData());
-      peer.disconnect(DisconnectReason.BREACH_OF_PROTOCOL_MALFORMED_MESSAGE_RECEIVED);
+      if (message != null) {
+        LOG.trace("Peer {} Malformed message data: {}", peer, message.getData());
+      }
+      if (peer != null) {
+        peer.disconnect(DisconnectReason.BREACH_OF_PROTOCOL_MALFORMED_MESSAGE_RECEIVED);
+      }
       promise.completeExceptionally(new PeerBreachedProtocolException());
     }
   }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractRetryingSwitchingPeerTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractRetryingSwitchingPeerTask.java
@@ -22,6 +22,7 @@ import org.hyperledger.besu.ethereum.eth.manager.exceptions.NoAvailablePeersExce
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.messages.DisconnectMessage.DisconnectReason;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractRetryingSwitchingPeerTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractRetryingSwitchingPeerTask.java
@@ -39,6 +39,7 @@ public abstract class AbstractRetryingSwitchingPeerTask<T> extends AbstractRetry
 
   private final Set<EthPeer> triedPeers = new HashSet<>();
   private final Set<EthPeer> failedPeers = new HashSet<>();
+  private Optional<Comparator<EthPeerImmutableAttributes>> peerComparator = Optional.empty();
 
   protected AbstractRetryingSwitchingPeerTask(
       final EthContext ethContext,
@@ -100,6 +101,10 @@ public abstract class AbstractRetryingSwitchingPeerTask<T> extends AbstractRetry
             });
   }
 
+  public void setPeerComparator(final Comparator<EthPeerImmutableAttributes> peerComparator) {
+    this.peerComparator = Optional.of(peerComparator);
+  }
+
   @Override
   protected void handleTaskError(final Throwable error) {
     if (isPeerFailure(error)) {
@@ -129,7 +134,8 @@ public abstract class AbstractRetryingSwitchingPeerTask<T> extends AbstractRetry
   protected Optional<EthPeer> nextPeerToTry() {
     return getEthContext()
         .getEthPeers()
-        .streamBestPeers()
+        .streamBestPeers(
+            peerComparator.orElse(getEthContext().getEthPeers().getBestPeerComparator()))
         .filter((peer) -> isSuitablePeer(peer) && !triedPeers.contains(peer.ethPeer()))
         .map(EthPeerImmutableAttributes::ethPeer)
         .findFirst();

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractRetryingSwitchingPeerTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractRetryingSwitchingPeerTask.java
@@ -133,13 +133,26 @@ public abstract class AbstractRetryingSwitchingPeerTask<T> extends AbstractRetry
   }
 
   protected Optional<EthPeer> nextPeerToTry() {
-    return getEthContext()
-        .getEthPeers()
-        .streamBestPeers(
-            peerComparator.orElse(getEthContext().getEthPeers().getBestPeerComparator()))
-        .filter((peer) -> isSuitablePeer(peer) && !triedPeers.contains(peer.ethPeer()))
-        .map(EthPeerImmutableAttributes::ethPeer)
-        .findFirst();
+    final Comparator<EthPeerImmutableAttributes> comparator =
+        peerComparator.orElse(getEthContext().getEthPeers().getBestPeerComparator());
+    final Optional<EthPeer> selectedPeer =
+        getEthContext()
+            .getEthPeers()
+            .streamBestPeers(comparator)
+            .filter((peer) -> isSuitablePeer(peer) && !triedPeers.contains(peer.ethPeer()))
+            .map(EthPeerImmutableAttributes::ethPeer)
+            .findFirst();
+
+    selectedPeer.ifPresent(
+        peer ->
+            LOG.atDebug()
+                .setMessage("Task {} selected peer {} using comparator {}")
+                .addArgument(this.getClass().getSimpleName())
+                .addArgument(peer::getLoggableId)
+                .addArgument(comparator)
+                .log());
+
+    return selectedPeer;
   }
 
   private void refreshPeers() {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/RequestDataStep.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/RequestDataStep.java
@@ -93,9 +93,10 @@ public class RequestDataStep {
             ethContext,
             accountDataRequest.getStartKeyHash(),
             accountDataRequest.getEndKeyHash(),
-             blockHeader,
+            blockHeader,
             metricsSystem);
-    ((RetryingGetAccountRangeFromPeerTask) getAccountTask).setPeerComparator(EthPeers.BY_HIGH_THROUGHPUT);
+    ((RetryingGetAccountRangeFromPeerTask) getAccountTask)
+        .setPeerComparator(EthPeers.BY_HIGH_THROUGHPUT);
     downloadState.addOutstandingTask(getAccountTask);
 
     return getAccountTask

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/RequestDataStep.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/RequestDataStep.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.ethereum.eth.sync.snapsync;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.eth.manager.EthContext;
+import org.hyperledger.besu.ethereum.eth.manager.EthPeers;
 import org.hyperledger.besu.ethereum.eth.manager.snap.RetryingGetAccountRangeFromPeerTask;
 import org.hyperledger.besu.ethereum.eth.manager.snap.RetryingGetBytecodeFromPeerTask;
 import org.hyperledger.besu.ethereum.eth.manager.snap.RetryingGetStorageRangeFromPeerTask;
@@ -92,9 +93,11 @@ public class RequestDataStep {
             ethContext,
             accountDataRequest.getStartKeyHash(),
             accountDataRequest.getEndKeyHash(),
-            blockHeader,
+             blockHeader,
             metricsSystem);
+    ((RetryingGetAccountRangeFromPeerTask) getAccountTask).setPeerComparator(EthPeers.BY_HIGH_THROUGHPUT);
     downloadState.addOutstandingTask(getAccountTask);
+
     return getAccountTask
         .run()
         .orTimeout(10, TimeUnit.SECONDS)
@@ -142,6 +145,8 @@ public class RequestDataStep {
     final EthTask<StorageRangeMessage.SlotRangeData> getStorageRangeTask =
         RetryingGetStorageRangeFromPeerTask.forStorageRange(
             ethContext, accountHashesAsBytes32, minRange, maxRange, blockHeader, metricsSystem);
+    ((RetryingGetStorageRangeFromPeerTask) getStorageRangeTask)
+        .setPeerComparator(EthPeers.BY_HIGH_THROUGHPUT);
     downloadState.addOutstandingTask(getStorageRangeTask);
     return getStorageRangeTask
         .run()
@@ -203,6 +208,7 @@ public class RequestDataStep {
     final EthTask<Map<Bytes32, Bytes>> getByteCodeTask =
         RetryingGetBytecodeFromPeerTask.forByteCode(
             ethContext, codeHashes, blockHeader, metricsSystem);
+    ((RetryingGetBytecodeFromPeerTask) getByteCodeTask).setPeerComparator(EthPeers.BY_LOW_LATENCY);
     downloadState.addOutstandingTask(getByteCodeTask);
     return getByteCodeTask
         .run()
@@ -249,6 +255,8 @@ public class RequestDataStep {
     final EthTask<Map<Bytes, Bytes>> getTrieNodeFromPeerTask =
         RetryingGetTrieNodeFromPeerTask.forTrieNodes(
             ethContext, message, blockHeader, metricsSystem);
+    ((RetryingGetTrieNodeFromPeerTask) getTrieNodeFromPeerTask)
+        .setPeerComparator(EthPeers.BY_LOW_LATENCY);
     downloadState.addOutstandingTask(getTrieNodeFromPeerTask);
     return getTrieNodeFromPeerTask
         .run()

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/EthPeerTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/EthPeerTest.java
@@ -545,7 +545,10 @@ public class EthPeerTest {
         EthProtocolConfiguration.DEFAULT_MAX_MESSAGE_SIZE,
         clock,
         Collections.emptyList(),
-        Bytes.random(64));
+        Bytes.random(64),
+        0.1,
+        v -> {},
+        v -> {});
   }
 
   private MockPeerConnection.PeerSendHandler getFailOnSend() {
@@ -580,7 +583,10 @@ public class EthPeerTest {
         EthProtocolConfiguration.DEFAULT_MAX_MESSAGE_SIZE,
         clock,
         permissioningProviders,
-        Bytes.random(64));
+        Bytes.random(64),
+        0.1,
+        v -> {},
+        v -> {});
   }
 
   private PeerConnection getPeerConnection(final MockPeerConnection.PeerSendHandler onSend) {

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/EthPeersTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/EthPeersTest.java
@@ -142,11 +142,11 @@ public class EthPeersTest {
     assertThat(EthPeers.BY_LOW_LATENCY.compare(attrA, attrB)).isGreaterThan(0);
     assertThat(EthPeers.BY_LOW_LATENCY.compare(attrB, attrA)).isLessThan(0);
 
-    // Peer with unknown latency should be worse than any known latency
+    // Peer with unknown latency should be better than any known latency (optimistic sampling)
     final EthPeer peerC =
         EthProtocolManagerTestUtil.createPeer(ethProtocolManager, 1000).getEthPeer();
     final EthPeerImmutableAttributes attrC = EthPeerImmutableAttributes.from(peerC);
-    assertThat(EthPeers.BY_LOW_LATENCY.compare(attrA, attrC)).isGreaterThan(0);
+    assertThat(EthPeers.BY_LOW_LATENCY.compare(attrA, attrC)).isLessThan(0);
   }
 
   @Test
@@ -165,6 +165,12 @@ public class EthPeersTest {
     // Larger throughput is better
     assertThat(EthPeers.BY_HIGH_THROUGHPUT.compare(attrA, attrB)).isGreaterThan(0);
     assertThat(EthPeers.BY_HIGH_THROUGHPUT.compare(attrB, attrA)).isLessThan(0);
+
+    // Peer with unknown throughput should be better than any known throughput (optimistic sampling)
+    final EthPeer peerC =
+        EthProtocolManagerTestUtil.createPeer(ethProtocolManager, 1000).getEthPeer();
+    final EthPeerImmutableAttributes attrC = EthPeerImmutableAttributes.from(peerC);
+    assertThat(EthPeers.BY_HIGH_THROUGHPUT.compare(attrA, attrC)).isLessThan(0);
   }
 
   @Test

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManagerTestBuilder.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManagerTestBuilder.java
@@ -209,7 +209,8 @@ public class EthProtocolManagerTestBuilder {
               25,
               false,
               SyncMode.FAST,
-              forkIdManager);
+              forkIdManager,
+              0.1);
     }
     ethPeers.setChainHeadTracker(EthProtocolManagerTestUtil.getChainHeadTrackerMock());
     if (ethMessages == null) {

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/RequestManagerTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/RequestManagerTest.java
@@ -227,7 +227,10 @@ public class RequestManagerTest {
         EthProtocolConfiguration.DEFAULT_MAX_MESSAGE_SIZE,
         TestClock.fixed(),
         Collections.emptyList(),
-        Bytes.random(64));
+        Bytes.random(64),
+        0.1,
+        v -> {},
+        v -> {});
   }
 
   @Test

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/ethtaskutils/AbstractMessageTaskTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/ethtaskutils/AbstractMessageTaskTest.java
@@ -126,7 +126,8 @@ public abstract class AbstractMessageTaskTest<T, R> {
                 MAX_PEERS,
                 false,
                 SyncMode.FAST,
-                new ForkIdManager(blockchain, Collections.emptyList(), Collections.emptyList())));
+                new ForkIdManager(blockchain, Collections.emptyList(), Collections.emptyList()),
+                0.1));
 
     final EthMessages ethMessages = new EthMessages();
     final EthScheduler ethScheduler =

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/ethtaskutils/PeerMessageTaskTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/ethtaskutils/PeerMessageTaskTest.java
@@ -167,6 +167,9 @@ public abstract class PeerMessageTaskTest<T>
         EthProtocolConfiguration.DEFAULT_MAX_MESSAGE_SIZE,
         TestClock.fixed(),
         Collections.emptyList(),
-        Bytes.random(64));
+        Bytes.random(64),
+        0.1,
+        v -> {},
+        v -> {});
   }
 }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/AbstractBlockPropagationManagerTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/AbstractBlockPropagationManagerTest.java
@@ -687,7 +687,8 @@ public abstract class AbstractBlockPropagationManagerTest {
                 25,
                 false,
                 SyncMode.SNAP,
-                new ForkIdManager(blockchain, Collections.emptyList(), Collections.emptyList())),
+                new ForkIdManager(blockchain, Collections.emptyList(), Collections.emptyList()),
+                0.1),
             new EthMessages(),
             ethScheduler,
             null);
@@ -828,7 +829,8 @@ public abstract class AbstractBlockPropagationManagerTest {
                 25,
                 false,
                 SyncMode.SNAP,
-                new ForkIdManager(blockchain, Collections.emptyList(), Collections.emptyList())),
+                new ForkIdManager(blockchain, Collections.emptyList(), Collections.emptyList()),
+                0.1),
             new EthMessages(),
             ethScheduler,
             null);

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/tasks/DownloadHeaderSequenceTaskTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/tasks/DownloadHeaderSequenceTaskTest.java
@@ -126,7 +126,8 @@ public class DownloadHeaderSequenceTaskTest {
                 5,
                 false,
                 SyncMode.FAST,
-                new ForkIdManager(blockchain, Collections.emptyList(), Collections.emptyList())));
+                new ForkIdManager(blockchain, Collections.emptyList(), Collections.emptyList()),
+                0.1));
 
     final EthMessages ethMessages = new EthMessages();
     final EthScheduler ethScheduler =

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TestNode.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TestNode.java
@@ -173,7 +173,8 @@ public class TestNode implements Closeable {
             25,
             false,
             SyncMode.SNAP,
-            new ForkIdManager(blockchain, Collections.emptyList(), Collections.emptyList()));
+            new ForkIdManager(blockchain, Collections.emptyList(), Collections.emptyList()),
+            0.1);
 
     final ChainHeadTracker mockCHT = getChainHeadTracker();
     ethPeers.setChainHeadTracker(mockCHT);

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolFactoryTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolFactoryTest.java
@@ -122,7 +122,8 @@ public class TransactionPoolFactoryTest {
             25,
             false,
             SyncMode.SNAP,
-            new ForkIdManager(blockchain, Collections.emptyList(), Collections.emptyList()));
+            new ForkIdManager(blockchain, Collections.emptyList(), Collections.emptyList()),
+            0.1);
     when(ethContext.getEthMessages()).thenReturn(ethMessages);
     when(ethContext.getEthPeers()).thenReturn(ethPeers);
 

--- a/ethereum/referencetests/src/reference-test/java/org/hyperledger/besu/ethereum/vm/BlockchainReferenceTestTools.java
+++ b/ethereum/referencetests/src/reference-test/java/org/hyperledger/besu/ethereum/vm/BlockchainReferenceTestTools.java
@@ -276,7 +276,8 @@ public class BlockchainReferenceTestTools {
               1,
               false,
               SyncMode.FULL,
-              new ForkIdManager(blockchain, Collections.emptyList(), Collections.emptyList()));
+              new ForkIdManager(blockchain, Collections.emptyList(), Collections.emptyList()),
+              0.1);
       final EthContext ethContext =
           new EthContext(
               ethPeers,


### PR DESCRIPTION
## PR description

Implement performance-based peer selection for Besu snap sync to improve world state sync performance by routing requests to peers with optimal latency and throughput characteristics.

## Fixed Issue(s)

Fixes #9722

### Changes

- Add peer performance metrics (latency, throughput) to EthPeer and EthPeerImmutableAttributes
- Capture latency and throughput in AbstractPeerRequestTask
- Add performance-based comparators (BY_LOW_LATENCY, BY_TRANSFER_SPEED) to EthPeers
- Update AbstractRetryingSwitchingPeerTask to support custom comparators
- Integrate performance-based selection into Snap Sync tasks and RequestDataStep
- Add comprehensive unit tests for peer selection and metrics capturing

### Testing

- [x] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests
