### PR TITLE
Remove deprecation warning from `--block-txs-selection-max-time` still used in PoS networks

### DIFF
--- a/app/src/main/java/org/hyperledger/besu/cli/options/MiningOptions.java
+++ b/app/src/main/java/org/hyperledger/besu/cli/options/MiningOptions.java
@@ -16,9 +16,9 @@ package org.hyperledger.besu.cli.options;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.Collections.singletonList;
-import static org.hyperledger.besu.ethereum.core.MiningConfiguration.DEFAULT_NON_POA_BLOCK_TXS_SELECTION_MAX_TIME;
 import static org.hyperledger.besu.ethereum.core.MiningConfiguration.DEFAULT_PLUGIN_BLOCK_TXS_SELECTION_MAX_TIME;
 import static org.hyperledger.besu.ethereum.core.MiningConfiguration.DEFAULT_POA_BLOCK_TXS_SELECTION_MAX_TIME;
+import static org.hyperledger.besu.ethereum.core.MiningConfiguration.DEFAULT_POS_BLOCK_TXS_SELECTION_MAX_TIME;
 import static org.hyperledger.besu.ethereum.core.MiningConfiguration.MutableInitValues.DEFAULT_EXTRA_DATA;
 import static org.hyperledger.besu.ethereum.core.MiningConfiguration.MutableInitValues.DEFAULT_MIN_BLOCK_OCCUPANCY_RATIO;
 import static org.hyperledger.besu.ethereum.core.MiningConfiguration.MutableInitValues.DEFAULT_MIN_PRIORITY_FEE_PER_GAS;
@@ -50,10 +50,6 @@ import picocli.CommandLine.ParameterException;
 
 /** The Mining CLI options. */
 public class MiningOptions implements CLIOptions<MiningConfiguration> {
-
-  private static final String DEPRECATION_PREFIX =
-      "Deprecated. PoW consensus is deprecated. See CHANGELOG for alternative options. ";
-
   @Option(
       names = {"--miner-extra-data"},
       description =
@@ -91,18 +87,16 @@ public class MiningOptions implements CLIOptions<MiningConfiguration> {
       names = {"--block-txs-selection-max-time"},
       converter = PositiveNumberConverter.class,
       description =
-          DEPRECATION_PREFIX
-              + "Specifies the maximum time, in milliseconds, that could be spent selecting transactions to be included in the block."
+          "Specifies the maximum time, in milliseconds, that could be spent selecting transactions to be included in the block on PoS networks."
               + " Not compatible with PoA networks, see poa-block-txs-selection-max-time. (default: ${DEFAULT-VALUE})")
-  private PositiveNumber nonPoaBlockTxsSelectionMaxTime =
-      DEFAULT_NON_POA_BLOCK_TXS_SELECTION_MAX_TIME;
+  private PositiveNumber posBlockTxsSelectionMaxTime = DEFAULT_POS_BLOCK_TXS_SELECTION_MAX_TIME;
 
   @Option(
       names = {"--poa-block-txs-selection-max-time"},
       converter = PositiveNumberConverter.class,
       description =
           "Specifies the maximum time that could be spent selecting transactions to be included in the block, as a percentage of the fixed block time of the PoA network."
-              + " To be only used on PoA networks, for other networks see block-txs-selection-max-time."
+              + " To be only used on PoA networks, for PoS networks see block-txs-selection-max-time."
               + " (default: ${DEFAULT-VALUE})")
   private PositiveNumber poaBlockTxsSelectionMaxTime = DEFAULT_POA_BLOCK_TXS_SELECTION_MAX_TIME;
 
@@ -268,8 +262,8 @@ public class MiningOptions implements CLIOptions<MiningConfiguration> {
     miningOptions.minTransactionGasPrice = miningConfiguration.getMinTransactionGasPrice();
     miningOptions.minPriorityFeePerGas = miningConfiguration.getMinPriorityFeePerGas();
     miningOptions.minBlockOccupancyRatio = miningConfiguration.getMinBlockOccupancyRatio();
-    miningOptions.nonPoaBlockTxsSelectionMaxTime =
-        miningConfiguration.getNonPoaBlockTxsSelectionMaxTime();
+    miningOptions.posBlockTxsSelectionMaxTime =
+        miningConfiguration.getPosBlockTxsSelectionMaxTime();
     miningOptions.poaBlockTxsSelectionMaxTime =
         miningConfiguration.getPoaBlockTxsSelectionMaxTime();
     miningOptions.pluginBlockTxsSelectionMaxTime =
@@ -318,7 +312,7 @@ public class MiningOptions implements CLIOptions<MiningConfiguration> {
         .mutableInitValues(updatableInitValuesBuilder.build())
         .maxBlobsPerBlock(
             maxBlobsPerBlock != null ? OptionalInt.of(maxBlobsPerBlock) : OptionalInt.empty())
-        .nonPoaBlockTxsSelectionMaxTime(nonPoaBlockTxsSelectionMaxTime)
+        .posBlockTxsSelectionMaxTime(posBlockTxsSelectionMaxTime)
         .poaBlockTxsSelectionMaxTime(poaBlockTxsSelectionMaxTime)
         .pluginBlockTxsSelectionMaxTime(pluginBlockTxsSelectionMaxTime)
         .unstable(

--- a/app/src/test/java/org/hyperledger/besu/cli/options/MiningOptionsTest.java
+++ b/app/src/test/java/org/hyperledger/besu/cli/options/MiningOptionsTest.java
@@ -15,9 +15,9 @@
 package org.hyperledger.besu.cli.options;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hyperledger.besu.ethereum.core.MiningConfiguration.DEFAULT_NON_POA_BLOCK_TXS_SELECTION_MAX_TIME;
 import static org.hyperledger.besu.ethereum.core.MiningConfiguration.DEFAULT_PLUGIN_BLOCK_TXS_SELECTION_MAX_TIME;
 import static org.hyperledger.besu.ethereum.core.MiningConfiguration.DEFAULT_POA_BLOCK_TXS_SELECTION_MAX_TIME;
+import static org.hyperledger.besu.ethereum.core.MiningConfiguration.DEFAULT_POS_BLOCK_TXS_SELECTION_MAX_TIME;
 import static org.hyperledger.besu.ethereum.core.MiningConfiguration.Unstable.DEFAULT_POS_BLOCK_CREATION_MAX_TIME;
 import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.verify;
@@ -180,8 +180,8 @@ public class MiningOptionsTest extends AbstractCLIOptionsTest<MiningConfiguratio
     internalTestSuccess(
         this::runtimeConfiguration,
         miningParams ->
-            assertThat(miningParams.getNonPoaBlockTxsSelectionMaxTime())
-                .isEqualTo(DEFAULT_NON_POA_BLOCK_TXS_SELECTION_MAX_TIME));
+            assertThat(miningParams.getPosBlockTxsSelectionMaxTime())
+                .isEqualTo(DEFAULT_POS_BLOCK_TXS_SELECTION_MAX_TIME));
   }
 
   @Test
@@ -212,7 +212,7 @@ public class MiningOptionsTest extends AbstractCLIOptionsTest<MiningConfiguratio
     internalTestSuccess(
         this::runtimeConfiguration,
         miningParams ->
-            assertThat(miningParams.getNonPoaBlockTxsSelectionMaxTime())
+            assertThat(miningParams.getPosBlockTxsSelectionMaxTime())
                 .isEqualTo(PositiveNumber.fromInt(2)),
         "--genesis-file",
         genesisFilePoS.toString(),
@@ -227,7 +227,7 @@ public class MiningOptionsTest extends AbstractCLIOptionsTest<MiningConfiguratio
     internalTestSuccess(
         this::runtimeConfiguration,
         miningParams -> {
-          assertThat(miningParams.getNonPoaBlockTxsSelectionMaxTime())
+          assertThat(miningParams.getPosBlockTxsSelectionMaxTime())
               .isEqualTo(PositiveNumber.fromInt(2000));
           assertThat(miningParams.getPoaBlockTxsSelectionMaxTime())
               .isEqualTo(PositiveNumber.fromInt(80));
@@ -250,7 +250,7 @@ public class MiningOptionsTest extends AbstractCLIOptionsTest<MiningConfiguratio
     internalTestSuccess(
         this::runtimeConfiguration,
         miningParams -> {
-          assertThat(miningParams.getNonPoaBlockTxsSelectionMaxTime())
+          assertThat(miningParams.getPosBlockTxsSelectionMaxTime())
               .isEqualTo(PositiveNumber.fromInt(2000));
           assertThat(miningParams.getPoaBlockTxsSelectionMaxTime())
               .isEqualTo(PositiveNumber.fromInt(80));

--- a/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockTransactionSelectorTest.java
+++ b/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockTransactionSelectorTest.java
@@ -23,7 +23,7 @@ import static org.hyperledger.besu.ethereum.blockcreation.AbstractBlockTransacti
 import static org.hyperledger.besu.ethereum.blockcreation.AbstractBlockTransactionSelectorTest.Sender.SENDER3;
 import static org.hyperledger.besu.ethereum.blockcreation.AbstractBlockTransactionSelectorTest.Sender.SENDER4;
 import static org.hyperledger.besu.ethereum.blockcreation.AbstractBlockTransactionSelectorTest.Sender.SENDER5;
-import static org.hyperledger.besu.ethereum.core.MiningConfiguration.DEFAULT_NON_POA_BLOCK_TXS_SELECTION_MAX_TIME;
+import static org.hyperledger.besu.ethereum.core.MiningConfiguration.DEFAULT_POS_BLOCK_TXS_SELECTION_MAX_TIME;
 import static org.hyperledger.besu.ethereum.transaction.TransactionInvalidReason.EXECUTION_INTERRUPTED;
 import static org.hyperledger.besu.ethereum.transaction.TransactionInvalidReason.NONCE_TOO_LOW;
 import static org.hyperledger.besu.plugin.data.TransactionSelectionResult.BLOCK_SELECTION_TIMEOUT;
@@ -165,7 +165,7 @@ public abstract class AbstractBlockTransactionSelectorTest {
             transactionSelectionService,
             Wei.ZERO,
             MIN_OCCUPANCY_80_PERCENT,
-            DEFAULT_NON_POA_BLOCK_TXS_SELECTION_MAX_TIME);
+            DEFAULT_POS_BLOCK_TXS_SELECTION_MAX_TIME);
 
     final Block genesisBlock =
         GenesisState.fromConfig(genesisConfig, protocolSchedule, new CodeCache()).getBlock();
@@ -520,7 +520,7 @@ public abstract class AbstractBlockTransactionSelectorTest {
                 transactionSelectionService,
                 Wei.ZERO,
                 MIN_OCCUPANCY_100_PERCENT,
-                DEFAULT_NON_POA_BLOCK_TXS_SELECTION_MAX_TIME),
+                DEFAULT_POS_BLOCK_TXS_SELECTION_MAX_TIME),
             transactionProcessor,
             blockHeader,
             miningBeneficiary,
@@ -582,7 +582,7 @@ public abstract class AbstractBlockTransactionSelectorTest {
                 transactionSelectionService,
                 Wei.ZERO,
                 MIN_OCCUPANCY_100_PERCENT,
-                DEFAULT_NON_POA_BLOCK_TXS_SELECTION_MAX_TIME),
+                DEFAULT_POS_BLOCK_TXS_SELECTION_MAX_TIME),
             transactionProcessor,
             blockHeader,
             miningBeneficiary,
@@ -824,7 +824,7 @@ public abstract class AbstractBlockTransactionSelectorTest {
                 transactionSelectionService,
                 Wei.ZERO,
                 MIN_OCCUPANCY_80_PERCENT,
-                DEFAULT_NON_POA_BLOCK_TXS_SELECTION_MAX_TIME),
+                DEFAULT_POS_BLOCK_TXS_SELECTION_MAX_TIME),
             transactionProcessor,
             blockHeader,
             miningBeneficiary,
@@ -1765,7 +1765,7 @@ public abstract class AbstractBlockTransactionSelectorTest {
                 .minBlockOccupancyRatio(minBlockOccupancyRatio)
                 .build())
         .transactionSelectionService(transactionSelectionService)
-        .nonPoaBlockTxsSelectionMaxTime(txsSelectionMaxTime)
+        .posBlockTxsSelectionMaxTime(txsSelectionMaxTime)
         .build();
   }
 

--- a/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/LondonFeeMarketBlockTransactionSelectorTest.java
+++ b/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/LondonFeeMarketBlockTransactionSelectorTest.java
@@ -18,7 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.hyperledger.besu.ethereum.blockcreation.AbstractBlockTransactionSelectorTest.Sender.SENDER1;
 import static org.hyperledger.besu.ethereum.blockcreation.AbstractBlockTransactionSelectorTest.Sender.SENDER2;
-import static org.hyperledger.besu.ethereum.core.MiningConfiguration.DEFAULT_NON_POA_BLOCK_TXS_SELECTION_MAX_TIME;
+import static org.hyperledger.besu.ethereum.core.MiningConfiguration.DEFAULT_POS_BLOCK_TXS_SELECTION_MAX_TIME;
 import static org.mockito.Mockito.mock;
 
 import org.hyperledger.besu.config.GenesisConfig;
@@ -122,7 +122,7 @@ public class LondonFeeMarketBlockTransactionSelectorTest
                 transactionSelectionService,
                 Wei.of(6),
                 MIN_OCCUPANCY_80_PERCENT,
-                DEFAULT_NON_POA_BLOCK_TXS_SELECTION_MAX_TIME),
+                DEFAULT_POS_BLOCK_TXS_SELECTION_MAX_TIME),
             transactionProcessor,
             blockHeader,
             miningBeneficiary,
@@ -154,7 +154,7 @@ public class LondonFeeMarketBlockTransactionSelectorTest
                 transactionSelectionService,
                 Wei.of(6),
                 MIN_OCCUPANCY_80_PERCENT,
-                DEFAULT_NON_POA_BLOCK_TXS_SELECTION_MAX_TIME),
+                DEFAULT_POS_BLOCK_TXS_SELECTION_MAX_TIME),
             transactionProcessor,
             blockHeader,
             miningBeneficiary,
@@ -185,7 +185,7 @@ public class LondonFeeMarketBlockTransactionSelectorTest
                 transactionSelectionService,
                 Wei.of(6),
                 MIN_OCCUPANCY_80_PERCENT,
-                DEFAULT_NON_POA_BLOCK_TXS_SELECTION_MAX_TIME),
+                DEFAULT_POS_BLOCK_TXS_SELECTION_MAX_TIME),
             transactionProcessor,
             blockHeader,
             miningBeneficiary,

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/MiningConfiguration.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/MiningConfiguration.java
@@ -41,7 +41,7 @@ import org.immutables.value.Value;
 @Value.Immutable
 @Value.Enclosing
 public abstract class MiningConfiguration {
-  public static final PositiveNumber DEFAULT_NON_POA_BLOCK_TXS_SELECTION_MAX_TIME =
+  public static final PositiveNumber DEFAULT_POS_BLOCK_TXS_SELECTION_MAX_TIME =
       PositiveNumber.fromInt((int) Duration.ofSeconds(5).toMillis());
   public static final PositiveNumber DEFAULT_POA_BLOCK_TXS_SELECTION_MAX_TIME =
       PositiveNumber.fromInt(75);
@@ -168,8 +168,8 @@ public abstract class MiningConfiguration {
   }
 
   @Value.Default
-  public PositiveNumber getNonPoaBlockTxsSelectionMaxTime() {
-    return DEFAULT_NON_POA_BLOCK_TXS_SELECTION_MAX_TIME;
+  public PositiveNumber getPosBlockTxsSelectionMaxTime() {
+    return DEFAULT_POS_BLOCK_TXS_SELECTION_MAX_TIME;
   }
 
   @Value.Default
@@ -214,7 +214,7 @@ public abstract class MiningConfiguration {
       }
     }
 
-    return Duration.ofMillis(getNonPoaBlockTxsSelectionMaxTime().getValue());
+    return Duration.ofMillis(getPosBlockTxsSelectionMaxTime().getValue());
   }
 
   public Duration getPluginTxsSelectionMaxTime(final Duration blockTxsSelectionMaxTime) {


### PR DESCRIPTION
## PR description

`block-txs-selection-max-time` option can be still used to limit the max time a block selection job can run for PoS networks

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


