### PR TITLE
Deprecate `--min-block-occupancy-ratio` for removal and make it noop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### Breaking Changes
 - Clique consensus has been removed. Besu can no longer start or mine on pure Clique networks. Syncing networks that started as Clique and have since transitioned to PoS via `terminalTotalDifficulty` (e.g. Linea Mainnet) are still supported. [#9852](https://github.com/hyperledger/besu/pull/9852)
+- Deprecated `--min-block-occupancy-ratio` for removal and make it noop. That option, that is ignored on PoS networks, is related to the deprecated PoW, and allowed to broadcast a mined block as soon as it reached a satisfying fill threshold. The option is still recognized, but it has no effect and will be completely removed in a future release. [#10036](https://github.com/besu-eth/besu/pull/10036)
+- Plugin API
+  - Removed `TransactionSelectionResult.BLOCK_OCCUPANCY_ABOVE_THRESHOLD`, in general it could be replaced with `BLOCK_FULL`
 
 ### Upcoming Breaking Changes
 - RPC changes to enhance compatibility with other ELs
@@ -18,6 +21,7 @@
 - Holesky network is deprecated [#9437](https://github.com/hyperledger/besu/pull/9437)
 - Sunsetting features - for more context on the reasoning behind the deprecation of these features, including alternative options, read [this blog post](https://www.lfdecentralizedtrust.org/blog/sunsetting-tessera-and-simplifying-hyperledger-besu)
   - Proof of Work consensus (PoW)
+- `--min-block-occupancy-ratio` is deprecated and will be removed in a future release
 - Plugin API
   - `PluginTransactionSelectorFactory.create(final SelectorsStateManager selectorsStateManager)` is deprecated for removal
 

--- a/app/src/main/java/org/hyperledger/besu/cli/options/MiningOptions.java
+++ b/app/src/main/java/org/hyperledger/besu/cli/options/MiningOptions.java
@@ -20,7 +20,6 @@ import static org.hyperledger.besu.ethereum.core.MiningConfiguration.DEFAULT_PLU
 import static org.hyperledger.besu.ethereum.core.MiningConfiguration.DEFAULT_POA_BLOCK_TXS_SELECTION_MAX_TIME;
 import static org.hyperledger.besu.ethereum.core.MiningConfiguration.DEFAULT_POS_BLOCK_TXS_SELECTION_MAX_TIME;
 import static org.hyperledger.besu.ethereum.core.MiningConfiguration.MutableInitValues.DEFAULT_EXTRA_DATA;
-import static org.hyperledger.besu.ethereum.core.MiningConfiguration.MutableInitValues.DEFAULT_MIN_BLOCK_OCCUPANCY_RATIO;
 import static org.hyperledger.besu.ethereum.core.MiningConfiguration.MutableInitValues.DEFAULT_MIN_PRIORITY_FEE_PER_GAS;
 import static org.hyperledger.besu.ethereum.core.MiningConfiguration.MutableInitValues.DEFAULT_MIN_TRANSACTION_GAS_PRICE;
 import static org.hyperledger.besu.ethereum.core.MiningConfiguration.Unstable.DEFAULT_POS_BLOCK_CREATION_MAX_TIME;
@@ -50,6 +49,10 @@ import picocli.CommandLine.ParameterException;
 
 /** The Mining CLI options. */
 public class MiningOptions implements CLIOptions<MiningConfiguration> {
+
+  private static final String DEPRECATION_PREFIX =
+      "Deprecated. PoW consensus is deprecated. See CHANGELOG for alternative options. ";
+
   @Option(
       names = {"--miner-extra-data"},
       description =
@@ -59,8 +62,13 @@ public class MiningOptions implements CLIOptions<MiningConfiguration> {
 
   @Option(
       names = {"--min-block-occupancy-ratio"},
-      description = "Minimum occupancy ratio for a mined block (default: ${DEFAULT-VALUE})")
-  private Double minBlockOccupancyRatio = DEFAULT_MIN_BLOCK_OCCUPANCY_RATIO;
+      hidden = true,
+      description =
+          DEPRECATION_PREFIX
+              + "Minimum occupancy ratio for a mined block (default: ${DEFAULT-VALUE})")
+  @SuppressWarnings("UnusedVariable")
+  @Deprecated
+  private Double minBlockOccupancyRatio = null;
 
   @Option(
       names = {"--min-gas-price"},
@@ -261,7 +269,6 @@ public class MiningOptions implements CLIOptions<MiningConfiguration> {
     miningOptions.extraData = miningConfiguration.getExtraData();
     miningOptions.minTransactionGasPrice = miningConfiguration.getMinTransactionGasPrice();
     miningOptions.minPriorityFeePerGas = miningConfiguration.getMinPriorityFeePerGas();
-    miningOptions.minBlockOccupancyRatio = miningConfiguration.getMinBlockOccupancyRatio();
     miningOptions.posBlockTxsSelectionMaxTime =
         miningConfiguration.getPosBlockTxsSelectionMaxTime();
     miningOptions.poaBlockTxsSelectionMaxTime =
@@ -296,8 +303,7 @@ public class MiningOptions implements CLIOptions<MiningConfiguration> {
         MutableInitValues.builder()
             .extraData(extraData)
             .minTransactionGasPrice(minTransactionGasPrice)
-            .minPriorityFeePerGas(minPriorityFeePerGas)
-            .minBlockOccupancyRatio(minBlockOccupancyRatio);
+            .minPriorityFeePerGas(minPriorityFeePerGas);
 
     if (maxBlobsPerTransaction != null) {
       updatableInitValuesBuilder.maxBlobsPerTransaction(maxBlobsPerTransaction);

--- a/app/src/test/java/org/hyperledger/besu/cli/options/MiningOptionsTest.java
+++ b/app/src/test/java/org/hyperledger/besu/cli/options/MiningOptionsTest.java
@@ -408,10 +408,7 @@ public class MiningOptionsTest extends AbstractCLIOptionsTest<MiningConfiguratio
   protected MiningConfiguration createCustomizedDomainObject() {
     return ImmutableMiningConfiguration.builder()
         .mutableInitValues(
-            MutableInitValues.builder()
-                .extraData(Bytes.fromHexString("0xabc321"))
-                .minBlockOccupancyRatio(0.5)
-                .build())
+            MutableInitValues.builder().extraData(Bytes.fromHexString("0xabc321")).build())
         .unstable(Unstable.builder().posBlockCreationMaxTime(1000).build())
         .build();
   }

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
@@ -76,15 +76,6 @@ import org.slf4j.LoggerFactory;
 public class MergeCoordinator implements MergeMiningCoordinator, BadChainListener {
   private static final Logger LOG = LoggerFactory.getLogger(MergeCoordinator.class);
 
-  /**
-   * On PoS you do not need to compete with other nodes for block production, since you have an
-   * allocated slot for that, so in this case make sense to always try to fill the block, if there
-   * are enough pending transactions, until the remaining gas is less than the minimum needed for
-   * the smaller transaction. So for PoS the min-block-occupancy-ratio option is set to always try
-   * to fill 100% of the block.
-   */
-  private static final double TRY_FILL_BLOCK = 1.0;
-
   /** The Mining parameters. */
   protected final MiningConfiguration miningConfiguration;
 
@@ -175,7 +166,6 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
     if (miningParams.getTargetGasLimit().isEmpty()) {
       getDefaultGasLimit(protocolSchedule).ifPresent(miningParams::setTargetGasLimit);
     }
-    miningParams.setMinBlockOccupancyRatio(TRY_FILL_BLOCK);
     this.miningConfiguration = miningParams;
 
     this.mergeBlockCreatorFactory = mergeBlockCreatorFactory;

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/AbstractJsonRpcHttpServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/AbstractJsonRpcHttpServiceTest.java
@@ -160,7 +160,6 @@ public abstract class AbstractJsonRpcHttpServiceTest {
             MutableInitValues.builder()
                 .extraData(Bytes.EMPTY)
                 .minTransactionGasPrice(Wei.ONE)
-                .minBlockOccupancyRatio(0d)
                 .coinbase(Address.ZERO)
                 .build())
         .build();

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/BlockSizeTransactionSelector.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/BlockSizeTransactionSelector.java
@@ -65,10 +65,7 @@ public class BlockSizeTransactionSelector extends AbstractStatefulTransactionSel
           .setMessage("Transaction {} too large to select for block creation")
           .addArgument(evaluationContext.getPendingTransaction()::toTraceLog)
           .log();
-      if (blockOccupancyAboveThreshold(state)) {
-        LOG.trace("Block occupancy above threshold, completing operation");
-        return TransactionSelectionResult.BLOCK_OCCUPANCY_ABOVE_THRESHOLD;
-      } else if (blockFull(state)) {
+      if (blockFull(state)) {
         LOG.trace("Block full, completing operation");
         return TransactionSelectionResult.BLOCK_FULL;
       } else {
@@ -125,29 +122,6 @@ public class BlockSizeTransactionSelector extends AbstractStatefulTransactionSel
   private boolean transactionTooLargeForBlock(final Transaction transaction, final GasState state) {
     return !gasAccountingStrategy.hasBlockCapacity(
         transaction.getGasLimit(), state.regularGas(), state.stateGas(), blockGasLimit);
-  }
-
-  /**
-   * Checks if the block occupancy is above the threshold.
-   *
-   * @param state The current gas state.
-   * @return True if the block occupancy is above the threshold, false otherwise.
-   */
-  private boolean blockOccupancyAboveThreshold(final GasState state) {
-    final long gasUsed =
-        gasAccountingStrategy.effectiveGasUsed(state.regularGas(), state.stateGas());
-    final long gasRemaining = blockGasLimit - gasUsed;
-    final double occupancyRatio = (double) gasUsed / (double) blockGasLimit;
-
-    LOG.trace(
-        "Min block occupancy ratio {}, gas used {}, available {}, remaining {}, used/available {}",
-        context.miningConfiguration().getMinBlockOccupancyRatio(),
-        gasUsed,
-        blockGasLimit,
-        gasRemaining,
-        occupancyRatio);
-
-    return occupancyRatio >= context.miningConfiguration().getMinBlockOccupancyRatio();
   }
 
   /**

--- a/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreatorTest.java
+++ b/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreatorTest.java
@@ -460,7 +460,6 @@ class AbstractBlockCreatorTest extends TrustedSetupClassLoaderExtension {
                 MutableInitValues.builder()
                     .extraData(Bytes.fromHexString("deadbeef"))
                     .minTransactionGasPrice(Wei.ONE)
-                    .minBlockOccupancyRatio(0d)
                     .coinbase(Address.ZERO)
                     .build())
             .build();

--- a/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockTransactionSelectorTest.java
+++ b/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockTransactionSelectorTest.java
@@ -21,7 +21,6 @@ import static org.awaitility.Awaitility.await;
 import static org.hyperledger.besu.ethereum.blockcreation.AbstractBlockTransactionSelectorTest.Sender.SENDER1;
 import static org.hyperledger.besu.ethereum.blockcreation.AbstractBlockTransactionSelectorTest.Sender.SENDER2;
 import static org.hyperledger.besu.ethereum.blockcreation.AbstractBlockTransactionSelectorTest.Sender.SENDER3;
-import static org.hyperledger.besu.ethereum.blockcreation.AbstractBlockTransactionSelectorTest.Sender.SENDER4;
 import static org.hyperledger.besu.ethereum.blockcreation.AbstractBlockTransactionSelectorTest.Sender.SENDER5;
 import static org.hyperledger.besu.ethereum.core.MiningConfiguration.DEFAULT_POS_BLOCK_TXS_SELECTION_MAX_TIME;
 import static org.hyperledger.besu.ethereum.transaction.TransactionInvalidReason.EXECUTION_INTERRUPTED;
@@ -132,8 +131,6 @@ import org.mockito.stubbing.Answer;
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 public abstract class AbstractBlockTransactionSelectorTest {
-  protected static final double MIN_OCCUPANCY_80_PERCENT = 0.8;
-  protected static final double MIN_OCCUPANCY_100_PERCENT = 1;
   protected static final BigInteger CHAIN_ID = BigInteger.valueOf(42L);
 
   protected final MetricsSystem metricsSystem = new NoOpMetricsSystem();
@@ -162,10 +159,7 @@ public abstract class AbstractBlockTransactionSelectorTest {
     transactionSelectionService = new TransactionSelectionServiceImpl();
     defaultTestMiningConfiguration =
         createMiningParameters(
-            transactionSelectionService,
-            Wei.ZERO,
-            MIN_OCCUPANCY_80_PERCENT,
-            DEFAULT_POS_BLOCK_TXS_SELECTION_MAX_TIME);
+            transactionSelectionService, Wei.ZERO, DEFAULT_POS_BLOCK_TXS_SELECTION_MAX_TIME);
 
     final Block genesisBlock =
         GenesisState.fromConfig(genesisConfig, protocolSchedule, new CodeCache()).getBlock();
@@ -386,10 +380,7 @@ public abstract class AbstractBlockTransactionSelectorTest {
     assertThat(results.getSelectedTransactions().containsAll(transactionsToInject.subList(0, 3)))
         .isTrue();
     assertThat(results.getNotSelectedTransactions())
-        .containsOnly(
-            entry(
-                transactionsToInject.get(3),
-                TransactionSelectionResult.BLOCK_OCCUPANCY_ABOVE_THRESHOLD));
+        .containsOnly(entry(transactionsToInject.get(3), TransactionSelectionResult.BLOCK_FULL));
     assertThat(results.getReceipts().size()).isEqualTo(3);
     assertThat(results.getCumulativeRegularGasUsed()).isEqualTo(300_000);
 
@@ -432,43 +423,6 @@ public abstract class AbstractBlockTransactionSelectorTest {
     assertThat(results.getSelectedTransactions()).containsExactly(txs[0], txs[2]);
     assertThat(results.getNotSelectedTransactions())
         .containsOnly(entry(txs[1], TransactionSelectionResult.TX_TOO_LARGE_FOR_REMAINING_GAS));
-  }
-
-  @Test
-  public void transactionSelectionStopsWhenSufficientBlockOccupancyIsReached() {
-    final ProcessableBlockHeader blockHeader = createBlock(300_000);
-    final Address miningBeneficiary = AddressHelpers.ofValue(1);
-    final BlockTransactionSelector selector =
-        createBlockSelectorAndSetupTxPool(
-            defaultTestMiningConfiguration,
-            transactionProcessor,
-            blockHeader,
-            miningBeneficiary,
-            Wei.ZERO,
-            transactionSelectionService);
-
-    // Add 4 transactions to the Pending Transactions 15% (ok), 79% (ok), 25% (too large), 10%
-    // (not included, it would fit, however previous transaction was too large and block was
-    // suitably populated).
-    // NOTE - PendingTransactions will output these in nonce order.
-    final Transaction[] txs =
-        new Transaction[] {
-          createTransaction(0, Wei.of(10), (long) (blockHeader.getGasLimit() * 0.15), SENDER1),
-          createTransaction(0, Wei.of(10), (long) (blockHeader.getGasLimit() * 0.79), SENDER2),
-          createTransaction(0, Wei.of(10), (long) (blockHeader.getGasLimit() * 0.25), SENDER3),
-          createTransaction(0, Wei.of(10), (long) (blockHeader.getGasLimit() * 0.1), SENDER4)
-        };
-
-    for (Transaction tx : txs) {
-      ensureTransactionIsValid(tx);
-    }
-    transactionPool.addRemoteTransactions(Arrays.stream(txs).toList());
-
-    final TransactionSelectionResults results = selector.buildTransactionListForBlock();
-
-    assertThat(results.getSelectedTransactions()).containsExactly(txs[0], txs[1]);
-    assertThat(results.getNotSelectedTransactions())
-        .containsOnly(entry(txs[2], TransactionSelectionResult.BLOCK_OCCUPANCY_ABOVE_THRESHOLD));
   }
 
   @Test
@@ -517,10 +471,7 @@ public abstract class AbstractBlockTransactionSelectorTest {
     final BlockTransactionSelector selector =
         createBlockSelectorAndSetupTxPool(
             createMiningParameters(
-                transactionSelectionService,
-                Wei.ZERO,
-                MIN_OCCUPANCY_100_PERCENT,
-                DEFAULT_POS_BLOCK_TXS_SELECTION_MAX_TIME),
+                transactionSelectionService, Wei.ZERO, DEFAULT_POS_BLOCK_TXS_SELECTION_MAX_TIME),
             transactionProcessor,
             blockHeader,
             miningBeneficiary,
@@ -534,7 +485,7 @@ public abstract class AbstractBlockTransactionSelectorTest {
     // 1) 90% of block (skipped since too large)
     // 2) enough gas to only leave space for a transaction with the min gas cost (selected)
     // 3) min gas cost (selected and 100% block gas used)
-    // 4) min gas cost (not selected since selection stopped after tx 3)
+    // 4) min gas cost (not selected since block is full)
     // NOTE - PendingTransactions outputs these in nonce order
 
     final long gasLimit0s1 = (long) (blockHeader.getGasLimit() * 0.9);
@@ -565,9 +516,7 @@ public abstract class AbstractBlockTransactionSelectorTest {
             entry(
                 transactionsToInject.get(1),
                 TransactionSelectionResult.TX_TOO_LARGE_FOR_REMAINING_GAS),
-            entry(
-                transactionsToInject.get(4),
-                TransactionSelectionResult.BLOCK_OCCUPANCY_ABOVE_THRESHOLD));
+            entry(transactionsToInject.get(4), TransactionSelectionResult.BLOCK_FULL));
     assertThat(results.getCumulativeRegularGasUsed()).isEqualTo(blockHeader.getGasLimit());
   }
 
@@ -579,10 +528,7 @@ public abstract class AbstractBlockTransactionSelectorTest {
     final BlockTransactionSelector selector =
         createBlockSelectorAndSetupTxPool(
             createMiningParameters(
-                transactionSelectionService,
-                Wei.ZERO,
-                MIN_OCCUPANCY_100_PERCENT,
-                DEFAULT_POS_BLOCK_TXS_SELECTION_MAX_TIME),
+                transactionSelectionService, Wei.ZERO, DEFAULT_POS_BLOCK_TXS_SELECTION_MAX_TIME),
             transactionProcessor,
             blockHeader,
             miningBeneficiary,
@@ -826,10 +772,7 @@ public abstract class AbstractBlockTransactionSelectorTest {
     final BlockTransactionSelector selector =
         createBlockSelectorAndSetupTxPool(
             createMiningParameters(
-                transactionSelectionService,
-                Wei.ZERO,
-                MIN_OCCUPANCY_80_PERCENT,
-                DEFAULT_POS_BLOCK_TXS_SELECTION_MAX_TIME),
+                transactionSelectionService, Wei.ZERO, DEFAULT_POS_BLOCK_TXS_SELECTION_MAX_TIME),
             transactionProcessor,
             blockHeader,
             miningBeneficiary,
@@ -1141,10 +1084,7 @@ public abstract class AbstractBlockTransactionSelectorTest {
     final BlockTransactionSelector selector =
         createBlockSelectorAndSetupTxPool(
             createMiningParameters(
-                transactionSelectionService,
-                Wei.ZERO,
-                MIN_OCCUPANCY_100_PERCENT,
-                PositiveNumber.fromInt(txsSelectionMaxTime)),
+                transactionSelectionService, Wei.ZERO, PositiveNumber.fromInt(txsSelectionMaxTime)),
             transactionProcessor,
             createBlock(301_000),
             AddressHelpers.ofValue(1),
@@ -1199,10 +1139,7 @@ public abstract class AbstractBlockTransactionSelectorTest {
     final BlockTransactionSelector selector =
         createBlockSelectorAndSetupTxPool(
             createMiningParameters(
-                transactionSelectionService,
-                Wei.ZERO,
-                MIN_OCCUPANCY_100_PERCENT,
-                PositiveNumber.fromInt(txsSelectionMaxTime)),
+                transactionSelectionService, Wei.ZERO, PositiveNumber.fromInt(txsSelectionMaxTime)),
             transactionProcessor,
             createBlock(301_000),
             AddressHelpers.ofValue(1),
@@ -1255,10 +1192,7 @@ public abstract class AbstractBlockTransactionSelectorTest {
     selector.set(
         createBlockSelectorAndSetupTxPool(
             createMiningParameters(
-                transactionSelectionService,
-                Wei.ZERO,
-                MIN_OCCUPANCY_100_PERCENT,
-                PositiveNumber.fromInt(1000)),
+                transactionSelectionService, Wei.ZERO, PositiveNumber.fromInt(1000)),
             transactionProcessor,
             createBlock(301_000),
             AddressHelpers.ofValue(1),
@@ -1346,13 +1280,11 @@ public abstract class AbstractBlockTransactionSelectorTest {
                 ? createMiningParameters(
                     transactionSelectionService,
                     Wei.ZERO,
-                    MIN_OCCUPANCY_100_PERCENT,
                     poaGenesisBlockPeriod,
                     PositiveNumber.fromInt(75))
                 : createMiningParameters(
                     transactionSelectionService,
                     Wei.ZERO,
-                    MIN_OCCUPANCY_100_PERCENT,
                     PositiveNumber.fromInt(blockTxsSelectionMaxTime)),
             transactionProcessor,
             blockHeader,
@@ -1510,13 +1442,11 @@ public abstract class AbstractBlockTransactionSelectorTest {
                 ? createMiningParameters(
                     transactionSelectionService,
                     Wei.ZERO,
-                    MIN_OCCUPANCY_100_PERCENT,
                     poaGenesisBlockPeriod,
                     PositiveNumber.fromInt(75))
                 : createMiningParameters(
                     transactionSelectionService,
                     Wei.ZERO,
-                    MIN_OCCUPANCY_100_PERCENT,
                     PositiveNumber.fromInt(blockTxsSelectionMaxTime)),
             transactionProcessor,
             blockHeader,
@@ -1762,14 +1692,9 @@ public abstract class AbstractBlockTransactionSelectorTest {
   protected MiningConfiguration createMiningParameters(
       final TransactionSelectionService transactionSelectionService,
       final Wei minGasPrice,
-      final double minBlockOccupancyRatio,
       final PositiveNumber txsSelectionMaxTime) {
     return ImmutableMiningConfiguration.builder()
-        .mutableInitValues(
-            MutableInitValues.builder()
-                .minTransactionGasPrice(minGasPrice)
-                .minBlockOccupancyRatio(minBlockOccupancyRatio)
-                .build())
+        .mutableInitValues(MutableInitValues.builder().minTransactionGasPrice(minGasPrice).build())
         .transactionSelectionService(transactionSelectionService)
         .posBlockTxsSelectionMaxTime(txsSelectionMaxTime)
         .build();
@@ -1778,14 +1703,12 @@ public abstract class AbstractBlockTransactionSelectorTest {
   protected MiningConfiguration createMiningParameters(
       final TransactionSelectionService transactionSelectionService,
       final Wei minGasPrice,
-      final double minBlockOccupancyRatio,
       final int genesisBlockPeriodSeconds,
       final PositiveNumber minBlockTimePercentage) {
     return ImmutableMiningConfiguration.builder()
         .mutableInitValues(
             MutableInitValues.builder()
                 .minTransactionGasPrice(minGasPrice)
-                .minBlockOccupancyRatio(minBlockOccupancyRatio)
                 .blockPeriodSeconds(genesisBlockPeriodSeconds)
                 .build())
         .transactionSelectionService(transactionSelectionService)

--- a/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/LondonFeeMarketBlockTransactionSelectorTest.java
+++ b/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/LondonFeeMarketBlockTransactionSelectorTest.java
@@ -119,10 +119,7 @@ public class LondonFeeMarketBlockTransactionSelectorTest
     final BlockTransactionSelector selector =
         createBlockSelectorAndSetupTxPool(
             createMiningParameters(
-                transactionSelectionService,
-                Wei.of(6),
-                MIN_OCCUPANCY_80_PERCENT,
-                DEFAULT_POS_BLOCK_TXS_SELECTION_MAX_TIME),
+                transactionSelectionService, Wei.of(6), DEFAULT_POS_BLOCK_TXS_SELECTION_MAX_TIME),
             transactionProcessor,
             blockHeader,
             miningBeneficiary,
@@ -151,10 +148,7 @@ public class LondonFeeMarketBlockTransactionSelectorTest
     final BlockTransactionSelector selector =
         createBlockSelectorAndSetupTxPool(
             createMiningParameters(
-                transactionSelectionService,
-                Wei.of(6),
-                MIN_OCCUPANCY_80_PERCENT,
-                DEFAULT_POS_BLOCK_TXS_SELECTION_MAX_TIME),
+                transactionSelectionService, Wei.of(6), DEFAULT_POS_BLOCK_TXS_SELECTION_MAX_TIME),
             transactionProcessor,
             blockHeader,
             miningBeneficiary,
@@ -182,10 +176,7 @@ public class LondonFeeMarketBlockTransactionSelectorTest
     final BlockTransactionSelector selector =
         createBlockSelectorAndSetupTxPool(
             createMiningParameters(
-                transactionSelectionService,
-                Wei.of(6),
-                MIN_OCCUPANCY_80_PERCENT,
-                DEFAULT_POS_BLOCK_TXS_SELECTION_MAX_TIME),
+                transactionSelectionService, Wei.of(6), DEFAULT_POS_BLOCK_TXS_SELECTION_MAX_TIME),
             transactionProcessor,
             blockHeader,
             miningBeneficiary,

--- a/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/TestingBuildBlockIntegrationTest.java
+++ b/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/TestingBuildBlockIntegrationTest.java
@@ -431,7 +431,6 @@ class TestingBuildBlockIntegrationTest {
                 MutableInitValues.builder()
                     .extraData(Bytes.fromHexString("deadbeef"))
                     .minTransactionGasPrice(Wei.ONE)
-                    .minBlockOccupancyRatio(0d)
                     .coinbase(Address.ZERO)
                     .build())
             .build();

--- a/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/BlockSizeTransactionSelectorTest.java
+++ b/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/BlockSizeTransactionSelectorTest.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.ethereum.blockcreation.txselection.selectors;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hyperledger.besu.ethereum.eth.transactions.PendingTransaction.MAX_SCORE;
 import static org.hyperledger.besu.plugin.data.TransactionSelectionResult.BLOCK_FULL;
-import static org.hyperledger.besu.plugin.data.TransactionSelectionResult.BLOCK_OCCUPANCY_ABOVE_THRESHOLD;
 import static org.hyperledger.besu.plugin.data.TransactionSelectionResult.SELECTED;
 import static org.hyperledger.besu.plugin.data.TransactionSelectionResult.TX_TOO_LARGE_FOR_REMAINING_GAS;
 import static org.mockito.Answers.RETURNS_DEEP_STUBS;
@@ -191,41 +190,11 @@ class BlockSizeTransactionSelectorTest {
   }
 
   @Test
-  void identifyWhenBlockOccupancyIsAboveThreshold() {
-    selectorsStateManager.blockSelectionStarted();
-
-    // create 2 txs with a gas limit just above the min block occupancy ratio
-    // so the first is accepted while the second not
-    final long justAboveOccupancyRatioGasLimit =
-        (long) (BLOCK_GAS_LIMIT * miningConfiguration.getMinBlockOccupancyRatio()) + 100;
-    final var tx1 = createPendingTransaction(justAboveOccupancyRatioGasLimit);
-
-    final var txEvaluationContext1 =
-        new TransactionEvaluationContext(
-            blockSelectionContext.pendingBlockHeader(), tx1, null, null, null, NEVER_CANCELLED);
-    evaluateAndAssertSelected(txEvaluationContext1, remainingGas(0));
-
-    assertThat(selector.getWorkingState().regularGas()).isEqualTo(justAboveOccupancyRatioGasLimit);
-
-    final var tx2 = createPendingTransaction(justAboveOccupancyRatioGasLimit);
-
-    final var txEvaluationContext2 =
-        new TransactionEvaluationContext(
-            blockSelectionContext.pendingBlockHeader(), tx2, null, null, null, NEVER_CANCELLED);
-    evaluateAndAssertNotSelected(txEvaluationContext2, BLOCK_OCCUPANCY_ABOVE_THRESHOLD);
-
-    assertThat(selector.getWorkingState().regularGas()).isEqualTo(justAboveOccupancyRatioGasLimit);
-  }
-
-  @Test
   void identifyWhenBlockIsFull() {
     when(blockSelectionContext.gasCalculator().getMinimumTransactionCost())
         .thenReturn(TRANSFER_GAS_LIMIT);
 
     selectorsStateManager.blockSelectionStarted();
-
-    // allow to completely fill the block
-    miningConfiguration.setMinBlockOccupancyRatio(1.0);
 
     // create 2 txs, where the first fill the block leaving less gas than the min required by a
     // transfer
@@ -416,7 +385,6 @@ class BlockSizeTransactionSelectorTest {
         .thenReturn(TRANSFER_GAS_LIMIT);
     selector = new BlockSizeTransactionSelector(blockSelectionContext, selectorsStateManager);
     selectorsStateManager.blockSelectionStarted();
-    miningConfiguration.setMinBlockOccupancyRatio(1.0);
 
     // Fill block with both dimensions nearly full: regular=990K, state=990K
     // gasMetered = max(990K, 990K) = 990K; remaining = 10K < 21K min cost

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/MiningConfiguration.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/MiningConfiguration.java
@@ -114,15 +114,6 @@ public abstract class MiningConfiguration {
     return this;
   }
 
-  public double getMinBlockOccupancyRatio() {
-    return getMutableRuntimeValues().minBlockOccupancyRatio;
-  }
-
-  public MiningConfiguration setMinBlockOccupancyRatio(final double minBlockOccupancyRatio) {
-    getMutableRuntimeValues().minBlockOccupancyRatio = minBlockOccupancyRatio;
-    return this;
-  }
-
   /**
    * Returns the maximum blobs per transaction. Note: Only applies from Osaka hardfork onwards.
    * Returns empty if not explicitly set by the user.
@@ -246,7 +237,6 @@ public abstract class MiningConfiguration {
 
     Wei DEFAULT_MIN_TRANSACTION_GAS_PRICE = Wei.of(1000);
     Wei DEFAULT_MIN_PRIORITY_FEE_PER_GAS = Wei.ZERO;
-    double DEFAULT_MIN_BLOCK_OCCUPANCY_RATIO = 0.8;
 
     MutableInitValues DEFAULT = ImmutableMiningConfiguration.MutableInitValues.builder().build();
 
@@ -268,11 +258,6 @@ public abstract class MiningConfiguration {
     @Value.Default
     default Wei getMinPriorityFeePerGas() {
       return DEFAULT_MIN_PRIORITY_FEE_PER_GAS;
-    }
-
-    @Value.Default
-    default double getMinBlockOccupancyRatio() {
-      return DEFAULT_MIN_BLOCK_OCCUPANCY_RATIO;
     }
 
     /**
@@ -297,7 +282,6 @@ public abstract class MiningConfiguration {
     private volatile Bytes extraData;
     private volatile Wei minTransactionGasPrice;
     private volatile Wei minPriorityFeePerGas;
-    private volatile double minBlockOccupancyRatio;
     private volatile Optional<Address> coinbase;
     private volatile OptionalLong targetGasLimit;
     private volatile Optional<Iterable<Long>> nonceGenerator;
@@ -309,7 +293,6 @@ public abstract class MiningConfiguration {
       extraData = initValues.getExtraData();
       minTransactionGasPrice = initValues.getMinTransactionGasPrice();
       minPriorityFeePerGas = initValues.getMinPriorityFeePerGas();
-      minBlockOccupancyRatio = initValues.getMinBlockOccupancyRatio();
       coinbase = initValues.getCoinbase();
       targetGasLimit = initValues.getTargetGasLimit();
       nonceGenerator = initValues.nonceGenerator();
@@ -323,7 +306,6 @@ public abstract class MiningConfiguration {
       if (o == null || getClass() != o.getClass()) return false;
       final MutableRuntimeValues that = (MutableRuntimeValues) o;
       return miningEnabled == that.miningEnabled
-          && Double.compare(minBlockOccupancyRatio, that.minBlockOccupancyRatio) == 0
           && Objects.equals(extraData, that.extraData)
           && Objects.equals(minTransactionGasPrice, that.minTransactionGasPrice)
           && Objects.equals(coinbase, that.coinbase)
@@ -341,7 +323,6 @@ public abstract class MiningConfiguration {
           extraData,
           minTransactionGasPrice,
           minPriorityFeePerGas,
-          minBlockOccupancyRatio,
           coinbase,
           targetGasLimit,
           nonceGenerator,
@@ -359,8 +340,6 @@ public abstract class MiningConfiguration {
           + minTransactionGasPrice
           + ", minPriorityFeePerGas="
           + minPriorityFeePerGas
-          + ", minBlockOccupancyRatio="
-          + minBlockOccupancyRatio
           + ", coinbase="
           + coinbase
           + ", targetGasLimit="

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/AbstractIsolationTests.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/AbstractIsolationTests.java
@@ -319,7 +319,6 @@ public abstract class AbstractIsolationTests {
                       .extraData(Bytes.fromHexString("deadbeef"))
                       .targetGasLimit(30_000_000L)
                       .minTransactionGasPrice(Wei.ONE)
-                      .minBlockOccupancyRatio(0d)
                       .coinbase(Address.ZERO)
                       .build())
               .build();

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -71,7 +71,7 @@ Calculated : ${currentHash}
 tasks.register('checkAPIChanges', FileStateChecker) {
   description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
   files = sourceSets.main.allJava.files
-  knownHash = '6hDXxhwrNO1YWmdkQKoG89kPWcS8j3CBjPeoePbjms0='
+  knownHash = '0rrsKtgrD9Erb8oygs0p8vDgk9jNWI8TvFFuGhyTOto='
 }
 check.dependsOn('checkAPIChanges')
 

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/data/TransactionSelectionResult.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/data/TransactionSelectionResult.java
@@ -165,13 +165,6 @@ public class TransactionSelectionResult {
       new TransactionSelectionResult(BaseStatus.INVALID_TX_EVALUATION_TOO_LONG);
 
   /**
-   * The transaction has not been selected since too large and the occupancy of the block is enough
-   * to stop the selection.
-   */
-  public static final TransactionSelectionResult BLOCK_OCCUPANCY_ABOVE_THRESHOLD =
-      new TransactionSelectionResult(BaseStatus.BLOCK_OCCUPANCY_ABOVE_THRESHOLD);
-
-  /**
    * There was an unhandled exception during the evaluation of the transaction. If this occurs, it
    * indicates there is a bug somewhere.
    */


### PR DESCRIPTION
## PR description

Deprecate `--min-block-occupancy-ratio` for removal and make it noop. That option, that is ignored on PoS networks, is related to the deprecated PoW, and allowed to broadcast a mined block as soon as it reached a satisfying fill threshold. The option is still recognized, but it has no effect and will be completely removed in a future release.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


