### PR TITLE
Use docker buildx imagetools for multi-arch manifest creation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1033,7 +1033,7 @@ task dockerUploadRelease {
   dependsOn dockerUploadReleaseArm64, dockerUploadReleaseAmd64
 }
 
-task manifestDockerCreate(type: Exec) {
+task manifestDocker(type: Exec) {
   def image = "${dockerImageName}:${dockerBuildVersion}"
   def archs = [
     "arm64",
@@ -1041,53 +1041,23 @@ task manifestDockerCreate(type: Exec) {
   doFirst {
     def targets = ""
     archs.forEach { arch -> targets += "'${image}-${arch}' " }
-    def cmd = "docker manifest create '${image}' ${targets}"
+    def cmd = "docker buildx imagetools create -t '${image}' ${targets}"
     println "Executing '${cmd}'"
     commandLine shell, "-c", cmd
   }
 }
 
-task manifestDockerPush(type: Exec) {
-  dependsOn manifestDockerCreate
-  def image = "${dockerImageName}:${dockerBuildVersion}"
-
-  doFirst {
-    def cmd = "docker manifest push '${image}'"
-    println "Executing '${cmd}'"
-    commandLine shell, "-c", cmd
-  }
-}
-
-task manifestDocker {
-  dependsOn manifestDockerPush
-}
-
-task manifestDockerReleaseCreate(type: Exec) {
+task manifestDockerRelease(type: Exec) {
   def archs = ["arm64", "amd64"]
   def baseTag = "${dockerImageName}:latest"
 
   doFirst {
     def targets = ""
     archs.forEach { arch -> targets += "'${baseTag}-${arch}' " }
-    def cmd = "docker manifest create '${baseTag}' ${targets} --amend"
+    def cmd = "docker buildx imagetools create -t '${baseTag}' ${targets}"
     println "Executing '${cmd}'"
     commandLine shell, "-c", cmd
   }
-}
-
-task manifestDockerReleasePush(type: Exec) {
-  dependsOn manifestDockerReleaseCreate
-  def baseTag = "${dockerImageName}:latest"
-
-  doFirst {
-    def cmd = "docker manifest push '${baseTag}'"
-    println "Executing '${cmd}'"
-    commandLine shell, "-c", cmd
-  }
-}
-
-task manifestDockerRelease {
-  dependsOn manifestDockerReleasePush
 }
 
 def sep = Pattern.quote(File.separator)


### PR DESCRIPTION
Implements https://github.com/hyperledger/besu/issues/9818

Docker 29 defaults to the containerd image store, which preserves BuildKit provenance attestations on push. This turns per-arch images into OCI indices (manifest lists), causing `docker manifest create` to reject them as sources. Switch to `docker buildx imagetools create` which handles OCI indices natively, and simplifies the tasks by combining create+push into a single command.
