### PR TITLE
fix UInt256: Take result from addBack in mulSubOverflow

### DIFF
--- a/evm/src/main/java/org/hyperledger/besu/evm/UInt256.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/UInt256.java
@@ -1011,7 +1011,8 @@ public record UInt256(long u3, long u2, long u1, long u0) {
     carry = u2 - 1 + ((Long.compareUnsigned(v2, res) < 0) ? 1 : 0);
 
     long z3 = v3 + u3 - carry - borrow;
-    // q = MAX may still be 1 too high; check if result >= modulus (i.e. negative wrapped)
+    // q = MAX may still be 1 too high - need to pass q - 1 (-2L) to addBack; check if result >=
+    // modulus (i.e. negative wrapped)
     if (Long.compareUnsigned(z3, u3) > 0
         || (z3 == u3
             && (Long.compareUnsigned(z2, u2) > 0
@@ -1175,8 +1176,10 @@ public record UInt256(long u3, long u2, long u1, long u0) {
   // --------------------------------------------------------------------------
   // endregion
 
-  // region Records
-  // --------------------------------------------------------------------------
+  // region Quotient / Remainder types
+  // These types are used to store the result of division. Due to the nature of the algorithm
+  // (div2by1) quotient (q) can't
+  // ever exceed 64 bits while remainder (r) can range from 64 to 256 bits.
   private record QR64(long q, long r) {}
 
   private record QR128(long q, UInt128 r) {}
@@ -1185,6 +1188,11 @@ public record UInt256(long u3, long u2, long u1, long u0) {
 
   private record QR256(long q, UInt256 r) {}
 
+  // --------------------------------------------------------------------------
+  // endregion
+
+  // region UInt* types
+  // --------------------------------------------------------------------------
   record UInt64(long u0) {
     UInt64 shiftLeft(final int shift) {
       return (shift == 0) ? this : new UInt64(u0 << shift);
@@ -1421,7 +1429,8 @@ public record UInt256(long u3, long u2, long u1, long u0) {
       long carry = u0 - 1 + ((Long.compareUnsigned(v0, z0) <= 0) ? 1 : 0);
 
       long z1 = v1 + u1 - carry;
-      // q = MAX may still be 1 too high; check if result >= modulus (i.e. negative wrapped)
+      // q = MAX may still be 1 too high - need to pass q - 1 (-2L) to addBack; check if result >=
+      // modulus (i.e. negative wrapped)
       if (Long.compareUnsigned(z1, u1) > 0 || (z1 == u1 && Long.compareUnsigned(z0, u0) >= 0)) {
         return addBack(z1, z0, -2L);
       }
@@ -1652,7 +1661,8 @@ public record UInt256(long u3, long u2, long u1, long u0) {
       carry = u1 - 1 + ((Long.compareUnsigned(v1, res) < 0) ? 1 : 0);
 
       long z2 = v2 - carry + u2 - borrow;
-      // q = MAX may still be 1 too high; check if result >= modulus (i.e. negative wrapped)
+      // q = MAX may still be 1 too high - need to pass q - 1 (-2L) to addBack; check if result >=
+      // modulus (i.e. negative wrapped)
       if (Long.compareUnsigned(z2, u2) > 0
           || (z2 == u2
               && (Long.compareUnsigned(z1, u1) > 0

--- a/evm/src/test/java/org/hyperledger/besu/evm/UInt256PropertyBasedTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/UInt256PropertyBasedTest.java
@@ -87,7 +87,7 @@ public class UInt256PropertyBasedTest {
             Tuple.of(4, Arbitraries.of(Pattern.ALL_ZERO)),
             Tuple.of(4, Arbitraries.of(Pattern.ALL_FF)),
             Tuple.of(4, Arbitraries.of(Pattern.LIMB_SIGN_BITS)),
-            Tuple.of(4, Arbitraries.of(Pattern.EQUAL_TOP_LIMBS)),
+            Tuple.of(4, Arbitraries.of(Pattern.FIXED_TOP_LIMBS)),
             Tuple.of(10, Arbitraries.of(Pattern.RANDOM)));
 
     return lengths.flatMap(
@@ -130,7 +130,7 @@ public class UInt256PropertyBasedTest {
     ALL_ZERO,
     ALL_FF,
     LIMB_SIGN_BITS,
-    EQUAL_TOP_LIMBS,
+    FIXED_TOP_LIMBS,
     RANDOM
   }
 
@@ -153,7 +153,7 @@ public class UInt256PropertyBasedTest {
         forceMsbAtIndexIfPresent(bytes, bytes.length - 1);
         yield bytes;
       }
-      case EQUAL_TOP_LIMBS -> {
+      case FIXED_TOP_LIMBS -> {
         int size = (int) Math.ceil(bytes.length / 8D) * 8;
         final byte[] newArray = new byte[size];
         System.arraycopy(bytes, 0, newArray, size - bytes.length, bytes.length);

--- a/evm/src/test/java/org/hyperledger/besu/evm/UInt256Test.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/UInt256Test.java
@@ -602,12 +602,15 @@ public class UInt256Test {
               },
               {"0xbf1256135bb3f72de074d0f237", "0x8b63235ac1765530"},
               {"0x5b35862b0027a502b1d4cbc4a09e25", "0x932542f4003763"},
-              // mulSubOverflow addBack bugs
               {
+                // Multiply and subtract overflows and we need to decrement quotient estimation -
+                // UInt192 case
                 "0x8200000000000000000000000000000000000000000000000000000000000000",
                 "0x8200000000000000fe000004000000ffff000000fffff700"
               },
               {
+                // Multiply and subtract overflows and we need to decrement quotient estimation -
+                // UInt128 case
                 "0x820000000000000000000000000000000000000000000000",
                 "0x8200000000000000fe00000000000001"
               },


### PR DESCRIPTION
## PR description
Added unit tests that trip the bugs and also property test patterns that are also tripping the those paths. Regarding `UInt256::mulSubOverflow` I don't think it is possible to get into `addBack` but I changed it just for algorithm correctness.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


