### PR TITLE
check connection is active if we detect already connected

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeers.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeers.java
@@ -440,11 +440,14 @@ public class EthPeers implements PeerSelector {
 
     final Bytes id = peer.getId();
     final EthPeer existingPeer = activeConnections.get(id);
-    if (existingPeer != null && !existingPeer.isDisconnected()) {
-      // Peer is actively trying to connect again while we have an existing registration.
-      // This typically happens after a restart race where TCP state diverges between the two
-      // nodes. Disconnect the stale entry and accept the fresh connection.
-      LOG.debug("Replacing stale connection to peer {} with new connection", peer.getLoggableId());
+    if (inbound && existingPeer != null && !existingPeer.isDisconnected()) {
+      // The peer is actively connecting to us while we have an existing registration.
+      // This typically happens after a restart race where TCP state diverges: the peer believes
+      // the old connection is dead but we still hold a stale entry. Accept the fresh inbound
+      // connection and disconnect the stale one.
+      LOG.debug(
+          "Replacing stale connection to peer {} with new inbound connection",
+          peer.getLoggableId());
       existingPeer.disconnect(DisconnectReason.ALREADY_CONNECTED);
     } else if (alreadyConnectedOrConnecting(inbound, id)) {
       LOG.atTrace()

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/EthPeersTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/EthPeersTest.java
@@ -490,39 +490,42 @@ public class EthPeersTest {
   }
 
   @Test
-  public void shouldReplaceStaleConnectionWhenPeerReconnects() {
+  public void shouldReplaceStaleConnectionWhenPeerConnectsInbound() {
     final RespondingEthPeer peer = EthProtocolManagerTestUtil.createPeer(ethProtocolManager, 1000);
     final EthPeer ethPeer = peer.getEthPeer();
     final PeerConnection oldConnection = ethPeer.getConnection();
 
     assertThat(oldConnection.isDisconnected()).isFalse();
 
-    // Same peer attempts to connect again (simulates restart race where server still holds the
-    // old registration but the peer believes the connection is dead)
+    // Peer initiates a new inbound connection to us while we have a stale registration.
+    // This simulates the restart race where we still hold the old entry but the peer
+    // believes the connection is dead and is reconnecting.
     final Optional<DisconnectReason> result =
-        ethPeers.gatePeerConnection(oldConnection.getPeer(), false);
+        ethPeers.gatePeerConnection(oldConnection.getPeer(), true);
 
-    // New connection should be allowed, not rejected with ALREADY_CONNECTED
+    // New inbound connection should be allowed
     assertThat(result).isEmpty();
     // Stale existing connection should have been disconnected
     assertThat(oldConnection.isDisconnected()).isTrue();
   }
 
   @Test
-  public void shouldRejectConnectionWhenGenuinelyAlreadyConnected() {
-    // Verify that a peer that has already been added to activeConnections via the normal path
-    // and whose connection is live does NOT get accepted as a second concurrent connection.
-    // The new behaviour replaces the old entry, so gating returns empty (allowed).
-    // This test documents the invariant: the old connection is always cleaned up.
+  public void shouldRejectOutboundConnectionWhenAlreadyConnected() {
+    // When WE try to connect outbound to a peer we already have in activeConnections,
+    // the existing connection should be kept and the outbound attempt rejected.
+    // This avoids disrupting healthy connections due to static-peer retry timers.
     final RespondingEthPeer peer = EthProtocolManagerTestUtil.createPeer(ethProtocolManager, 1000);
-    final PeerConnection firstConnection = peer.getEthPeer().getConnection();
+    final PeerConnection existingConnection = peer.getEthPeer().getConnection();
 
-    assertThat(firstConnection.isDisconnected()).isFalse();
+    assertThat(existingConnection.isDisconnected()).isFalse();
 
-    // Second connection attempt from the same peer
-    ethPeers.gatePeerConnection(firstConnection.getPeer(), false);
+    // We attempt another outbound connection to the same peer
+    final Optional<DisconnectReason> result =
+        ethPeers.gatePeerConnection(existingConnection.getPeer(), false);
 
-    // Old connection must be disconnected regardless
-    assertThat(firstConnection.isDisconnected()).isTrue();
+    // Should be rejected — we already have this peer
+    assertThat(result).contains(DisconnectReason.ALREADY_CONNECTED);
+    // Existing connection should be untouched
+    assertThat(existingConnection.isDisconnected()).isFalse();
   }
 }


### PR DESCRIPTION
## PR description
  - Active peer in activeConnections: disconnect it and fall through to allow the new connection
  - In-progress incomplete connections (the alreadyConnectedOrConnecting else branch): still rejected as before — those are mid-handshake connections where we genuinely shouldn't have two in-flight
  - Everything else: unchanged

One note: calling existingPeer.disconnect() is asynchronous — it sends the DISCONNECT message and schedules the channel close. The new connection is allowed to proceed immediately after. If both connections briefly overlap in activeConnections, the later addPeerToEthPeers call at line 774 handles that case (it already has dedup logic there via the eviction listener at line 758-772). So there's no double-registration risk.

## Fixed Issue(s)
fixes  #10040

### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew build`
- [x] acceptance tests: `./gradlew acceptanceTest`
- [x] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


