### PR TITLE
Fix Hash.toHexString() compilation error in DebugTraceBlockStreamer

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceBlockStreamer.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceBlockStreamer.java
@@ -209,7 +209,7 @@ public class DebugTraceBlockStreamer {
 
     try {
       gen.writeStartObject();
-      gen.writeStringField("txHash", transaction.getHash().toHexString());
+      gen.writeStringField("txHash", transaction.getHash().toString());
       gen.writeFieldName("result");
       gen.writeStartObject();
 


### PR DESCRIPTION
## Summary
- Fix compilation error in `DebugTraceBlockStreamer.java:212` where `Hash.toHexString()` was called but doesn't exist
- `Hash` extends `BytesHolder` which doesn't expose `toHexString()` — use `toString()` instead, which delegates to `Bytes.toString()` and returns the same `0x`-prefixed hex string

## Test plan
- [ ] Verify CI build passes (previously failing with `cannot find symbol: method toHexString()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)