### PR TITLE
PeerTaskValidationResponse - accept NO_RESULTS_RETURNED

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/peertask/PeerTaskValidationResponse.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/peertask/PeerTaskValidationResponse.java
@@ -19,7 +19,7 @@ import org.hyperledger.besu.ethereum.p2p.rlpx.wire.messages.DisconnectMessage;
 import java.util.Optional;
 
 public enum PeerTaskValidationResponse {
-  NO_RESULTS_RETURNED(null, true),
+  NO_RESULTS_RETURNED(null, false),
   TOO_MANY_RESULTS_RETURNED(null, true),
   RESULTS_DO_NOT_MATCH_QUERY(null, true),
   NON_SEQUENTIAL_HEADERS_RETURNED(


### PR DESCRIPTION
Per the ETH spec, a peer may return an empty response to GetBlockHeaders if it does not have the requested block. This is not a protocol violation. Treating it as a useless response causes the peer to be disconnected and denylisted after 5 retries, which is particularly harmful when only one server peer is available (e.g. during snap sync pivot selection).

A server that is slightly behind the current safe block will always return empty for pivot header requests. The client should wait for the next safe block announcement rather than disconnecting.

## Fixed Issue(s)
fixes #10029

### Thanks for sending a pull request! Have you done the following?

- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew build`
- [x] acceptance tests: `./gradlew acceptanceTest`
- [x] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`


