### PR TITLE
Plugin API: pass pending block header when creating selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 - Holesky network is deprecated [#9437](https://github.com/hyperledger/besu/pull/9437)
 - Sunsetting features - for more context on the reasoning behind the deprecation of these features, including alternative options, read [this blog post](https://www.lfdecentralizedtrust.org/blog/sunsetting-tessera-and-simplifying-hyperledger-besu)
   - Proof of Work consensus (PoW)
+- Plugin API
+  - `PluginTransactionSelectorFactory.create(final SelectorsStateManager selectorsStateManager)` is deprecated for removal
 
 ### Bug fixes
 - BFT forks that change block period on time-based forks don't take effect [9681](https://github.com/hyperledger/besu/issues/9681)
@@ -39,6 +41,7 @@ are provided with different values, using input as per the execution-apis spec i
 - Implement `txpool_status` RPC method [#10002](https://github.com/hyperledger/besu/pull/10002)
 - Support [EIP-7975](https://eips.ethereum.org/EIPS/eip-7975): eth/70 - partial block receipt lists
 - Limit pooled tx requests by size and remove pre-eth/68 transaction announcement support [#9990](https://github.com/besu-eth/besu/pull/9990)
+- Plugin API: pass pending block header when creating selectors [#10034](https://github.com/besu-eth/besu/pull/10034)
 
 ## 26.2.0
 

--- a/acceptance-tests/detached-test-plugins/src/main/java/org/hyperledger/besu/tests/acceptance/plugins/AbstractTestTransactionSelectorPlugin.java
+++ b/acceptance-tests/detached-test-plugins/src/main/java/org/hyperledger/besu/tests/acceptance/plugins/AbstractTestTransactionSelectorPlugin.java
@@ -131,6 +131,7 @@ public abstract class AbstractTestTransactionSelectorPlugin implements BesuPlugi
 
                 @Override
                 public PluginTransactionSelector create(
+                    final ProcessableBlockHeader pendingBlockHeader,
                     final SelectorsStateManager selectorsStateManager) {
                   return new PluginTransactionSelector() {
 

--- a/acceptance-tests/detached-test-plugins/src/main/java/org/hyperledger/besu/tests/acceptance/plugins/TestBundlePlugin.java
+++ b/acceptance-tests/detached-test-plugins/src/main/java/org/hyperledger/besu/tests/acceptance/plugins/TestBundlePlugin.java
@@ -130,6 +130,7 @@ public class TestBundlePlugin implements BesuPlugin {
 
                 @Override
                 public PluginTransactionSelector create(
+                    final ProcessableBlockHeader pendingBlockHeader,
                     final SelectorsStateManager selectorsStateManager) {
                   return new PluginTransactionSelector() {
 

--- a/app/src/main/java/org/hyperledger/besu/services/TransactionSelectionServiceImpl.java
+++ b/app/src/main/java/org/hyperledger/besu/services/TransactionSelectionServiceImpl.java
@@ -53,12 +53,15 @@ public class TransactionSelectionServiceImpl implements TransactionSelectionServ
 
   @Override
   public PluginTransactionSelector createPluginTransactionSelector(
+      final ProcessableBlockHeader processableBlockHeader,
       final SelectorsStateManager selectorsStateManager) {
     if (factories == null) {
       return PluginTransactionSelector.ACCEPT_ALL;
     }
     return new AggregatedPluginTransactionSelector(
-        factories.stream().map(factory -> factory.create(selectorsStateManager)).toList());
+        factories.stream()
+            .map(factory -> factory.create(processableBlockHeader, selectorsStateManager))
+            .toList());
   }
 
   @Override

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreator.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreator.java
@@ -222,7 +222,7 @@ public abstract class AbstractBlockCreator implements AsyncBlockCreator {
       final var pluginTransactionSelector =
           miningConfiguration
               .getTransactionSelectionService()
-              .createPluginTransactionSelector(selectorsStateManager);
+              .createPluginTransactionSelector(processableBlockHeader, selectorsStateManager);
       final var operationTracer = pluginTransactionSelector.getOperationTracer();
       operationTracer.traceStartBlock(
           disposableWorldState, processableBlockHeader, miningBeneficiary);

--- a/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockTransactionSelectorTest.java
+++ b/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockTransactionSelectorTest.java
@@ -706,6 +706,7 @@ public abstract class AbstractBlockTransactionSelectorTest {
         new PluginTransactionSelectorFactory() {
           @Override
           public PluginTransactionSelector create(
+              final org.hyperledger.besu.plugin.data.ProcessableBlockHeader pendingBlockHeader,
               final SelectorsStateManager selectorsStateManager) {
             return pluginTransactionSelector;
           }
@@ -717,6 +718,7 @@ public abstract class AbstractBlockTransactionSelectorTest {
         new PluginTransactionSelectorFactory() {
           @Override
           public PluginTransactionSelector create(
+              final org.hyperledger.besu.plugin.data.ProcessableBlockHeader pendingBlockHeader,
               final SelectorsStateManager selectorsStateManager) {
             return colletorPluginTransactionSelector;
           }
@@ -797,6 +799,7 @@ public abstract class AbstractBlockTransactionSelectorTest {
         new PluginTransactionSelectorFactory() {
           @Override
           public PluginTransactionSelector create(
+              final org.hyperledger.besu.plugin.data.ProcessableBlockHeader pendingBlockHeader,
               final SelectorsStateManager selectorsStateManager) {
             return pluginTransactionSelector;
           }
@@ -808,6 +811,7 @@ public abstract class AbstractBlockTransactionSelectorTest {
         new PluginTransactionSelectorFactory() {
           @Override
           public PluginTransactionSelector create(
+              final org.hyperledger.besu.plugin.data.ProcessableBlockHeader pendingBlockHeader,
               final SelectorsStateManager selectorsStateManager) {
             return colletorPluginTransactionSelector;
           }
@@ -865,7 +869,7 @@ public abstract class AbstractBlockTransactionSelectorTest {
           when(transactionSelector.evaluateTransactionPreProcessing(any())).thenReturn(SELECTED);
           when(transactionSelector.evaluateTransactionPostProcessing(any(), any()))
               .thenReturn(SELECTED);
-          when(transactionSelectorFactory.create(any())).thenReturn(transactionSelector);
+          when(transactionSelectorFactory.create(any(), any())).thenReturn(transactionSelector);
           return new Mocks(transactionSelectorFactory, transactionSelector);
         };
 
@@ -1163,7 +1167,7 @@ public abstract class AbstractBlockTransactionSelectorTest {
 
     final PluginTransactionSelectorFactory transactionSelectorFactory =
         mock(PluginTransactionSelectorFactory.class);
-    when(transactionSelectorFactory.create(any()))
+    when(transactionSelectorFactory.create(any(), any()))
         .thenReturn(
             new PluginTransactionSelector() {
               @Override
@@ -1224,7 +1228,7 @@ public abstract class AbstractBlockTransactionSelectorTest {
     final AtomicReference<BlockTransactionSelector> selector = new AtomicReference<>();
     final PluginTransactionSelectorFactory transactionSelectorFactory =
         mock(PluginTransactionSelectorFactory.class);
-    when(transactionSelectorFactory.create(any()))
+    when(transactionSelectorFactory.create(any(), any()))
         .thenReturn(
             new PluginTransactionSelector() {
               @Override
@@ -1331,7 +1335,7 @@ public abstract class AbstractBlockTransactionSelectorTest {
 
     final PluginTransactionSelectorFactory transactionSelectorFactory =
         mock(PluginTransactionSelectorFactory.class);
-    when(transactionSelectorFactory.create(any())).thenReturn(transactionSelector);
+    when(transactionSelectorFactory.create(any(), any())).thenReturn(transactionSelector);
 
     transactionSelectionService.registerPluginTransactionSelectorFactory(
         transactionSelectorFactory);
@@ -1495,7 +1499,7 @@ public abstract class AbstractBlockTransactionSelectorTest {
 
     final PluginTransactionSelectorFactory transactionSelectorFactory =
         mock(PluginTransactionSelectorFactory.class);
-    when(transactionSelectorFactory.create(any())).thenReturn(transactionSelector);
+    when(transactionSelectorFactory.create(any(), any())).thenReturn(transactionSelector);
 
     transactionSelectionService.registerPluginTransactionSelectorFactory(
         transactionSelectorFactory);
@@ -1595,7 +1599,8 @@ public abstract class AbstractBlockTransactionSelectorTest {
             miningBeneficiary,
             blobGasPrice,
             protocolSpec,
-            transactionSelectionService.createPluginTransactionSelector(selectorsStateManager),
+            transactionSelectionService.createPluginTransactionSelector(
+                blockHeader, selectorsStateManager),
             ethScheduler,
             selectorsStateManager,
             Optional.empty());

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/MiningConfiguration.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/MiningConfiguration.java
@@ -187,6 +187,7 @@ public abstract class MiningConfiguration {
     return new TransactionSelectionService() {
       @Override
       public PluginTransactionSelector createPluginTransactionSelector(
+          final ProcessableBlockHeader pendingBlockHeader,
           final SelectorsStateManager selectorsStateManager) {
         return PluginTransactionSelector.ACCEPT_ALL;
       }

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -71,7 +71,7 @@ Calculated : ${currentHash}
 tasks.register('checkAPIChanges', FileStateChecker) {
   description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
   files = sourceSets.main.allJava.files
-  knownHash = '0EGHYlomDjcBMwQmKy9qhqGaLhcIxkWUthAGdYSTxNc='
+  knownHash = '6hDXxhwrNO1YWmdkQKoG89kPWcS8j3CBjPeoePbjms0='
 }
 check.dependsOn('checkAPIChanges')
 

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/TransactionSelectionService.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/TransactionSelectionService.java
@@ -31,11 +31,12 @@ public interface TransactionSelectionService extends BesuService {
   /**
    * Create a transaction selector plugin
    *
+   * @param pendingBlockHeader the header of the block being created
    * @param selectorsStateManager the selectors state manager
    * @return the transaction selector plugin
    */
   PluginTransactionSelector createPluginTransactionSelector(
-      SelectorsStateManager selectorsStateManager);
+      ProcessableBlockHeader pendingBlockHeader, SelectorsStateManager selectorsStateManager);
 
   /**
    * Called during the block creation to allow plugins to propose their own pending transactions for

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/txselection/PluginTransactionSelectorFactory.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/txselection/PluginTransactionSelectorFactory.java
@@ -32,9 +32,26 @@ public interface PluginTransactionSelectorFactory {
    *
    * @param selectorsStateManager the selectors state manager
    * @return the transaction selector
+   * @deprecated use {@link PluginTransactionSelectorFactory#create(ProcessableBlockHeader,
+   *     SelectorsStateManager)} instead
    */
+  @Deprecated(forRemoval = true)
   default PluginTransactionSelector create(final SelectorsStateManager selectorsStateManager) {
     return PluginTransactionSelector.ACCEPT_ALL;
+  }
+
+  /**
+   * Create a plugin transaction selector, that can be used during block creation to apply custom
+   * filters to proposed pending transactions
+   *
+   * @param pendingBlockHeader the header of the block being created
+   * @param selectorsStateManager the selectors state manager
+   * @return the transaction selector
+   */
+  default PluginTransactionSelector create(
+      final ProcessableBlockHeader pendingBlockHeader,
+      final SelectorsStateManager selectorsStateManager) {
+    return create(selectorsStateManager);
   }
 
   /**


### PR DESCRIPTION
## PR description

This branch adds `ProcessableBlockHeader` as a parameter to the plugin transaction selector factory’s create method and to
`TransactionSelectionService.createPluginTransactionSelector`. This allows plugins to access the pending block header at the time a
selector is created — useful for block-aware filtering logic. 

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


