### PR TITLE
Flag for EVM v2 --Xevm-go-fast / --Xevm-v2

### DIFF
--- a/app/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/app/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -2987,6 +2987,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
         .setTxPoolImplementation(buildTransactionPoolConfiguration().getTxPoolImplementation())
         .setWorldStateUpdateMode(unstableEvmOptions.toDomainObject().worldUpdaterMode())
         .setEnabledOpcodeOptimizations(unstableEvmOptions.toDomainObject().enableOptimizedOpcodes())
+        .setEvmV2(unstableEvmOptions.toDomainObject().enableEvmV2())
         .setPluginContext(this.besuPluginContext)
         .setHistoryExpiryPruneEnabled(getDataStorageConfiguration().getHistoryExpiryPruneEnabled())
         .setBlobDBSettings(rocksDBPlugin.getBlobDBSettings());

--- a/app/src/main/java/org/hyperledger/besu/cli/ConfigurationOverviewBuilder.java
+++ b/app/src/main/java/org/hyperledger/besu/cli/ConfigurationOverviewBuilder.java
@@ -65,6 +65,7 @@ public class ConfigurationOverviewBuilder {
   private TransactionPoolConfiguration.Implementation txPoolImplementation;
   private EvmConfiguration.WorldUpdaterMode worldStateUpdateMode;
   private boolean enabledOpcodeOptimizations;
+  private boolean evmV2 = false;
   private Map<String, String> environment;
   private BesuPluginContextImpl besuPluginContext;
   private boolean isHistoryExpiryPruneEnabled = false;
@@ -321,6 +322,17 @@ public class ConfigurationOverviewBuilder {
   }
 
   /**
+   * Sets whether the experimental EVM v2 (long[] stack) is enabled.
+   *
+   * @param evmV2 true if --Xevm-go-fast / --Xevm-v2 is enabled
+   * @return the builder
+   */
+  public ConfigurationOverviewBuilder setEvmV2(final boolean evmV2) {
+    this.evmV2 = evmV2;
+    return this;
+  }
+
+  /**
    * Sets the engine jwt file path.
    *
    * @param engineJwtFilePath the engine apis
@@ -513,7 +525,11 @@ public class ConfigurationOverviewBuilder {
 
     lines.add("Using " + worldStateUpdateMode + " worldstate update mode");
 
-    lines.add("Opcode optimizations " + (enabledOpcodeOptimizations ? "enabled" : "disabled"));
+    if (evmV2) {
+      lines.add("Experimental EVM v2 (long[] stack) enabled");
+    } else {
+      lines.add("Opcode optimizations " + (enabledOpcodeOptimizations ? "enabled" : "disabled"));
+    }
 
     if (isParallelTxProcessingEnabled) {
       lines.add("Parallel transaction processing enabled");

--- a/app/src/main/java/org/hyperledger/besu/cli/options/EvmOptions.java
+++ b/app/src/main/java/org/hyperledger/besu/cli/options/EvmOptions.java
@@ -32,6 +32,9 @@ public class EvmOptions implements CLIOptions<EvmConfiguration> {
   /** The constant OPTIMIZED_OP_CODES. */
   public static final String OPTIMIZED_OP_CODES = "--Xevm-optimized-opcodes";
 
+  /** The constant EVM_GO_FAST. */
+  public static final String EVM_GO_FAST = "--Xevm-go-fast";
+
   /** Default constructor. */
   EvmOptions() {}
 
@@ -72,10 +75,18 @@ public class EvmOptions implements CLIOptions<EvmConfiguration> {
       arity = "1")
   private boolean enableOptimizedOpcodes = true;
 
+  @CommandLine.Option(
+      names = {EVM_GO_FAST, "--Xevm-v2"},
+      description = "Enable experimental EVM v2 with long[] stack representation (default: false)",
+      fallbackValue = "false",
+      hidden = true,
+      arity = "1")
+  private boolean enableEvmV2 = false;
+
   @Override
   public EvmConfiguration toDomainObject() {
     return new EvmConfiguration(
-        jumpDestCacheWeightKilobytes, worldstateUpdateMode, enableOptimizedOpcodes);
+        jumpDestCacheWeightKilobytes, worldstateUpdateMode, enableOptimizedOpcodes, enableEvmV2);
   }
 
   @Override

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/EvmToolCommand.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/EvmToolCommand.java
@@ -326,7 +326,13 @@ public class EvmToolCommand implements Runnable {
     addForkHelp(commandLine.getSubcommands().get("t8n"));
     addForkHelp(commandLine.getSubcommands().get("t8n-server"));
 
-    commandLine.setExecutionStrategy(new CommandLine.RunLast());
+    commandLine.setExecutionStrategy(
+        parseResult -> {
+          if (daggerOptions.isEvmV2Enabled()) {
+            out.println("EVM v2 (long[] stack) enabled");
+          }
+          return new CommandLine.RunLast().execute(parseResult);
+        });
     commandLine.execute(args);
   }
 

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/EvmToolCommandOptionsModule.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/EvmToolCommandOptionsModule.java
@@ -142,11 +142,29 @@ public class EvmToolCommandOptionsModule {
       arity = "1")
   private boolean enableOptimizedOpcodes = true;
 
+  @CommandLine.Option(
+      names = {"--Xevm-go-fast", "--Xevm-v2"},
+      description = "Enable experimental EVM v2 with long[] stack representation (default: false)",
+      fallbackValue = "false",
+      defaultValue = "false",
+      hidden = true,
+      arity = "1")
+  private boolean enableEvmV2 = false;
+
   @Provides
   @Singleton
   EvmConfiguration provideEvmConfiguration() {
     return new EvmConfiguration(
-        jumpDestCacheWeightKilobytes, worldstateUpdateMode, enableOptimizedOpcodes);
+        jumpDestCacheWeightKilobytes, worldstateUpdateMode, enableOptimizedOpcodes, enableEvmV2);
+  }
+
+  /**
+   * Returns whether experimental EVM v2 is enabled. Used by the tool to emit a startup notice.
+   *
+   * @return true if EVM v2 is enabled
+   */
+  public boolean isEvmV2Enabled() {
+    return enableEvmV2;
   }
 
   /** Default constructor for the EvmToolCommandOptionsModule class. */

--- a/evm/src/main/java/org/hyperledger/besu/evm/internal/EvmConfiguration.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/internal/EvmConfiguration.java
@@ -25,6 +25,7 @@ import java.util.OptionalInt;
  * @param jumpDestCacheWeightKB the jump destination cache weight in kb
  * @param worldUpdaterMode the world updater mode
  * @param enableOptimizedOpcodes enable optimized implementation of certain opcodes in the EVM
+ * @param enableEvmV2 enable experimental EVM v2 with long[] stack representation
  * @param evmStackSize the maximum evm stack size
  * @param maxCodeSizeOverride An optional override of the maximum code size set by the EVM fork
  * @param maxInitcodeSizeOverride An optional override of the maximum initcode size set by the EVM
@@ -34,6 +35,7 @@ public record EvmConfiguration(
     long jumpDestCacheWeightKB,
     WorldUpdaterMode worldUpdaterMode,
     boolean enableOptimizedOpcodes,
+    boolean enableEvmV2,
     Integer evmStackSize,
     Optional<Integer> maxCodeSizeOverride,
     Optional<Integer> maxInitcodeSizeOverride) {
@@ -50,7 +52,7 @@ public record EvmConfiguration(
 
   /** The constant DEFAULT. */
   public static final EvmConfiguration DEFAULT =
-      new EvmConfiguration(32_000L, WorldUpdaterMode.STACKED, true);
+      new EvmConfiguration(32_000L, WorldUpdaterMode.STACKED, true, false);
 
   /**
    * Create an EVM Configuration without any overrides
@@ -67,6 +69,30 @@ public record EvmConfiguration(
         jumpDestCacheWeightKilobytes,
         worldstateUpdateMode,
         enableOptimizedOpcodes,
+        false,
+        MessageFrame.DEFAULT_MAX_STACK_SIZE,
+        Optional.empty(),
+        Optional.empty());
+  }
+
+  /**
+   * Create an EVM Configuration without any overrides, with explicit EVM v2 flag
+   *
+   * @param jumpDestCacheWeightKilobytes the jump dest cache weight (in kibibytes)
+   * @param worldstateUpdateMode the world update mode
+   * @param enableOptimizedOpcodes enabled opcode optimizations
+   * @param enableEvmV2 enable experimental EVM v2 with long[] stack representation
+   */
+  public EvmConfiguration(
+      final Long jumpDestCacheWeightKilobytes,
+      final WorldUpdaterMode worldstateUpdateMode,
+      final boolean enableOptimizedOpcodes,
+      final boolean enableEvmV2) {
+    this(
+        jumpDestCacheWeightKilobytes,
+        worldstateUpdateMode,
+        enableOptimizedOpcodes,
+        enableEvmV2,
         MessageFrame.DEFAULT_MAX_STACK_SIZE,
         Optional.empty(),
         Optional.empty());
@@ -98,6 +124,7 @@ public record EvmConfiguration(
         jumpDestCacheWeightKB,
         worldUpdaterMode,
         enableOptimizedOpcodes,
+        enableEvmV2,
         newEvmStackSize.orElse(MessageFrame.DEFAULT_MAX_STACK_SIZE),
         newMaxCodeSize.isPresent() ? Optional.of(newMaxCodeSize.getAsInt()) : Optional.empty(),
         newMaxInitcodeSize.isPresent()


### PR DESCRIPTION
Introduces an evm v2 flag (disabled by default) that currently only logs when it's enabled, either in Besu startup config or evmtool

Changes:
- Add `enableEvmV2` field to EvmConfiguration (default false)
- Wire `--Xevm-go-fast` hidden CLI flag in EvmOptions and evmtool
- ConfigurationOverviewBuilder: prints EVM v2 notice when enabled; suppresses redundant opcode-optimizations line in that mode
- evmtool: execution-strategy wrapper prints v2 notice before any subcommand, covering benchmark (which never calls getEvmConfiguration via Dagger)
- --Xevm-v2 added as CLI alias alongside --Xevm-go-fast


Logging when flag enabled...

```
$ evmtool --Xevm-v2 true block-test
EVM v2 (long[] stack) enabled
```

```
$ evmtool --Xevm-v2 true benchmark
EVM v2 (long[] stack) enabled
```

```
$ besu --Xevm-v2 true
2026-03-26 14:14:06.059+1000 | main | INFO  | Besu | Starting Besu
...
2026-03-26 14:14:06.994+1000 | main | INFO  | Besu |
####################################################################################################
#                                                                                                  #
# Besu version 26.3-develop-66b64f7                                                                #
...
# Experimental EVM v2 (long[] stack) enabled                                                       #
...
```
