### PR TITLE
Log ENR URL at startup alongside enode URL

### DIFF
--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetwork.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetwork.java
@@ -505,6 +505,7 @@ public class DefaultP2PNetwork implements P2PNetwork {
             .build();
 
     LOG.info("Enode URL {}", localEnode.toString());
+    getLocalEnr().ifPresent(enr -> LOG.info("ENR URL {}", enr));
     LOG.info("Node address {}", Util.publicKeyToAddress(localEnode.getNodeId()));
     localNode.setEnode(localEnode);
   }


### PR DESCRIPTION
## PR description

Log the local node's ENR URL at startup, right after the existing enode URL log line. This helps operators easily identify both their node's enode and ENR identifiers from the logs.

```
2026-03-10 09:27:05.592+1000 | main | INFO  | DefaultP2PNetwork | Enode URL enode://c00f87e44076e3097e43aa6adb46069b8379d25793c43ea3bb43dc8820699e9833d418323b251ac3e3018df290c228a88c095ead4825a93743d36e961574c1e7@127.0.0.1:30303
2026-03-10 09:27:05.592+1000 | main | INFO  | DefaultP2PNetwork | ENR URL enr:-Ly4QOzCOv8-gHF5b_iAqsA0hbcTUl3h7nV0aep_1N6FU_FdK0APJxU6CsNCig7Jieriii20n_BMuLlQO0Q4UQahmGABg2V0aMfGhMXIWLWAgmlkgnY0gmlwhH8AAAGDaXA2kAAAAAAAAAAAAAAAAAAAAAGJc2VjcDI1NmsxoQPAD4fkQHbjCX5DqmrbRgabg3nSV5PEPqO7Q9yIIGmemIN0Y3CCdl-EdGNwNoJ2xIN1ZHCCdl-EdWRwNoJ2xA
```

The ENR is only logged when available (i.e., when a discovery agent is running). Uses the existing `getLocalEnr()` method which returns the `enr:` prefixed base64url encoded form.

## Fixed Issue(s)

fixes #9967

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)