### PR TITLE
Implement `txpool_status` RPC method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Plugin API: Allow the registration of multiple PluginTransactionPoolValidatorFactory [#9964](https://github.com/hyperledger/besu/pull/9964)
 - Add `-Pcases` case name filtering to JMH benchmark suite [#9982](https://github.com/hyperledger/besu/pull/9982)
 - Use JDK SHA-256 provider to leverage hardware SHA-NI instructions instead of BouncyCastle [#9924](https://github.com/hyperledger/besu/pull/9924)
+- Implement `txpool_status` RPC method [#10002](https://github.com/hyperledger/besu/pull/10002)
 - Support [EIP-7975](https://eips.ethereum.org/EIPS/eip-7975): eth/70 - partial block receipt lists
 - Limit pooled tx requests by size and remove pre-eth/68 transaction announcement support [#9990](https://github.com/besu-eth/besu/pull/9990)
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/RpcMethod.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/RpcMethod.java
@@ -168,6 +168,7 @@ public enum RpcMethod {
   TX_POOL_BESU_STATISTICS("txpool_besuStatistics"),
   TX_POOL_BESU_TRANSACTIONS("txpool_besuTransactions"),
   TX_POOL_BESU_PENDING_TRANSACTIONS("txpool_besuPendingTransactions"),
+  TX_POOL_STATUS("txpool_status"),
   WEB3_CLIENT_VERSION("web3_clientVersion"),
   WEB3_SHA3("web3_sha3"),
   PLUGINS_RELOAD_CONFIG("plugins_reloadPluginConfig"),

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TxPoolStatus.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TxPoolStatus.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
+
+import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.TransactionPoolStatusResult;
+import org.hyperledger.besu.ethereum.eth.transactions.PendingTransactions;
+import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
+
+public class TxPoolStatus implements JsonRpcMethod {
+
+  private final TransactionPool transactionPool;
+
+  public TxPoolStatus(final TransactionPool transactionPool) {
+    this.transactionPool = transactionPool;
+  }
+
+  @Override
+  public String getName() {
+    return RpcMethod.TX_POOL_STATUS.getMethodName();
+  }
+
+  @Override
+  public JsonRpcResponse response(final JsonRpcRequestContext requestContext) {
+    return new JsonRpcSuccessResponse(requestContext.getRequest().getId(), status());
+  }
+
+  private TransactionPoolStatusResult status() {
+    final PendingTransactions.Status status = transactionPool.getStatus();
+    return new TransactionPoolStatusResult(status.pendingCount(), status.queuedCount());
+  }
+}

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/TransactionPoolStatusResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/TransactionPoolStatusResult.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal.results;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+
+public class TransactionPoolStatusResult {
+
+  private final long pending;
+  private final long queued;
+
+  public TransactionPoolStatusResult(final long pending, final long queued) {
+    this.pending = pending;
+    this.queued = queued;
+  }
+
+  @JsonGetter
+  public String getPending() {
+    return Quantity.create(pending);
+  }
+
+  @JsonGetter
+  public String getQueued() {
+    return Quantity.create(queued);
+  }
+}

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/TxPoolJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/TxPoolJsonRpcMethods.java
@@ -19,6 +19,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.TxPoolBesuPendingTransactions;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.TxPoolBesuStatistics;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.TxPoolBesuTransactions;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.TxPoolStatus;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 
 import java.util.Map;
@@ -41,6 +42,7 @@ public class TxPoolJsonRpcMethods extends ApiGroupJsonRpcMethods {
     return mapOf(
         new TxPoolBesuTransactions(transactionPool),
         new TxPoolBesuPendingTransactions(transactionPool),
-        new TxPoolBesuStatistics(transactionPool));
+        new TxPoolBesuStatistics(transactionPool),
+        new TxPoolStatus(transactionPool));
   }
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TxPoolStatusTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TxPoolStatusTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.TransactionPoolStatusResult;
+import org.hyperledger.besu.ethereum.eth.transactions.PendingTransactions;
+import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class TxPoolStatusTest {
+
+  @Mock private TransactionPool transactionPool;
+  private TxPoolStatus method;
+  private static final String JSON_RPC_VERSION = "2.0";
+  private static final String TXPOOL_STATUS_METHOD = "txpool_status";
+
+  @BeforeEach
+  public void setUp() {
+    method = new TxPoolStatus(transactionPool);
+  }
+
+  @Test
+  public void returnsCorrectMethodName() {
+    assertThat(method.getName()).isEqualTo(TXPOOL_STATUS_METHOD);
+  }
+
+  @Test
+  public void shouldReturnZeroCountsWhenPoolIsEmpty() {
+    when(transactionPool.getStatus()).thenReturn(new PendingTransactions.Status(0, 0));
+
+    final JsonRpcRequestContext request = buildRequest();
+    final JsonRpcSuccessResponse response = (JsonRpcSuccessResponse) method.response(request);
+    final TransactionPoolStatusResult result = (TransactionPoolStatusResult) response.getResult();
+
+    assertThat(result.getPending()).isEqualTo("0x0");
+    assertThat(result.getQueued()).isEqualTo("0x0");
+  }
+
+  @Test
+  public void shouldReturnCorrectCountsWithPendingAndQueuedTransactions() {
+    when(transactionPool.getStatus()).thenReturn(new PendingTransactions.Status(10, 7));
+
+    final JsonRpcRequestContext request = buildRequest();
+    final JsonRpcSuccessResponse response = (JsonRpcSuccessResponse) method.response(request);
+    final TransactionPoolStatusResult result = (TransactionPoolStatusResult) response.getResult();
+
+    assertThat(result.getPending()).isEqualTo("0xa");
+    assertThat(result.getQueued()).isEqualTo("0x7");
+  }
+
+  @Test
+  public void shouldReturnCorrectCountsWithOnlyPendingTransactions() {
+    when(transactionPool.getStatus()).thenReturn(new PendingTransactions.Status(5, 0));
+
+    final JsonRpcRequestContext request = buildRequest();
+    final JsonRpcSuccessResponse response = (JsonRpcSuccessResponse) method.response(request);
+    final TransactionPoolStatusResult result = (TransactionPoolStatusResult) response.getResult();
+
+    assertThat(result.getPending()).isEqualTo("0x5");
+    assertThat(result.getQueued()).isEqualTo("0x0");
+  }
+
+  @Test
+  public void shouldReturnCorrectCountsWithOnlyQueuedTransactions() {
+    when(transactionPool.getStatus()).thenReturn(new PendingTransactions.Status(0, 3));
+
+    final JsonRpcRequestContext request = buildRequest();
+    final JsonRpcSuccessResponse response = (JsonRpcSuccessResponse) method.response(request);
+    final TransactionPoolStatusResult result = (TransactionPoolStatusResult) response.getResult();
+
+    assertThat(result.getPending()).isEqualTo("0x0");
+    assertThat(result.getQueued()).isEqualTo("0x3");
+  }
+
+  @Test
+  public void shouldReturnHexEncodedLargeValues() {
+    when(transactionPool.getStatus()).thenReturn(new PendingTransactions.Status(256, 4096));
+
+    final JsonRpcRequestContext request = buildRequest();
+    final JsonRpcSuccessResponse response = (JsonRpcSuccessResponse) method.response(request);
+    final TransactionPoolStatusResult result = (TransactionPoolStatusResult) response.getResult();
+
+    assertThat(result.getPending()).isEqualTo("0x100");
+    assertThat(result.getQueued()).isEqualTo("0x1000");
+  }
+
+  private JsonRpcRequestContext buildRequest() {
+    return new JsonRpcRequestContext(
+        new JsonRpcRequest(JSON_RPC_VERSION, TXPOOL_STATUS_METHOD, new Object[] {}));
+  }
+}

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/DisabledPendingTransactions.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/DisabledPendingTransactions.java
@@ -118,6 +118,11 @@ public class DisabledPendingTransactions implements PendingTransactions {
   }
 
   @Override
+  public Status getStatus() {
+    return new Status(0, 0);
+  }
+
+  @Override
   public Optional<Transaction> restoreBlob(final Transaction transaction) {
     return Optional.empty();
   }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/PendingTransactions.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/PendingTransactions.java
@@ -73,6 +73,8 @@ public interface PendingTransactions {
 
   String logStats();
 
+  Status getStatus();
+
   Optional<Transaction> restoreBlob(Transaction transaction);
 
   @FunctionalInterface
@@ -80,4 +82,6 @@ public interface PendingTransactions {
     Map<PendingTransaction, TransactionSelectionResult> evaluatePendingTransactions(
         List<PendingTransaction> candidatePendingTransactions);
   }
+
+  record Status(long pendingCount, long queuedCount) {}
 }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
@@ -576,6 +576,10 @@ public class TransactionPool implements BlockAddedObserver {
     return pendingTransactions.logStats();
   }
 
+  public PendingTransactions.Status getStatus() {
+    return pendingTransactions.getStatus();
+  }
+
   @VisibleForTesting
   Class<? extends PendingTransactions> pendingTransactionsImplementation() {
     return pendingTransactions.getClass();

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/layered/AbstractSequentialTransactionsLayer.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/layered/AbstractSequentialTransactionsLayer.java
@@ -22,6 +22,7 @@ import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.ethereum.eth.manager.EthScheduler;
 import org.hyperledger.besu.ethereum.eth.transactions.BlobCache;
 import org.hyperledger.besu.ethereum.eth.transactions.PendingTransaction;
+import org.hyperledger.besu.ethereum.eth.transactions.PendingTransactions;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolConfiguration;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolMetrics;
 import org.hyperledger.besu.ethereum.eth.transactions.layered.LayeredRemovalReason.PoolRemovalReason;
@@ -121,6 +122,13 @@ public abstract class AbstractSequentialTransactionsLayer extends AbstractTransa
       return OptionalLong.of(senderTxs.firstKey());
     }
     return nextLayer.getCurrentNonceFor(sender);
+  }
+
+  @Override
+  public PendingTransactions.Status getStatus() {
+    final PendingTransactions.Status nextLayerStatus = nextLayer.getStatus();
+    return new PendingTransactions.Status(
+        nextLayerStatus.pendingCount() + pendingTransactions.size(), nextLayerStatus.queuedCount());
   }
 
   @Override

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/layered/EndLayer.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/layered/EndLayer.java
@@ -24,6 +24,7 @@ import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.eth.transactions.PendingTransaction;
 import org.hyperledger.besu.ethereum.eth.transactions.PendingTransactionAddedListener;
 import org.hyperledger.besu.ethereum.eth.transactions.PendingTransactionDroppedListener;
+import org.hyperledger.besu.ethereum.eth.transactions.PendingTransactions;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionAddedResult;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolMetrics;
 import org.hyperledger.besu.ethereum.eth.transactions.layered.LayeredRemovalReason.PoolRemovalReason;
@@ -181,6 +182,11 @@ public class EndLayer implements TransactionsLayer {
   @Override
   public String logStats() {
     return "Dropped: " + droppedCount;
+  }
+
+  @Override
+  public PendingTransactions.Status getStatus() {
+    return new PendingTransactions.Status(0, 0);
   }
 
   @Override

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/layered/LayeredPendingTransactions.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/layered/LayeredPendingTransactions.java
@@ -434,6 +434,11 @@ public class LayeredPendingTransactions implements PendingTransactions {
   }
 
   @Override
+  public synchronized Status getStatus() {
+    return prioritizedTransactions.getStatus();
+  }
+
+  @Override
   public Optional<Transaction> restoreBlob(final Transaction transaction) {
     return prioritizedTransactions.getBlobCache().restoreBlob(transaction);
   }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/layered/SparseTransactions.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/layered/SparseTransactions.java
@@ -23,6 +23,7 @@ import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.eth.manager.EthScheduler;
 import org.hyperledger.besu.ethereum.eth.transactions.BlobCache;
 import org.hyperledger.besu.ethereum.eth.transactions.PendingTransaction;
+import org.hyperledger.besu.ethereum.eth.transactions.PendingTransactions;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionAddedResult;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolConfiguration;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolMetrics;
@@ -214,6 +215,23 @@ public class SparseTransactions extends AbstractTransactionsLayer {
     }
 
     return promotedTxs;
+  }
+
+  @Override
+  public PendingTransactions.Status getStatus() {
+    final PendingTransactions.Status nextLayerStatus = nextLayer.getStatus();
+    long pendingCount = nextLayerStatus.pendingCount();
+    long queueCount = nextLayerStatus.queuedCount();
+    for (final Map.Entry<Address, Integer> entry : gapBySender.entrySet()) {
+      final Address sender = entry.getKey();
+      final int gap = entry.getValue();
+      if (gap == 0) {
+        pendingCount += txsBySender.get(sender).size();
+      } else {
+        queueCount += txsBySender.get(sender).size();
+      }
+    }
+    return new PendingTransactions.Status(pendingCount, queueCount);
   }
 
   private NavigableMap<Long, PendingTransaction> getSequentialSubset(

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/layered/TransactionsLayer.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/layered/TransactionsLayer.java
@@ -21,6 +21,7 @@ import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.eth.transactions.PendingTransaction;
 import org.hyperledger.besu.ethereum.eth.transactions.PendingTransactionAddedListener;
 import org.hyperledger.besu.ethereum.eth.transactions.PendingTransactionDroppedListener;
+import org.hyperledger.besu.ethereum.eth.transactions.PendingTransactions;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionAddedResult;
 import org.hyperledger.besu.ethereum.eth.transactions.layered.LayeredRemovalReason.PoolRemovalReason;
 import org.hyperledger.besu.ethereum.mainnet.feemarket.FeeMarket;
@@ -126,6 +127,8 @@ public interface TransactionsLayer {
   long getCumulativeUsedSpace();
 
   String logStats();
+
+  PendingTransactions.Status getStatus();
 
   String logSender(Address sender);
 }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/sorter/AbstractPendingTransactionsSorter.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/sorter/AbstractPendingTransactionsSorter.java
@@ -508,6 +508,20 @@ public abstract class AbstractPendingTransactionsSorter implements PendingTransa
   }
 
   @Override
+  public Status getStatus() {
+    long pendingCount = 0;
+    long queuedCount = 0;
+    synchronized (lock) {
+      for (final PendingTransactionsForSender pendingTxsForSender : transactionsBySender.values()) {
+        final Status accountStatus = pendingTxsForSender.getStatus();
+        pendingCount += accountStatus.pendingCount();
+        queuedCount += accountStatus.queuedCount();
+      }
+    }
+    return new Status(pendingCount, queuedCount);
+  }
+
+  @Override
   public String toTraceLog() {
     synchronized (lock) {
       StringBuilder sb =

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/sorter/PendingTransactionsForSender.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/sorter/PendingTransactionsForSender.java
@@ -15,10 +15,10 @@
 package org.hyperledger.besu.ethereum.eth.transactions.sorter;
 
 import org.hyperledger.besu.ethereum.eth.transactions.PendingTransaction;
+import org.hyperledger.besu.ethereum.eth.transactions.PendingTransactions;
 import org.hyperledger.besu.evm.account.Account;
 
 import java.util.List;
-import java.util.Map;
 import java.util.NavigableMap;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -70,12 +70,16 @@ public class PendingTransactionsForSender {
     this.maybeSenderAccount = maybeSenderAccount;
   }
 
-  public long getSenderAccountNonce() {
-    return maybeSenderAccount.map(Account::getNonce).orElse(0L);
-  }
-
-  public Optional<Account> getSenderAccount() {
-    return maybeSenderAccount;
+  PendingTransactions.Status getStatus() {
+    synchronized (pendingTransactions) {
+      if (nextGap.isPresent()) {
+        final long gap = nextGap.getAsLong();
+        final long accountNonce = maybeSenderAccount.map(Account::getNonce).orElse(0L);
+        final long nonGapped = Math.max(0, gap - accountNonce);
+        return new PendingTransactions.Status(nonGapped, transactionCount() - nonGapped);
+      }
+      return new PendingTransactions.Status(transactionCount(), 0);
+    }
   }
 
   private void findGap() {
@@ -107,10 +111,6 @@ public class PendingTransactionsForSender {
         return OptionalLong.empty();
       }
     }
-  }
-
-  public Optional<PendingTransaction> maybeLastPendingTransaction() {
-    return Optional.ofNullable(pendingTransactions.lastEntry()).map(Map.Entry::getValue);
   }
 
   public int transactionCount() {

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/layered/LayeredPendingTransactionsTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/layered/LayeredPendingTransactionsTest.java
@@ -46,6 +46,7 @@ import org.hyperledger.besu.ethereum.eth.transactions.ImmutableTransactionPoolCo
 import org.hyperledger.besu.ethereum.eth.transactions.PendingTransaction;
 import org.hyperledger.besu.ethereum.eth.transactions.PendingTransactionAddedListener;
 import org.hyperledger.besu.ethereum.eth.transactions.PendingTransactionDroppedListener;
+import org.hyperledger.besu.ethereum.eth.transactions.PendingTransactions;
 import org.hyperledger.besu.ethereum.eth.transactions.RemovalReason;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolConfiguration;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolMetrics;
@@ -819,6 +820,78 @@ public class LayeredPendingTransactionsTest extends BaseTransactionPoolTest {
     assertThat(pendingTransactions.getNextNonceForSender(addedTxs[0].transaction.getSender()))
         .isPresent()
         .hasValue(1);
+  }
+
+  @Test
+  public void shouldReturnZeroStatusWhenPoolIsEmpty() {
+    final PendingTransactions.Status status = pendingTransactions.getStatus();
+    assertThat(status.pendingCount()).isZero();
+    assertThat(status.queuedCount()).isZero();
+  }
+
+  @Test
+  public void shouldCountAllTransactionsAsPendingWhenNoncesAreSequential() {
+    pendingTransactions.addTransaction(
+        createRemotePendingTransaction(createTransaction(0, KEYS1)), Optional.empty());
+    pendingTransactions.addTransaction(
+        createRemotePendingTransaction(createTransaction(1, KEYS1)), Optional.empty());
+    pendingTransactions.addTransaction(
+        createRemotePendingTransaction(createTransaction(2, KEYS1)), Optional.empty());
+
+    final PendingTransactions.Status status = pendingTransactions.getStatus();
+    assertThat(status.pendingCount()).isEqualTo(3);
+    assertThat(status.queuedCount()).isZero();
+  }
+
+  @Test
+  public void shouldCountTransactionsBeyondNonceGapAsQueued() {
+    // nonce 0 lands in prioritized/ready (pending), nonce 2 lands in sparse with gap=1 (queued)
+    pendingTransactions.addTransaction(
+        createRemotePendingTransaction(createTransaction(0, KEYS1)), Optional.empty());
+    pendingTransactions.addTransaction(
+        createRemotePendingTransaction(createTransaction(2, KEYS1)), Optional.empty());
+
+    final PendingTransactions.Status status = pendingTransactions.getStatus();
+    assertThat(status.pendingCount()).isEqualTo(1);
+    assertThat(status.queuedCount()).isEqualTo(1);
+  }
+
+  @Test
+  public void shouldAggregatePendingAndQueuedAcrossMultipleSenders() {
+    // SENDER1: nonces 0, 1 — sequential, all pending
+    pendingTransactions.addTransaction(
+        createRemotePendingTransaction(createTransaction(0, KEYS1)), Optional.empty());
+    pendingTransactions.addTransaction(
+        createRemotePendingTransaction(createTransaction(1, KEYS1)), Optional.empty());
+    // SENDER2: nonces 0, 2 — gap at 1: 1 pending, 1 queued
+    pendingTransactions.addTransaction(
+        createRemotePendingTransaction(createTransaction(0, KEYS2)), Optional.empty());
+    pendingTransactions.addTransaction(
+        createRemotePendingTransaction(createTransaction(2, KEYS2)), Optional.empty());
+
+    final PendingTransactions.Status status = pendingTransactions.getStatus();
+    assertThat(status.pendingCount()).isEqualTo(3);
+    assertThat(status.queuedCount()).isEqualTo(1);
+  }
+
+  @Test
+  public void shouldMoveTxFromQueuedToPendingWhenGapIsFilled() {
+    // start with a gap: nonce 0 pending, nonce 2 queued
+    pendingTransactions.addTransaction(
+        createRemotePendingTransaction(createTransaction(0, KEYS1)), Optional.empty());
+    pendingTransactions.addTransaction(
+        createRemotePendingTransaction(createTransaction(2, KEYS1)), Optional.empty());
+
+    assertThat(pendingTransactions.getStatus().pendingCount()).isEqualTo(1);
+    assertThat(pendingTransactions.getStatus().queuedCount()).isEqualTo(1);
+
+    // fill the gap: nonce 1 arrives, nonce 2 is promoted from sparse to ready/prioritized
+    pendingTransactions.addTransaction(
+        createRemotePendingTransaction(createTransaction(1, KEYS1)), Optional.empty());
+
+    final PendingTransactions.Status status = pendingTransactions.getStatus();
+    assertThat(status.pendingCount()).isEqualTo(3);
+    assertThat(status.queuedCount()).isZero();
   }
 
   private TransactionAndAccount[] populateCache(final int numTxs, final long startingNonce) {

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/sorter/AbstractPendingTransactionsTestBase.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/sorter/AbstractPendingTransactionsTestBase.java
@@ -625,6 +625,78 @@ public abstract class AbstractPendingTransactionsTestBase {
         });
   }
 
+  @Test
+  public void shouldReturnZeroStatusWhenPoolIsEmpty() {
+    final PendingTransactions.Status status = transactions.getStatus();
+    assertThat(status.pendingCount()).isZero();
+    assertThat(status.queuedCount()).isZero();
+  }
+
+  @Test
+  public void shouldCountAllTransactionsAsPendingWhenNonceIsSequential() {
+    transactions.addTransaction(
+        createRemotePendingTransaction(transactionWithNonceAndSender(0, KEYS1)), Optional.empty());
+    transactions.addTransaction(
+        createRemotePendingTransaction(transactionWithNonceAndSender(1, KEYS1)), Optional.empty());
+    transactions.addTransaction(
+        createRemotePendingTransaction(transactionWithNonceAndSender(2, KEYS1)), Optional.empty());
+
+    final PendingTransactions.Status status = transactions.getStatus();
+    assertThat(status.pendingCount()).isEqualTo(3);
+    assertThat(status.queuedCount()).isZero();
+  }
+
+  @Test
+  public void shouldCountTransactionsBeyondNonceGapAsQueued() {
+    // nonce 0 is pending, nonce 2 is queued (gap at 1)
+    transactions.addTransaction(
+        createRemotePendingTransaction(transactionWithNonceAndSender(0, KEYS1)), Optional.empty());
+    transactions.addTransaction(
+        createRemotePendingTransaction(transactionWithNonceAndSender(2, KEYS1)), Optional.empty());
+
+    final PendingTransactions.Status status = transactions.getStatus();
+    assertThat(status.pendingCount()).isEqualTo(1);
+    assertThat(status.queuedCount()).isEqualTo(1);
+  }
+
+  @Test
+  public void shouldAggregatePendingAndQueuedAcrossMultipleSenders() {
+    // SENDER1: nonces 0, 1 — sequential, all pending
+    transactions.addTransaction(
+        createRemotePendingTransaction(transactionWithNonceAndSender(0, KEYS1)), Optional.empty());
+    transactions.addTransaction(
+        createRemotePendingTransaction(transactionWithNonceAndSender(1, KEYS1)), Optional.empty());
+    // SENDER2: nonces 0, 2 — gap at 1: 1 pending, 1 queued
+    transactions.addTransaction(
+        createRemotePendingTransaction(transactionWithNonceAndSender(0, KEYS2)), Optional.empty());
+    transactions.addTransaction(
+        createRemotePendingTransaction(transactionWithNonceAndSender(2, KEYS2)), Optional.empty());
+
+    final PendingTransactions.Status status = transactions.getStatus();
+    assertThat(status.pendingCount()).isEqualTo(3);
+    assertThat(status.queuedCount()).isEqualTo(1);
+  }
+
+  @Test
+  public void shouldUseAccountNonceToComputePendingCountWhenGapIsPresent() {
+    // account nonce is 2, txs at 2, 3, 5 — gap at 4: 2 pending (nonces 2,3), 1 queued (nonce 5)
+    final Account sender = mock(Account.class);
+    when(sender.getNonce()).thenReturn(2L);
+    transactions.addTransaction(
+        createRemotePendingTransaction(transactionWithNonceAndSender(2, KEYS1)),
+        Optional.of(sender));
+    transactions.addTransaction(
+        createRemotePendingTransaction(transactionWithNonceAndSender(3, KEYS1)),
+        Optional.of(sender));
+    transactions.addTransaction(
+        createRemotePendingTransaction(transactionWithNonceAndSender(5, KEYS1)),
+        Optional.of(sender));
+
+    final PendingTransactions.Status status = transactions.getStatus();
+    assertThat(status.pendingCount()).isEqualTo(2);
+    assertThat(status.queuedCount()).isEqualTo(1);
+  }
+
   protected void assertMaximumNonceForSender(final Address sender1, final int i) {
     assertThat(transactions.getNextNonceForSender(sender1)).isEqualTo(OptionalLong.of(i));
   }


### PR DESCRIPTION
## PR description

Implements the `txpool_status` JSON-RPC method to align Besu with other Ethereum clients (go-ethereum, Nethermind, Erigon).

The method returns the number of pending and queued transactions currently in the pool, hex-encoded per the spec:

```json
{
  "pending": "0xa",
  "queued": "0x7"
}
```

**Spec:** [execution-apis txpool_status](https://github.com/bomanaps/execution-apis/blob/abcfa477c21a5da0c59879fcd5949ea7c8c5b6ad/src/txpool/pool.yaml)

### Changes

- `TxPoolStatus` — new RPC method handler
- `TransactionPoolStatusResult` — new JSON result POJO with `pending` and `queued` hex-encoded fields
- `PendingTransactions.Status` — new record added to the `PendingTransactions` interface
- `getStatus()` implemented across all `PendingTransactions` implementations:
  - `LayeredPendingTransactions` / `AbstractSequentialTransactionsLayer` / `SparseTransactions` / `EndLayer`
  - `AbstractPendingTransactionsSorter` / `PendingTransactionsForSender`
  - `DisabledPendingTransactions`
- `TxPoolJsonRpcMethods` — method registered under the `TXPOOL` API group

### Bugs fixed during review

- `getQueued()` was named `getQueue()`, causing the JSON field to serialize as `"queue"` instead of `"queued"`
- Hex values were returned without the `0x` prefix (`Long.toHexString()` → `Quantity.create()`)

### Tests

- `TxPoolStatusTest` — unit tests for the RPC method (method name, zero counts, mixed counts, hex encoding)
- `AbstractPendingTransactionsTestBase` — `getStatus()` tests for the sorter implementations (empty pool, sequential nonces, nonce gap, multiple senders, account nonce arithmetic)
- `LayeredPendingTransactionsTest` — `getStatus()` tests for the layered implementation (empty pool, sequential nonces, nonce gap into sparse layer, multiple senders, gap-filling promotion from sparse to ready)

## Related to
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
https://github.com/ethereum/execution-apis/pull/758

### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)