### PR TITLE
fix config for bft soak acceptance test task; add manual trigger GHA

### DIFF
--- a/.github/workflows/bft-soak-test.yml
+++ b/.github/workflows/bft-soak-test.yml
@@ -9,7 +9,7 @@ on:
         type: string
 
 env:
-  GRADLE_OPTS: "-Xmx6g -Dorg.gradle.daemon=false -Dorg.gradle.parallel=true -Dorg.gradle.caching=true"
+  GRADLE_OPTS: "-Xmx6g -Dorg.gradle.daemon=false -Dorg.gradle.parallel=true"
 
 jobs:
   bft-soak-test:
@@ -34,7 +34,7 @@ jobs:
         with:
           cache-disabled: true
       - name: run BFT soak test
-        run: ./gradlew :acceptance-tests:tests:acceptanceTestBftSoak -Dacctests.soakTimeMins=${{ inputs.soak-time-mins }}
+        run: ./gradlew :acceptance-tests:tests:acceptanceTestBftSoak -Dacctests.soakTimeMins=${{ inputs['soak-time-mins'] }}
       - name: Upload BFT Soak Test HTML Reports
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3
         if: always()

--- a/acceptance-tests/tests/build.gradle
+++ b/acceptance-tests/tests/build.gradle
@@ -113,7 +113,7 @@ testing {
         acceptanceTestBftSoak {
           testTask.configure {
             // Clear the exclude inherited from the 'all' block
-            excludes = []
+            excludes.clear()
             include '**/bftsoak/**'
 
             dependsOn(rootProject.installDist)


### PR DESCRIPTION
## PR description
With recent changes for gradle 9, this task is missing some config 
Also added a GHA workflow so maintainers can trigger it as needed

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


