### PR TITLE
evm: do not charge code deposit state gas on failure paths (EIP-8037)

### DIFF
--- a/evm/src/main/java/org/hyperledger/besu/evm/frame/MessageFrame.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/frame/MessageFrame.java
@@ -879,32 +879,6 @@ public class MessageFrame {
   }
 
   /**
-   * Consumes state gas, draining all available gas even when the full amount cannot be covered.
-   * Always increments stateGasUsed by the full amount regardless of gas availability. Used when a
-   * transaction-level (depth-0) contract creation fails after state gas has been partially
-   * committed: we must record the charge for block accounting even though execution fails.
-   *
-   * @param amount the amount of state gas to consume
-   * @return true if sufficient gas was available, false if gas was insufficient (but drained
-   *     anyway)
-   */
-  public boolean consumeStateGasForced(final long amount) {
-    final long reservoir = txValues.stateGasReservoir().get();
-    if (reservoir >= amount) {
-      txValues.stateGasReservoir().set(reservoir - amount);
-      txValues.stateGasUsed().set(txValues.stateGasUsed().get() + amount);
-      return true;
-    } else {
-      final long overflow = amount - reservoir;
-      txValues.stateGasReservoir().set(0L);
-      final boolean sufficient = gasRemaining >= overflow;
-      gasRemaining = Math.max(0L, gasRemaining - overflow);
-      txValues.stateGasUsed().set(txValues.stateGasUsed().get() + amount);
-      return sufficient;
-    }
-  }
-
-  /**
    * Accumulates state gas that spilled into gasRemaining in a reverted child frame (EIP-8037). This
    * counter is NOT undone on revert — it tracks permanently burned spill gas for block accounting.
    *

--- a/evm/src/main/java/org/hyperledger/besu/evm/processor/ContractCreationProcessor.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/processor/ContractCreationProcessor.java
@@ -201,24 +201,13 @@ public class ContractCreationProcessor extends AbstractMessageProcessor {
             .stateGasCostCalculator()
             .chargeCodeDepositStateGas(frame, contractCode.size())) {
           LOG.trace("Contract creation error: insufficient state gas for code deposit");
-          // EIP-8037: For depth-0 (initial tx) frames, use forced charge + no-rollback failure so
-          // that stateGasUsed is preserved for block gas accounting (e.g. short_one_gas test).
-          if (frame.getDepth() == 0) {
-            final long stateGasAmount =
-                evm.getGasCalculator()
-                    .stateGasCostCalculator()
-                    .codeDepositStateGas(contractCode.size(), frame.getBlockValues().getGasLimit());
-            if (stateGasAmount > 0) {
-              frame.consumeStateGasForced(stateGasAmount);
-            }
-            failCodeDepositWithoutRollback(
-                frame, operationTracer, Optional.of(ExceptionalHaltReason.INSUFFICIENT_GAS));
-          } else {
-            frame.setExceptionalHaltReason(Optional.of(ExceptionalHaltReason.INSUFFICIENT_GAS));
-            frame.setState(MessageFrame.State.EXCEPTIONAL_HALT);
-            operationTracer.traceAccountCreationResult(
-                frame, Optional.of(ExceptionalHaltReason.INSUFFICIENT_GAS));
-          }
+          // EIP-8037: Code-store OOG is a failure path — do NOT charge GAS_CODE_DEPOSIT state gas.
+          // Per spec: "Failure paths (OOG during code deposit): Do NOT charge GAS_CODE_DEPOSIT * L"
+          // State gas is restored by the normal exceptional halt rollback.
+          frame.setExceptionalHaltReason(Optional.of(ExceptionalHaltReason.INSUFFICIENT_GAS));
+          frame.setState(MessageFrame.State.EXCEPTIONAL_HALT);
+          operationTracer.traceAccountCreationResult(
+              frame, Optional.of(ExceptionalHaltReason.INSUFFICIENT_GAS));
           return;
         }
 
@@ -236,26 +225,9 @@ public class ContractCreationProcessor extends AbstractMessageProcessor {
           operationTracer.traceAccountCreationResult(frame, Optional.empty());
         }
       } else {
-        // EIP-8037: For depth-0 (initial tx) frames with code that fails validation (e.g.
-        // CODE_TOO_LARGE), charge the code deposit state gas before failing so the charge is
-        // preserved in stateGasUsed for block gas accounting (e.g. over_max test).
-        // Use consumeStateGas (not forced) — it returns false without modifying on failure, so
-        // we can safely fall through to EXCEPTIONAL_HALT if gas is insufficient.
-        if (frame.getDepth() == 0) {
-          final long stateGasAmount =
-              evm.getGasCalculator()
-                  .stateGasCostCalculator()
-                  .codeDepositStateGas(contractCode.size(), frame.getBlockValues().getGasLimit());
-          if (stateGasAmount > 0 && frame.consumeStateGas(stateGasAmount)) {
-            // Sufficient state gas: charge succeeded, fail without rollback so stateGasUsed
-            // is preserved for block accounting.
-            final Optional<ExceptionalHaltReason> haltReason = invalidReason.get();
-            failCodeDepositWithoutRollback(frame, operationTracer, haltReason);
-            return;
-          }
-          // Insufficient state gas or no state gas (non-EIP-8037): fall through to
-          // EXCEPTIONAL_HALT.
-        }
+        // EIP-8037: Code validation failure (CODE_TOO_LARGE, INVALID_CODE) is a failure path.
+        // Per spec: "Failure paths (L > MAX_CODE_SIZE): Do NOT charge GAS_CODE_DEPOSIT * L"
+        // State gas is restored by the normal exceptional halt rollback.
         final Optional<ExceptionalHaltReason> exceptionalHaltReason = invalidReason.get();
         frame.setExceptionalHaltReason(exceptionalHaltReason);
         frame.setState(MessageFrame.State.EXCEPTIONAL_HALT);
@@ -264,34 +236,4 @@ public class ContractCreationProcessor extends AbstractMessageProcessor {
     }
   }
 
-  /**
-   * Fails a depth-0 code deposit without triggering the normal EXCEPTIONAL_HALT rollback path. This
-   * preserves stateGasUsed for EIP-8037 block gas accounting. The world state is still reverted and
-   * all gas is cleared.
-   *
-   * @param frame the message frame
-   * @param operationTracer the operation tracer
-   * @param haltReason the exceptional halt reason to report
-   */
-  private void failCodeDepositWithoutRollback(
-      final MessageFrame frame,
-      final OperationTracer operationTracer,
-      final Optional<ExceptionalHaltReason> haltReason) {
-    LOG.trace(
-        "Contract creation failed (no rollback): {} for address {}",
-        haltReason,
-        frame.getContractAddress());
-    // Revert world state changes without calling frame.rollback() (which would undo stateGasUsed).
-    frame.getWorldUpdater().revert();
-    frame.getWorldUpdater().commit();
-    frame.clearLogs();
-    frame.clearGasRefund();
-    frame.clearAllGas();
-    frame.clearOutputData();
-    // Do NOT call frame.setExceptionalHaltReason() here — MTP zeros the state gas reservoir when
-    // exceptionalHaltReason is present, which would inflate block gas accounting. Setting
-    // COMPLETED_FAILED state is sufficient to signal failure to the caller.
-    frame.setState(MessageFrame.State.COMPLETED_FAILED);
-    operationTracer.traceAccountCreationResult(frame, haltReason);
-  }
 }


### PR DESCRIPTION
## Summary

Remove two depth-0 special cases that incorrectly charged `GAS_CODE_DEPOSIT` state gas on failure paths, violating EIP-8037 spec.

## Problem

EIP-8037 §"Contract deployment cost calculation" explicitly says:

> **Failure paths** (REVERT, OOG/invalid during initcode, **OOG during code deposit**, or **`L > MAX_CODE_SIZE`**):
> Do NOT charge `GAS_CODE_DEPOSIT * L` or `HASH_COST(L)`

And §"Transaction-level gas accounting":

> On child **exceptional halt**, all state gas consumed by the child, both from the reservoir and any that spilled into `gas_left`, is restored to the parent's reservoir.

Besu had two depth-0 special cases that violated this:

1. **Code-store OOG** (`ContractCreationProcessor.java:206-215`): `consumeStateGasForced()` charged the full code deposit state gas (`cpsb * codeSize`) even though the gas check failed, then used `failCodeDepositWithoutRollback()` to preserve the charge for block accounting.

2. **Code validation failure** (`ContractCreationProcessor.java:244-255`): For `CODE_TOO_LARGE` / `INVALID_CODE` at depth 0, charged code deposit state gas before failing via `failCodeDepositWithoutRollback()`.

This caused consensus failures with geth under evm-fuzz load — blocks containing depth-0 CREATE transactions that fail code storage had different `block.gasUsed` (EIP-8037 `max(regular, state)` divergence).

## Fix

Remove both depth-0 special cases. All failure paths now use the standard `EXCEPTIONAL_HALT` flow, which correctly:
- Consumes all remaining regular gas (exceptional halt semantics)
- Reverts state gas via the normal rollback mechanism
- Does NOT charge `GAS_CODE_DEPOSIT * L`

Also removes the now-unused `consumeStateGasForced()` method from `MessageFrame` and `failCodeDepositWithoutRollback()` from `ContractCreationProcessor`.

## Cross-client alignment

This matches geth's fix for the same issue ([go-ethereum#33972](https://github.com/ethereum/go-ethereum/pull/33972)).

## Test plan
- [ ] Existing EIP-8037 reference tests
- [ ] geth+besu Kurtosis with evm-fuzz (contract deployment under load)

🤖 Generated with [Claude Code](https://claude.com/claude-code)