### PR TITLE
Exit on OOM

### DIFF
--- a/app/src/main/java/org/hyperledger/besu/Besu.java
+++ b/app/src/main/java/org/hyperledger/besu/Besu.java
@@ -92,6 +92,11 @@ public final class Besu {
 
   private static Thread.UncaughtExceptionHandler slf4jExceptionHandler(final Logger logger) {
     return (thread, error) -> {
+      if (error instanceof OutOfMemoryError) {
+        // Halt immediately — logging would fail due to allocation.
+        // Belt-and-suspenders backup for -XX:+ExitOnOutOfMemoryError.
+        Runtime.getRuntime().halt(137);
+      }
       if (logger.isErrorEnabled()) {
         logger.error(String.format("Uncaught exception in thread \"%s\"", thread.getName()), error);
       }

--- a/build.gradle
+++ b/build.gradle
@@ -711,7 +711,9 @@ application {
     "java.base/jdk.internal.misc=ALL-UNNAMED",
     "--add-opens",
     "java.base/java.nio=ALL-UNNAMED",
-    "--enable-native-access=ALL-UNNAMED"
+    "--enable-native-access=ALL-UNNAMED",
+    // Immediately exit on OOM rather than becoming a zombie process
+    '-XX:+ExitOnOutOfMemoryError'
   ]
 }
 


### PR DESCRIPTION
## PR description

When Besu run into OOM issues the node is unable to recover and only outputs new error messages like these:

```
Exception: java.lang.OutOfMemoryError thrown from the UncaughtExceptionHandler in thread "JNA Cleaner"

Exception: java.lang.OutOfMemoryError thrown from the UncaughtExceptionHandler in thread "idle-timeout-task"

Exception: java.lang.OutOfMemoryError thrown from the UncaughtExceptionHandler in thread "JFR Periodic Tasks"

Exception: java.lang.OutOfMemoryError thrown from the UncaughtExceptionHandler in thread "vertx-blocked-thread-checker"

Exception: java.lang.OutOfMemoryError thrown from the UncaughtExceptionHandler in thread "vertx-blocked-thread-checker"

Exception: java.lang.OutOfMemoryError thrown from the UncaughtExceptionHandler in thread "EthScheduler-Workers-1"

Exception: java.lang.OutOfMemoryError thrown from the UncaughtExceptionHandler in thread "HTTP-Dispatcher"

Exception: java.lang.OutOfMemoryError thrown from the UncaughtExceptionHandler in thread "EthScheduler-Workers-6"

Exception: java.lang.OutOfMemoryError thrown from the UncaughtExceptionHandler in thread "nioEventLoopGroup-2-1"

Exception: java.lang.OutOfMemoryError thrown from the UncaughtExceptionHandler in thread "EthScheduler-Transactions-2"

Exception: java.lang.OutOfMemoryError thrown from the UncaughtExceptionHandler in thread "EthScheduler-Workers-3"

Exception: java.lang.OutOfMemoryError thrown from the UncaughtExceptionHandler in thread "vert.x-worker-thread-0"

Exception: java.lang.OutOfMemoryError thrown from the UncaughtExceptionHandler in thread "EthScheduler-Transactions-1"

Exception: java.lang.OutOfMemoryError thrown from the UncaughtExceptionHandler in thread "nioEventLoopGroup-3-8"

Exception: java.lang.OutOfMemoryError thrown from the UncaughtExceptionHandler in thread "EthScheduler-Workers-4"

Exception: java.lang.OutOfMemoryError thrown from the UncaughtExceptionHandler in thread "EthScheduler-Workers-5"

Exception: java.lang.OutOfMemoryError thrown from the UncaughtExceptionHandler in thread "EthScheduler-Services-37"

Exception: java.lang.OutOfMemoryError thrown from the UncaughtExceptionHandler in thread "vert.x-worker-thread-7"

Exception: java.lang.OutOfMemoryError thrown from the UncaughtExceptionHandler in thread "EthScheduler-Services-28"
```

This PR sets the JVM to exit on OOM instead of being stuck. This does not solve the underlying OOM issue, but allows the node to restart and recover until the issue is fixed.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


