### PR TITLE
docs: add RLPx protocol implementation documentation

### DIFF
--- a/docs/p2p/peer-connection-limits.md
+++ b/docs/p2p/peer-connection-limits.md
@@ -1,0 +1,108 @@
+Summary of Peer Connection Limits in Besu
+
+I've completed a thorough analysis of how peer connection limits work in the Besu codebase. Here's the comprehensive picture:
+
+1. Where TOO_MANY_PEERS Disconnect Reason is Used
+
+The TOO_MANY_PEERS disconnect reason (code 0x04) is defined in:
+- File: ./ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/wire/messages/DisconnectMessage.java (line 138)
+- Definition: TOO_MANY_PEERS((byte) 0x04, "Too many peers")
+
+It's used in 4 main places in ./ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeers.java:
+
+1. enforceRemoteConnectionLimits() (line 708) - Disconnects remotely initiated connections when inbound limit exceeded
+2. enforceConnectionLimits() (line 733) - Disconnects low-priority peers when overall peer count exceeds limit
+3. addPeerToEthPeers() (lines 802, 817, 833) - Multiple places where existing peers are disconnected to make room for new higher-priority peers
+
+2. How RlpxAgent Tracks Active Connections
+
+The RlpxAgent (./ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgent.java) is the core connection management class:
+
+- Stores maxPeers: Field at line 72: private final int maxPeers;
+- Gets connection count: Method getConnectionCount() (line 156-162) - returns count of active connections via supplier
+- Connection suppliers: Lines 73-74 use lambdas to get all connections and all active connections
+- Key method getMaxPeers() (line 359-361): Returns the configured maximum peers
+
+However, RlpxAgent does NOT directly enforce the limit - it just stores the config and provides access to connections. The actual enforcement happens in EthPeers.
+
+3. Where the "Too Many Peers" Check Happens in Connection Flow
+
+The limit checks happen AFTER the HELLO exchange, not during:
+
+Connection Flow Timeline:
+1. TCP connection accepted by Netty server
+2. Handshake handler (AbstractHandshakeHandler lines 98-146) performs ECIES encryption handshake
+3. After handshake completes, DeFramer is added and HELLO messages are exchanged
+4. After HELLO exchange (in DeFramer.decode(), line 124-198):
+  - Creates peer connection object
+  - Validates shared capabilities
+  - Completes the connection future
+5. Connection is registered with EthPeers via registerNewConnection() (line 201-224)
+6. After protocol status exchange, ethPeerStatusExchanged() is called (lines 560-633)
+7. Finally, addPeerToEthPeers() is called (line 626) - THIS IS WHERE THE LIMITS ARE ACTUALLY ENFORCED
+
+4. Classes Holding maxPeers Configuration
+
+Two main classes hold the peer limit configuration:
+
+A. RlpxAgent (./ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgent.java):
+- Field: private final int maxPeers; (line 72)
+- Method: public int getMaxPeers() (line 359-361)
+- Set via Builder: .maxPeers(int maxPeers) (line 474-477)
+
+B. EthPeers (./ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeers.java):
+- Field: private final int peerUpperBound; (line 105) - the actual limit
+- Field: private final int maxRemotelyInitiatedConnections; (line 106) - separate limit for inbound connections
+- Method: public int getMaxPeers() (line 352-354) - returns peerUpperBound
+- Constructor: Sets these from parameters (lines 143-152)
+
+5. Existing "Should Accept Connection" Checks
+
+There is a sophisticated callback-based system for deciding whether to accept connections:
+
+The Flow:
+
+1. RlpxAgent has a list of ShouldConnectCallback subscribers (line 67):
+private final List<ShouldConnectCallback> connectRequestSubscribers = new ArrayList<>();
+2. Before accepting any connection, RlpxAgent calls checkWhetherToConnect() (lines 249-252):
+private boolean checkWhetherToConnect(final Peer peer, final boolean incoming) {
+  return connectRequestSubscribers.stream()
+      .anyMatch(callback -> callback.shouldConnect(peer, incoming));
+}
+3. This is called in two places:
+  - Outbound (line 216): Before initiating outbound connections
+  - Inbound (line 327): Before accepting inbound connections in handleIncomingConnection()
+4. The callback is registered via NetworkRunner.builder():
+network.subscribeConnectRequest(ethPeersShouldConnect::apply);
+4. This passes a BiFunction<Peer, Boolean, Boolean> that typically comes from EthPeers
+5. The actual limit enforcement happens in EthPeers.addPeerToEthPeers() (line 769-862):
+  - Checks if at peerUpperBound (line 780)
+  - For non-random priority mode: Can optionally disconnect an existing peer to make room
+  - For random priority mode: Adds peer first, then enforces limits via:
+      - enforceRemoteConnectionLimits() (lines 858)
+    - enforceConnectionLimits() (lines 859)
+
+6. Key Limits in EthPeers
+
+There are actually 3 separate limits:
+
+1. peerUpperBound (line 105) - Overall maximum peers (from --max-peers CLI option)
+2. maxRemotelyInitiatedConnections (line 106) - Maximum inbound connections (separate limit to prevent eclipse attacks)
+3. snapServerTargetNumber (line 150-151) - 50% of peers should be snap servers during snap sync
+
+The system also uses:
+- Peer privileges (via rlpxAgent.canExceedConnectionLimits(), line 306-308) to allow certain peers (like trusted nodes) to exceed limits
+- Peer comparison (method comparePeerPriorities(), lines 661-675) to prioritize peers by privilege level and connection age
+- Peer reputation/utility scoring to determine which low-priority peers to disconnect when limits are hit
+
+7. File Locations Summary
+
+Key files for understanding peer limits:
+
+1. ./ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeers.java - Main enforcement logic (lines 769-862)
+2. ./ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgent.java - Connection tracking and config storage
+3. ./ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/netty/DeFramer.java - Post-HELLO peer creation (lines
+124-210)
+4. ./ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/wire/ShouldConnectCallback.java - Callback interface for accept/reject
+decisions
+5. ./ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/network/NetworkRunner.java - Registers the callback with RlpxAgent

--- a/docs/p2p/rlpx/netty-pipeline-for-rlpx.md
+++ b/docs/p2p/rlpx/netty-pipeline-for-rlpx.md
@@ -1,0 +1,286 @@
+Comprehensive Exploration of Netty Pipeline Setup for RLPx Connections
+
+Based on my thorough exploration of the Besu codebase, here's a detailed analysis of how the Netty pipeline is set up for RLPx connections:
+
+---
+1. HIGH-LEVEL ARCHITECTURE OVERVIEW
+
+The RLPx connection lifecycle in Besu follows this flow:
+1. Connection Initiation via NettyConnectionInitializer
+2. TCP Establishment with timeout handling
+3. Crypto Handshake (ECIES) with separate inbound/outbound handlers
+4. Pipeline Replacement - handshake handler replaced with DeFramer
+5. Message Framing - frame encoding/decoding layer
+6. Protocol Handlers - keep-alive, API dispatch, and capability multiplexing
+
+---
+2. ENTRY POINT: NettyConnectionInitializer
+
+File: ./ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/netty/NettyConnectionInitializer.java
+
+Key responsibilities:
+- Manages server bootstrap (for inbound connections) and client bootstrap (for outbound)
+- Uses Netty's EventLoopGroup: 1 boss thread, 10 worker threads
+- Implements both ConnectionInitializer, HandshakerProvider, and FramerProvider interfaces
+- Constant 10-second timeout for all connections
+
+Inbound Connection Flow:
+// Line 218-232
+inboundChannelInitializer() creates a new pipeline for incoming connections
+- Adds TimeoutHandler
+- Adds additional protocol-specific handlers (extensible hook)
+- Adds HandshakeHandlerInbound
+
+Outbound Connection Flow:
+// Line 199-213
+outboundChannelInitializer() creates pipeline for outgoing connections
+- Sets TCP_NODELAY and CONNECT_TIMEOUT_MILLIS (10 seconds)
+- Adds TimeoutHandler
+- Adds additional protocol-specific handlers
+- Adds HandshakeHandlerOutbound
+
+---
+3. TIMEOUT HANDLING DURING HANDSHAKE
+
+File: ./ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/netty/TimeoutHandler.java
+
+The TimeoutHandler is a Netty ChannelInitializer that:
+- Schedules a task on the event loop for 10 seconds
+- Checks if a condition is met (typically: connectionFuture.isDone())
+- If timeout expires and condition not met, closes the channel and invokes callback
+- Callback completes future with TimeoutException
+
+This handler is added early in the pipeline before handshake handlers to ensure connection timeouts are properly enforced.
+
+---
+4. HANDSHAKE HANDLER SETUP
+
+4.1 Base Class: AbstractHandshakeHandler
+
+File: ./ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/netty/AbstractHandshakeHandler.java
+
+Extends SimpleChannelInboundHandler<ByteBuf> and orchestrates the entire handshake:
+
+Key method: channelRead0() (line 98-145)
+1. Calls abstract nextHandshakeMessage(msg) to process incoming bytes
+2. If handshake message returned: writes it back with ctx.writeAndFlush()
+3. Waits for more bytes if handshake still IN_PROGRESS
+4. When handshake SUCCESS:
+  - Creates a Framer from handshaker secrets
+  - Creates a DeFramer decoder
+  - REPLACES itself with DeFramer in the pipeline: pipeline().replace(this, "DeFramer", deFramer)
+  - Adds validation handler ValidateFirstOutboundMessage before DeFramer
+  - Writes framed HELLO message via new handler
+  - Calls ctx.fireChannelRead(msg) to pass data to DeFramer
+
+The ValidateFirstOutboundMessage inner class (line 167-186):
+- Ensures the first wire message sent is HELLO
+- Throws if first message isn't HELLO
+- Removes itself after first message validation
+
+4.2 Inbound Handler: HandshakeHandlerInbound
+
+File: ./ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/netty/HandshakeHandlerInbound.java
+
+For inbound (server) connections:
+- Constructor calls handshaker.prepareResponder(nodeKey) (line 57)
+- Implements nextHandshakeMessage() to process bytes while IN_PROGRESS
+- Returns Optional.empty() once handshake succeeds
+
+4.3 Outbound Handler: HandshakeHandlerOutbound
+
+File: ./ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/netty/HandshakeHandlerOutbound.java
+
+For outbound (client) connections:
+- Constructor calls handshaker.prepareInitiator(nodeKey, theirPubKey) (line 67-68)
+- Stores first handshake message as ByteBuf first (line 69)
+- Overrides channelActive() to write initial crypto message (line 84-94)
+- Sends first message immediately when channel becomes active
+
+---
+5. DEFRAMER AND PIPELINE REPLACEMENT
+
+File: ./ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/netty/DeFramer.java
+
+The DeFramer replaces the handshake handler after cryptographic handshake completes.
+
+Key responsibilities:
+- Extends ByteToMessageDecoder - decrypts and parses RLPx frames
+- Uses Framer to deframe encrypted wire protocol messages
+- Waits for HELLO message exchange (line 124-141)
+
+Flow when HELLO received (line 124-210):
+1. Decodes HELLO using HelloMessage.readFrom(message)
+2. Enables compression if peer supports it (version >= 5)
+3. Creates CapabilityMultiplexer from negotiated capabilities
+4. Creates/validates peer from HELLO data
+5. Creates NettyPeerConnection object
+6. Adds new handlers to pipeline (line 202-209):
+  - IdleStateHandler(15, 0, 0) - detects reader idle after 15 seconds
+  - WireKeepAlive - handles PING/PONG for keep-alive
+  - ApiHandler - demultiplexes and dispatches protocol messages
+  - MessageFramer - frames outbound messages using RLPx framing
+7. Completes connectFuture with the connection (line 210)
+
+Pipeline state at this point:
+Channel Pipeline (after HELLO exchange):
+  [TimeoutHandler]
+  [DeFramer]
+  [IdleStateHandler]
+  [WireKeepAlive]
+  [ApiHandler]
+  [MessageFramer]
+
+---
+6. POST-HANDSHAKE HANDLERS
+
+6.1 WireKeepAlive
+
+File: ./ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/netty/WireKeepAlive.java
+
+Extends ChannelDuplexHandler (inbound + outbound):
+- Monitors IdleStateEvent from IdleStateHandler
+- When reader idle detected (15 seconds):
+  - If waiting for PONG: disconnect with TIMEOUT
+  - Otherwise: send PING message and set waiting flag
+
+6.2 ApiHandler
+
+File: ./ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/netty/ApiHandler.java
+
+Extends SimpleChannelInboundHandler<MessageData>:
+- Receives decoded MessageData from DeFramer
+- Handles wire protocol messages (PING, PONG, DISCONNECT)
+- Demultiplexes protocol-specific messages using CapabilityMultiplexer
+- Dispatches to registered protocol handlers via connectionEventDispatcher
+
+6.3 MessageFramer
+
+File: ./ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/netty/MessageFramer.java
+
+Extends MessageToByteEncoder<OutboundMessage>:
+- Encodes outbound OutboundMessage to framed bytes
+- Uses CapabilityMultiplexer to multiplex messages to correct protocol code
+- Uses Framer to apply RLPx framing (encryption, MAC)
+- Output is written to the Netty channel
+
+---
+7. FRAMING LAYER (ENCRYPTION)
+
+File: ./ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/framing/Framer.java
+
+The Framer class handles RLPx frame encryption/decryption:
+- Encryption: Uses AES-SIC stream cipher from handshake secrets
+- Authentication: Adds MAC (Message Authentication Code) using AES-ECB
+- Compression: Optional Snappy compression for messages
+- Deframing: Reads frame headers, validates MAC, decrypts payload
+- Framing: Encrypts payload, generates MAC, creates frame header
+
+Frame structure:
+[Frame Header (16 bytes)] [MAC (16 bytes)] [Encrypted Payload]
+
+---
+8. CONNECTION INITIALIZATION SEQUENCE
+
+Complete outbound connection flow:
+
+1. RlpxAgent.connect(peer)
+  - Checks permissions
+  - Calls connectionInitializer.connect(peer)
+2. NettyConnectionInitializer.connect(peer) (line 173-193)
+  - Creates Bootstrap with worker EventLoopGroup
+  - Sets TCP options: TCP_NODELAY=true, CONNECT_TIMEOUT=10s
+  - Calls outboundChannelInitializer(peer, connectionFuture)
+  - Returns future
+3. Channel Initialization (outboundChannelInitializer)
+  - Adds TimeoutHandler
+  - Adds HandshakeHandlerOutbound
+4. HandshakeHandlerOutbound.channelActive()
+  - Writes first handshake message
+5. ECIES Handshake exchange (2 messages for ECIES v4)
+  - Initiator → Responder: initial message
+  - Responder → Initiator: response message
+6. AbstractHandshakeHandler.channelRead0() completes handshake
+  - Creates DeFramer and Framer
+  - Replaces pipeline
+  - Sends HELLO message via new MessageFramer
+7. DeFramer receives HELLO
+  - Creates NettyPeerConnection
+  - Adds IdleStateHandler, WireKeepAlive, ApiHandler, MessageFramer
+  - Completes connectionFuture
+
+---
+## 9. KEY PIPELINE REPLACEMENT POINTS
+
+| Stage | Old Handler | New Handlers | Trigger |
+|-------|-------------|--------------|---------|
+| Initial | TimeoutHandler, HandshakeHandler | - | Channel created |
+| After Handshake | HandshakeHandler | DeFramer, ValidateFirstOutboundMessage | Crypto handshake SUCCESS |
+| After HELLO | ValidateFirstOutboundMessage | IdleStateHandler, WireKeepAlive, ApiHandler, MessageFramer | HELLO message received |
+---
+10. NETTY PEER CONNECTION
+
+File: ./ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/netty/NettyPeerConnection.java
+
+Represents an active P2P connection:
+- Wraps Netty ChannelHandlerContext
+- doSendMessage(): writes OutboundMessage to channel
+- closeConnection(): schedules close in 2 seconds
+- closeConnectionImmediately(): closes immediately
+- Listens to channel close future to terminate connection
+
+---
+11. FLOW DIAGRAM: FROM TCP TO PROTOCOL MESSAGES
+
+TCP Connection Established
+    ↓
+[TimeoutHandler] (10s timeout)
+    ↓
+[HandshakeHandler] ← receives raw encrypted bytes
+    ├→ ECIES Key Exchange
+    └→ Handshake SUCCESS
+        ↓
+[DeFramer] ← replaces HandshakeHandler
+    ├→ Decrypts frames
+    ├→ Waits for HELLO
+    └→ HELLO Received
+        ↓
+[IdleStateHandler]
+[WireKeepAlive]    ← PING/PONG keep-alive
+[ApiHandler]       ← demultiplex & dispatch
+[MessageFramer]    ← encrypt & frame outbound
+    ↓
+Protocol Messages (eth, snap, etc.)
+
+---
+12. TIMEOUT HANDLING DETAILS
+
+- TCP Connection Timeout: 10 seconds (CONNECT_TIMEOUT_MILLIS)
+- Handshake Timeout: 10 seconds (TimeoutHandler scheduled task)
+- Keep-Alive Timeout: 15 seconds reader idle (IdleStateHandler)
+- Close Delay: 2 seconds graceful close (NettyPeerConnection.closeConnection)
+
+---
+## 13. KEY CLASSES SUMMARY
+
+| Class | Location | Purpose |
+|-------|----------|---------|
+| NettyConnectionInitializer | netty/ | Bootstrap server/client, create channel initializers |
+| HandshakeHandlerInbound | netty/ | Process ECIES handshake for incoming connections |
+| HandshakeHandlerOutbound | netty/ | Process ECIES handshake for outgoing connections |
+| AbstractHandshakeHandler | netty/ | Common handshake logic, pipeline replacement |
+| DeFramer | netty/ | Decrypt frames, validate HELLO, add post-handshake handlers |
+| MessageFramer | netty/ | Encrypt and frame outbound messages |
+| WireKeepAlive | netty/ | Send keep-alive PINGs |
+| ApiHandler | netty/ | Demultiplex and dispatch protocol messages |
+| TimeoutHandler | netty/ | Enforce connection timeouts |
+| Framer | framing/ | RLPx encryption/decryption/framing |
+| RlpxAgent | rlpx/ | High-level connection management |
+---
+This comprehensive analysis shows that the Besu RLPx implementation uses Netty's pipeline architecture elegantly:
+
+1. Separation of concerns - handshake vs. framing vs. protocol dispatch
+2. Dynamic pipeline modification - handlers are replaced/added as state progresses
+3. Layered security - crypto handshake → encrypted framing → protocol dispatch
+4. Timeout safety - multiple timeout points ensure stuck connections are cleaned up
+5. Keep-alive - idle detection with PING/PONG ensures connection health

--- a/docs/p2p/rlpx/rlpx-handshake.md
+++ b/docs/p2p/rlpx/rlpx-handshake.md
@@ -1,0 +1,270 @@
+RLPx Handshake Implementation Exploration Summary
+
+I've thoroughly explored the RLPx handshake implementation in this Besu codebase. Here's a comprehensive analysis of the complete handshake flow:
+
+1. Core Handshake Classes
+
+Main Interfaces and Base Classes:
+
+- Handshaker (interface): ./ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/Handshaker.java
+  - Defines the handshake protocol with states: UNINITIALIZED → PREPARED → IN_PROGRESS → SUCCESS/FAILED
+  - Methods: prepareInitiator(), prepareResponder(), firstMessage(), handleMessage(), getStatus(), secrets(), partyPubKey()
+- ECIESHandshaker (implementation): ./ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/ECIESHandshaker.java
+  - Implements Elliptic Curve Integrated Encryption Scheme (ECIES) handshake
+  - Supports both V1 (legacy) and V4 (EIP-8) message formats
+  - Manages ephemeral key pairs, nonces, and message encryption/decryption
+
+---
+2. Message Construction Flow
+
+Initiator Auth Message (First Message):
+
+Location: InitiatorHandshakeMessageV1 and InitiatorHandshakeMessageV4
+
+The initiator constructs the auth message with:
+
+1. V1 Format (167 bytes, legacy):
+  - Signature (65 bytes): S(ephemeral-privk, static-shared-secret XOR nonce)
+  - Hash of ephemeral pubkey (32 bytes): H(ephemeral-pubk)
+  - Static public key (64 bytes)
+  - Nonce (32 bytes)
+  - Token flag (1 byte)
+
+Structure in ./ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/InitiatorHandshakeMessageV1.java:
+authInitiator -> E(remote-pubk,
+                   S(ephemeral-privk, static-shared-secret ^ nonce)
+                    || H(ephemeral-pubk)
+                   || pubk
+                   || nonce
+                   || 0x0)
+2. V4 Format (RLP-encoded, modern):
+  - Signature (65 bytes)
+  - Static public key (64 bytes)
+  - Nonce (32 bytes)
+  - Version (1 byte)
+  - Encoded as RLP (supports variable length, forward-compatible)
+
+Location: ./ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/InitiatorHandshakeMessageV4.java
+
+Key Agreement Step:
+// Line 132 in ECIESHandshaker.java
+final Bytes32 staticSharedSecret = nodeKey.calculateECDHKeyAgreement(partyPubKey);
+// Then signature is created:
+// S(ephemeral-privk, static-shared-secret ^ nonce)
+
+Responder Auth-Ack Message:
+
+Location: ResponderHandshakeMessageV1 and ResponderHandshakeMessageV4
+
+The responder constructs simpler message:
+
+1. V1 Format (97 bytes):
+  - Ephemeral public key (64 bytes)
+  - Nonce (32 bytes)
+  - Token flag (1 byte)
+2. V4 Format (RLP-encoded):
+  - Ephemeral public key (64 bytes)
+  - Nonce (32 bytes)
+  - Version (1 byte)
+
+Location: ./ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/ResponderHandshakeMessageV4.java
+
+---
+3. Message Encryption/Decryption
+
+Location: ./ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/EncryptedMessage.java
+
+Encryption Process:
+- Uses ECIES (Integrated Encryption Scheme)
+- Generates random ephemeral key pair for encryption
+- Generates random IV (16 bytes)
+- Format: ephemeral-pubkey (65 bytes, uncompressed with 0x04 prefix) || IV (16 bytes) || encrypted-payload || MAC
+- V4 adds size prefix (2 bytes) and RLP padding
+
+Decryption Process:
+- Extracts ephemeral public key from message
+- Uses receiver's private key to perform ECDH with ephemeral pubkey
+- Derives decryption keys from the agreed secret
+- Verifies MAC before returning plaintext
+
+---
+4. ECDH Key Agreement
+
+Location: ECIESEncryptionEngine, ECIESHandshaker, and InitiatorHandshakeMessageV4
+
+Two levels of ECDH operations:
+
+1. Static Key Agreement (during handshake init):
+// Line 132 in ECIESHandshaker.java
+staticSharedSecret = nodeKey.calculateECDHKeyAgreement(partyPubKey)
+// Used to create signature: S(ephemeral-privk, static-shared-secret ^ nonce)
+2. Ephemeral Key Agreement (for message encryption):
+// Line 362 in ECIESHandshaker.java
+agreedSecret = signatureAlgorithm.calculateECDHKeyAgreement(
+    ephKeyPair.getPrivateKey(),
+    partyEphPubKey
+)
+3. For Encryption/Decryption in EncryptedMessage:
+// Line 102 in ECIESEncryptionEngine.java
+Bytes agreedSecret = nodeKey.calculateECDHKeyAgreement(ephPubKey)
+
+---
+5. Shared Secrets Derivation
+
+Location: ./ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/ECIESHandshaker.java (lines 360-387)
+
+Handshake Secret Computation (computeSecrets() method):
+
+// Agreed secret from ephemeral ECDH
+agreedSecret = ECDH(ephPrivKey, partyEphPubKey)
+
+// Shared secret combines both nonces
+sharedSecret = keccak256(
+    agreedSecret
+    || keccak256(responderNonce || initiatorNonce)
+)
+
+// Derive three secrets via Keccak256 hashing
+aesSecret = keccak256(agreedSecret || sharedSecret)
+macSecret = keccak256(agreedSecret || aesSecret)
+token = keccak256(sharedSecret)
+
+// Initialize MACs with the secrets
+initiatorMac = macSecret XOR responderNonce || initiatorMsgEnc
+responderMac = macSecret XOR initiatorNonce || responderMsgEnc
+
+Result: HandshakeSecrets object containing:
+- aesSecret (32 bytes): Used for AES-256-SIC (AES in streaming mode) encryption
+- macSecret (32 bytes): Used for HMAC-SHA256 authentication
+- token (32 bytes): Session identifier (currently unused)
+- egressMac (Keccak256): Continuously updated with outgoing bytes
+- ingressMac (Keccak256): Continuously updated with incoming bytes
+
+---
+6. Frame Encryption Setup (Post-Handshake)
+
+Location: ./ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/framing/Framer.java (lines 100-114)
+
+Once handshake succeeds, secrets are passed to Framer:
+
+public Framer(final HandshakeSecrets secrets) {
+    this.secrets = secrets;
+
+    // Extract keys
+    final KeyParameter aesKey = new KeyParameter(secrets.getAesSecret());
+    final KeyParameter macKey = new KeyParameter(secrets.getMacSecret());
+
+    // Initialize encryption/decryption streams
+    encryptor = new SICBlockCipher(new AESEngine());
+    encryptor.init(true, new ParametersWithIV(aesKey, ZERO_IV));
+
+    decryptor = new SICBlockCipher(new AESEngine());
+    decryptor.init(false, new ParametersWithIV(aesKey, ZERO_IV));
+
+    // Initialize MAC encryptor
+    macEncryptor = new AESEngine();
+    macEncryptor.init(true, macKey);
+}
+
+Frame Structure:
+- 16-byte header (encrypted): message length + payload type
+- 16-byte header MAC
+- Variable-length payload (encrypted)
+- Padding to 16-byte boundary
+- 16-byte payload MAC
+
+---
+7. RLP Encoding/Decoding of Handshake Messages
+
+V4 Messages (RLP-encoded):
+
+InitiatorHandshakeMessageV4 (lines 93-102):
+public Bytes encode() {
+    BytesValueRLPOutput temp = new BytesValueRLPOutput();
+    temp.startList();
+    temp.writeBytes(signature.encodedBytes());     // 65 bytes
+    temp.writeBytes(pubKey.getEncodedBytes());    // 64 bytes
+    temp.writeBytes(nonce);                        // 32 bytes
+    temp.writeIntScalar(VERSION);                  // 1 byte
+    temp.endList();
+    return temp.encoded();
+}
+
+ResponderHandshakeMessageV4 (lines 61-69):
+public Bytes encode() {
+    BytesValueRLPOutput temp = new BytesValueRLPOutput();
+    temp.startList();
+    temp.writeBytes(ephPublicKey.getEncodedBytes());  // 64 bytes
+    temp.writeBytes(nonce);                           // 32 bytes
+    temp.writeIntScalar(InitiatorHandshakeMessageV4.VERSION); // 1 byte
+    temp.endList();
+    return temp.encoded();
+}
+
+V1 Messages (Fixed binary format):
+- No RLP encoding, strict fixed byte positions
+- Used for backward compatibility with older nodes
+
+---
+8. Complete Handshake Flow
+
+Initiator Side:
+1. prepareInitiator(nodeKey, peerPublicKey) - Generates ephemeral key pair, creates nonce
+2. firstMessage() - Creates auth message, performs ECDH with peer's static key, signs with ephemeral key, encrypts with peer's public key
+3. Receives responder's auth-ack message
+4. handleMessage(authAck) - Decrypts, extracts responder's ephemeral pubkey and nonce
+5. computeSecrets() - Performs ECDH with responder's ephemeral pubkey, derives shared secrets
+
+Responder Side:
+1. prepareResponder(nodeKey) - Generates ephemeral key pair, creates nonce
+2. Receives initiator's auth message
+3. handleMessage(auth) - Decrypts, extracts initiator's data, verifies ephemeral pubkey hash, creates auth-ack message
+4. Sends auth-ack response
+5. computeSecrets() - Performs ECDH with initiator's ephemeral pubkey, derives shared secrets
+
+Post-Handshake:
+1. Both sides have identical HandshakeSecrets
+2. Framer is instantiated with secrets
+3. Wire protocol (HELLO message) is exchanged using framed encryption
+4. MACs are continuously updated for each frame
+
+---
+9. Integration Points
+
+Handshaker to Framer Connection:
+
+Location: ./ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/netty/AbstractHandshakeHandler.java (lines 102-145)
+
+// Once handshake succeeds (line 117)
+final Framer framer = this.framerProvider.buildFramer(handshaker.secrets());
+
+// Pipeline is replaced with DeFramer for message processing
+ctx.channel().pipeline().replace(this, "DeFramer", deFramer)
+    .addBefore("DeFramer", "validate", new ValidateFirstOutboundMessage(framer));
+
+---
+10. Testing Infrastructure
+
+Test Files:
+- ./ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/ECIESHandshakeTest.java - Full handshake test vectors
+from PyEVM
+- ./ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/InitiatorHandshakeMessageV4Test.java - V4 message
+encoding/decoding tests
+
+---
+## Summary of Key Files
+
+| Component | File Path |
+|-----------|-----------|
+| Handshaker Interface | Handshaker.java |
+| ECIES Implementation | ECIESHandshaker.java |
+| Secrets Container | HandshakeSecrets.java |
+| Auth Message V1 | InitiatorHandshakeMessageV1.java |
+| Auth Message V4 | InitiatorHandshakeMessageV4.java |
+| Auth-Ack Message V1 | ResponderHandshakeMessageV1.java |
+| Auth-Ack Message V4 | ResponderHandshakeMessageV4.java |
+| Encryption/Decryption | EncryptedMessage.java |
+| ECIES Crypto Engine | ECIESEncryptionEngine.java |
+| Frame Encryption | Framer.java |
+| Netty Integration | AbstractHandshakeHandler.java |
+This implementation follows the Ethereum RLPx specification and supports both legacy (V1) and modern (V4/EIP-8) handshake formats for backward compatibility.


### PR DESCRIPTION
Add comprehensive documentation for:
- RLPx handshake implementation and message flow
- Netty pipeline setup for RLPx connections
- Peer connection limits and enforcement

## Context

While trying out a POC for https://github.com/hyperledger/besu/issues/8957 Claude Code generated some nice documentation along the way.

If these kind of docs are desirable, I would suggest we either do this piecemeal as we work in certain complex/less well known areas of the codebase;
Or we could document specific areas of the codebase upfront using AI (which could be discovered by agents the next time we work in that area).

Open question: is it better to have everything under docs/ as per status quo, or have inline md files inside the relevant packages? Or potentially both (one points to the other)?
Humans and agents may have different preferences for this :)
