### PR TITLE
Disable docker build provenance

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -915,7 +915,7 @@ task distDocker(type: Exec) {
     dockerPlatform = "--platform ${project.getProperty('docker-platform')}"
   }
   def gitDetails = getGitCommitDetails(7)
-  args "-c", "docker build ${dockerPlatform} --build-arg BUILD_DATE=${buildTime()} --build-arg VERSION=${dockerBuildVersion} --build-arg VCS_REF=${gitDetails.hash} -t ${image} ."
+  args "-c", "docker build ${dockerPlatform} --provenance=false --build-arg BUILD_DATE=${buildTime()} --build-arg VERSION=${dockerBuildVersion} --build-arg VCS_REF=${gitDetails.hash} -t ${image} ."
 }
 
 tasks.register("downloadGossBinaries") {


### PR DESCRIPTION
Attempt to fix CI

Since https://github.com/hyperledger/besu/actions/runs/21971865415/job/63792916929 the manifestDocker task has been broken.
Comparing to last successful run: https://github.com/hyperledger/besu/actions/runs/21936617233/job/63352108687

You can see the github runner was upgraded (20260201.24.1 -> 20260209.31.1), which included upgrading docker to 29.

Chain of events:
- `distDocker` tasks's `docker build` now adds provenance attestations by default
- `dockerUpload` task's docker push pushes an OCI index instead of a single image manifest
- `manifestDockerCreate` rejects OCI indices as source images


Can confirm this with: 
```
docker manifest inspect docker.io/hyperledger/besu:develop-amd64
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.oci.image.index.v1+json",
   "manifests": [
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "size": 1817,
         "digest": "sha256:e8972be162a8249ef94613e0a807d9231d9fe95354c4d8b2037d17c66943eae9",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "size": 566,
         "digest": "sha256:94f88f6a4bbfd053810183def1aa1b95a714ff60dc7bec9b787167cdc443bef5",
         "platform": {
            "architecture": "unknown",
            "os": "unknown"
         }
      }
   ]
}
```

compared to:
```
 docker manifest inspect docker.io/hyperledger/besu:26.1.0-amd64
{
        "schemaVersion": 2,
        "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
        "config": {
                "mediaType": "application/vnd.docker.container.image.v1+json",
                "size": 8285,
                "digest": "sha256:0c55ff792c237123a59614c495317cbd2953cef9839d81de43022cc251444fcb"
        },
        "layers": [
                {
                        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
                        "size": 29726011,
                        "digest": "sha256:a3629ac5b9f4680dc2032439ff2354e73b06aecc2e68f0035a2d7c001c8b4114"
                },
                {
                        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
                        "size": 1216764,
                        "digest": "sha256:ca294c04d5fe45801ce5e0b3744c77b6db95bf1bf80d06088dd3087d327e8727"
                },
                {
                        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
                        "size": 62593239,
                        "digest": "sha256:0633f0a04d3ea18f31ba49fbe60aba27d6a2f127ab63872665d78d2966eef2cb"
                },
                {
                        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
                        "size": 32,
                        "digest": "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1"
                },
                {
                        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
                        "size": 208515634,
                        "digest": "sha256:1b4cf2ddd6980a9d14a9619cd88075ddef428051ee2dbab1257916091abbc1ce"
                },
                {
                        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
                        "size": 5111222,
                        "digest": "sha256:bd7f9c042ecf94217dabf55e676fae21bebd32459b19bda2038b71f0b40012e0"
                },
                {
                        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
                        "size": 386,
                        "digest": "sha256:38bf00833820014624ecf7cabac6eaf50a0f0766a495b71f06513a1607b1ff42"
                },
                {
                        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
                        "size": 32,
                        "digest": "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1"
                }
        ]
}
```

`--provenance=false` shoudl return behaviour to before the upgrade.

Relevant thread https://github.com/docker/buildx/issues/1509#issuecomment-1378454396

Will open an issue to consider supporting provenance which is a bigger change.