### PR TITLE
Migrate JSR305 nullness annotations to JSpecify

### DIFF
--- a/consensus/common/build.gradle
+++ b/consensus/common/build.gradle
@@ -43,7 +43,7 @@ dependencies {
   implementation project(':evm')
   implementation project(':util')
 
-  compileOnly 'com.google.code.findbugs:jsr305'
+  compileOnly 'org.jspecify:jspecify'
 
   implementation 'com.fasterxml.jackson.core:jackson-databind'
   implementation 'com.google.guava:guava'

--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/BftEventQueue.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/BftEventQueue.java
@@ -21,8 +21,8 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import javax.annotation.Nullable;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/ethereum/api/build.gradle
+++ b/ethereum/api/build.gradle
@@ -34,7 +34,7 @@ dependencies {
   api 'org.slf4j:slf4j-api'
   api 'org.apache.logging.log4j:log4j-api'
 
-  compileOnly 'com.google.code.findbugs:jsr305'
+  compileOnly 'org.jspecify:jspecify'
 
   implementation project(':config')
   implementation project(':consensus:merge')

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/TransactionAdapter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/TransactionAdapter.java
@@ -36,11 +36,11 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import javax.annotation.Nullable;
 
 import graphql.schema.DataFetchingEnvironment;
 import jakarta.validation.constraints.NotNull;
 import org.apache.tuweni.bytes.Bytes;
+import org.jspecify.annotations.Nullable;
 
 /**
  * The TransactionAdapter class provides methods to retrieve the transaction details.

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/EngineJsonRpcService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/EngineJsonRpcService.java
@@ -59,7 +59,6 @@ import java.util.Optional;
 import java.util.StringJoiner;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
-import javax.annotation.Nullable;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.opentelemetry.api.OpenTelemetry;
@@ -96,6 +95,7 @@ import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.BodyHandler;
 import io.vertx.ext.web.handler.CorsHandler;
 import jakarta.validation.constraints.NotNull;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpService.java
@@ -51,7 +51,6 @@ import java.util.Optional;
 import java.util.StringJoiner;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
-import javax.annotation.Nullable;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.opentelemetry.api.OpenTelemetry;
@@ -84,6 +83,7 @@ import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.BodyHandler;
 import io.vertx.ext.web.handler.CorsHandler;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/DefaultAuthenticationService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/DefaultAuthenticationService.java
@@ -21,7 +21,6 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.WebSocketConfiguratio
 import java.io.File;
 import java.util.Collection;
 import java.util.Optional;
-import javax.annotation.Nullable;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.netty.handler.codec.http.HttpResponseStatus;
@@ -39,6 +38,7 @@ import io.vertx.ext.auth.authorization.PermissionBasedAuthorization;
 import io.vertx.ext.auth.jwt.JWTAuth;
 import io.vertx.ext.auth.jwt.JWTAuthOptions;
 import io.vertx.ext.web.RoutingContext;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV1.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV1.java
@@ -39,10 +39,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import javax.annotation.Nullable;
 
 import io.vertx.core.Vertx;
 import jakarta.validation.constraints.NotNull;
+import org.jspecify.annotations.Nullable;
 
 /**
  * #### Specification

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV3.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV3.java
@@ -41,10 +41,10 @@ import org.hyperledger.besu.util.HexUtils;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import javax.annotation.Nullable;
 
 import io.vertx.core.Vertx;
 import jakarta.validation.constraints.NotNull;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/TransactionTraceParams.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/TransactionTraceParams.java
@@ -23,7 +23,6 @@ import org.hyperledger.besu.evm.tracing.OpCodeTracerConfigBuilder.OpCodeTracerCo
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Set;
-import javax.annotation.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -31,6 +30,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.value.Value;
+import org.jspecify.annotations.Nullable;
 
 @Value.Immutable
 @JsonSerialize(as = ImmutableTransactionTraceParams.class)
@@ -39,28 +39,24 @@ import org.immutables.value.Value;
 public interface TransactionTraceParams {
 
   @JsonProperty("txHash")
-  @Nullable
-  String getTransactionHash();
+  @Nullable String getTransactionHash();
 
   @JsonProperty(value = "disableStorage")
-  @Nullable
-  Boolean disableStorageNullable();
+  @Nullable Boolean disableStorageNullable();
 
   default boolean disableStorage() {
     return Boolean.TRUE.equals(disableStorageNullable());
   }
 
   @JsonProperty(value = "disableMemory")
-  @Nullable
-  Boolean disableMemoryNullable();
+  @Nullable Boolean disableMemoryNullable();
 
   default boolean disableMemory() {
     return Boolean.TRUE.equals(disableMemoryNullable());
   }
 
   @JsonProperty(value = "disableStack")
-  @Nullable
-  Boolean disableStackNullable();
+  @Nullable Boolean disableStackNullable();
 
   default boolean disableStack() {
     return Boolean.TRUE.equals(disableStackNullable());
@@ -68,8 +64,7 @@ public interface TransactionTraceParams {
 
   @JsonProperty("tracer")
   @JsonInclude(JsonInclude.Include.NON_NULL)
-  @Nullable
-  String tracer();
+  @Nullable String tracer();
 
   @JsonProperty("tracerConfig")
   @Nullable

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/FeeHistory.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/FeeHistory.java
@@ -20,11 +20,11 @@ import org.hyperledger.besu.datatypes.Wei;
 
 import java.util.List;
 import java.util.Optional;
-import javax.annotation.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.immutables.value.Value;
+import org.jspecify.annotations.Nullable;
 
 @Value.Immutable
 public interface FeeHistory {

--- a/ethereum/core/build.gradle
+++ b/ethereum/core/build.gradle
@@ -32,7 +32,7 @@ dependencies {
   api 'org.slf4j:slf4j-api'
   api 'org.web3j:core'
 
-  compileOnly 'com.google.code.findbugs:jsr305'
+  compileOnly 'org.jspecify:jspecify'
 
   implementation project(path: ':util')
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/encoding/receipt/TransactionReceiptDecoder.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/encoding/receipt/TransactionReceiptDecoder.java
@@ -24,9 +24,9 @@ import org.hyperledger.besu.ethereum.rlp.RLPInput;
 
 import java.util.List;
 import java.util.Optional;
-import javax.annotation.Nullable;
 
 import org.apache.tuweni.bytes.Bytes;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Decodes transaction receipts from RLP.

--- a/ethereum/eth/build.gradle
+++ b/ethereum/eth/build.gradle
@@ -38,7 +38,7 @@ dependencies {
   api 'org.slf4j:slf4j-api'
   api project(':util')
 
-  compileOnly 'com.google.code.findbugs:jsr305'
+  compileOnly 'org.jspecify:jspecify'
 
   implementation project(':config')
   implementation project(':datatypes')

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/messages/snap/GetStorageRangeMessage.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/messages/snap/GetStorageRangeMessage.java
@@ -24,12 +24,12 @@ import org.hyperledger.besu.ethereum.rlp.RLPInput;
 import java.math.BigInteger;
 import java.util.List;
 import java.util.Optional;
-import javax.annotation.Nullable;
 
 import kotlin.collections.ArrayDeque;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.immutables.value.Value;
+import org.jspecify.annotations.Nullable;
 
 public final class GetStorageRangeMessage extends AbstractSnapMessageData {
 
@@ -134,8 +134,7 @@ public final class GetStorageRangeMessage extends AbstractSnapMessageData {
 
     Hash startKeyHash();
 
-    @Nullable
-    Hash endKeyHash();
+    @Nullable Hash endKeyHash();
 
     BigInteger responseBytes();
   }

--- a/ethereum/ethstats/build.gradle
+++ b/ethereum/ethstats/build.gradle
@@ -31,7 +31,7 @@ jar {
 dependencies {
   api 'org.slf4j:slf4j-api'
 
-  compileOnly 'com.google.code.findbugs:jsr305'
+  compileOnly 'org.jspecify:jspecify'
 
   implementation 'com.fasterxml.jackson.core:jackson-databind'
   implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8'

--- a/ethereum/ethstats/src/main/java/org/hyperledger/besu/ethstats/util/EthStatsConnectOptions.java
+++ b/ethereum/ethstats/src/main/java/org/hyperledger/besu/ethstats/util/EthStatsConnectOptions.java
@@ -18,9 +18,9 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import java.net.URI;
 import java.nio.file.Path;
-import javax.annotation.Nullable;
 
 import org.immutables.value.Value;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.LoggerFactory;
 
 /**
@@ -34,8 +34,7 @@ public interface EthStatsConnectOptions {
    *
    * @return the scheme of the connection.
    */
-  @Nullable
-  String getScheme();
+  @Nullable String getScheme();
 
   /**
    * Gets the node name of the connection.
@@ -77,8 +76,7 @@ public interface EthStatsConnectOptions {
    *
    * @return the CA certificate of the connection.
    */
-  @Nullable
-  Path getCaCert();
+  @Nullable Path getCaCert();
 
   /**
    * Gets the ethstats report interval.

--- a/ethereum/referencetests/build.gradle
+++ b/ethereum/referencetests/build.gradle
@@ -254,7 +254,7 @@ configurations {
 }
 
 dependencies {
-  compileOnly 'com.google.code.findbugs:jsr305'
+  compileOnly 'org.jspecify:jspecify'
 
   implementation project(':config')
   implementation project(':crypto:algorithms')

--- a/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/GeneralStateTestCaseSpec.java
+++ b/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/GeneralStateTestCaseSpec.java
@@ -28,11 +28,11 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
-import javax.annotation.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.jspecify.annotations.Nullable;
 
 /** A Transaction test case specification. */
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/StateTestVersionedTransaction.java
+++ b/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/StateTestVersionedTransaction.java
@@ -28,7 +28,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
-import javax.annotation.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -37,6 +36,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Represents the "transaction" part of the JSON of a general state tests.

--- a/evm/build.gradle
+++ b/evm/build.gradle
@@ -54,7 +54,7 @@ dependencies {
   implementation 'io.consensys.protocols:jc-kzg-4844'
 
   compileOnly 'com.fasterxml.jackson.core:jackson-databind'
-  compileOnly 'com.google.code.findbugs:jsr305'
+  compileOnly 'org.jspecify:jspecify'
   compileOnly 'io.vertx:vertx-core'
 
   testImplementation 'com.fasterxml.jackson.core:jackson-databind'

--- a/evm/src/main/java/org/hyperledger/besu/collections/undo/UndoTable.java
+++ b/evm/src/main/java/org/hyperledger/besu/collections/undo/UndoTable.java
@@ -21,10 +21,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import javax.annotation.CheckForNull;
 
 import com.google.common.collect.Table;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A Table that supports rolling back the Table to a prior state.
@@ -123,7 +123,7 @@ public class UndoTable<R, C, V> implements Table<R, C, V>, Undoable {
   }
 
   @Override
-  @CheckForNull
+  @Nullable
   public V get(final Object rowKey, final Object columnKey) {
     return delegate.get(rowKey, columnKey);
   }
@@ -135,7 +135,7 @@ public class UndoTable<R, C, V> implements Table<R, C, V>, Undoable {
 
   @Override
   @CanIgnoreReturnValue
-  @CheckForNull
+  @Nullable
   public V put(final R rowKey, final C columnKey, final V value) {
     V oldV = delegate.put(rowKey, columnKey, value);
     undoLog.add(new UndoEntry<>(rowKey, columnKey, oldV));
@@ -156,7 +156,7 @@ public class UndoTable<R, C, V> implements Table<R, C, V>, Undoable {
   @SuppressWarnings("unchecked")
   @Override
   @CanIgnoreReturnValue
-  @CheckForNull
+  @Nullable
   public V remove(final Object rowKey, final Object columnKey) {
     V oldV = delegate.remove(rowKey, columnKey);
     undoLog.add(new UndoEntry<>((R) rowKey, (C) columnKey, oldV));

--- a/evm/src/main/java/org/hyperledger/besu/evm/worldstate/JournaledAccount.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/worldstate/JournaledAccount.java
@@ -29,11 +29,11 @@ import org.hyperledger.besu.evm.account.MutableAccount;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.TreeMap;
-import javax.annotation.Nullable;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
+import org.jspecify.annotations.Nullable;
 
 /**
  * An implementation of {@link MutableAccount} that tracks updates made to the account since the

--- a/evm/src/main/java/org/hyperledger/besu/evm/worldstate/UpdateTrackingAccount.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/worldstate/UpdateTrackingAccount.java
@@ -29,11 +29,11 @@ import org.hyperledger.besu.evm.internal.CodeCache;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.TreeMap;
-import javax.annotation.Nullable;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
+import org.jspecify.annotations.Nullable;
 
 /**
  * An implementation of {@link MutableAccount} that tracks updates made to the account since the

--- a/platform/build.gradle
+++ b/platform/build.gradle
@@ -84,7 +84,7 @@ dependencies {
 
     api 'org.checkerframework:checker-qual:3.43.0'
 
-    api 'com.google.code.findbugs:jsr305:3.0.2'
+    api 'org.jspecify:jspecify:1.0.0'
 
     api 'com.google.protobuf:protobuf-java:3.25.5'
 

--- a/testutil/build.gradle
+++ b/testutil/build.gradle
@@ -33,7 +33,7 @@ sonarqube {
 }
 
 dependencies {
-  compileOnly 'com.google.code.findbugs:jsr305'
+  compileOnly 'org.jspecify:jspecify'
 
   implementation project(':ethereum:eth')
   implementation project(':plugin-api')

--- a/testutil/src/main/java/org/hyperledger/besu/testutil/JsonTestParameters.java
+++ b/testutil/src/main/java/org/hyperledger/besu/testutil/JsonTestParameters.java
@@ -33,7 +33,6 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
-import javax.annotation.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -42,6 +41,7 @@ import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Utility class for generating JUnit test parameters from json files. Each set of test parameters


### PR DESCRIPTION
## PR description

- Replace javax.annotation.Nullable and javax.annotation.CheckForNull with org.jspecify.annotations.Nullable across 18 Java files
- Update platform constraint to org.jspecify:jspecify:1.0.0
- Replace compileOnly com.google.code.findbugs:jsr305 with compileOnly org.jspecify:jspecify in affected modules

## Fixed Issue(s)
fixes #9917

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


