### PR TITLE
snap sync - don't disconnect peer for late responses

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/snap/SnapProtocolManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/snap/SnapProtocolManager.java
@@ -106,8 +106,10 @@ public class SnapProtocolManager implements ProtocolManager {
 
     final EthMessage ethMessage = new EthMessage(ethPeer, message.getData());
     if (!ethPeer.validateReceivedMessage(ethMessage, getSupportedProtocol())) {
-      LOG.debug("Unsolicited message {} received from, disconnecting: {}", code, ethPeer);
-      ethPeer.disconnect(DisconnectReason.BREACH_OF_PROTOCOL_UNSOLICITED_MESSAGE_RECEIVED);
+      LOG.debug(
+          "Dropping unsolicited snap message {} from peer {} - likely a late response after timeout",
+          code,
+          ethPeer);
       return;
     }
 


### PR DESCRIPTION
## PR description
When a snap sync client sent a request (e.g. GetTrieNodes) that subsequently timed out or was cancelled, and the server then delivered the response late, SnapProtocolManager treated the arriving TrieNodes response as an unsolicited message and disconnected the peer with BREACH_OF_PROTOCOL_UNSOLICITED_MESSAGE_RECEIVED.

Root cause

validateReceivedMessage returns false when a known response message code arrives with no outstanding requests. The existing code treated this as a protocol violation and disconnected. But a late response arriving after a timeout or cancellation is not a protocol violation - the server did exactly what was asked, just slowly.

Fix

Drop the late response silently (with a DEBUG log) instead of disconnecting. validateReceivedMessage only returns false for known response codes (AccountRange/StorageRange/ByteCodes/TrieNodes) with zero outstanding requests, so this change is narrowly scoped to that case.
Unknown message codes are unaffected - they pass validateReceivedMessage via orElse(true) and are handled downstream.

## Fixed Issue(s)
fixes #10086


### Thanks for sending a pull request! Have you done the following?

- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew build`
- [x] acceptance tests: `./gradlew acceptanceTest`
- [x] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`


