### PR TITLE
Allow the registration of multiple `PluginTransactionPoolValidatorFactory`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Add IPv6 dual-stack support for DiscV5 peer discovery (enabled via `--Xv5-discovery-enabled`): new `--p2p-host-ipv6`, `--p2p-interface-ipv6`, and `--p2p-port-ipv6` CLI options enable a second UDP discovery socket; `--p2p-ipv6-outbound-enabled` controls whether IPv6 is preferred for outbound connections when a peer advertises both address families [#9763](https://github.com/hyperledger/besu/pull/9763); RLPx now also binds a second TCP socket on the IPv6 interface so IPv6-only peers can establish connections [#9873](https://github.com/hyperledger/besu/pull/9873)
 - Stop EngineQosTimer as part of shutdown [#9903](https://github.com/hyperledger/besu/pull/9903)
 - Add blockTimestamp to transaction RPC results [#9887](https://github.com/hyperledger/besu/pull/9887)
+- Plugin API: Allow the registration of multiple PluginTransactionPoolValidatorFactory [#9964](https://github.com/hyperledger/besu/pull/9964)
 
 ## 26.2.0
 

--- a/acceptance-tests/detached-test-plugins/src/main/java/org/hyperledger/besu/tests/acceptance/plugins/TestTransactionPoolValidatorPlugin1.java
+++ b/acceptance-tests/detached-test-plugins/src/main/java/org/hyperledger/besu/tests/acceptance/plugins/TestTransactionPoolValidatorPlugin1.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.tests.acceptance.plugins;
+
+import org.hyperledger.besu.datatypes.TransactionType;
+import org.hyperledger.besu.plugin.BesuPlugin;
+import org.hyperledger.besu.plugin.ServiceManager;
+import org.hyperledger.besu.plugin.services.PicoCLIOptions;
+import org.hyperledger.besu.plugin.services.TransactionPoolValidatorService;
+
+import java.util.Optional;
+
+import com.google.auto.service.AutoService;
+import picocli.CommandLine.Option;
+
+@AutoService(BesuPlugin.class)
+public class TestTransactionPoolValidatorPlugin1 implements BesuPlugin {
+
+  @Option(names = "--plugin-txpool-validator1-test-enabled")
+  boolean enabled = false;
+
+  private ServiceManager serviceManager;
+
+  @Override
+  public void register(final ServiceManager serviceManager) {
+    this.serviceManager = serviceManager;
+    serviceManager
+        .getService(PicoCLIOptions.class)
+        .orElseThrow()
+        .addPicoCLIOptions("txpool-validator1", this);
+  }
+
+  @Override
+  public void beforeExternalServices() {
+    serviceManager
+        .getService(TransactionPoolValidatorService.class)
+        .orElseThrow()
+        .registerPluginTransactionValidatorFactory(
+            () ->
+                (tx, isLocal, hasPriority) ->
+                    enabled && !tx.getType().equals(TransactionType.FRONTIER)
+                        ? Optional.of("Only Frontier transactions are allowed here")
+                        : Optional.empty());
+  }
+
+  @Override
+  public void start() {}
+
+  @Override
+  public void stop() {}
+}

--- a/acceptance-tests/detached-test-plugins/src/main/java/org/hyperledger/besu/tests/acceptance/plugins/TestTransactionPoolValidatorPlugin2.java
+++ b/acceptance-tests/detached-test-plugins/src/main/java/org/hyperledger/besu/tests/acceptance/plugins/TestTransactionPoolValidatorPlugin2.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.tests.acceptance.plugins;
+
+import org.hyperledger.besu.plugin.BesuPlugin;
+import org.hyperledger.besu.plugin.ServiceManager;
+import org.hyperledger.besu.plugin.services.PicoCLIOptions;
+import org.hyperledger.besu.plugin.services.TransactionPoolValidatorService;
+
+import java.util.Optional;
+
+import com.google.auto.service.AutoService;
+import picocli.CommandLine.Option;
+
+@AutoService(BesuPlugin.class)
+public class TestTransactionPoolValidatorPlugin2 implements BesuPlugin {
+
+  @Option(names = "--plugin-txpool-validator2-test-enabled")
+  boolean enabled = false;
+
+  private ServiceManager serviceManager;
+
+  @Override
+  public void register(final ServiceManager serviceManager) {
+    this.serviceManager = serviceManager;
+    serviceManager
+        .getService(PicoCLIOptions.class)
+        .orElseThrow()
+        .addPicoCLIOptions("txpool-validator2", this);
+  }
+
+  @Override
+  public void beforeExternalServices() {
+    serviceManager
+        .getService(TransactionPoolValidatorService.class)
+        .orElseThrow()
+        .registerPluginTransactionValidatorFactory(
+            () ->
+                (tx, isLocal, hasPriority) ->
+                    enabled && tx.getData().map(bytes -> !bytes.isEmpty()).orElse(false)
+                        ? Optional.of("Transaction with payload not allowed here")
+                        : Optional.empty());
+  }
+
+  @Override
+  public void start() {}
+
+  @Override
+  public void stop() {}
+}

--- a/acceptance-tests/tests/src/acceptanceTest/java/org/hyperledger/besu/tests/acceptance/plugins/TransactionPoolValidatorPluginTest.java
+++ b/acceptance-tests/tests/src/acceptanceTest/java/org/hyperledger/besu/tests/acceptance/plugins/TransactionPoolValidatorPluginTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.tests.acceptance.plugins;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.hyperledger.besu.crypto.SECP256K1;
+import org.hyperledger.besu.ethereum.core.plugins.PluginConfiguration;
+import org.hyperledger.besu.tests.acceptance.dsl.AcceptanceTestBase;
+import org.hyperledger.besu.tests.acceptance.dsl.account.Account;
+import org.hyperledger.besu.tests.acceptance.dsl.blockchain.Amount;
+import org.hyperledger.besu.tests.acceptance.dsl.node.BesuNode;
+import org.hyperledger.besu.tests.acceptance.dsl.transaction.SignUtil;
+
+import java.math.BigInteger;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.web3j.crypto.RawTransaction;
+import org.web3j.tx.gas.DefaultGasProvider;
+import org.web3j.utils.Numeric;
+
+public class TransactionPoolValidatorPluginTest extends AcceptanceTestBase {
+  private BesuNode node;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    node =
+        besu.createQbftPluginsNode(
+            "node",
+            Collections.singletonList("testPlugins"),
+            PluginConfiguration.DEFAULT,
+            List.of(
+                "--plugin-txpool-validator1-test-enabled=true",
+                "--plugin-txpool-validator2-test-enabled=true"));
+    cluster.start(node);
+  }
+
+  @Test
+  public void transactionIsAccepted() {
+    final Account recipient = accounts.createAccount("recipient");
+
+    // txpool validator plugins accepts only Frontier txs without a payload
+    final var transferTx =
+        accountTransactions.createTransfer(recipient, Amount.wei(BigInteger.ONE));
+
+    final var txHash = node.execute(transferTx);
+
+    node.verify(eth.expectSuccessfulTransactionReceipt(txHash.getBytes().toHexString()));
+  }
+
+  @Test
+  public void transactionIsRejectedByPlugin1() {
+    // wait for London HF to activate
+    cluster.verify(blockchain.reachesHeight(node, 2));
+
+    final Account recipient = accounts.createAccount("recipient");
+
+    // txpool validator plugins accepts only Frontier txs without a payload
+    final var eip1559TransferTx =
+        accountTransactions.create1559Transfer(recipient, 1, 4, Amount.wei(BigInteger.TEN));
+
+    assertThatThrownBy(() -> node.execute(eip1559TransferTx))
+        .hasMessageContaining("Only Frontier transactions are allowed here");
+  }
+
+  @Test
+  public void transactionIsRejectedByPlugin2() {
+
+    final Account recipient = accounts.createAccount("recipient");
+
+    // txpool validator plugins accepts only Frontier txs without a payload
+    final RawTransaction txWithPayload =
+        RawTransaction.createTransaction(
+            BigInteger.ZERO,
+            DefaultGasProvider.GAS_PRICE,
+            DefaultGasProvider.GAS_LIMIT,
+            recipient.getAddress(),
+            BigInteger.ZERO,
+            "0x11");
+
+    final String rawSigned =
+        Numeric.toHexString(
+            SignUtil.signTransaction(
+                txWithPayload, accounts.getPrimaryBenefactor(), new SECP256K1(), Optional.empty()));
+
+    assertThatThrownBy(() -> node.execute(ethTransactions.sendRawTransaction(rawSigned)))
+        .hasMessageContaining("Transaction with payload not allowed here");
+  }
+
+  @Test
+  public void transactionIsRejectedByBothPlugins() {
+    // wait for London HF to activate
+    cluster.verify(blockchain.reachesHeight(node, 2));
+
+    final Account recipient = accounts.createAccount("recipient");
+
+    // txpool validator plugins accepts only Frontier txs without a payload
+    // order of validation is not fixed
+    final RawTransaction txWithPayload =
+        RawTransaction.createTransaction(
+            4,
+            BigInteger.ZERO,
+            DefaultGasProvider.GAS_LIMIT,
+            recipient.getAddress(),
+            BigInteger.ZERO,
+            "0x11",
+            DefaultGasProvider.GAS_PRICE,
+            DefaultGasProvider.GAS_PRICE);
+
+    final String rawSigned =
+        Numeric.toHexString(
+            SignUtil.signTransaction(
+                txWithPayload, accounts.getPrimaryBenefactor(), new SECP256K1(), Optional.empty()));
+
+    assertThatThrownBy(() -> node.execute(ethTransactions.sendRawTransaction(rawSigned)))
+        .extracting(Throwable::getMessage)
+        .matches(
+            msg ->
+                msg.contains("Transaction with payload not allowed here")
+                    || msg.contains("Only Frontier transactions are allowed here"));
+  }
+}

--- a/app/src/main/java/org/hyperledger/besu/services/TransactionPoolValidatorServiceImpl.java
+++ b/app/src/main/java/org/hyperledger/besu/services/TransactionPoolValidatorServiceImpl.java
@@ -18,26 +18,42 @@ import org.hyperledger.besu.plugin.services.TransactionPoolValidatorService;
 import org.hyperledger.besu.plugin.services.txvalidator.PluginTransactionPoolValidator;
 import org.hyperledger.besu.plugin.services.txvalidator.PluginTransactionPoolValidatorFactory;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import com.google.common.base.Preconditions;
 
 /** The Transaction pool validator service implementation. */
 public class TransactionPoolValidatorServiceImpl implements TransactionPoolValidatorService {
 
-  private Optional<PluginTransactionPoolValidatorFactory> factory = Optional.empty();
+  private final List<PluginTransactionPoolValidatorFactory> factories =
+      new CopyOnWriteArrayList<>();
 
   /** Default Constructor. */
   public TransactionPoolValidatorServiceImpl() {}
 
   @Override
   public PluginTransactionPoolValidator createTransactionValidator() {
-    return factory
-        .map(PluginTransactionPoolValidatorFactory::createTransactionValidator)
-        .orElse(PluginTransactionPoolValidator.VALIDATE_ALL);
+    if (factories.isEmpty()) {
+      return PluginTransactionPoolValidator.VALIDATE_ALL;
+    }
+
+    return (transaction, isLocal, hasPriority) ->
+        factories.stream()
+            .map(PluginTransactionPoolValidatorFactory::createTransactionValidator)
+            .map(validator -> validator.validateTransaction(transaction, isLocal, hasPriority))
+            .filter(Optional::isPresent)
+            .findAny()
+            .orElse(Optional.empty());
   }
 
   @Override
   public void registerPluginTransactionValidatorFactory(
       final PluginTransactionPoolValidatorFactory pluginTransactionPoolValidatorFactory) {
-    factory = Optional.ofNullable(pluginTransactionPoolValidatorFactory);
+    Preconditions.checkNotNull(
+        pluginTransactionPoolValidatorFactory,
+        "PluginTransactionPoolValidatorFactory must not be null");
+    factories.add(pluginTransactionPoolValidatorFactory);
   }
 }


### PR DESCRIPTION
## PR description

This PR allow for multiple plugins to register a `PluginTransactionPoolValidatorFactory`

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


