### PR TITLE
remove invalid warning pre glamsterdam

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/ChainDataPruner.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/ChainDataPruner.java
@@ -72,8 +72,9 @@ public class ChainDataPruner implements BlockAddedObserver {
     final long storedBlockPruningMark = prunerStorage.getChainPruningMark().orElse(blockNumber);
     final long storedBalPruningMark = prunerStorage.getBalPruningMark().orElse(blockNumber);
 
-    final boolean balPresent = event.getHeader().getBalHash().isPresent();
-    validatePruningMarks(blockNumber, storedBlockPruningMark, storedBalPruningMark, balPresent);
+    final boolean isBalHashPresent = event.getHeader().getBalHash().isPresent();
+    validatePruningMarks(
+        blockNumber, storedBlockPruningMark, storedBalPruningMark, isBalHashPresent);
     recordForkBlock(event, blockNumber);
 
     if (!event.isNewCanonicalHead()) {
@@ -88,14 +89,14 @@ public class ChainDataPruner implements BlockAddedObserver {
       final long blockNumber,
       final long storedPruningMark,
       final long storedBalPruningMark,
-      final boolean balPresent) {
+      final boolean isBalHashPresent) {
     if (config.isBlockPruningEnabled() && blockNumber < storedPruningMark) {
       LOG.warn(
           "Block number {} is less than pruning mark {} - chain-pruning-blocks-retained may be too small",
           blockNumber,
           storedPruningMark);
     }
-    if (config.isBalPruningEnabled() && balPresent && blockNumber < storedBalPruningMark) {
+    if (config.isBalPruningEnabled() && isBalHashPresent && blockNumber < storedBalPruningMark) {
       LOG.warn(
           "Block number {} is less than BAL pruning mark {} - chain-pruning-bals-retained may be too small",
           blockNumber,

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/ChainDataPruner.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/ChainDataPruner.java
@@ -72,7 +72,8 @@ public class ChainDataPruner implements BlockAddedObserver {
     final long storedBlockPruningMark = prunerStorage.getChainPruningMark().orElse(blockNumber);
     final long storedBalPruningMark = prunerStorage.getBalPruningMark().orElse(blockNumber);
 
-    validatePruningMarks(blockNumber, storedBlockPruningMark, storedBalPruningMark);
+    final boolean balPresent = event.getHeader().getBalHash().isPresent();
+    validatePruningMarks(blockNumber, storedBlockPruningMark, storedBalPruningMark, balPresent);
     recordForkBlock(event, blockNumber);
 
     if (!event.isNewCanonicalHead()) {
@@ -84,14 +85,17 @@ public class ChainDataPruner implements BlockAddedObserver {
   }
 
   private void validatePruningMarks(
-      final long blockNumber, final long storedPruningMark, final long storedBalPruningMark) {
+      final long blockNumber,
+      final long storedPruningMark,
+      final long storedBalPruningMark,
+      final boolean balPresent) {
     if (config.isBlockPruningEnabled() && blockNumber < storedPruningMark) {
       LOG.warn(
           "Block number {} is less than pruning mark {} - chain-pruning-blocks-retained may be too small",
           blockNumber,
           storedPruningMark);
     }
-    if (config.isBalPruningEnabled() && blockNumber < storedBalPruningMark) {
+    if (config.isBalPruningEnabled() && balPresent && blockNumber < storedBalPruningMark) {
       LOG.warn(
           "Block number {} is less than BAL pruning mark {} - chain-pruning-bals-retained may be too small",
           blockNumber,

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/chain/ChainDataPrunerTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/chain/ChainDataPrunerTest.java
@@ -25,6 +25,7 @@ import org.hyperledger.besu.ethereum.storage.keyvalue.VariablesKeyValueStorage;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.services.kvstore.InMemoryKeyValueStorage;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.AbstractExecutorService;
@@ -32,6 +33,12 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 
 import jakarta.validation.constraints.NotNull;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -1376,6 +1383,171 @@ public class ChainDataPrunerTest {
     // All blocks should still exist
     for (int i = 0; i <= 500; i++) {
       assertThat(blockchain.getBlockHeader(i)).isPresent();
+    }
+  }
+
+  @SuppressWarnings("BannedMethod")
+  @Test
+  public void noBalPruningWarningBeforeGlamsterdam() {
+    final BlockDataGenerator gen = new BlockDataGenerator();
+    final BlockchainStorage blockchainStorage =
+        new KeyValueStoragePrefixedKeyBlockchainStorage(
+            new InMemoryKeyValueStorage(),
+            new VariablesKeyValueStorage(new InMemoryKeyValueStorage()),
+            new MainnetBlockHeaderFunctions(),
+            false);
+    final ChainDataPruner chainDataPruner =
+        new ChainDataPruner(
+            blockchainStorage,
+            () -> {},
+            new ChainDataPrunerStorage(new InMemoryKeyValueStorage()),
+            0,
+            ChainDataPruner.PruningMode.CHAIN_PRUNING,
+            new ChainPrunerConfiguration(
+                ChainDataPruner.ChainPruningStrategy.BAL,
+                Long.MAX_VALUE,
+                256,
+                Long.MAX_VALUE,
+                0,
+                0),
+            new BlockingExecutor());
+    Block genesisBlock = gen.genesisBlock();
+    final MutableBlockchain blockchain =
+        DefaultBlockchain.createMutable(
+            genesisBlock, blockchainStorage, new NoOpMetricsSystem(), 0);
+    blockchain.observeBlockAdded(chainDataPruner);
+
+    gen.setBlockOptionsSupplier(
+        () -> BlockDataGenerator.BlockOptions.create().withoutGeneratedBlockAccessList());
+
+    final Logger log4jLogger = (Logger) LogManager.getLogger(ChainDataPruner.class);
+    final List<LogEvent> capturedEvents = new ArrayList<>();
+    final AbstractAppender testAppender =
+        new AbstractAppender("test", null, null, false, Property.EMPTY_ARRAY) {
+          @Override
+          public void append(final LogEvent event) {
+            capturedEvents.add(event.toImmutable());
+          }
+        };
+    testAppender.start();
+    log4jLogger.addAppender(testAppender);
+
+    try {
+      List<Block> canonicalChain = gen.blockSequence(genesisBlock, 258);
+      List<Block> forkChain = gen.blockSequence(genesisBlock, 16);
+
+      for (Block blk : canonicalChain) {
+        blockchain.appendBlock(blk, gen.receipts(blk));
+      }
+
+      // Fork blocks at lower heights: before the fix, blockNumber < storedBalPruningMark
+      // would trigger a spurious warning even though BAL is not activated yet.
+      for (Block blk : forkChain) {
+        blockchain.storeBlock(blk, gen.receipts(blk));
+      }
+
+      assertThat(
+              capturedEvents.stream()
+                  .filter(e -> e.getLevel().equals(Level.WARN))
+                  .map(e -> e.getMessage().getFormattedMessage())
+                  .anyMatch(msg -> msg.contains("is less than BAL pruning mark")))
+          .as("No BAL pruning warning should be emitted for pre-Glamsterdam blocks")
+          .isFalse();
+    } finally {
+      log4jLogger.removeAppender(testAppender);
+    }
+  }
+
+  @SuppressWarnings("BannedMethod")
+  @Test
+  public void balPruningWarningAfterGlamsterdam() {
+    final BlockDataGenerator gen = new BlockDataGenerator();
+    final BlockchainStorage blockchainStorage =
+        new KeyValueStoragePrefixedKeyBlockchainStorage(
+            new InMemoryKeyValueStorage(),
+            new VariablesKeyValueStorage(new InMemoryKeyValueStorage()),
+            new MainnetBlockHeaderFunctions(),
+            false);
+    final ChainDataPruner chainDataPruner =
+        new ChainDataPruner(
+            blockchainStorage,
+            () -> {},
+            new ChainDataPrunerStorage(new InMemoryKeyValueStorage()),
+            0,
+            ChainDataPruner.PruningMode.CHAIN_PRUNING,
+            new ChainPrunerConfiguration(
+                ChainDataPruner.ChainPruningStrategy.BAL,
+                Long.MAX_VALUE,
+                256,
+                Long.MAX_VALUE,
+                0,
+                0),
+            new BlockingExecutor());
+    Block genesisBlock = gen.genesisBlock();
+    final MutableBlockchain blockchain =
+        DefaultBlockchain.createMutable(
+            genesisBlock, blockchainStorage, new NoOpMetricsSystem(), 0);
+    blockchain.observeBlockAdded(chainDataPruner);
+
+    // Post-glamsterdam: blocks WITH BAL
+    gen.setBlockOptionsSupplier(
+        () -> BlockDataGenerator.BlockOptions.create().withGeneratedBlockAccessList());
+
+    final Logger log4jLogger = (Logger) LogManager.getLogger(ChainDataPruner.class);
+    final List<LogEvent> capturedEvents = new ArrayList<>();
+    final AbstractAppender testAppender =
+        new AbstractAppender("test-post-glamsterdam", null, null, false, Property.EMPTY_ARRAY) {
+          @Override
+          public void append(final LogEvent event) {
+            capturedEvents.add(event.toImmutable());
+          }
+        };
+    testAppender.start();
+    log4jLogger.addAppender(testAppender);
+
+    try {
+      List<BlockDataGenerator.BlockWithAccessList> canonicalChain =
+          gen.blockSequenceWithAccessList(genesisBlock, 258);
+      List<BlockDataGenerator.BlockWithAccessList> forkChain =
+          gen.blockSequenceWithAccessList(genesisBlock, 16);
+
+      for (BlockDataGenerator.BlockWithAccessList blockWithBal : canonicalChain) {
+        final Block blk = blockWithBal.getBlock();
+        blockWithBal
+            .getBlockAccessList()
+            .ifPresent(
+                bal -> {
+                  final BlockchainStorage.Updater updater = blockchainStorage.updater();
+                  updater.putBlockAccessList(blk.getHash(), bal);
+                  updater.commit();
+                });
+        blockchain.appendBlock(blk, gen.receipts(blk));
+      }
+
+      // Fork blocks with BAL at lower heights (1-16).
+      // blockNumber < storedBalPruningMark → warning expected.
+      for (BlockDataGenerator.BlockWithAccessList blockWithBal : forkChain) {
+        final Block blk = blockWithBal.getBlock();
+        blockWithBal
+            .getBlockAccessList()
+            .ifPresent(
+                bal -> {
+                  final BlockchainStorage.Updater updater = blockchainStorage.updater();
+                  updater.putBlockAccessList(blk.getHash(), bal);
+                  updater.commit();
+                });
+        blockchain.storeBlock(blk, gen.receipts(blk));
+      }
+
+      assertThat(
+              capturedEvents.stream()
+                  .filter(e -> e.getLevel().equals(Level.WARN))
+                  .map(e -> e.getMessage().getFormattedMessage())
+                  .anyMatch(msg -> msg.contains("is less than BAL pruning mark")))
+          .as("BAL pruning warning should be emitted for post-Glamsterdam fork blocks")
+          .isTrue();
+    } finally {
+      log4jLogger.removeAppender(testAppender);
     }
   }
 

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/chain/ChainDataPrunerTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/chain/ChainDataPrunerTest.java
@@ -25,10 +25,10 @@ import org.hyperledger.besu.ethereum.storage.keyvalue.VariablesKeyValueStorage;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.services.kvstore.InMemoryKeyValueStorage;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 
@@ -1386,7 +1386,6 @@ public class ChainDataPrunerTest {
     }
   }
 
-  @SuppressWarnings("BannedMethod")
   @Test
   public void noBalPruningWarningBeforeGlamsterdam() {
     final BlockDataGenerator gen = new BlockDataGenerator();
@@ -1420,45 +1419,33 @@ public class ChainDataPrunerTest {
     gen.setBlockOptionsSupplier(
         () -> BlockDataGenerator.BlockOptions.create().withoutGeneratedBlockAccessList());
 
-    final Logger log4jLogger = (Logger) LogManager.getLogger(ChainDataPruner.class);
-    final List<LogEvent> capturedEvents = new ArrayList<>();
-    final AbstractAppender testAppender =
-        new AbstractAppender("test", null, null, false, Property.EMPTY_ARRAY) {
-          @Override
-          public void append(final LogEvent event) {
-            capturedEvents.add(event.toImmutable());
-          }
-        };
-    testAppender.start();
-    log4jLogger.addAppender(testAppender);
+    final List<LogEvent> capturedEvents =
+        withLogCapture(
+            ChainDataPruner.class,
+            () -> {
+              List<Block> canonicalChain = gen.blockSequence(genesisBlock, 258);
+              List<Block> forkChain = gen.blockSequence(genesisBlock, 16);
 
-    try {
-      List<Block> canonicalChain = gen.blockSequence(genesisBlock, 258);
-      List<Block> forkChain = gen.blockSequence(genesisBlock, 16);
+              for (Block blk : canonicalChain) {
+                blockchain.appendBlock(blk, gen.receipts(blk));
+              }
 
-      for (Block blk : canonicalChain) {
-        blockchain.appendBlock(blk, gen.receipts(blk));
-      }
+              // Fork blocks at lower heights: blockNumber < storedBalPruningMark,
+              // but no warning expected because BAL is not activated yet.
+              for (Block blk : forkChain) {
+                blockchain.storeBlock(blk, gen.receipts(blk));
+              }
+            });
 
-      // Fork blocks at lower heights: before the fix, blockNumber < storedBalPruningMark
-      // would trigger a spurious warning even though BAL is not activated yet.
-      for (Block blk : forkChain) {
-        blockchain.storeBlock(blk, gen.receipts(blk));
-      }
-
-      assertThat(
-              capturedEvents.stream()
-                  .filter(e -> e.getLevel().equals(Level.WARN))
-                  .map(e -> e.getMessage().getFormattedMessage())
-                  .anyMatch(msg -> msg.contains("is less than BAL pruning mark")))
-          .as("No BAL pruning warning should be emitted for pre-Glamsterdam blocks")
-          .isFalse();
-    } finally {
-      log4jLogger.removeAppender(testAppender);
-    }
+    assertThat(
+            capturedEvents.stream()
+                .filter(e -> e.getLevel().equals(Level.WARN))
+                .map(e -> e.getMessage().getFormattedMessage())
+                .anyMatch(msg -> msg.contains("is less than BAL pruning mark")))
+        .as("No BAL pruning warning should be emitted for pre-Glamsterdam blocks")
+        .isFalse();
   }
 
-  @SuppressWarnings("BannedMethod")
   @Test
   public void balPruningWarningAfterGlamsterdam() {
     final BlockDataGenerator gen = new BlockDataGenerator();
@@ -1489,66 +1476,54 @@ public class ChainDataPrunerTest {
             genesisBlock, blockchainStorage, new NoOpMetricsSystem(), 0);
     blockchain.observeBlockAdded(chainDataPruner);
 
-    // Post-glamsterdam: blocks WITH BAL
     gen.setBlockOptionsSupplier(
         () -> BlockDataGenerator.BlockOptions.create().withGeneratedBlockAccessList());
 
-    final Logger log4jLogger = (Logger) LogManager.getLogger(ChainDataPruner.class);
-    final List<LogEvent> capturedEvents = new ArrayList<>();
-    final AbstractAppender testAppender =
-        new AbstractAppender("test-post-glamsterdam", null, null, false, Property.EMPTY_ARRAY) {
-          @Override
-          public void append(final LogEvent event) {
-            capturedEvents.add(event.toImmutable());
-          }
-        };
-    testAppender.start();
-    log4jLogger.addAppender(testAppender);
+    final List<LogEvent> capturedEvents =
+        withLogCapture(
+            ChainDataPruner.class,
+            () -> {
+              List<BlockDataGenerator.BlockWithAccessList> canonicalChain =
+                  gen.blockSequenceWithAccessList(genesisBlock, 258);
+              List<BlockDataGenerator.BlockWithAccessList> forkChain =
+                  gen.blockSequenceWithAccessList(genesisBlock, 16);
 
-    try {
-      List<BlockDataGenerator.BlockWithAccessList> canonicalChain =
-          gen.blockSequenceWithAccessList(genesisBlock, 258);
-      List<BlockDataGenerator.BlockWithAccessList> forkChain =
-          gen.blockSequenceWithAccessList(genesisBlock, 16);
+              for (BlockDataGenerator.BlockWithAccessList blockWithBal : canonicalChain) {
+                final Block blk = blockWithBal.getBlock();
+                blockWithBal
+                    .getBlockAccessList()
+                    .ifPresent(
+                        bal -> {
+                          final BlockchainStorage.Updater updater = blockchainStorage.updater();
+                          updater.putBlockAccessList(blk.getHash(), bal);
+                          updater.commit();
+                        });
+                blockchain.appendBlock(blk, gen.receipts(blk));
+              }
 
-      for (BlockDataGenerator.BlockWithAccessList blockWithBal : canonicalChain) {
-        final Block blk = blockWithBal.getBlock();
-        blockWithBal
-            .getBlockAccessList()
-            .ifPresent(
-                bal -> {
-                  final BlockchainStorage.Updater updater = blockchainStorage.updater();
-                  updater.putBlockAccessList(blk.getHash(), bal);
-                  updater.commit();
-                });
-        blockchain.appendBlock(blk, gen.receipts(blk));
-      }
+              // Fork blocks with BAL at lower heights (1-16).
+              // blockNumber < storedBalPruningMark → warning expected.
+              for (BlockDataGenerator.BlockWithAccessList blockWithBal : forkChain) {
+                final Block blk = blockWithBal.getBlock();
+                blockWithBal
+                    .getBlockAccessList()
+                    .ifPresent(
+                        bal -> {
+                          final BlockchainStorage.Updater updater = blockchainStorage.updater();
+                          updater.putBlockAccessList(blk.getHash(), bal);
+                          updater.commit();
+                        });
+                blockchain.storeBlock(blk, gen.receipts(blk));
+              }
+            });
 
-      // Fork blocks with BAL at lower heights (1-16).
-      // blockNumber < storedBalPruningMark → warning expected.
-      for (BlockDataGenerator.BlockWithAccessList blockWithBal : forkChain) {
-        final Block blk = blockWithBal.getBlock();
-        blockWithBal
-            .getBlockAccessList()
-            .ifPresent(
-                bal -> {
-                  final BlockchainStorage.Updater updater = blockchainStorage.updater();
-                  updater.putBlockAccessList(blk.getHash(), bal);
-                  updater.commit();
-                });
-        blockchain.storeBlock(blk, gen.receipts(blk));
-      }
-
-      assertThat(
-              capturedEvents.stream()
-                  .filter(e -> e.getLevel().equals(Level.WARN))
-                  .map(e -> e.getMessage().getFormattedMessage())
-                  .anyMatch(msg -> msg.contains("is less than BAL pruning mark")))
-          .as("BAL pruning warning should be emitted for post-Glamsterdam fork blocks")
-          .isTrue();
-    } finally {
-      log4jLogger.removeAppender(testAppender);
-    }
+    assertThat(
+            capturedEvents.stream()
+                .filter(e -> e.getLevel().equals(Level.WARN))
+                .map(e -> e.getMessage().getFormattedMessage())
+                .anyMatch(msg -> msg.contains("is less than BAL pruning mark")))
+        .as("BAL pruning warning should be emitted for post-Glamsterdam fork blocks")
+        .isTrue();
   }
 
   @Test
@@ -1598,6 +1573,32 @@ public class ChainDataPrunerTest {
 
     checkBlocks(blockchain, 1, mergeBlock - 1, Optional::isEmpty);
     checkBlocks(blockchain, mergeBlock, blockchain.getChainHeadBlockNumber(), Optional::isPresent);
+  }
+
+  /**
+   * Attaches a temporary log4j appender to the given class's logger, runs the action, and returns
+   * all captured log events. The appender is properly stopped and removed regardless of outcome.
+   */
+  @SuppressWarnings("BannedMethod")
+  private static List<LogEvent> withLogCapture(final Class<?> loggerClass, final Runnable action) {
+    final Logger logger = (Logger) LogManager.getLogger(loggerClass);
+    final List<LogEvent> events = new CopyOnWriteArrayList<>();
+    final AbstractAppender appender =
+        new AbstractAppender("test-capture", null, null, false, Property.EMPTY_ARRAY) {
+          @Override
+          public void append(final LogEvent event) {
+            events.add(event.toImmutable());
+          }
+        };
+    appender.start();
+    logger.addAppender(appender);
+    try {
+      action.run();
+    } finally {
+      logger.removeAppender(appender);
+      appender.stop();
+    }
+    return events;
   }
 
   /**


### PR DESCRIPTION
## PR description

Fix invalid warning pre glamsterdam

> Block number 2424429 is less than BAL pruning mark 2424464
## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


