### PR TITLE
Implemented TODO to add clioptions interface

### DIFF
--- a/app/src/main/java/org/hyperledger/besu/cli/options/ApiConfigurationOptions.java
+++ b/app/src/main/java/org/hyperledger/besu/cli/options/ApiConfigurationOptions.java
@@ -21,6 +21,8 @@ import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.api.ApiConfiguration;
 import org.hyperledger.besu.ethereum.api.ImmutableApiConfiguration;
 
+import java.util.List;
+
 import org.slf4j.Logger;
 import picocli.CommandLine;
 
@@ -28,8 +30,7 @@ import picocli.CommandLine;
  * Handles configuration options for the API in Besu, including gas price settings, RPC log range,
  * and trace filter range.
  */
-// TODO: implement CLIOption<ApiConfiguration>
-public class ApiConfigurationOptions {
+public class ApiConfigurationOptions implements CLIOptions<ApiConfiguration> {
   /** Default constructor. */
   public ApiConfigurationOptions() {}
 
@@ -120,6 +121,16 @@ public class ApiConfigurationOptions {
         asList(
             "--api-gas-and-priority-fee-upper-bound-coefficient",
             "--api-gas-and-priority-fee-lower-bound-coefficient"));
+  }
+
+  @Override
+  public ApiConfiguration toDomainObject() {
+    return apiConfiguration();
+  }
+
+  @Override
+  public List<String> getCLIOptions() {
+    return CommandLineUtils.getCLIOptions(this, new ApiConfigurationOptions());
   }
 
   /**

--- a/app/src/main/java/org/hyperledger/besu/cli/options/GraphQlOptions.java
+++ b/app/src/main/java/org/hyperledger/besu/cli/options/GraphQlOptions.java
@@ -29,8 +29,7 @@ import org.slf4j.Logger;
 import picocli.CommandLine;
 
 /** Handles configuration options for the GraphQL HTTP service in Besu. */
-// TODO: implement CLIOptions<GraphQLConfiguration>
-public class GraphQlOptions {
+public class GraphQlOptions implements CLIOptions<GraphQLConfiguration> {
   @CommandLine.Option(
       names = {"--graphql-http-enabled"},
       description = "Set to start the GraphQL HTTP service (default: ${DEFAULT-VALUE})")
@@ -124,6 +123,29 @@ public class GraphQlOptions {
         asList("--graphql-tls-truststore-file", "--graphql-tls-truststore-password-file"));
   }
 
+  @Override
+  public GraphQLConfiguration toDomainObject() {
+    final GraphQLConfiguration graphQLConfiguration = GraphQLConfiguration.createDefault();
+    graphQLConfiguration.setEnabled(isGraphQLHttpEnabled);
+    if (!Strings.isNullOrEmpty(graphQLHttpHost)) {
+      graphQLConfiguration.setHost(graphQLHttpHost);
+    }
+    graphQLConfiguration.setPort(graphQLHttpPort);
+    graphQLConfiguration.setCorsAllowedDomains(graphQLHttpCorsAllowedOrigins);
+    graphQLConfiguration.setTlsEnabled(graphqlTlsEnabled);
+    graphQLConfiguration.setTlsKeyStorePath(graphqlTlsKeystoreFile);
+    graphQLConfiguration.setTlsKeyStorePasswordFile(graphqlTlsKeystorePasswordFile);
+    graphQLConfiguration.setMtlsEnabled(graphqlMtlsEnabled);
+    graphQLConfiguration.setTlsTrustStorePath(graphqlTlsTruststoreFile);
+    graphQLConfiguration.setTlsTrustStorePasswordFile(graphqlTlsTruststorePasswordFile);
+    return graphQLConfiguration;
+  }
+
+  @Override
+  public List<String> getCLIOptions() {
+    return CommandLineUtils.getCLIOptions(this, new GraphQlOptions());
+  }
+
   /**
    * Creates a GraphQLConfiguration based on the provided options.
    *
@@ -134,22 +156,11 @@ public class GraphQlOptions {
    */
   public GraphQLConfiguration graphQLConfiguration(
       final List<String> hostsAllowlist, final String defaultHostAddress, final Long timeoutSec) {
-    final GraphQLConfiguration graphQLConfiguration = GraphQLConfiguration.createDefault();
-    graphQLConfiguration.setEnabled(isGraphQLHttpEnabled);
-    graphQLConfiguration.setHost(
-        Strings.isNullOrEmpty(graphQLHttpHost) ? defaultHostAddress : graphQLHttpHost);
-    graphQLConfiguration.setPort(graphQLHttpPort);
-    graphQLConfiguration.setHostsAllowlist(hostsAllowlist);
-    graphQLConfiguration.setCorsAllowedDomains(graphQLHttpCorsAllowedOrigins);
-    graphQLConfiguration.setHttpTimeoutSec(timeoutSec);
-    graphQLConfiguration.setTlsEnabled(graphqlTlsEnabled);
-    graphQLConfiguration.setTlsKeyStorePath(graphqlTlsKeystoreFile);
-    graphQLConfiguration.setTlsKeyStorePasswordFile(graphqlTlsKeystorePasswordFile);
-    graphQLConfiguration.setMtlsEnabled(graphqlMtlsEnabled);
-    graphQLConfiguration.setTlsTrustStorePath(graphqlTlsTruststoreFile);
-    graphQLConfiguration.setTlsTrustStorePasswordFile(graphqlTlsTruststorePasswordFile);
-
-    return graphQLConfiguration;
+    final GraphQLConfiguration config = toDomainObject();
+    config.setHost(Strings.isNullOrEmpty(graphQLHttpHost) ? defaultHostAddress : graphQLHttpHost);
+    config.setHostsAllowlist(hostsAllowlist);
+    config.setHttpTimeoutSec(timeoutSec);
+    return config;
   }
 
   /**

--- a/app/src/main/java/org/hyperledger/besu/cli/options/JsonRpcHttpOptions.java
+++ b/app/src/main/java/org/hyperledger/besu/cli/options/JsonRpcHttpOptions.java
@@ -53,8 +53,7 @@ import picocli.CommandLine;
  * Handles configuration options for the JSON-RPC HTTP service, including validation and creation of
  * a JSON-RPC configuration.
  */
-// TODO: implement CLIOption<JsonRpcConfiguration>
-public class JsonRpcHttpOptions {
+public class JsonRpcHttpOptions implements CLIOptions<JsonRpcConfiguration> {
   @CommandLine.Option(
       names = {"--rpc-http-enabled"},
       description = "Set to start the JSON-RPC HTTP service (default: ${DEFAULT-VALUE})")
@@ -268,6 +267,16 @@ public class JsonRpcHttpOptions {
     if (isRpcTlsConfigurationRequired()) {
       validateTls(commandLine);
     }
+  }
+
+  @Override
+  public JsonRpcConfiguration toDomainObject() {
+    return jsonRpcConfiguration();
+  }
+
+  @Override
+  public List<String> getCLIOptions() {
+    return CommandLineUtils.getCLIOptions(this, new JsonRpcHttpOptions());
   }
 
   /**

--- a/app/src/main/java/org/hyperledger/besu/cli/options/PermissionsOptions.java
+++ b/app/src/main/java/org/hyperledger/besu/cli/options/PermissionsOptions.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.cli.options;
 
 import org.hyperledger.besu.cli.DefaultCommandValues;
+import org.hyperledger.besu.cli.util.CommandLineUtils;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcApis;
 import org.hyperledger.besu.ethereum.p2p.peers.EnodeDnsConfiguration;
 import org.hyperledger.besu.ethereum.permissioning.LocalPermissioningConfiguration;
@@ -22,14 +23,14 @@ import org.hyperledger.besu.ethereum.permissioning.PermissioningConfiguration;
 import org.hyperledger.besu.ethereum.permissioning.PermissioningConfigurationBuilder;
 
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Optional;
 
 import org.slf4j.Logger;
 import picocli.CommandLine;
 
 /** Handles configuration options for permissions in Besu. */
-// TODO: implement CLIOption<PermissioningConfiguration>
-public class PermissionsOptions {
+public class PermissionsOptions implements CLIOptions<PermissioningConfiguration> {
   @CommandLine.Option(
       names = {"--permissions-nodes-config-file-enabled"},
       description = "Enable node level permissions (default: ${DEFAULT-VALUE})")
@@ -56,6 +57,23 @@ public class PermissionsOptions {
 
   /** Default constructor. */
   public PermissionsOptions() {}
+
+  @Override
+  public PermissioningConfiguration toDomainObject() {
+    if (!localPermissionsEnabled()) {
+      return PermissioningConfiguration.createDefault();
+    }
+    final LocalPermissioningConfiguration localConfig =
+        LocalPermissioningConfiguration.createDefault();
+    localConfig.setNodePermissioningConfigFilePath(nodePermissionsConfigFile);
+    localConfig.setAccountPermissioningConfigFilePath(accountPermissionsConfigFile);
+    return new PermissioningConfiguration(Optional.of(localConfig));
+  }
+
+  @Override
+  public List<String> getCLIOptions() {
+    return CommandLineUtils.getCLIOptions(this, new PermissionsOptions());
+  }
 
   /**
    * Creates a PermissioningConfiguration based on the provided options.


### PR DESCRIPTION
## PR description
  Implements the CLIOptions<T> interface on four CLI options classes that had outstanding TODOs, bringing them in line with the existing pattern established by EngineRPCOptions, MiningOptions, DnsOptions, and
  others. No changes to BesuCommand — all existing call sites remain valid.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


