### PR TITLE
dependabot to watch github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Dependabot will open a single grouped PR each week if any actions have updates, with the new SHAs and version comments added automatically. You won't need to manually look up SHAs again.


