### PR TITLE
Cleanup leftovers after the removal of eth/66

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/EthProtocol.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/EthProtocol.java
@@ -29,7 +29,6 @@ import java.util.Set;
 public class EthProtocol implements SubProtocol {
   public static final String NAME = "eth";
   private static final EthProtocol INSTANCE = new EthProtocol();
-  public static final Capability ETH66 = Capability.create(NAME, EthProtocolVersion.V66);
   public static final Capability ETH68 = Capability.create(NAME, EthProtocolVersion.V68);
   public static final Capability ETH69 = Capability.create(NAME, EthProtocolVersion.V69);
   public static final BitSet REQUEST_ID_MESSAGES;
@@ -49,7 +48,7 @@ public class EthProtocol implements SubProtocol {
             EthProtocolMessages.RECEIPTS);
     REQUEST_ID_MESSAGES =
         new BitSet(requestIdMessages.stream().mapToInt(i -> i).max().getAsInt() + 1);
-    requestIdMessages.forEach(requestIdMessage -> REQUEST_ID_MESSAGES.set(requestIdMessage));
+    requestIdMessages.forEach(REQUEST_ID_MESSAGES::set);
   }
 
   // Latest version of the Eth protocol
@@ -67,7 +66,7 @@ public class EthProtocol implements SubProtocol {
   @Override
   public int messageSpace(final int protocolVersion) {
     return switch (protocolVersion) {
-      case EthProtocolVersion.V66, EthProtocolVersion.V68 -> 17;
+      case EthProtocolVersion.V68 -> 17;
       case EthProtocolVersion.V69 -> 18;
       default -> 0;
     };
@@ -80,40 +79,24 @@ public class EthProtocol implements SubProtocol {
 
   @Override
   public String messageName(final int protocolVersion, final int code) {
-    switch (code) {
-      case EthProtocolMessages.STATUS:
-        return "Status";
-      case EthProtocolMessages.NEW_BLOCK_HASHES:
-        return "NewBlockHashes";
-      case EthProtocolMessages.TRANSACTIONS:
-        return "Transactions";
-      case EthProtocolMessages.GET_BLOCK_HEADERS:
-        return "GetBlockHeaders";
-      case EthProtocolMessages.BLOCK_HEADERS:
-        return "BlockHeaders";
-      case EthProtocolMessages.GET_BLOCK_BODIES:
-        return "GetBlockBodies";
-      case EthProtocolMessages.BLOCK_BODIES:
-        return "BlockBodies";
-      case EthProtocolMessages.NEW_BLOCK:
-        return "NewBlock";
-      case EthProtocolMessages.NEW_POOLED_TRANSACTION_HASHES:
-        return "NewPooledTransactionHashes";
-      case EthProtocolMessages.GET_POOLED_TRANSACTIONS:
-        return "GetPooledTransactions";
-      case EthProtocolMessages.POOLED_TRANSACTIONS:
-        return "PooledTransactions";
-      case EthProtocolMessages.GET_NODE_DATA:
-        return "GetNodeData";
-      case EthProtocolMessages.NODE_DATA:
-        return "NodeData";
-      case EthProtocolMessages.GET_RECEIPTS:
-        return "GetReceipts";
-      case EthProtocolMessages.RECEIPTS:
-        return "Receipts";
-      default:
-        return INVALID_MESSAGE_NAME;
-    }
+    return switch (code) {
+      case EthProtocolMessages.STATUS -> "Status";
+      case EthProtocolMessages.NEW_BLOCK_HASHES -> "NewBlockHashes";
+      case EthProtocolMessages.TRANSACTIONS -> "Transactions";
+      case EthProtocolMessages.GET_BLOCK_HEADERS -> "GetBlockHeaders";
+      case EthProtocolMessages.BLOCK_HEADERS -> "BlockHeaders";
+      case EthProtocolMessages.GET_BLOCK_BODIES -> "GetBlockBodies";
+      case EthProtocolMessages.BLOCK_BODIES -> "BlockBodies";
+      case EthProtocolMessages.NEW_BLOCK -> "NewBlock";
+      case EthProtocolMessages.NEW_POOLED_TRANSACTION_HASHES -> "NewPooledTransactionHashes";
+      case EthProtocolMessages.GET_POOLED_TRANSACTIONS -> "GetPooledTransactions";
+      case EthProtocolMessages.POOLED_TRANSACTIONS -> "PooledTransactions";
+      case EthProtocolMessages.GET_NODE_DATA -> "GetNodeData";
+      case EthProtocolMessages.NODE_DATA -> "NodeData";
+      case EthProtocolMessages.GET_RECEIPTS -> "GetReceipts";
+      case EthProtocolMessages.RECEIPTS -> "Receipts";
+      default -> INVALID_MESSAGE_NAME;
+    };
   }
 
   public static EthProtocol get() {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/EthProtocolVersion.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/EthProtocolVersion.java
@@ -25,28 +25,8 @@ import java.util.List;
  * (ETH)</a>}
  */
 public class EthProtocolVersion {
-  public static final int V66 = 66;
   public static final int V68 = 68;
   public static final int V69 = 69;
-
-  /** eth/66 */
-  private static final List<Integer> eth66Messages =
-      List.of(
-          EthProtocolMessages.STATUS,
-          EthProtocolMessages.NEW_BLOCK_HASHES,
-          EthProtocolMessages.TRANSACTIONS,
-          EthProtocolMessages.GET_BLOCK_HEADERS,
-          EthProtocolMessages.BLOCK_HEADERS,
-          EthProtocolMessages.GET_BLOCK_BODIES,
-          EthProtocolMessages.BLOCK_BODIES,
-          EthProtocolMessages.NEW_BLOCK,
-          EthProtocolMessages.GET_NODE_DATA,
-          EthProtocolMessages.NODE_DATA,
-          EthProtocolMessages.GET_RECEIPTS,
-          EthProtocolMessages.RECEIPTS,
-          EthProtocolMessages.NEW_POOLED_TRANSACTION_HASHES,
-          EthProtocolMessages.GET_POOLED_TRANSACTIONS,
-          EthProtocolMessages.POOLED_TRANSACTIONS);
 
   /** eth/68 */
   private static final List<Integer> eth68Messages =
@@ -94,15 +74,10 @@ public class EthProtocolVersion {
    * @return a list containing the codes of supported messages
    */
   public static List<Integer> getSupportedMessages(final int protocolVersion) {
-    switch (protocolVersion) {
-      case EthProtocolVersion.V66:
-        return eth66Messages;
-      case EthProtocolVersion.V68:
-        return eth68Messages;
-      case EthProtocolVersion.V69:
-        return eth69Messages;
-      default:
-        return Collections.emptyList();
-    }
+    return switch (protocolVersion) {
+      case EthProtocolVersion.V68 -> eth68Messages;
+      case EthProtocolVersion.V69 -> eth69Messages;
+      default -> Collections.emptyList();
+    };
   }
 }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/encoding/TransactionAnnouncementEncoder.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/encoding/TransactionAnnouncementEncoder.java
@@ -14,12 +14,9 @@
  */
 package org.hyperledger.besu.ethereum.eth.encoding;
 
-import static org.hyperledger.besu.ethereum.core.Transaction.toHashList;
-
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.TransactionType;
 import org.hyperledger.besu.ethereum.core.Transaction;
-import org.hyperledger.besu.ethereum.eth.EthProtocolVersion;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Capability;
 import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
 
@@ -45,25 +42,7 @@ public class TransactionAnnouncementEncoder {
    * @return the correct encoder
    */
   public static Encoder getEncoder(final Capability capability) {
-    if (capability.getVersion() >= EthProtocolVersion.V68) {
-      return TransactionAnnouncementEncoder::encodeForEth68;
-    } else {
-      return TransactionAnnouncementEncoder::encodeForEth66;
-    }
-  }
-
-  /**
-   * Encode a list of hashes for the NewPooledTransactionHashesMessage using the Eth/66
-   *
-   * <p>format: [hash_0: B_32, hash_1: B_32, ...]
-   *
-   * @param transactions the list to encode
-   * @return the encoded value. The message data will contain only the transaction hashes
-   */
-  private static Bytes encodeForEth66(final List<Transaction> transactions) {
-    final BytesValueRLPOutput out = new BytesValueRLPOutput();
-    out.writeList(toHashList(transactions), (h, w) -> w.writeBytes(h.getBytes()));
-    return out.encoded();
+    return TransactionAnnouncementEncoder::encodeForEth68;
   }
 
   /**

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/messages/NewPooledTransactionHashesMessageTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/messages/NewPooledTransactionHashesMessageTest.java
@@ -35,7 +35,7 @@ public class NewPooledTransactionHashesMessageTest {
   public void roundTripNewPooledTransactionHashesMessage() {
     final List<Transaction> transactions = List.of(new BlockDataGenerator().transaction());
     final NewPooledTransactionHashesMessage msg =
-        NewPooledTransactionHashesMessage.create(transactions, EthProtocol.ETH66);
+        NewPooledTransactionHashesMessage.create(transactions, EthProtocol.LATEST);
     assertThat(msg.getCode()).isEqualTo(EthProtocolMessages.NEW_POOLED_TRANSACTION_HASHES);
     final List<Hash> pendingHashes = msg.pendingTransactionHashes();
     assertThat(pendingHashes).isEqualTo(toHashList(transactions));
@@ -46,6 +46,6 @@ public class NewPooledTransactionHashesMessageTest {
     final RawMessage rawMsg = new RawMessage(EthProtocolMessages.BLOCK_HEADERS, Bytes.of(0));
 
     assertThatExceptionOfType(IllegalArgumentException.class)
-        .isThrownBy(() -> NewPooledTransactionHashesMessage.readFrom(rawMsg, EthProtocol.ETH66));
+        .isThrownBy(() -> NewPooledTransactionHashesMessage.readFrom(rawMsg, EthProtocol.LATEST));
   }
 }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/NewPooledTransactionHashesMessageSenderTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/NewPooledTransactionHashesMessageSenderTest.java
@@ -143,7 +143,7 @@ public class NewPooledTransactionHashesMessageSenderTest {
 
   private Set<Hash> getTransactionsFromMessage(final MessageData message) {
     final NewPooledTransactionHashesMessage transactionsMessage =
-        NewPooledTransactionHashesMessage.readFrom(message, EthProtocol.ETH66);
+        NewPooledTransactionHashesMessage.readFrom(message, EthProtocol.LATEST);
     return newHashSet(transactionsMessage.pendingTransactionHashes());
   }
 }


### PR DESCRIPTION
## PR description

Follow up to https://github.com/hyperledger/besu/pull/9814, `eth/66` is no more announced and so it is possible to remove so more dead code related to it

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


