### PR TITLE
Acceptance Tests - narrower port range to minimise conflicts

### DIFF
--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/configuration/BesuNodeFactory.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/configuration/BesuNodeFactory.java
@@ -365,8 +365,9 @@ public class BesuNodeFactory {
     rpcConfig.addRpcApi("ADMIN,TXPOOL");
     if (fixedPort) {
       rpcConfig.setPort(
-          Math.abs(name.hashCode() % 60000)
-              + 1024); // Generate a consistent port for p2p based on node name
+          Math.abs(name.hashCode() % 8000)
+              + 20000); // Generate a consistent port based on node name, in range 20000-27999
+      // (avoids Linux ephemeral port range 32768-60999 and privileged ports)
     }
 
     BesuNodeConfigurationBuilder builder =
@@ -383,10 +384,9 @@ public class BesuNodeFactory {
             .genesisConfigProvider(GenesisConfigurationFactory::createIbft2GenesisConfig);
     if (fixedPort) {
       builder.p2pPort(
-          Math.abs(name.hashCode() % 60000)
-              + 1024
-              + 500); // Generate a consistent port for p2p based on node name (+ 500 to avoid
-      // clashing with RPC port or other nodes with a similar name)
+          Math.abs(name.hashCode() % 8000)
+              + 20000
+              + 500); // P2P port offset by 500 from RPC to avoid clashing
     }
     return create(builder.build());
   }
@@ -398,8 +398,9 @@ public class BesuNodeFactory {
     rpcConfig.addRpcApi("ADMIN,TXPOOL");
     if (fixedPort) {
       rpcConfig.setPort(
-          Math.abs(name.hashCode() % 60000)
-              + 1024); // Generate a consistent port for p2p based on node name
+          Math.abs(name.hashCode() % 8000)
+              + 20000); // Generate a consistent port based on node name, in range 20000-27999
+      // (avoids Linux ephemeral port range 32768-60999 and privileged ports)
     }
 
     BesuNodeConfigurationBuilder builder =
@@ -418,10 +419,9 @@ public class BesuNodeFactory {
             .genesisConfigProvider(GenesisConfigurationFactory::createQbftGenesisConfig);
     if (fixedPort) {
       builder.p2pPort(
-          Math.abs(name.hashCode() % 60000)
-              + 1024
-              + 500); // Generate a consistent port for p2p based on node name (+ 500 to avoid
-      // clashing with RPC port or other nodes with a similar name)
+          Math.abs(name.hashCode() % 8000)
+              + 20000
+              + 500); // P2P port offset by 500 from RPC to avoid clashing
     }
     return create(builder.build());
   }


### PR DESCRIPTION
Port Range Problem

The formula can generate ports from 1024 to 61023, which overlaps heavily with the Linux ephemeral port range (32768–60999). CI runners running many processes are likely to have ephemeral connections occupying those ports.

example failure
https://github.com/besu-eth/besu/actions/runs/23415478722/job/68110048993?pr=10073

```
BftSyncAcceptanceTest > shouldSyncValidatorNode(String, BftAcceptanceTestParameterization, SyncMode) > 2: qbft with FULL sync FAILED
    org.awaitility.core.ConditionTimeoutException: Assertion condition defined as a Lambda expression in org.hyperledger.besu.tests.acceptance.dsl.condition.net.AwaitNetPeerCount null within 1 minutes.
        at app//org.awaitility.core.ConditionAwaiter.await(ConditionAwaiter.java:167)
        at app//org.awaitility.core.AssertionCondition.await(AssertionCondition.java:119)
        at app//org.awaitility.core.AssertionCondition.await(AssertionCondition.java:31)
        at app//org.awaitility.core.ConditionFactory.until(ConditionFactory.java:1160)
        at app//org.awaitility.core.ConditionFactory.untilAsserted(ConditionFactory.java:790)
        at app//org.hyperledger.besu.tests.acceptance.dsl.WaitUtils.waitFor(WaitUtils.java:31)
        at app//org.hyperledger.besu.tests.acceptance.dsl.condition.net.AwaitNetPeerCount.verify(AwaitNetPeerCount.java:48)
        at app//org.hyperledger.besu.tests.acceptance.dsl.node.BesuNode.verify(BesuNode.java:888)
        at app//org.hyperledger.besu.tests.acceptance.dsl.node.BesuNode.awaitPeerDiscovery(BesuNode.java:616)
        at app//org.hyperledger.besu.tests.acceptance.dsl.node.cluster.Cluster.addNode(Cluster.java:134)
        at app//org.hyperledger.besu.tests.acceptance.bft.BftSyncAcceptanceTest.shouldSyncValidatorNode(BftSyncAcceptanceTest.java:81)

        Caused by:
        java.lang.IllegalStateException: JSON-RPC port not available for node validator4. Node may have failed to start or ports file was not written.
            at org.hyperledger.besu.tests.acceptance.dsl.node.BesuNode.jsonRpcBaseUrl(BesuNode.java:369)
            at org.hyperledger.besu.tests.acceptance.dsl.node.BesuNode.nodeRequests(BesuNode.java:478)
            at org.hyperledger.besu.tests.acceptance.dsl.node.BesuNode.execute(BesuNode.java:883)
            at org.hyperledger.besu.tests.acceptance.dsl.condition.net.AwaitNetPeerCount.lambda$verify$0(AwaitNetPeerCount.java:49)
            at org.awaitility.core.AssertionCondition.lambda$new$0(AssertionCondition.java:53)
            at org.awaitility.core.ConditionAwaiter$ConditionPoller.call(ConditionAwaiter.java:248)
            at org.awaitility.core.ConditionAwaiter$ConditionPoller.call(ConditionAwaiter.java:235)
            at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
            at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
            at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
            at java.base/java.lang.Thread.run(Thread.java:1583)
```