### PR TITLE
fix: check regular and state gas dimensions independently

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/BlockGasAccountingStrategy.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/BlockGasAccountingStrategy.java
@@ -99,10 +99,18 @@ public interface BlockGasAccountingStrategy {
             final long cumulativeRegularGas,
             final long cumulativeStateGas,
             final long blockGasLimit) {
-          final long headroom =
-              Math.max(0, blockGasLimit - cumulativeRegularGas)
-                  + Math.max(0, blockGasLimit - cumulativeStateGas);
-          return txGasLimit <= headroom;
+          // EIP-8037: check each gas dimension independently per the spec's
+          // check_transaction:
+          //   min(TX_MAX_GAS_LIMIT, tx.gas) <= block_gas_limit − Σ regular
+          //   tx.gas <= block_gas_limit − Σ state
+          // The regular dimension uses min(TX_MAX_GAS_LIMIT, tx.gas) because
+          // EIP-8037 allows tx.gas > TX_MAX_GAS_LIMIT (overflow goes to the
+          // state gas reservoir), while regular gas is capped.
+          // TX_MAX_GAS_LIMIT = 2^24 = 16,777,216 (EIP-7825)
+          final long regularRemaining = Math.max(0, blockGasLimit - cumulativeRegularGas);
+          final long stateRemaining = Math.max(0, blockGasLimit - cumulativeStateGas);
+          return regularRemaining >= Math.min(txGasLimit, 16_777_216L)
+              && stateRemaining >= txGasLimit;
         }
 
         @Override


### PR DESCRIPTION
## Summary

Fix remaining EELS hive failures on `bal-devnet-3` against `bal@v5.5.1` fixtures.

Requires EELS mapper changes: https://github.com/ethereum/execution-specs/pull/2565

### Check regular and state gas dimensions independently in hasBlockCapacity [`043d2911`](https://github.com/spencer-tb/besu/commit/043d29119f)

The Amsterdam `hasBlockCapacity` summed remaining regular and state headroom into a single value This allowed transactions to borrow unused capacity from the other dimension. When a transaction should have been rejected (exceeding one dimension's capacity), the surplus from the other dimension let it through. The transaction then executed, added BAL entries, and the BAL hash didn't match the fixture (which expects the transaction to not be included).

The EELS specs [`check_transaction`](https://github.com/ethereum/execution-specs/blob/devnets/bal/3/src/ethereum/forks/amsterdam/fork.py#L551) checks each dimension independently. The regular dimension uses `min(TX_MAX_GAS_LIMIT, tx.gas)` because EIP-8037 allows `tx.gas > TX_MAX_GAS_LIMIT` (overflow goes to the state gas reservoir), while regular gas is capped at `TX_MAX_GAS_LIMIT`.

**Tests fixed (10):**
- `test_block_regular_gas_limit[exceed_block_gas_limit_True]`
- `test_block_state_gas_limit[exceed_block_gas_limit_True]`
- `test_multi_transaction_gas_accounting` × 8 (all `exceed_block_gas_limit_True`)

**Tests fixed by EELS mapper [#2565](https://github.com/ethereum/execution-specs/pull/2565) (2):**
- `test_create_tx_intrinsic_gas_boundary[below_intrinsic]`
- `test_authorization_exact_state_gas_boundary[one_short]`
