### PR TITLE
fix: register AbstractPeerRequestTask timeout immediately to prevent BWS hang

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractPeerRequestTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractPeerRequestTask.java
@@ -61,16 +61,16 @@ public abstract class AbstractPeerRequestTask<R> extends AbstractPeerTask<R> {
   @Override
   protected final void executeTask() {
     final CompletableFuture<R> promise = new CompletableFuture<>();
+    // Register timeout immediately so it fires even if the request is queued in
+    // pendingRequests and never dispatched to a peer.
+    ethContext.getScheduler().failAfterTimeout(promise, timeout);
+
     responseStream = sendRequest();
     responseStream.then(
-        stream -> {
-          // Start the timeout now that the request has actually been sent
-          ethContext.getScheduler().failAfterTimeout(promise, timeout);
-
-          stream.then(
-              (streamClosed, message, peer1) ->
-                  handleMessage(promise, streamClosed, message, peer1));
-        },
+        stream ->
+            stream.then(
+                (streamClosed, message, peer1) ->
+                    handleMessage(promise, streamClosed, message, peer1)),
         promise::completeExceptionally);
 
     promise.whenComplete(

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardSyncAlgorithm.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardSyncAlgorithm.java
@@ -103,15 +103,21 @@ public class BackwardSyncAlgorithm implements BesuEvents.InitialSyncCompletionLi
 
   private CompletableFuture<Void> handleSyncStep(final Hash firstHash) {
     final CompletableFuture<Void> syncStep = new CompletableFuture<>();
-    executeSyncStep(firstHash)
-        .whenComplete(
-            (result, error) -> {
-              if (error != null) {
-                handleSyncStepError(error, firstHash, syncStep);
-              } else {
-                handleSyncStepSuccess(result, firstHash, syncStep);
-              }
-            });
+    try {
+      executeSyncStep(firstHash)
+          .whenComplete(
+              (result, error) -> {
+                if (error != null) {
+                  handleSyncStepError(error, firstHash, syncStep);
+                } else {
+                  handleSyncStepSuccess(result, firstHash, syncStep);
+                }
+              });
+      // Catch Throwable (not just Exception) so that even programming errors complete
+      // syncStep rather than leaving it permanently pending and stalling the sync loop.
+    } catch (final Throwable t) {
+      syncStep.completeExceptionally(t);
+    }
     return syncStep;
   }
 

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractPeerRequestTaskTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractPeerRequestTaskTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.eth.manager.task;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.eth.EthProtocol;
+import org.hyperledger.besu.ethereum.eth.manager.EthContext;
+import org.hyperledger.besu.ethereum.eth.manager.EthPeer;
+import org.hyperledger.besu.ethereum.eth.manager.EthProtocolManager;
+import org.hyperledger.besu.ethereum.eth.manager.EthProtocolManagerTestBuilder;
+import org.hyperledger.besu.ethereum.eth.manager.EthProtocolManagerTestUtil;
+import org.hyperledger.besu.ethereum.eth.manager.PendingPeerRequest;
+import org.hyperledger.besu.ethereum.eth.manager.RespondingEthPeer;
+import org.hyperledger.besu.ethereum.eth.messages.EthProtocolMessages;
+import org.hyperledger.besu.ethereum.eth.sync.ChainHeadTracker;
+import org.hyperledger.besu.ethereum.p2p.rlpx.wire.MessageData;
+import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class AbstractPeerRequestTaskTest {
+
+  private EthProtocolManager ethProtocolManager;
+  private EthContext ethContext;
+  private final MetricsSystem metricsSystem = new NoOpMetricsSystem();
+
+  @BeforeEach
+  public void setup() throws Exception {
+    ethProtocolManager = EthProtocolManagerTestBuilder.builder().build();
+    ethContext = ethProtocolManager.ethContext();
+    final ChainHeadTracker chainHeadTracker = mock(ChainHeadTracker.class);
+    final BlockHeader blockHeader = mock(BlockHeader.class);
+    when(chainHeadTracker.getBestHeaderFromPeer(any()))
+        .thenReturn(CompletableFuture.completedFuture(blockHeader));
+    ethContext.getEthPeers().setChainHeadTracker(chainHeadTracker);
+  }
+
+  @Test
+  public void taskShouldTimeoutWhenRequestStuckInPendingQueue() throws Exception {
+    final RespondingEthPeer peer = EthProtocolManagerTestUtil.createPeer(ethProtocolManager, 1000);
+    final EthPeer ethPeer = peer.getEthPeer();
+
+    // Consume all peer capacity so the request will be queued in pendingRequests
+    while (ethPeer.hasAvailableRequestCapacity()) {
+      ethPeer.getNodeData(singletonList(Hash.ZERO));
+    }
+    assertThat(ethPeer.hasAvailableRequestCapacity()).isFalse();
+
+    // Create a task with the busy peer assigned and a short timeout
+    final TestPeerRequestTask task = new TestPeerRequestTask(ethContext, metricsSystem);
+    task.setTimeout(Duration.ofMillis(100));
+    task.assignPeer(ethPeer);
+
+    // Run the task - request will be stuck in pendingRequests since peer is busy
+    final CompletableFuture<AbstractPeerTask.PeerTaskResult<String>> result = task.run();
+
+    // The timeout should fire and complete the task exceptionally, even though the request
+    // was never actually sent to the peer. Expire any pending timeouts tracked by the
+    // deterministic scheduler.
+    EthProtocolManagerTestUtil.expirePendingTimeouts(ethProtocolManager);
+
+    // The timeout is registered immediately in executeTask(), so it fires even though
+    // the request was never dispatched. The task completes exceptionally with TimeoutException.
+    assertThat(result.isDone()).isTrue();
+    assertThat(result.isCompletedExceptionally()).isTrue();
+  }
+
+  @Test
+  public void taskShouldTimeoutWhenRequestSentButNoPeerResponse() throws Exception {
+    final RespondingEthPeer peer = EthProtocolManagerTestUtil.createPeer(ethProtocolManager, 1000);
+    final EthPeer ethPeer = peer.getEthPeer();
+
+    // Peer has capacity - request will be sent immediately
+    assertThat(ethPeer.hasAvailableRequestCapacity()).isTrue();
+
+    final TestPeerRequestTask task = new TestPeerRequestTask(ethContext, metricsSystem);
+    task.setTimeout(Duration.ofMillis(100));
+    task.assignPeer(ethPeer);
+
+    final CompletableFuture<AbstractPeerTask.PeerTaskResult<String>> result = task.run();
+
+    // Request was sent, so failAfterTimeout was called. Expire the timeout.
+    EthProtocolManagerTestUtil.expirePendingTimeouts(ethProtocolManager);
+
+    // This should pass even with the current code - timeout fires because the request was sent
+    assertThat(result.isDone()).isTrue();
+    assertThat(result.isCompletedExceptionally()).isTrue();
+  }
+
+  @Test
+  public void taskShouldTimeoutEvenAfterRunningPendingFuturesWhenPeerBusy() throws Exception {
+    final RespondingEthPeer peer = EthProtocolManagerTestUtil.createPeer(ethProtocolManager, 1000);
+    final EthPeer ethPeer = peer.getEthPeer();
+
+    // Consume all capacity
+    while (ethPeer.hasAvailableRequestCapacity()) {
+      ethPeer.getNodeData(singletonList(Hash.ZERO));
+    }
+
+    final TestPeerRequestTask task = new TestPeerRequestTask(ethContext, metricsSystem);
+    task.setTimeout(Duration.ofMillis(100));
+    task.assignPeer(ethPeer);
+
+    final CompletableFuture<AbstractPeerTask.PeerTaskResult<String>> result = task.run();
+
+    // Expire all registered timeouts
+    EthProtocolManagerTestUtil.expirePendingTimeouts(ethProtocolManager);
+
+    // Run any pending futures
+    EthProtocolManagerTestUtil.runPendingFutures(ethProtocolManager);
+
+    // The timeout fires even after running pending futures — the fix holds regardless
+    // of whether the futures executor is also drained.
+    assertThat(result.isDone()).isTrue();
+    assertThat(result.isCompletedExceptionally()).isTrue();
+  }
+
+  @Test
+  public void expiringTimeoutsCompletesTaskWhenRequestStuckInPendingQueue() throws Exception {
+    final RespondingEthPeer peer = EthProtocolManagerTestUtil.createPeer(ethProtocolManager, 1000);
+    final EthPeer ethPeer = peer.getEthPeer();
+
+    // Consume all capacity
+    while (ethPeer.hasAvailableRequestCapacity()) {
+      ethPeer.getNodeData(singletonList(Hash.ZERO));
+    }
+
+    final TestPeerRequestTask task = new TestPeerRequestTask(ethContext, metricsSystem);
+    task.setTimeout(Duration.ofMillis(100));
+    task.assignPeer(ethPeer);
+
+    final CompletableFuture<AbstractPeerTask.PeerTaskResult<String>> result = task.run();
+
+    // Expire all pending timeouts - timeout is registered immediately, so this completes the task
+    EthProtocolManagerTestUtil.expirePendingTimeouts(ethProtocolManager);
+
+    assertThat(result.isDone()).isTrue();
+    assertThat(result.isCompletedExceptionally()).isTrue();
+  }
+
+  /**
+   * Concrete test implementation of AbstractPeerRequestTask that sends a simple request. The
+   * response processing is irrelevant for these timeout tests - we're testing what happens when the
+   * request is never sent at all.
+   */
+  private static class TestPeerRequestTask extends AbstractPeerRequestTask<String> {
+
+    protected TestPeerRequestTask(final EthContext ethContext, final MetricsSystem metricsSystem) {
+      super(ethContext, EthProtocol.NAME, EthProtocolMessages.GET_BLOCK_BODIES, metricsSystem);
+    }
+
+    @Override
+    protected PendingPeerRequest sendRequest() {
+      // Use a real PendingPeerRequest through the standard path.
+      // This hits EthPeers.executePeerRequest which will queue the request
+      // in pendingRequests if the assigned peer has no capacity.
+      return sendRequestToPeer(peer -> peer.getNodeData(singletonList(Hash.ZERO)), 0);
+    }
+
+    @Override
+    protected Optional<String> processResponse(
+        final boolean streamClosed, final MessageData message, final EthPeer peer) {
+      if (streamClosed) {
+        return Optional.of("closed");
+      }
+      return Optional.empty();
+    }
+  }
+}

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardSyncAlgSpecTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardSyncAlgSpecTest.java
@@ -20,6 +20,7 @@ import static org.hyperledger.besu.ethereum.core.InMemoryKeyValueStorageProvider
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -34,6 +35,7 @@ import org.hyperledger.besu.plugin.services.BesuEvents;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import jakarta.validation.constraints.NotNull;
@@ -213,6 +215,28 @@ public class BackwardSyncAlgSpecTest {
     doReturn(true).when(context).isReady();
     algorithm.pickNextStep();
     verify(algorithm).executeSyncStep(hash);
+  }
+
+  @Test
+  public void shouldCompleteExceptionallyWhenExecuteSyncStepThrowsSynchronously() {
+    final BackwardChain backwardChain = createBackwardChain(LOCAL_HEIGHT, LOCAL_HEIGHT + 10);
+    doReturn(backwardChain).when(context).getBackwardChain();
+    doReturn(true).when(context).isReady();
+    backwardChain.addNewHash(hash);
+
+    // Simulate executeSyncStep throwing synchronously instead of returning a failed future.
+    // Without the try-catch fix, syncStep would leak as permanently PENDING.
+    doThrow(new RuntimeException("simulated sync executor failure"))
+        .when(algorithm)
+        .executeSyncStep(hash);
+
+    final CompletableFuture<Void> future = algorithm.pickNextStep();
+
+    // After the fix: future should be done (completed exceptionally), not stuck pending
+    assertThatThrownBy(() -> future.get())
+        .isInstanceOf(ExecutionException.class)
+        .hasCauseInstanceOf(RuntimeException.class)
+        .hasMessageContaining("simulated sync executor failure");
   }
 
   @Test


### PR DESCRIPTION
## Problem

BWS stalled silently for 7+ hours after snap sync + reorg. Heap dump showed all executor pools idle, `EthScheduler-Timer-0` with nothing queued, and a 14-deep `thenCompose` chain permanently pending.

The timeout in `AbstractPeerRequestTask.executeTask()` was registered *inside* the `responseStream.then()` callback — which only fires when the request is dispatched to a peer. When peers are at capacity the request queues in `EthPeers.pendingRequests`, the callback never fires, no timeout is registered, and the promise stays pending forever, freezing the entire BWS chain.

Secondary risk: `handleSyncStep()` creates a manual `CompletableFuture` that leaks permanently PENDING if `executeSyncStep()` throws synchronously.

## Fix

- **Primary:** Move `failAfterTimeout` before `sendRequest()` so the timeout always fires whether the request is queued or dispatched.
- **Defensive:** Wrap `handleSyncStep()` in try-catch so a synchronous exception from `executeSyncStep()` completes the CF exceptionally.


🤖 Generated with [Claude Code](https://claude.com/claude-code)