### PR TITLE
RocksDB: native column-family options with Besu; unlock settings beyond rocksdbjni Java API

### DIFF
--- a/app/src/test/java/org/hyperledger/besu/RunnerTest.java
+++ b/app/src/test/java/org/hyperledger/besu/RunnerTest.java
@@ -414,6 +414,8 @@ public final class RunnerTest {
                         DEFAULT_ENABLE_READ_CACHE_FOR_SNAPSHOTS,
                         false,
                         Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
                         Optional.empty()),
                 Arrays.asList(KeyValueSegmentIdentifier.values()),
                 RocksDBMetricsFactory.PUBLIC_ROCKS_DB_METRICS))

--- a/app/src/test/java/org/hyperledger/besu/RunnerTest.java
+++ b/app/src/test/java/org/hyperledger/besu/RunnerTest.java
@@ -416,7 +416,8 @@ public final class RunnerTest {
                         Optional.empty(),
                         Optional.empty(),
                         Optional.empty(),
-                        Optional.empty()),
+                        Optional.empty(),
+                        false),
                 Arrays.asList(KeyValueSegmentIdentifier.values()),
                 RocksDBMetricsFactory.PUBLIC_ROCKS_DB_METRICS))
         .withCommonConfiguration(besuConfiguration)

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/AbstractIsolationTests.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/AbstractIsolationTests.java
@@ -216,6 +216,8 @@ public abstract class AbstractIsolationTests {
                         false,
                         false,
                         Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
                         Optional.empty()),
                 Arrays.asList(KeyValueSegmentIdentifier.values()),
                 RocksDBMetricsFactory.PUBLIC_ROCKS_DB_METRICS))

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/AbstractIsolationTests.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/AbstractIsolationTests.java
@@ -218,7 +218,8 @@ public abstract class AbstractIsolationTests {
                         Optional.empty(),
                         Optional.empty(),
                         Optional.empty(),
-                        Optional.empty()),
+                        Optional.empty(),
+                        false),
                 Arrays.asList(KeyValueSegmentIdentifier.values()),
                 RocksDBMetricsFactory.PUBLIC_ROCKS_DB_METRICS))
         .withCommonConfiguration(

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDbNativeOptionStrings.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDbNativeOptionStrings.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.plugin.services.storage.rocksdb;
+
+import java.util.Properties;
+
+import com.google.common.base.Splitter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Parses RocksDB option strings in the same style as Nethermind's {@code RocksDbOptions} / {@code
+ * AdditionalRocksDbOptions}: semicolon-separated {@code key=value} pairs passed to the native
+ * option parser via {@link org.rocksdb.ColumnFamilyOptions#getColumnFamilyOptionsFromProps} and
+ * {@link org.rocksdb.DBOptions#getDBOptionsFromProps}.
+ *
+ * <p>Additional column-family strings are parsed here, applied in {@link
+ * org.hyperledger.besu.plugin.services.storage.rocksdb.segmented.RocksDBColumnarKeyValueStorage}
+ * via {@code getColumnFamilyOptionsFromProps}, then Besu overwrites selected options in Java where
+ * it sets them explicitly (block table, compaction, blob, etc.).
+ */
+public final class RocksDbNativeOptionStrings {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RocksDbNativeOptionStrings.class);
+
+  private RocksDbNativeOptionStrings() {}
+
+  /**
+   * Parses {@code key=value;} pairs for {@link org.rocksdb.DBOptions#getDBOptionsFromProps}.
+   */
+  public static Properties parseDbOptionString(final String raw) {
+    return parseSemicolonKeyValueString(raw);
+  }
+
+  /** Nethermind-style {@code a=b;c=d;} into flat {@link Properties} keys. */
+  public static Properties parseSemicolonKeyValueString(final String raw) {
+    final Properties props = new Properties();
+    if (raw == null || raw.isBlank()) {
+      return props;
+    }
+    for (final String segment : Splitter.on(';').split(raw)) {
+      final String part = segment.trim();
+      if (part.isEmpty()) {
+        continue;
+      }
+      final int eq = part.indexOf('=');
+      if (eq <= 0 || eq == part.length() - 1) {
+        LOG.warn("Ignoring malformed RocksDB option segment (expected key=value): {}", part);
+        continue;
+      }
+      final String key = part.substring(0, eq).trim();
+      final String value = part.substring(eq + 1).trim();
+      props.setProperty(key, value);
+    }
+    return props;
+  }
+}

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDbNativeOptionStrings.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDbNativeOptionStrings.java
@@ -1,8 +1,8 @@
 /*
  * Copyright contributors to Hyperledger Besu.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -14,7 +14,12 @@
  */
 package org.hyperledger.besu.plugin.services.storage.rocksdb;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Properties;
+import java.util.Set;
 
 import com.google.common.base.Splitter;
 import org.slf4j.Logger;
@@ -28,15 +33,44 @@ import org.slf4j.LoggerFactory;
  *
  * <p>Additional column-family strings are parsed here; {@link
  * org.hyperledger.besu.plugin.services.storage.rocksdb.segmented.RocksDBColumnarKeyValueStorage}
- * merges Besu's block-table defaults into the same {@link Properties} map, then applies everything
- * with one {@code getColumnFamilyOptionsFromProps} call (compaction and blob options may still be
- * set in Java afterward).
+ * merges Besu defaults using {@link InsertionOrderedProperties} so JNI builds a deterministic
+ * option string (standard {@link Properties} iteration order is undefined).
  */
 public final class RocksDbNativeOptionStrings {
 
   private static final Logger LOG = LoggerFactory.getLogger(RocksDbNativeOptionStrings.class);
 
   private RocksDbNativeOptionStrings() {}
+
+  /**
+   * {@link Properties} whose {@link #stringPropertyNames()} follows insertion order, so {@link
+   * org.rocksdb.Options#getOptionStringFromProps} emits a stable option string for JNI.
+   */
+  public static final class InsertionOrderedProperties extends Properties {
+    private final List<String> insertionOrder = new ArrayList<>();
+    private final Set<String> seenKeys = new HashSet<>();
+
+    @Override
+    public synchronized Object put(final Object key, final Object value) {
+      if (key instanceof final String s && seenKeys.add(s)) {
+        insertionOrder.add(s);
+      }
+      return super.put(key, value);
+    }
+
+    @Override
+    public Set<String> stringPropertyNames() {
+      synchronized (this) {
+        final LinkedHashSet<String> names = new LinkedHashSet<>();
+        for (final String k : insertionOrder) {
+          if (containsKey(k)) {
+            names.add(k);
+          }
+        }
+        return names;
+      }
+    }
+  }
 
   /**
    * Parses a DB options string for {@link org.rocksdb.DBOptions#getDBOptionsFromProps}.

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDbNativeOptionStrings.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDbNativeOptionStrings.java
@@ -26,10 +26,11 @@ import org.slf4j.LoggerFactory;
  * option parser via {@link org.rocksdb.ColumnFamilyOptions#getColumnFamilyOptionsFromProps} and
  * {@link org.rocksdb.DBOptions#getDBOptionsFromProps}.
  *
- * <p>Additional column-family strings are parsed here, applied in {@link
+ * <p>Additional column-family strings are parsed here; {@link
  * org.hyperledger.besu.plugin.services.storage.rocksdb.segmented.RocksDBColumnarKeyValueStorage}
- * via {@code getColumnFamilyOptionsFromProps}, then Besu overwrites selected options in Java where
- * it sets them explicitly (block table, compaction, blob, etc.).
+ * merges Besu's block-table defaults into the same {@link Properties} map, then applies everything
+ * with one {@code getColumnFamilyOptionsFromProps} call (compaction and blob options may still be
+ * set in Java afterward).
  */
 public final class RocksDbNativeOptionStrings {
 

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDbNativeOptionStrings.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDbNativeOptionStrings.java
@@ -37,9 +37,7 @@ public final class RocksDbNativeOptionStrings {
 
   private RocksDbNativeOptionStrings() {}
 
-  /**
-   * Parses {@code key=value;} pairs for {@link org.rocksdb.DBOptions#getDBOptionsFromProps}.
-   */
+  /** Parses {@code key=value;} pairs for {@link org.rocksdb.DBOptions#getDBOptionsFromProps}. */
   public static Properties parseDbOptionString(final String raw) {
     return parseSemicolonKeyValueString(raw);
   }

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDbNativeOptionStrings.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDbNativeOptionStrings.java
@@ -20,8 +20,8 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
+import java.util.StringTokenizer;
 
-import com.google.common.base.Splitter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,8 +54,14 @@ public final class RocksDbNativeOptionStrings {
    * org.rocksdb.Options#getOptionStringFromProps} emits a stable option string for JNI.
    */
   public static final class InsertionOrderedProperties extends Properties {
+    /** Keys in the order they were first inserted via {@link #put}. */
     private final List<String> insertionOrder = new ArrayList<>();
+
+    /** Keys already recorded in {@link #insertionOrder} to avoid duplicates on overwrite. */
     private final Set<String> seenKeys = new HashSet<>();
+
+    /** Creates an empty map; key iteration order follows first insertion. */
+    public InsertionOrderedProperties() {}
 
     @Override
     public synchronized Object put(final Object key, final Object value) {
@@ -102,7 +108,9 @@ public final class RocksDbNativeOptionStrings {
     if (raw == null || raw.isBlank()) {
       return props;
     }
-    for (final String segment : Splitter.on(';').split(raw)) {
+    final StringTokenizer tokenizer = new StringTokenizer(raw, ";");
+    while (tokenizer.hasMoreTokens()) {
+      final String segment = tokenizer.nextToken();
       final String part = segment.trim();
       if (part.isEmpty()) {
         continue;

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDbNativeOptionStrings.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDbNativeOptionStrings.java
@@ -98,13 +98,15 @@ public final class RocksDbNativeOptionStrings {
 
   /**
    * Parses a semicolon-separated options string ({@code a=b;c=d;}) into flat {@link Properties}
-   * keys.
+   * keys. The returned instance is {@link InsertionOrderedProperties}: {@link
+   * InsertionOrderedProperties#stringPropertyNames()} follows first-seen order in {@code raw}
+   * (stable without sorting).
    *
    * @param raw semicolon-separated {@code key=value} segments; may be null or blank
    * @return parsed properties; malformed segments are skipped with a warning
    */
   public static Properties parseSemicolonKeyValueString(final String raw) {
-    final Properties props = new Properties();
+    final InsertionOrderedProperties props = new InsertionOrderedProperties();
     if (raw == null || raw.isBlank()) {
       return props;
     }

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDbNativeOptionStrings.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDbNativeOptionStrings.java
@@ -37,12 +37,23 @@ public final class RocksDbNativeOptionStrings {
 
   private RocksDbNativeOptionStrings() {}
 
-  /** Parses {@code key=value;} pairs for {@link org.rocksdb.DBOptions#getDBOptionsFromProps}. */
+  /**
+   * Parses a DB options string for {@link org.rocksdb.DBOptions#getDBOptionsFromProps}.
+   *
+   * @param raw semicolon-separated {@code key=value} segments; may be null or blank
+   * @return properties suitable for {@code getDBOptionsFromProps}; empty if {@code raw} is null or
+   *     blank
+   */
   public static Properties parseDbOptionString(final String raw) {
     return parseSemicolonKeyValueString(raw);
   }
 
-  /** Nethermind-style {@code a=b;c=d;} into flat {@link Properties} keys. */
+  /**
+   * Parses a Nethermind-style options string ({@code a=b;c=d;}) into flat {@link Properties} keys.
+   *
+   * @param raw semicolon-separated {@code key=value} segments; may be null or blank
+   * @return parsed properties; malformed segments are skipped with a warning
+   */
   public static Properties parseSemicolonKeyValueString(final String raw) {
     final Properties props = new Properties();
     if (raw == null || raw.isBlank()) {

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDbNativeOptionStrings.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDbNativeOptionStrings.java
@@ -26,8 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Parses RocksDB option strings in the same style as Nethermind's {@code RocksDbOptions} / {@code
- * AdditionalRocksDbOptions}: semicolon-separated {@code key=value} pairs passed to the native
+ * Parses RocksDB option strings as semicolon-separated {@code key=value} pairs passed to the native
  * option parser via {@link org.rocksdb.ColumnFamilyOptions#getColumnFamilyOptionsFromProps} and
  * {@link org.rocksdb.DBOptions#getDBOptionsFromProps}.
  *
@@ -35,6 +34,14 @@ import org.slf4j.LoggerFactory;
  * org.hyperledger.besu.plugin.services.storage.rocksdb.segmented.RocksDBColumnarKeyValueStorage}
  * merges Besu defaults using {@link InsertionOrderedProperties} so JNI builds a deterministic
  * option string (standard {@link Properties} iteration order is undefined).
+ *
+ * <p>Options are applied through RocksDB's native option parser ({@code
+ * GetColumnFamilyOptionsFromString} / block-table factory configuration), not only through
+ * rocksdbjni Java setters. That means column-family and block-table settings that are valid in
+ * RocksDB's C++ option map but missing or incomplete on {@link org.rocksdb.BlockBasedTableConfig}
+ * (or other Java wrappers) can still be supplied via {@code
+ * --Xplugin-rocksdb-additional-column-family-options}, as long as the key names match the native
+ * option registry for the linked RocksDB version.
  */
 public final class RocksDbNativeOptionStrings {
 
@@ -84,7 +91,8 @@ public final class RocksDbNativeOptionStrings {
   }
 
   /**
-   * Parses a Nethermind-style options string ({@code a=b;c=d;}) into flat {@link Properties} keys.
+   * Parses a semicolon-separated options string ({@code a=b;c=d;}) into flat {@link Properties}
+   * keys.
    *
    * @param raw semicolon-separated {@code key=value} segments; may be null or blank
    * @return parsed properties; malformed segments are skipped with a warning

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBCLIOptions.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBCLIOptions.java
@@ -66,6 +66,14 @@ public class RocksDBCLIOptions {
   public static final String BLOB_GARBAGE_COLLECTION_FORCE_THRESHOLD =
       "--Xplugin-rocksdb-blob-garbage-collection-force-threshold";
 
+  /** Additional column-family options as a semicolon-separated native RocksDB string. */
+  public static final String ADDITIONAL_COLUMN_FAMILY_OPTIONS =
+      "--Xplugin-rocksdb-additional-column-family-options";
+
+  /** Additional DB-level RocksDB options as a semicolon-separated native string. */
+  public static final String ADDITIONAL_DATABASE_OPTIONS =
+      "--Xplugin-rocksdb-additional-database-options";
+
   /** The Max open files. */
   @CommandLine.Option(
       names = {MAX_OPEN_FILES_FLAG},
@@ -144,6 +152,31 @@ public class RocksDBCLIOptions {
       description = "Blob garbage collection force threshold (default: ${DEFAULT-VALUE})")
   Optional<Double> blobGarbageCollectionForceThreshold = Optional.empty();
 
+  /**
+   * Semicolon-separated column-family options passed to RocksDB's native parser (Nethermind-style),
+   * then Besu applies its own block table, compaction, and blob settings in Java where it sets them
+   * explicitly (overlapping native values are replaced).
+   */
+  @CommandLine.Option(
+      names = {ADDITIONAL_COLUMN_FAMILY_OPTIONS},
+      hidden = true,
+      paramLabel = "<STRING>",
+      description =
+          "Extra column-family options as key=value pairs separated by ';' (native string); Besu overlays programmatic CF settings afterward.")
+  Optional<String> additionalColumnFamilyOptions = Optional.empty();
+
+  /**
+   * Semicolon-separated {@code DBOptions} for {@code DBOptions.getDBOptionsFromProps}; Besu still
+   * sets create paths, max open files, statistics, env threads, and WAL limits afterward.
+   */
+  @CommandLine.Option(
+      names = {ADDITIONAL_DATABASE_OPTIONS},
+      hidden = true,
+      paramLabel = "<STRING>",
+      description =
+          "Extra DB options as key=value pairs separated by ';' (native RocksDB DBOptions string).")
+  Optional<String> additionalDatabaseOptions = Optional.empty();
+
   private RocksDBCLIOptions() {}
 
   /**
@@ -171,6 +204,8 @@ public class RocksDBCLIOptions {
     options.isBlockchainGarbageCollectionEnabled = config.isBlockchainGarbageCollectionEnabled();
     options.blobGarbageCollectionAgeCutoff = config.getBlobGarbageCollectionAgeCutoff();
     options.blobGarbageCollectionForceThreshold = config.getBlobGarbageCollectionForceThreshold();
+    options.additionalColumnFamilyOptions = config.getAdditionalColumnFamilyOptions();
+    options.additionalDatabaseOptions = config.getAdditionalDatabaseOptions();
     return options;
   }
 
@@ -188,7 +223,9 @@ public class RocksDBCLIOptions {
         enableReadCacheForSnapshots,
         isBlockchainGarbageCollectionEnabled,
         blobGarbageCollectionAgeCutoff,
-        blobGarbageCollectionForceThreshold);
+        blobGarbageCollectionForceThreshold,
+        additionalColumnFamilyOptions,
+        additionalDatabaseOptions);
   }
 
   /**
@@ -223,6 +260,8 @@ public class RocksDBCLIOptions {
         .add("isBlockchainGarbageCollectionEnabled", isBlockchainGarbageCollectionEnabled)
         .add("blobGarbageCollectionAgeCutoff", blobGarbageCollectionAgeCutoff)
         .add("blobGarbageCollectionForceThreshold", blobGarbageCollectionForceThreshold)
+        .add("additionalColumnFamilyOptions", additionalColumnFamilyOptions)
+        .add("additionalDatabaseOptions", additionalDatabaseOptions)
         .toString();
   }
 

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBCLIOptions.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBCLIOptions.java
@@ -153,9 +153,9 @@ public class RocksDBCLIOptions {
   Optional<Double> blobGarbageCollectionForceThreshold = Optional.empty();
 
   /**
-   * Semicolon-separated column-family options passed to RocksDB's native parser (Nethermind-style),
-   * then Besu applies its own block table, compaction, and blob settings in Java where it sets them
-   * explicitly (overlapping native values are replaced).
+   * Semicolon-separated column-family options passed to RocksDB's native parser; Besu merges its
+   * own block-table defaults into the same map, then applies compaction and blob settings in Java
+   * where needed.
    */
   @CommandLine.Option(
       names = {ADDITIONAL_COLUMN_FAMILY_OPTIONS},

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBCLIOptions.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBCLIOptions.java
@@ -83,7 +83,7 @@ public class RocksDBCLIOptions {
   /**
    * When true, enables mmap SST reads for Bonsai {@code ACCOUNT_STORAGE_STORAGE}, {@code
    * ACCOUNT_STORAGE_ARCHIVE}, and {@code TRIE_BRANCH_STORAGE} column families ({@code
-   * block_based_table_factory.allow_mmap_reads}) and sets {@link org.rocksdb.DBOptions#setAllowMmapReads}
+   * table format via Java}) and sets {@link org.rocksdb.DBOptions#setAllowMmapReads}
    * so RocksDB logs {@code Options.allow_mmap_reads: 1} for this database. Prefer {@link
    * #MAX_OPEN_FILES_FLAG} {@code -1} so RocksDB can keep SSTs open. Experimental.
    */
@@ -201,7 +201,7 @@ public class RocksDBCLIOptions {
       negatable = true,
       paramLabel = "<BOOLEAN>",
       description =
-          "Mmap SST reads for ACCOUNT_STORAGE_* / TRIE_BRANCH_STORAGE CFs and DBOptions.allow_mmap_reads for this DB (default: ${DEFAULT-VALUE}). Prefer unlimited max open files for this experiment.")
+          "Mmap SST reads for ACCOUNT_STORAGE_* / TRIE_BRANCH_STORAGE CFs: DBOptions.allow_mmap_reads, no block cache on those CFs, fill_cache=false on reads (default: ${DEFAULT-VALUE}). Prefer unlimited max open files for this experiment.")
   boolean mmapReadsBonsaiSlotTrieBranch = DEFAULT_MMAP_READS_BONSAI_SLOT_TRIE_BRANCH;
 
   private RocksDBCLIOptions() {}

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBCLIOptions.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBCLIOptions.java
@@ -37,6 +37,12 @@ public class RocksDBCLIOptions {
   /** The default value indicating whether read caching is enabled for snapshot access. */
   public static final boolean DEFAULT_ENABLE_READ_CACHE_FOR_SNAPSHOTS = false;
 
+  /**
+   * Default: do not use mmap for SST reads on Bonsai slot / trie-branch column families (see {@link
+   * #MMAP_READS_BONSAI_SLOT_TRIE_BRANCH_FLAG}).
+   */
+  public static final boolean DEFAULT_MMAP_READS_BONSAI_SLOT_TRIE_BRANCH = true;
+
   /** The constant MAX_OPEN_FILES_FLAG. */
   public static final String MAX_OPEN_FILES_FLAG = "--Xplugin-rocksdb-max-open-files";
 
@@ -74,13 +80,23 @@ public class RocksDBCLIOptions {
   public static final String ADDITIONAL_DATABASE_OPTIONS =
       "--Xplugin-rocksdb-additional-database-options";
 
+  /**
+   * When true, enables {@code block_based_table_factory.allow_mmap_reads} for Bonsai {@code
+   * ACCOUNT_STORAGE_STORAGE}, {@code ACCOUNT_STORAGE_ARCHIVE}, and {@code TRIE_BRANCH_STORAGE}
+   * column families only. Prefer {@link #MAX_OPEN_FILES_FLAG} {@code -1} so RocksDB can keep SSTs
+   * open for mmap. Experimental.
+   */
+  public static final String MMAP_READS_BONSAI_SLOT_TRIE_BRANCH_FLAG =
+      "--Xplugin-rocksdb-mmap-reads-bonsai-slot-trie-branch-enabled";
+
   /** The Max open files. */
   @CommandLine.Option(
       names = {MAX_OPEN_FILES_FLAG},
       hidden = true,
-      defaultValue = "1024",
+      defaultValue = "-1",
       paramLabel = "<INTEGER>",
-      description = "Max number of files RocksDB will open (default: ${DEFAULT-VALUE})")
+      description =
+          "Max number of files RocksDB will open; -1 means unlimited (default: ${DEFAULT-VALUE})")
   int maxOpenFiles;
 
   /** The Cache capacity. */
@@ -177,6 +193,16 @@ public class RocksDBCLIOptions {
           "Extra DB options as key=value pairs separated by ';' (native RocksDB DBOptions string).")
   Optional<String> additionalDatabaseOptions = Optional.empty();
 
+  /** Enables mmap reads for Bonsai slot and trie-branch column families (experimental). */
+  @CommandLine.Option(
+      names = {MMAP_READS_BONSAI_SLOT_TRIE_BRANCH_FLAG},
+      hidden = true,
+      negatable = true,
+      paramLabel = "<BOOLEAN>",
+      description =
+          "Use mmap for SST reads on ACCOUNT_STORAGE_* and TRIE_BRANCH_STORAGE column families (default: ${DEFAULT-VALUE}). Prefer unlimited max open files for this experiment.")
+  boolean mmapReadsBonsaiSlotTrieBranch = DEFAULT_MMAP_READS_BONSAI_SLOT_TRIE_BRANCH;
+
   private RocksDBCLIOptions() {}
 
   /**
@@ -206,6 +232,7 @@ public class RocksDBCLIOptions {
     options.blobGarbageCollectionForceThreshold = config.getBlobGarbageCollectionForceThreshold();
     options.additionalColumnFamilyOptions = config.getAdditionalColumnFamilyOptions();
     options.additionalDatabaseOptions = config.getAdditionalDatabaseOptions();
+    options.mmapReadsBonsaiSlotTrieBranch = config.isMmapReadsBonsaiSlotTrieBranchEnabled();
     return options;
   }
 
@@ -225,7 +252,8 @@ public class RocksDBCLIOptions {
         blobGarbageCollectionAgeCutoff,
         blobGarbageCollectionForceThreshold,
         additionalColumnFamilyOptions,
-        additionalDatabaseOptions);
+        additionalDatabaseOptions,
+        mmapReadsBonsaiSlotTrieBranch);
   }
 
   /**
@@ -262,6 +290,7 @@ public class RocksDBCLIOptions {
         .add("blobGarbageCollectionForceThreshold", blobGarbageCollectionForceThreshold)
         .add("additionalColumnFamilyOptions", additionalColumnFamilyOptions)
         .add("additionalDatabaseOptions", additionalDatabaseOptions)
+        .add("mmapReadsBonsaiSlotTrieBranch", mmapReadsBonsaiSlotTrieBranch)
         .toString();
   }
 

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBCLIOptions.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBCLIOptions.java
@@ -41,7 +41,7 @@ public class RocksDBCLIOptions {
    * Default: do not use mmap for SST reads on Bonsai slot / trie-branch column families (see {@link
    * #MMAP_READS_BONSAI_SLOT_TRIE_BRANCH_FLAG}).
    */
-  public static final boolean DEFAULT_MMAP_READS_BONSAI_SLOT_TRIE_BRANCH = true;
+  public static final boolean DEFAULT_MMAP_READS_BONSAI_SLOT_TRIE_BRANCH = false;
 
   /** The constant MAX_OPEN_FILES_FLAG. */
   public static final String MAX_OPEN_FILES_FLAG = "--Xplugin-rocksdb-max-open-files";
@@ -81,10 +81,11 @@ public class RocksDBCLIOptions {
       "--Xplugin-rocksdb-additional-database-options";
 
   /**
-   * When true, enables {@code block_based_table_factory.allow_mmap_reads} for Bonsai {@code
-   * ACCOUNT_STORAGE_STORAGE}, {@code ACCOUNT_STORAGE_ARCHIVE}, and {@code TRIE_BRANCH_STORAGE}
-   * column families only. Prefer {@link #MAX_OPEN_FILES_FLAG} {@code -1} so RocksDB can keep SSTs
-   * open for mmap. Experimental.
+   * When true, enables mmap SST reads for Bonsai {@code ACCOUNT_STORAGE_STORAGE}, {@code
+   * ACCOUNT_STORAGE_ARCHIVE}, and {@code TRIE_BRANCH_STORAGE} column families ({@code
+   * block_based_table_factory.allow_mmap_reads}) and sets {@link org.rocksdb.DBOptions#setAllowMmapReads}
+   * so RocksDB logs {@code Options.allow_mmap_reads: 1} for this database. Prefer {@link
+   * #MAX_OPEN_FILES_FLAG} {@code -1} so RocksDB can keep SSTs open. Experimental.
    */
   public static final String MMAP_READS_BONSAI_SLOT_TRIE_BRANCH_FLAG =
       "--Xplugin-rocksdb-mmap-reads-bonsai-slot-trie-branch-enabled";
@@ -200,7 +201,7 @@ public class RocksDBCLIOptions {
       negatable = true,
       paramLabel = "<BOOLEAN>",
       description =
-          "Use mmap for SST reads on ACCOUNT_STORAGE_* and TRIE_BRANCH_STORAGE column families (default: ${DEFAULT-VALUE}). Prefer unlimited max open files for this experiment.")
+          "Mmap SST reads for ACCOUNT_STORAGE_* / TRIE_BRANCH_STORAGE CFs and DBOptions.allow_mmap_reads for this DB (default: ${DEFAULT-VALUE}). Prefer unlimited max open files for this experiment.")
   boolean mmapReadsBonsaiSlotTrieBranch = DEFAULT_MMAP_READS_BONSAI_SLOT_TRIE_BRANCH;
 
   private RocksDBCLIOptions() {}

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBConfiguration.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBConfiguration.java
@@ -30,6 +30,8 @@ public class RocksDBConfiguration {
   private final boolean isBlockchainGarbageCollectionEnabled;
   private final Optional<Double> blobGarbageCollectionAgeCutoff;
   private final Optional<Double> blobGarbageCollectionForceThreshold;
+  private final Optional<String> additionalColumnFamilyOptions;
+  private final Optional<String> additionalDatabaseOptions;
 
   /**
    * Instantiates a new RocksDb configuration.
@@ -45,6 +47,8 @@ public class RocksDBConfiguration {
    *     column family
    * @param blobGarbageCollectionAgeCutoff the blob garbage collection age cutoff
    * @param blobGarbageCollectionForceThreshold the blob garbage collection force threshold
+   * @param additionalColumnFamilyOptions additional native column-family options string
+   * @param additionalDatabaseOptions optional native DB options string
    */
   public RocksDBConfiguration(
       final Path databaseDir,
@@ -56,7 +60,9 @@ public class RocksDBConfiguration {
       final boolean enableReadCacheForSnapshots,
       final boolean isBlockchainGarbageCollectionEnabled,
       final Optional<Double> blobGarbageCollectionAgeCutoff,
-      final Optional<Double> blobGarbageCollectionForceThreshold) {
+      final Optional<Double> blobGarbageCollectionForceThreshold,
+      final Optional<String> additionalColumnFamilyOptions,
+      final Optional<String> additionalDatabaseOptions) {
     this.backgroundThreadCount = backgroundThreadCount;
     this.databaseDir = databaseDir;
     this.maxOpenFiles = maxOpenFiles;
@@ -67,6 +73,8 @@ public class RocksDBConfiguration {
     this.isBlockchainGarbageCollectionEnabled = isBlockchainGarbageCollectionEnabled;
     this.blobGarbageCollectionAgeCutoff = blobGarbageCollectionAgeCutoff;
     this.blobGarbageCollectionForceThreshold = blobGarbageCollectionForceThreshold;
+    this.additionalColumnFamilyOptions = additionalColumnFamilyOptions;
+    this.additionalDatabaseOptions = additionalDatabaseOptions;
   }
 
   /**
@@ -157,5 +165,23 @@ public class RocksDBConfiguration {
    */
   public Optional<Double> getBlobGarbageCollectionForceThreshold() {
     return blobGarbageCollectionForceThreshold;
+  }
+
+  /**
+   * Returns additional column-family options string (semicolon-separated), if any.
+   *
+   * @return the options string, or empty if unset
+   */
+  public Optional<String> getAdditionalColumnFamilyOptions() {
+    return additionalColumnFamilyOptions;
+  }
+
+  /**
+   * Returns additional {@code DBOptions} string (semicolon-separated), if any.
+   *
+   * @return the options string, or empty if unset
+   */
+  public Optional<String> getAdditionalDatabaseOptions() {
+    return additionalDatabaseOptions;
   }
 }

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBConfiguration.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBConfiguration.java
@@ -50,7 +50,8 @@ public class RocksDBConfiguration {
    * @param blobGarbageCollectionForceThreshold the blob garbage collection force threshold
    * @param additionalColumnFamilyOptions additional native column-family options string
    * @param additionalDatabaseOptions optional native DB options string
-   * @param mmapReadsBonsaiSlotTrieBranch mmap SST reads on Bonsai slot / trie-branch CFs
+   * @param mmapReadsBonsaiSlotTrieBranch mmap SST reads ({@code DBOptions} + targeted table options)
+   *     on Bonsai slot / trie-branch CFs
    */
   public RocksDBConfiguration(
       final Path databaseDir,
@@ -190,7 +191,8 @@ public class RocksDBConfiguration {
   }
 
   /**
-   * Whether mmap reads are enabled for Bonsai slot and trie-branch column families.
+   * Whether mmap SST reads are enabled for this database ({@code DBOptions}) and for Bonsai slot /
+   * trie-branch column families ({@code block_based_table_factory}).
    *
    * @return true when mmap reads are enabled for Bonsai slot and trie-branch column families
    */

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBConfiguration.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBConfiguration.java
@@ -32,6 +32,7 @@ public class RocksDBConfiguration {
   private final Optional<Double> blobGarbageCollectionForceThreshold;
   private final Optional<String> additionalColumnFamilyOptions;
   private final Optional<String> additionalDatabaseOptions;
+  private final boolean mmapReadsBonsaiSlotTrieBranch;
 
   /**
    * Instantiates a new RocksDb configuration.
@@ -49,6 +50,7 @@ public class RocksDBConfiguration {
    * @param blobGarbageCollectionForceThreshold the blob garbage collection force threshold
    * @param additionalColumnFamilyOptions additional native column-family options string
    * @param additionalDatabaseOptions optional native DB options string
+   * @param mmapReadsBonsaiSlotTrieBranch mmap SST reads on Bonsai slot / trie-branch CFs
    */
   public RocksDBConfiguration(
       final Path databaseDir,
@@ -62,7 +64,8 @@ public class RocksDBConfiguration {
       final Optional<Double> blobGarbageCollectionAgeCutoff,
       final Optional<Double> blobGarbageCollectionForceThreshold,
       final Optional<String> additionalColumnFamilyOptions,
-      final Optional<String> additionalDatabaseOptions) {
+      final Optional<String> additionalDatabaseOptions,
+      final boolean mmapReadsBonsaiSlotTrieBranch) {
     this.backgroundThreadCount = backgroundThreadCount;
     this.databaseDir = databaseDir;
     this.maxOpenFiles = maxOpenFiles;
@@ -75,6 +78,7 @@ public class RocksDBConfiguration {
     this.blobGarbageCollectionForceThreshold = blobGarbageCollectionForceThreshold;
     this.additionalColumnFamilyOptions = additionalColumnFamilyOptions;
     this.additionalDatabaseOptions = additionalDatabaseOptions;
+    this.mmapReadsBonsaiSlotTrieBranch = mmapReadsBonsaiSlotTrieBranch;
   }
 
   /**
@@ -183,5 +187,14 @@ public class RocksDBConfiguration {
    */
   public Optional<String> getAdditionalDatabaseOptions() {
     return additionalDatabaseOptions;
+  }
+
+  /**
+   * Whether mmap reads are enabled for Bonsai slot and trie-branch column families.
+   *
+   * @return true when mmap reads are enabled for Bonsai slot and trie-branch column families
+   */
+  public boolean isMmapReadsBonsaiSlotTrieBranchEnabled() {
+    return mmapReadsBonsaiSlotTrieBranch;
   }
 }

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBConfigurationBuilder.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBConfigurationBuilder.java
@@ -196,8 +196,7 @@ public class RocksDBConfigurationBuilder {
         .enableReadCacheForSnapshots(configuration.isReadCacheEnabledForSnapshots())
         .isBlockchainGarbageCollectionEnabled(configuration.isBlockchainGarbageCollectionEnabled())
         .blobGarbageCollectionAgeCutoff(configuration.getBlobGarbageCollectionAgeCutoff())
-        .blobGarbageCollectionForceThreshold(
-            configuration.getBlobGarbageCollectionForceThreshold())
+        .blobGarbageCollectionForceThreshold(configuration.getBlobGarbageCollectionForceThreshold())
         .additionalColumnFamilyOptions(configuration.getAdditionalColumnFamilyOptions())
         .additionalDatabaseOptions(configuration.getAdditionalDatabaseOptions());
   }

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBConfigurationBuilder.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBConfigurationBuilder.java
@@ -36,6 +36,8 @@ public class RocksDBConfigurationBuilder {
   private boolean isBlockchainGarbageCollectionEnabled = false;
   private Optional<Double> blobGarbageCollectionAgeCutoff = Optional.empty();
   private Optional<Double> blobGarbageCollectionForceThreshold = Optional.empty();
+  private Optional<String> additionalColumnFamilyOptions = Optional.empty();
+  private Optional<String> additionalDatabaseOptions = Optional.empty();
 
   /** Instantiates a new Rocks db configuration builder. */
   public RocksDBConfigurationBuilder() {}
@@ -155,6 +157,31 @@ public class RocksDBConfigurationBuilder {
   }
 
   /**
+   * Additional column-family options (semicolon-separated {@code key=value;}), merged with Besu
+   * defaults and parsed natively except {@code block_based_table_factory.*} keys.
+   *
+   * @param additionalColumnFamilyOptions the options string
+   * @return this builder
+   */
+  public RocksDBConfigurationBuilder additionalColumnFamilyOptions(
+      final Optional<String> additionalColumnFamilyOptions) {
+    this.additionalColumnFamilyOptions = additionalColumnFamilyOptions;
+    return this;
+  }
+
+  /**
+   * Additional {@link org.rocksdb.DBOptions} as a semicolon-separated native string.
+   *
+   * @param additionalDatabaseOptions the options string
+   * @return this builder
+   */
+  public RocksDBConfigurationBuilder additionalDatabaseOptions(
+      final Optional<String> additionalDatabaseOptions) {
+    this.additionalDatabaseOptions = additionalDatabaseOptions;
+    return this;
+  }
+
+  /**
    * From.
    *
    * @param configuration the configuration
@@ -170,7 +197,9 @@ public class RocksDBConfigurationBuilder {
         .isBlockchainGarbageCollectionEnabled(configuration.isBlockchainGarbageCollectionEnabled())
         .blobGarbageCollectionAgeCutoff(configuration.getBlobGarbageCollectionAgeCutoff())
         .blobGarbageCollectionForceThreshold(
-            configuration.getBlobGarbageCollectionForceThreshold());
+            configuration.getBlobGarbageCollectionForceThreshold())
+        .additionalColumnFamilyOptions(configuration.getAdditionalColumnFamilyOptions())
+        .additionalDatabaseOptions(configuration.getAdditionalDatabaseOptions());
   }
 
   /**
@@ -189,6 +218,8 @@ public class RocksDBConfigurationBuilder {
         enableReadCacheForSnapshots,
         isBlockchainGarbageCollectionEnabled,
         blobGarbageCollectionAgeCutoff,
-        blobGarbageCollectionForceThreshold);
+        blobGarbageCollectionForceThreshold,
+        additionalColumnFamilyOptions,
+        additionalDatabaseOptions);
   }
 }

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBConfigurationBuilder.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBConfigurationBuilder.java
@@ -157,8 +157,9 @@ public class RocksDBConfigurationBuilder {
   }
 
   /**
-   * Additional column-family options (semicolon-separated {@code key=value;}), merged with Besu
-   * defaults and parsed natively except {@code block_based_table_factory.*} keys.
+   * Additional column-family options (semicolon-separated {@code key=value;}). Besu merges its own
+   * {@code block_based_table_factory.*} defaults into the same native map before parsing; keys
+   * listed there are overwritten by Besu.
    *
    * @param additionalColumnFamilyOptions the options string
    * @return this builder

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBConfigurationBuilder.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBConfigurationBuilder.java
@@ -19,6 +19,7 @@ import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration
 import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.DEFAULT_ENABLE_READ_CACHE_FOR_SNAPSHOTS;
 import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.DEFAULT_IS_HIGH_SPEC;
 import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.DEFAULT_MAX_OPEN_FILES;
+import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.DEFAULT_MMAP_READS_BONSAI_SLOT_TRIE_BRANCH;
 
 import java.nio.file.Path;
 import java.util.Optional;
@@ -38,6 +39,7 @@ public class RocksDBConfigurationBuilder {
   private Optional<Double> blobGarbageCollectionForceThreshold = Optional.empty();
   private Optional<String> additionalColumnFamilyOptions = Optional.empty();
   private Optional<String> additionalDatabaseOptions = Optional.empty();
+  private boolean mmapReadsBonsaiSlotTrieBranch = DEFAULT_MMAP_READS_BONSAI_SLOT_TRIE_BRANCH;
 
   /** Instantiates a new Rocks db configuration builder. */
   public RocksDBConfigurationBuilder() {}
@@ -183,6 +185,18 @@ public class RocksDBConfigurationBuilder {
   }
 
   /**
+   * Enables mmap SST reads for Bonsai slot and trie-branch column families (experimental).
+   *
+   * @param mmapReadsBonsaiSlotTrieBranch when true, enable mmap reads for those CFs
+   * @return this builder
+   */
+  public RocksDBConfigurationBuilder mmapReadsBonsaiSlotTrieBranch(
+      final boolean mmapReadsBonsaiSlotTrieBranch) {
+    this.mmapReadsBonsaiSlotTrieBranch = mmapReadsBonsaiSlotTrieBranch;
+    return this;
+  }
+
+  /**
    * From.
    *
    * @param configuration the configuration
@@ -199,7 +213,8 @@ public class RocksDBConfigurationBuilder {
         .blobGarbageCollectionAgeCutoff(configuration.getBlobGarbageCollectionAgeCutoff())
         .blobGarbageCollectionForceThreshold(configuration.getBlobGarbageCollectionForceThreshold())
         .additionalColumnFamilyOptions(configuration.getAdditionalColumnFamilyOptions())
-        .additionalDatabaseOptions(configuration.getAdditionalDatabaseOptions());
+        .additionalDatabaseOptions(configuration.getAdditionalDatabaseOptions())
+        .mmapReadsBonsaiSlotTrieBranch(configuration.isMmapReadsBonsaiSlotTrieBranchEnabled());
   }
 
   /**
@@ -220,6 +235,7 @@ public class RocksDBConfigurationBuilder {
         blobGarbageCollectionAgeCutoff,
         blobGarbageCollectionForceThreshold,
         additionalColumnFamilyOptions,
-        additionalDatabaseOptions);
+        additionalDatabaseOptions,
+        mmapReadsBonsaiSlotTrieBranch);
   }
 }

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBFactoryConfiguration.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBFactoryConfiguration.java
@@ -43,7 +43,8 @@ public class RocksDBFactoryConfiguration {
    * @param blobGarbageCollectionAgeCutoff the blob garbage collection age cutoff
    * @param blobGarbageCollectionForceThreshold the blob garbage collection force threshold
    * @param additionalColumnFamilyOptions semicolon-separated RocksDB column-family options parsed
-   *     natively (Nethermind-style); Besu then overlays programmatic CF settings in Java
+   *     natively; Besu merges block-table defaults into the same map, then sets other CF options in
+   *     Java where needed
    * @param additionalDatabaseOptions semicolon-separated {@code DBOptions} string for {@code
    *     DBOptions.getDBOptionsFromProps}; Besu still overlays create paths, max open files, stats,
    *     env threads, and WAL sizing

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBFactoryConfiguration.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBFactoryConfiguration.java
@@ -27,6 +27,8 @@ public class RocksDBFactoryConfiguration {
   private final boolean isBlockchainGarbageCollectionEnabled;
   private final Optional<Double> blobGarbageCollectionAgeCutoff;
   private final Optional<Double> blobGarbageCollectionForceThreshold;
+  private final Optional<String> additionalColumnFamilyOptions;
+  private final Optional<String> additionalDatabaseOptions;
 
   /**
    * Instantiates a new RocksDb factory configuration.
@@ -40,6 +42,11 @@ public class RocksDBFactoryConfiguration {
    *     column family
    * @param blobGarbageCollectionAgeCutoff the blob garbage collection age cutoff
    * @param blobGarbageCollectionForceThreshold the blob garbage collection force threshold
+   * @param additionalColumnFamilyOptions semicolon-separated RocksDB column-family options parsed
+   *     natively (Nethermind-style); Besu then overlays programmatic CF settings in Java
+   * @param additionalDatabaseOptions semicolon-separated {@code DBOptions} string for {@code
+   *     DBOptions.getDBOptionsFromProps}; Besu still overlays create paths, max open files, stats,
+   *     env threads, and WAL sizing
    */
   public RocksDBFactoryConfiguration(
       final int maxOpenFiles,
@@ -49,7 +56,9 @@ public class RocksDBFactoryConfiguration {
       final boolean enableReadCacheForSnapshots,
       final boolean isBlockchainGarbageCollectionEnabled,
       final Optional<Double> blobGarbageCollectionAgeCutoff,
-      final Optional<Double> blobGarbageCollectionForceThreshold) {
+      final Optional<Double> blobGarbageCollectionForceThreshold,
+      final Optional<String> additionalColumnFamilyOptions,
+      final Optional<String> additionalDatabaseOptions) {
     this.backgroundThreadCount = backgroundThreadCount;
     this.maxOpenFiles = maxOpenFiles;
     this.cacheCapacity = cacheCapacity;
@@ -58,6 +67,8 @@ public class RocksDBFactoryConfiguration {
     this.isBlockchainGarbageCollectionEnabled = isBlockchainGarbageCollectionEnabled;
     this.blobGarbageCollectionAgeCutoff = blobGarbageCollectionAgeCutoff;
     this.blobGarbageCollectionForceThreshold = blobGarbageCollectionForceThreshold;
+    this.additionalColumnFamilyOptions = additionalColumnFamilyOptions;
+    this.additionalDatabaseOptions = additionalDatabaseOptions;
   }
 
   /**
@@ -130,5 +141,24 @@ public class RocksDBFactoryConfiguration {
    */
   public Optional<Double> getBlobGarbageCollectionForceThreshold() {
     return blobGarbageCollectionForceThreshold;
+  }
+
+  /**
+   * Additional column-family options as a semicolon-separated {@code key=value;} string, parsed
+   * through RocksDB's native option parser where possible.
+   *
+   * @return the additional options, if any
+   */
+  public Optional<String> getAdditionalColumnFamilyOptions() {
+    return additionalColumnFamilyOptions;
+  }
+
+  /**
+   * Additional {@link org.rocksdb.DBOptions} as a semicolon-separated native string.
+   *
+   * @return the options string, if any
+   */
+  public Optional<String> getAdditionalDatabaseOptions() {
+    return additionalDatabaseOptions;
   }
 }

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBFactoryConfiguration.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBFactoryConfiguration.java
@@ -170,8 +170,8 @@ public class RocksDBFactoryConfiguration {
 
   /**
    * When true, SST reads use RocksDB mmap: {@code DBOptions.allow_mmap_reads} for this database
-   * plus {@code block_based_table_factory.allow_mmap_reads} on Bonsai {@code
-   * ACCOUNT_STORAGE_STORAGE}, {@code ACCOUNT_STORAGE_ARCHIVE}, and {@code TRIE_BRANCH_STORAGE}.
+   * and no block cache on Bonsai {@code ACCOUNT_STORAGE_STORAGE}, {@code ACCOUNT_STORAGE_ARCHIVE},
+   * and {@code TRIE_BRANCH_STORAGE} (table format set in Java).
    *
    * @return whether mmap reads are enabled for those column families
    */

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBFactoryConfiguration.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBFactoryConfiguration.java
@@ -29,6 +29,7 @@ public class RocksDBFactoryConfiguration {
   private final Optional<Double> blobGarbageCollectionForceThreshold;
   private final Optional<String> additionalColumnFamilyOptions;
   private final Optional<String> additionalDatabaseOptions;
+  private final boolean mmapReadsBonsaiSlotTrieBranch;
 
   /**
    * Instantiates a new RocksDb factory configuration.
@@ -48,6 +49,8 @@ public class RocksDBFactoryConfiguration {
    * @param additionalDatabaseOptions semicolon-separated {@code DBOptions} string for {@code
    *     DBOptions.getDBOptionsFromProps}; Besu still overlays create paths, max open files, stats,
    *     env threads, and WAL sizing
+   * @param mmapReadsBonsaiSlotTrieBranch when true, use mmap SST reads on Bonsai slot and trie
+   *     branch column families
    */
   public RocksDBFactoryConfiguration(
       final int maxOpenFiles,
@@ -59,7 +62,8 @@ public class RocksDBFactoryConfiguration {
       final Optional<Double> blobGarbageCollectionAgeCutoff,
       final Optional<Double> blobGarbageCollectionForceThreshold,
       final Optional<String> additionalColumnFamilyOptions,
-      final Optional<String> additionalDatabaseOptions) {
+      final Optional<String> additionalDatabaseOptions,
+      final boolean mmapReadsBonsaiSlotTrieBranch) {
     this.backgroundThreadCount = backgroundThreadCount;
     this.maxOpenFiles = maxOpenFiles;
     this.cacheCapacity = cacheCapacity;
@@ -70,6 +74,7 @@ public class RocksDBFactoryConfiguration {
     this.blobGarbageCollectionForceThreshold = blobGarbageCollectionForceThreshold;
     this.additionalColumnFamilyOptions = additionalColumnFamilyOptions;
     this.additionalDatabaseOptions = additionalDatabaseOptions;
+    this.mmapReadsBonsaiSlotTrieBranch = mmapReadsBonsaiSlotTrieBranch;
   }
 
   /**
@@ -161,5 +166,15 @@ public class RocksDBFactoryConfiguration {
    */
   public Optional<String> getAdditionalDatabaseOptions() {
     return additionalDatabaseOptions;
+  }
+
+  /**
+   * When true, SST reads for Bonsai {@code ACCOUNT_STORAGE_STORAGE}, {@code
+   * ACCOUNT_STORAGE_ARCHIVE}, and {@code TRIE_BRANCH_STORAGE} use RocksDB mmap.
+   *
+   * @return whether mmap reads are enabled for those column families
+   */
+  public boolean isMmapReadsBonsaiSlotTrieBranchEnabled() {
+    return mmapReadsBonsaiSlotTrieBranch;
   }
 }

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBFactoryConfiguration.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBFactoryConfiguration.java
@@ -49,8 +49,8 @@ public class RocksDBFactoryConfiguration {
    * @param additionalDatabaseOptions semicolon-separated {@code DBOptions} string for {@code
    *     DBOptions.getDBOptionsFromProps}; Besu still overlays create paths, max open files, stats,
    *     env threads, and WAL sizing
-   * @param mmapReadsBonsaiSlotTrieBranch when true, use mmap SST reads on Bonsai slot and trie
-   *     branch column families
+   * @param mmapReadsBonsaiSlotTrieBranch when true, enable mmap SST reads ({@code DBOptions} and
+   *     targeted {@code block_based_table_factory} options) for Bonsai slot and trie-branch CFs
    */
   public RocksDBFactoryConfiguration(
       final int maxOpenFiles,
@@ -169,8 +169,9 @@ public class RocksDBFactoryConfiguration {
   }
 
   /**
-   * When true, SST reads for Bonsai {@code ACCOUNT_STORAGE_STORAGE}, {@code
-   * ACCOUNT_STORAGE_ARCHIVE}, and {@code TRIE_BRANCH_STORAGE} use RocksDB mmap.
+   * When true, SST reads use RocksDB mmap: {@code DBOptions.allow_mmap_reads} for this database
+   * plus {@code block_based_table_factory.allow_mmap_reads} on Bonsai {@code
+   * ACCOUNT_STORAGE_STORAGE}, {@code ACCOUNT_STORAGE_ARCHIVE}, and {@code TRIE_BRANCH_STORAGE}.
    *
    * @return whether mmap reads are enabled for those column families
    */

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/OptimisticRocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/OptimisticRocksDBColumnarKeyValueStorage.java
@@ -99,6 +99,10 @@ public class OptimisticRocksDBColumnarKeyValueStorage extends RocksDBColumnarKey
   public RocksDBColumnarKeyValueSnapshot takeSnapshot() throws StorageException {
     throwIfClosed();
     return new RocksDBColumnarKeyValueSnapshot(
-        db, configuration.isReadCacheEnabledForSnapshots(), this::safeColumnHandle, metrics);
+        db,
+        configuration.isReadCacheEnabledForSnapshots(),
+        configuration.isMmapReadsBonsaiSlotTrieBranchEnabled(),
+        this::safeColumnHandle,
+        metrics);
   }
 }

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueSnapshot.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueSnapshot.java
@@ -69,7 +69,9 @@ public class RocksDBColumnarKeyValueSnapshot
   private final boolean isReadCacheEnabledForSnapshots;
   private final RocksDBMetrics metrics;
   private final Function<SegmentIdentifier, ColumnFamilyHandle> columnFamilyMapper;
+  private final boolean mmapReadsBonsaiSlotTrieBranchEnabled;
   private final ReadOptions readOptions;
+  private final ReadOptions mmapReadOptions;
 
   /**
    * Instantiates a new RocksDb columnar key value snapshot.
@@ -80,15 +82,26 @@ public class RocksDBColumnarKeyValueSnapshot
   RocksDBColumnarKeyValueSnapshot(
       final OptimisticTransactionDB db,
       final boolean isReadCacheEnabledForSnapshots,
+      final boolean mmapReadsBonsaiSlotTrieBranchEnabled,
       final Function<SegmentIdentifier, ColumnFamilyHandle> columnFamilyMapper,
       final RocksDBMetrics metrics) {
     this.db = db;
     this.isReadCacheEnabledForSnapshots = isReadCacheEnabledForSnapshots;
+    this.mmapReadsBonsaiSlotTrieBranchEnabled = mmapReadsBonsaiSlotTrieBranchEnabled;
     this.metrics = metrics;
     this.columnFamilyMapper = columnFamilyMapper;
     this.snapshot = new RocksDBSnapshot(db);
     this.readOptions =
         new ReadOptions().setVerifyChecksums(false).setSnapshot(snapshot.getSnapshot());
+    if (mmapReadsBonsaiSlotTrieBranchEnabled) {
+      this.mmapReadOptions =
+          new ReadOptions()
+              .setVerifyChecksums(false)
+              .setFillCache(false)
+              .setSnapshot(snapshot.getSnapshot());
+    } else {
+      this.mmapReadOptions = this.readOptions;
+    }
     if (isReadCacheEnabledForSnapshots) {
       maybeCache =
           Optional.of(
@@ -106,25 +119,35 @@ public class RocksDBColumnarKeyValueSnapshot
     try (final OperationTimer.TimingContext ignored = metrics.getReadLatency().startTimer()) {
       final ColumnFamilyHandle handle = columnFamilyMapper.apply(segment);
       if (isReadCacheEnabledForSnapshots && segment.isEligibleToHighSpecFlag()) {
-        return getFromCacheOrRead(segment.getId(), key, handle, maybeCache.get());
+        return getFromCacheOrRead(
+            segment.getId(), key, handle, maybeCache.get(), readOptionsFor(segment));
       } else {
-        return Optional.ofNullable(snapshot.get(handle, readOptions, key));
+        return Optional.ofNullable(snapshot.get(handle, readOptionsFor(segment), key));
       }
     } catch (final RocksDBException e) {
       throw new StorageException(e);
     }
   }
 
+  private ReadOptions readOptionsFor(final SegmentIdentifier segment) {
+    if (mmapReadsBonsaiSlotTrieBranchEnabled
+        && RocksDBColumnarKeyValueStorage.isMmapReadsTargetBonsaiSegment(segment)) {
+      return mmapReadOptions;
+    }
+    return readOptions;
+  }
+
   private Optional<byte[]> getFromCacheOrRead(
       final byte[] segmentId,
       final byte[] key,
       final ColumnFamilyHandle handle,
-      final Cache<Bytes, Optional<byte[]>> cache)
+      final Cache<Bytes, Optional<byte[]>> cache,
+      final ReadOptions segmentReadOptions)
       throws RocksDBException {
     final Bytes cacheKey = makeCacheKey(segmentId, key);
     Optional<byte[]> cached = cache.getIfPresent(cacheKey);
     if (cached == null) {
-      final byte[] value = snapshot.get(handle, readOptions, key);
+      final byte[] value = snapshot.get(handle, segmentReadOptions, key);
       cached = Optional.ofNullable(value);
       cache.put(cacheKey, cached);
     }
@@ -143,7 +166,8 @@ public class RocksDBColumnarKeyValueSnapshot
       final SegmentIdentifier segmentIdentifier, final Bytes key) throws StorageException {
 
     try (final RocksIterator rocksIterator =
-        db.newIterator(columnFamilyMapper.apply(segmentIdentifier), readOptions)) {
+        db.newIterator(
+            columnFamilyMapper.apply(segmentIdentifier), readOptionsFor(segmentIdentifier))) {
       rocksIterator.seekForPrev(key.toArrayUnsafe());
       return Optional.of(rocksIterator)
           .filter(AbstractRocksIterator::isValid)
@@ -155,7 +179,8 @@ public class RocksDBColumnarKeyValueSnapshot
   public Optional<NearestKeyValue> getNearestAfter(
       final SegmentIdentifier segmentIdentifier, final Bytes key) throws StorageException {
     try (final RocksIterator rocksIterator =
-        db.newIterator(columnFamilyMapper.apply(segmentIdentifier), readOptions)) {
+        db.newIterator(
+            columnFamilyMapper.apply(segmentIdentifier), readOptionsFor(segmentIdentifier))) {
       rocksIterator.seek(key.toArrayUnsafe());
       return Optional.of(rocksIterator)
           .filter(AbstractRocksIterator::isValid)
@@ -167,7 +192,7 @@ public class RocksDBColumnarKeyValueSnapshot
   public Stream<Pair<byte[], byte[]>> stream(final SegmentIdentifier segment) {
     throwIfClosed();
     final RocksIterator rocksIterator =
-        db.newIterator(columnFamilyMapper.apply(segment), readOptions);
+        db.newIterator(columnFamilyMapper.apply(segment), readOptionsFor(segment));
     rocksIterator.seekToFirst();
     return RocksDbIterator.create(rocksIterator).toStream();
   }
@@ -178,7 +203,7 @@ public class RocksDBColumnarKeyValueSnapshot
     throwIfClosed();
 
     final RocksIterator rocksIterator =
-        db.newIterator(columnFamilyMapper.apply(segment), readOptions);
+        db.newIterator(columnFamilyMapper.apply(segment), readOptionsFor(segment));
     rocksIterator.seek(startKey);
     return RocksDbIterator.create(rocksIterator).toStream();
   }
@@ -190,7 +215,7 @@ public class RocksDBColumnarKeyValueSnapshot
     final Bytes endKeyBytes = Bytes.wrap(endKey);
 
     final RocksIterator rocksIterator =
-        db.newIterator(columnFamilyMapper.apply(segment), readOptions);
+        db.newIterator(columnFamilyMapper.apply(segment), readOptionsFor(segment));
     rocksIterator.seek(startKey);
     return RocksDbIterator.create(rocksIterator)
         .toStream()
@@ -202,7 +227,7 @@ public class RocksDBColumnarKeyValueSnapshot
     throwIfClosed();
 
     final RocksIterator rocksIterator =
-        db.newIterator(columnFamilyMapper.apply(segment), readOptions);
+        db.newIterator(columnFamilyMapper.apply(segment), readOptionsFor(segment));
     rocksIterator.seekToFirst();
     return RocksDbIterator.create(rocksIterator).toStreamKeys();
   }
@@ -257,6 +282,9 @@ public class RocksDBColumnarKeyValueSnapshot
     if (closed.compareAndSet(false, true)) {
       closed.set(true);
       readOptions.close();
+      if (mmapReadOptions != readOptions) {
+        mmapReadOptions.close();
+      }
       snapshot.close();
     }
   }

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
@@ -200,10 +200,12 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
    * then builds {@link RocksDbNativeOptionStrings.InsertionOrderedProperties} by applying its
    * block-table keys in a fixed order (so {@code index_type} precedes {@code partition_filters} in
    * the JNI option string), then copies remaining user keys. A single {@code
-   * getColumnFamilyOptionsFromProps} call follows. Compaction and blob options are still set in
-   * Java where needed. {@code level_compaction_dynamic_level_bytes} is taken from the latest
-   * on-disk {@code OPTIONS-*} file when present for this column family (existing deployments);
-   * otherwise it defaults to {@code true}.
+   * getColumnFamilyOptionsFromProps} call follows, which unlocks any column-family or {@code
+   * block_based_table_factory.*} option the native RocksDB build accepts, even when rocksdbjni does
+   * not expose it on Java option classes. Compaction and blob options are still set in Java where
+   * needed. {@code level_compaction_dynamic_level_bytes} is taken from the latest on-disk {@code
+   * OPTIONS-*} file when present for this column family (existing deployments); otherwise it
+   * defaults to {@code true}.
    *
    * @param segment the segment identifier
    * @param configuration RocksDB configuration

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
@@ -34,6 +34,7 @@ import org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksD
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -90,6 +91,19 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
 
   /** RocksDb Time to roll a log file (1 day = 3600 * 24 seconds) */
   private static final long TIME_TO_ROLL_LOG_FILE = 86_400L;
+
+  /**
+   * Keys set by {@link #mergeBesuNativeColumnFamilyOptionsBeforeParse}; user CLI cannot override.
+   */
+  private static final Set<String> BESU_MERGED_NATIVE_COLUMN_FAMILY_KEYS =
+      Set.of(
+          "block_based_table_factory.index_type",
+          "block_based_table_factory.format_version",
+          "block_based_table_factory.filter_policy",
+          "block_based_table_factory.partition_filters",
+          "block_based_table_factory.cache_index_and_filter_blocks",
+          "block_based_table_factory.block_size",
+          "block_based_table_factory.block_cache");
 
   static {
     RocksDbUtil.loadNativeLibrary();
@@ -182,13 +196,14 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
    * Create a Column Family Descriptor for a given segment It defines basically the different
    * options to apply to the corresponding Column Family
    *
-   * <p>Additional CF options from configuration are parsed into {@link Properties}; Besu merges its
-   * block-table defaults into that map (same flat keys as the CLI string) before a single {@code
-   * getColumnFamilyOptionsFromProps} call so user keys such as {@code
-   * block_based_table_factory.prepopulate_block_cache} are not lost. Compaction and blob options
-   * are still set in Java where needed. {@code level_compaction_dynamic_level_bytes} is taken from
-   * the latest on-disk {@code OPTIONS-*} file when present for this column family (existing
-   * deployments); otherwise it defaults to {@code true}.
+   * <p>Additional CF options from configuration are parsed into a scratch {@link Properties}; Besu
+   * then builds {@link RocksDbNativeOptionStrings.InsertionOrderedProperties} by applying its
+   * block-table keys in a fixed order (so {@code index_type} precedes {@code partition_filters} in
+   * the JNI option string), then copies remaining user keys. A single {@code
+   * getColumnFamilyOptionsFromProps} call follows. Compaction and blob options are still set in
+   * Java where needed. {@code level_compaction_dynamic_level_bytes} is taken from the latest
+   * on-disk {@code OPTIONS-*} file when present for this column family (existing deployments);
+   * otherwise it defaults to {@code true}.
    *
    * @param segment the segment identifier
    * @param configuration RocksDB configuration
@@ -199,13 +214,21 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
     final boolean dynamicLevelCompaction =
         readLevelCompactionDynamicLevelBytesFromOptionsFile(segment, configuration);
 
-    final Properties additionalCfProps =
+    final Properties userCfProps =
         RocksDbNativeOptionStrings.parseSemicolonKeyValueString(
             configuration.getAdditionalColumnFamilyOptions().orElse(""));
-    mergeBesuNativeColumnFamilyOptionsBeforeParse(additionalCfProps, segment, configuration);
+    final RocksDbNativeOptionStrings.InsertionOrderedProperties cfProps =
+        new RocksDbNativeOptionStrings.InsertionOrderedProperties();
+    mergeBesuNativeColumnFamilyOptionsBeforeParse(cfProps, segment, configuration);
+    final List<String> userKeys = new ArrayList<>(userCfProps.stringPropertyNames());
+    Collections.sort(userKeys);
+    for (final String key : userKeys) {
+      if (!BESU_MERGED_NATIVE_COLUMN_FAMILY_KEYS.contains(key)) {
+        cfProps.setProperty(key, userCfProps.getProperty(key));
+      }
+    }
 
-    final ColumnFamilyOptions columnOpts =
-        columnFamilyOptionsFromNativeProperties(additionalCfProps);
+    final ColumnFamilyOptions columnOpts = columnFamilyOptionsFromNativeProperties(cfProps);
 
     columnOpts.setLevelCompactionDynamicLevelBytes(dynamicLevelCompaction);
     if (segment.containsStaticData()) {
@@ -215,19 +238,21 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
   }
 
   /**
-   * Inserts Besu's block-table defaults as {@code block_based_table_factory.*} properties before
-   * {@link ColumnFamilyOptions#getColumnFamilyOptionsFromProps}, so they follow the same code path
-   * as keys from {@code --Xplugin-rocksdb-additional-column-family-options}. These entries
-   * intentionally overwrite user values for the same keys.
+   * Writes Besu's block-table defaults onto {@code cfProps} in this call order so the JNI option
+   * string has {@code index_type=kTwoLevelIndexSearch} before {@code partition_filters=true}
+   * (partitioned filters need a two-level index when options are applied incrementally in native
+   * code). Must run on an empty {@link RocksDbNativeOptionStrings.InsertionOrderedProperties}
+   * before user keys are added.
    */
   private static void mergeBesuNativeColumnFamilyOptionsBeforeParse(
-      final Properties cfProps,
+      final RocksDbNativeOptionStrings.InsertionOrderedProperties cfProps,
       final SegmentIdentifier segment,
       final RocksDBConfiguration configuration) {
     final long blockCacheBytes =
         configuration.isHighSpec() && segment.isEligibleToHighSpecFlag()
             ? ROCKSDB_BLOCKCACHE_SIZE_HIGH_SPEC
             : configuration.getCacheCapacity();
+    cfProps.setProperty("block_based_table_factory.index_type", "kTwoLevelIndexSearch");
     cfProps.setProperty(
         "block_based_table_factory.format_version", Integer.toString(ROCKSDB_FORMAT_VERSION));
     cfProps.setProperty("block_based_table_factory.filter_policy", "bloomfilter:10:false");

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
@@ -234,9 +234,9 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
 
   /**
    * RocksDB stores column-family options in an {@code OPTIONS-*} file under the data directory. On
-   * reopen, reading the on-disk value avoids overriding {@code level_compaction_dynamic_level_bytes}
-   * and changing compaction behaviour for existing databases. New databases have no file yet; we
-   * default to {@code true} (historical Besu default).
+   * reopen, reading the on-disk value avoids overriding {@code
+   * level_compaction_dynamic_level_bytes} and changing compaction behaviour for existing databases.
+   * New databases have no file yet; we default to {@code true} (historical Besu default).
    */
   private boolean readLevelCompactionDynamicLevelBytesFromOptionsFile(
       final SegmentIdentifier segment, final RocksDBConfiguration configuration) {
@@ -270,16 +270,15 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
 
   /**
    * Always builds from {@code getColumnFamilyOptionsFromProps} (including when the properties map
-   * is empty), then applies Besu's fixed {@code ttl=0} and LZ4 compression on top so they are
-   * never omitted. On null or parse failure, starts from a bare {@link ColumnFamilyOptions}.
+   * is empty), then applies Besu's fixed {@code ttl=0} and LZ4 compression on top so they are never
+   * omitted. On null or parse failure, starts from a bare {@link ColumnFamilyOptions}.
    */
   private static ColumnFamilyOptions columnFamilyOptionsFromNativeProperties(
       final Properties nativeCfProps) {
     ColumnFamilyOptions base;
     try {
       final ColumnFamilyOptions fromNative =
-          ColumnFamilyOptions.getColumnFamilyOptionsFromProps(
-              new ConfigOptions(), nativeCfProps);
+          ColumnFamilyOptions.getColumnFamilyOptionsFromProps(new ConfigOptions(), nativeCfProps);
       if (fromNative != null) {
         base = fromNative;
       } else {
@@ -296,9 +295,7 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
           ex.getMessage());
       base = new ColumnFamilyOptions();
     }
-    return base
-        .setTtl(0)
-        .setCompressionType(CompressionType.LZ4_COMPRESSION);
+    return base.setTtl(0).setCompressionType(CompressionType.LZ4_COMPRESSION);
   }
 
   private static void configureBlobDBForSegment(

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
@@ -49,8 +49,6 @@ import com.google.common.collect.Streams;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tuweni.bytes.Bytes;
 import org.rocksdb.AbstractRocksIterator;
-import org.rocksdb.BlockBasedTableConfig;
-import org.rocksdb.BloomFilter;
 import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.ColumnFamilyOptions;
@@ -58,7 +56,6 @@ import org.rocksdb.CompressionType;
 import org.rocksdb.ConfigOptions;
 import org.rocksdb.DBOptions;
 import org.rocksdb.Env;
-import org.rocksdb.LRUCache;
 import org.rocksdb.Options;
 import org.rocksdb.OptionsUtil;
 import org.rocksdb.ReadOptions;
@@ -185,12 +182,13 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
    * Create a Column Family Descriptor for a given segment It defines basically the different
    * options to apply to the corresponding Column Family
    *
-   * <p>Additional CF options from configuration are parsed into {@link Properties} and applied with
-   * {@code getColumnFamilyOptionsFromProps}; Besu then sets block table, compaction, and blob
-   * options in Java, which override any overlapping native values when applicable. {@code
-   * level_compaction_dynamic_level_bytes} is taken from the latest on-disk {@code OPTIONS-*} file
-   * when present for this column family (existing deployments); otherwise it defaults to {@code
-   * true}.
+   * <p>Additional CF options from configuration are parsed into {@link Properties}; Besu merges its
+   * block-table defaults into that map (same flat keys as the CLI string) before a single {@code
+   * getColumnFamilyOptionsFromProps} call so user keys such as {@code
+   * block_based_table_factory.prepopulate_block_cache} are not lost. Compaction and blob options
+   * are still set in Java where needed. {@code level_compaction_dynamic_level_bytes} is taken from
+   * the latest on-disk {@code OPTIONS-*} file when present for this column family (existing
+   * deployments); otherwise it defaults to {@code true}.
    *
    * @param segment the segment identifier
    * @param configuration RocksDB configuration
@@ -204,32 +202,39 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
     final Properties additionalCfProps =
         RocksDbNativeOptionStrings.parseSemicolonKeyValueString(
             configuration.getAdditionalColumnFamilyOptions().orElse(""));
+    mergeBesuNativeColumnFamilyOptionsBeforeParse(additionalCfProps, segment, configuration);
 
     final ColumnFamilyOptions columnOpts =
         columnFamilyOptionsFromNativeProperties(additionalCfProps);
-
-    final var existingTable = columnOpts.tableFormatConfig();
-    final BlockBasedTableConfig blockTable =
-        existingTable instanceof BlockBasedTableConfig b ? b : new BlockBasedTableConfig();
-    final LRUCache blockCache =
-        new LRUCache(
-            configuration.isHighSpec() && segment.isEligibleToHighSpecFlag()
-                ? ROCKSDB_BLOCKCACHE_SIZE_HIGH_SPEC
-                : configuration.getCacheCapacity());
-    blockTable
-        .setBlockCache(blockCache)
-        .setFormatVersion(ROCKSDB_FORMAT_VERSION)
-        .setFilterPolicy(new BloomFilter(10, false))
-        .setPartitionFilters(true)
-        .setCacheIndexAndFilterBlocks(false)
-        .setBlockSize(ROCKSDB_BLOCK_SIZE);
-    columnOpts.setTableFormatConfig(blockTable);
 
     columnOpts.setLevelCompactionDynamicLevelBytes(dynamicLevelCompaction);
     if (segment.containsStaticData()) {
       configureBlobDBForSegment(segment, configuration, columnOpts);
     }
     return new ColumnFamilyDescriptor(segment.getId(), columnOpts);
+  }
+
+  /**
+   * Inserts Besu's block-table defaults as {@code block_based_table_factory.*} properties before
+   * {@link ColumnFamilyOptions#getColumnFamilyOptionsFromProps}, so they follow the same code path
+   * as keys from {@code --Xplugin-rocksdb-additional-column-family-options}. These entries
+   * intentionally overwrite user values for the same keys.
+   */
+  private static void mergeBesuNativeColumnFamilyOptionsBeforeParse(
+      final Properties cfProps,
+      final SegmentIdentifier segment,
+      final RocksDBConfiguration configuration) {
+    final long blockCacheBytes =
+        configuration.isHighSpec() && segment.isEligibleToHighSpecFlag()
+            ? ROCKSDB_BLOCKCACHE_SIZE_HIGH_SPEC
+            : configuration.getCacheCapacity();
+    cfProps.setProperty(
+        "block_based_table_factory.format_version", Integer.toString(ROCKSDB_FORMAT_VERSION));
+    cfProps.setProperty("block_based_table_factory.filter_policy", "bloomfilter:10:false");
+    cfProps.setProperty("block_based_table_factory.partition_filters", "true");
+    cfProps.setProperty("block_based_table_factory.cache_index_and_filter_blocks", "false");
+    cfProps.setProperty("block_based_table_factory.block_size", Long.toString(ROCKSDB_BLOCK_SIZE));
+    cfProps.setProperty("block_based_table_factory.block_cache", Long.toString(blockCacheBytes));
   }
 
   /**

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
@@ -91,19 +91,6 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
   /** RocksDb Time to roll a log file (1 day = 3600 * 24 seconds) */
   private static final long TIME_TO_ROLL_LOG_FILE = 86_400L;
 
-  /**
-   * Keys set by {@link #mergeBesuNativeColumnFamilyOptionsBeforeParse}; user CLI cannot override.
-   */
-  private static final Set<String> BESU_MERGED_NATIVE_COLUMN_FAMILY_KEYS =
-      Set.of(
-          "block_based_table_factory.index_type",
-          "block_based_table_factory.format_version",
-          "block_based_table_factory.filter_policy",
-          "block_based_table_factory.partition_filters",
-          "block_based_table_factory.cache_index_and_filter_blocks",
-          "block_based_table_factory.block_size",
-          "block_based_table_factory.block_cache");
-
   static {
     RocksDbUtil.loadNativeLibrary();
   }
@@ -198,13 +185,13 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
    * <p>Additional CF options from configuration are parsed into a scratch {@link Properties}; Besu
    * then builds {@link RocksDbNativeOptionStrings.InsertionOrderedProperties} by applying its
    * block-table keys in a fixed order (so {@code index_type} precedes {@code partition_filters} in
-   * the JNI option string), then copies remaining user keys. A single {@code
-   * getColumnFamilyOptionsFromProps} call follows, which unlocks any column-family or {@code
-   * block_based_table_factory.*} option the native RocksDB build accepts, even when rocksdbjni does
-   * not expose it on Java option classes. Compaction and blob options are still set in Java where
-   * needed. {@code level_compaction_dynamic_level_bytes} is taken from the latest on-disk {@code
-   * OPTIONS-*} file when present for this column family (existing deployments); otherwise it
-   * defaults to {@code true}.
+   * the JNI option string), then merges user keys (same key in user config overrides the Besu
+   * default). A single {@code getColumnFamilyOptionsFromProps} call follows, which unlocks any
+   * column-family or {@code block_based_table_factory.*} option the native RocksDB build accepts,
+   * even when rocksdbjni does not expose it on Java option classes. Compaction and blob options are
+   * still set in Java where needed. {@code level_compaction_dynamic_level_bytes} is taken from the
+   * latest on-disk {@code OPTIONS-*} file when present for this column family (existing
+   * deployments); otherwise it defaults to {@code true}.
    *
    * @param segment the segment identifier
    * @param configuration RocksDB configuration
@@ -222,9 +209,7 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
         new RocksDbNativeOptionStrings.InsertionOrderedProperties();
     mergeBesuNativeColumnFamilyOptionsBeforeParse(cfProps, segment, configuration);
     for (final String key : userCfProps.stringPropertyNames()) {
-      if (!BESU_MERGED_NATIVE_COLUMN_FAMILY_KEYS.contains(key)) {
-        cfProps.setProperty(key, userCfProps.getProperty(key));
-      }
+      cfProps.setProperty(key, userCfProps.getProperty(key));
     }
 
     final ColumnFamilyOptions columnOpts = columnFamilyOptionsFromNativeProperties(cfProps);

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
@@ -25,8 +25,10 @@ import org.hyperledger.besu.plugin.services.storage.SegmentedKeyValueStorage;
 import org.hyperledger.besu.plugin.services.storage.rocksdb.RocksDBMetrics;
 import org.hyperledger.besu.plugin.services.storage.rocksdb.RocksDBMetricsFactory;
 import org.hyperledger.besu.plugin.services.storage.rocksdb.RocksDbIterator;
+import org.hyperledger.besu.plugin.services.storage.rocksdb.RocksDbNativeOptionStrings;
 import org.hyperledger.besu.plugin.services.storage.rocksdb.RocksDbSegmentIdentifier;
 import org.hyperledger.besu.plugin.services.storage.rocksdb.RocksDbUtil;
+import org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions;
 import org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBConfiguration;
 
 import java.nio.charset.StandardCharsets;
@@ -35,6 +37,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
@@ -182,58 +185,120 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
    * Create a Column Family Descriptor for a given segment It defines basically the different
    * options to apply to the corresponding Column Family
    *
+   * <p>Additional CF options from configuration are parsed into {@link Properties} and applied with
+   * {@code getColumnFamilyOptionsFromProps}; Besu then sets block table, compaction, and blob
+   * options in Java, which override any overlapping native values when applicable. {@code
+   * level_compaction_dynamic_level_bytes} is taken from the latest on-disk {@code OPTIONS-*} file
+   * when present for this column family (existing deployments); otherwise it defaults to {@code
+   * true}.
+   *
    * @param segment the segment identifier
    * @param configuration RocksDB configuration
    * @return a column family descriptor
    */
   private ColumnFamilyDescriptor createColumnDescriptor(
       final SegmentIdentifier segment, final RocksDBConfiguration configuration) {
-    boolean dynamicLevelBytes = true;
-    try {
-      ConfigOptions configOptions = new ConfigOptions();
-      DBOptions dbOptions = new DBOptions();
-      List<ColumnFamilyDescriptor> cfDescriptors = new ArrayList<>();
+    final boolean dynamicLevelCompaction =
+        readLevelCompactionDynamicLevelBytesFromOptionsFile(segment, configuration);
 
-      String latestOptionsFileName =
+    final Properties additionalCfProps =
+        RocksDbNativeOptionStrings.parseSemicolonKeyValueString(
+            configuration.getAdditionalColumnFamilyOptions().orElse(""));
+
+    final ColumnFamilyOptions columnOpts =
+        columnFamilyOptionsFromNativeProperties(additionalCfProps);
+
+    final var existingTable = columnOpts.tableFormatConfig();
+    final BlockBasedTableConfig blockTable =
+        existingTable instanceof BlockBasedTableConfig b ? b : new BlockBasedTableConfig();
+    final LRUCache blockCache =
+        new LRUCache(
+            configuration.isHighSpec() && segment.isEligibleToHighSpecFlag()
+                ? ROCKSDB_BLOCKCACHE_SIZE_HIGH_SPEC
+                : configuration.getCacheCapacity());
+    blockTable
+        .setBlockCache(blockCache)
+        .setFormatVersion(ROCKSDB_FORMAT_VERSION)
+        .setFilterPolicy(new BloomFilter(10, false))
+        .setPartitionFilters(true)
+        .setCacheIndexAndFilterBlocks(false)
+        .setBlockSize(ROCKSDB_BLOCK_SIZE);
+    columnOpts.setTableFormatConfig(blockTable);
+
+    columnOpts.setLevelCompactionDynamicLevelBytes(dynamicLevelCompaction);
+    if (segment.containsStaticData()) {
+      configureBlobDBForSegment(segment, configuration, columnOpts);
+    }
+    return new ColumnFamilyDescriptor(segment.getId(), columnOpts);
+  }
+
+  /**
+   * RocksDB stores column-family options in an {@code OPTIONS-*} file under the data directory. On
+   * reopen, reading the on-disk value avoids overriding {@code level_compaction_dynamic_level_bytes}
+   * and changing compaction behaviour for existing databases. New databases have no file yet; we
+   * default to {@code true} (historical Besu default).
+   */
+  private boolean readLevelCompactionDynamicLevelBytesFromOptionsFile(
+      final SegmentIdentifier segment, final RocksDBConfiguration configuration) {
+    try {
+      final ConfigOptions configOptions = new ConfigOptions();
+      final DBOptions dbOptions = new DBOptions();
+      final List<ColumnFamilyDescriptor> cfDescriptors = new ArrayList<>();
+
+      final String latestOptionsFileName =
           OptionsUtil.getLatestOptionsFileName(
               configuration.getDatabaseDir().toString(), Env.getDefault());
-      LOG.trace("Latest OPTIONS file detected: " + latestOptionsFileName);
+      LOG.trace("Latest OPTIONS file detected: {}", latestOptionsFileName);
 
-      String optionsFilePath =
+      final String optionsFilePath =
           configuration.getDatabaseDir().toString() + "/" + latestOptionsFileName;
       OptionsUtil.loadOptionsFromFile(configOptions, optionsFilePath, dbOptions, cfDescriptors);
+      LOG.trace("RocksDB options loaded successfully from: {}", optionsFilePath);
 
-      LOG.trace("RocksDB options loaded successfully from: " + optionsFilePath);
-
-      if (!cfDescriptors.isEmpty()) {
-        Optional<ColumnFamilyOptions> matchedCfOptions = Optional.empty();
-        for (ColumnFamilyDescriptor descriptor : cfDescriptors) {
-          if (Arrays.equals(descriptor.getName(), segment.getId())) {
-            matchedCfOptions = Optional.of(descriptor.getOptions());
-            break;
-          }
-        }
-        if (matchedCfOptions.isPresent()) {
-          dynamicLevelBytes = matchedCfOptions.get().levelCompactionDynamicLevelBytes();
-          LOG.trace("dynamicLevelBytes is set to an existing value : " + dynamicLevelBytes);
+      for (ColumnFamilyDescriptor descriptor : cfDescriptors) {
+        if (Arrays.equals(descriptor.getName(), segment.getId())) {
+          final boolean value = descriptor.getOptions().levelCompactionDynamicLevelBytes();
+          LOG.trace("dynamicLevelBytes from existing DB options file: {}", value);
+          return value;
         }
       }
-    } catch (RocksDBException ex) {
-      // Options file is not found in the database
+    } catch (final RocksDBException ex) {
+      // New database: no OPTIONS-* file to load yet.
     }
-    BlockBasedTableConfig basedTableConfig = createBlockBasedTableConfig(segment, configuration);
+    return true;
+  }
 
-    final var options =
-        new ColumnFamilyOptions()
-            .setTtl(0)
-            .setCompressionType(CompressionType.LZ4_COMPRESSION)
-            .setTableFormatConfig(basedTableConfig)
-            .setLevelCompactionDynamicLevelBytes(dynamicLevelBytes);
-    if (segment.containsStaticData()) {
-      configureBlobDBForSegment(segment, configuration, options);
+  /**
+   * Always builds from {@code getColumnFamilyOptionsFromProps} (including when the properties map
+   * is empty), then applies Besu's fixed {@code ttl=0} and LZ4 compression on top so they are
+   * never omitted. On null or parse failure, starts from a bare {@link ColumnFamilyOptions}.
+   */
+  private static ColumnFamilyOptions columnFamilyOptionsFromNativeProperties(
+      final Properties nativeCfProps) {
+    ColumnFamilyOptions base;
+    try {
+      final ColumnFamilyOptions fromNative =
+          ColumnFamilyOptions.getColumnFamilyOptionsFromProps(
+              new ConfigOptions(), nativeCfProps);
+      if (fromNative != null) {
+        base = fromNative;
+      } else {
+        if (!nativeCfProps.isEmpty()) {
+          LOG.warn(
+              "RocksDB getColumnFamilyOptionsFromProps returned null; using bare ColumnFamilyOptions. Check {} for invalid native keys.",
+              RocksDBCLIOptions.ADDITIONAL_COLUMN_FAMILY_OPTIONS);
+        }
+        base = new ColumnFamilyOptions();
+      }
+    } catch (final IllegalArgumentException ex) {
+      LOG.warn(
+          "Invalid RocksDB column-family options passed to getColumnFamilyOptionsFromProps; using bare ColumnFamilyOptions. {}",
+          ex.getMessage());
+      base = new ColumnFamilyOptions();
     }
-
-    return new ColumnFamilyDescriptor(segment.getId(), options);
+    return base
+        .setTtl(0)
+        .setCompressionType(CompressionType.LZ4_COMPRESSION);
   }
 
   private static void configureBlobDBForSegment(
@@ -273,47 +338,46 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
   }
 
   /***
-   * Create a Block Base Table configuration for each segment, depending on the configuration in place
-   * and the segment itself
-   *
-   * @param segment The segment related to the column family
-   * @param config RocksDB configuration
-   * @return Block Base Table configuration
-   */
-  private BlockBasedTableConfig createBlockBasedTableConfig(
-      final SegmentIdentifier segment, final RocksDBConfiguration config) {
-    final LRUCache cache =
-        new LRUCache(
-            config.isHighSpec() && segment.isEligibleToHighSpecFlag()
-                ? ROCKSDB_BLOCKCACHE_SIZE_HIGH_SPEC
-                : config.getCacheCapacity());
-    return new BlockBasedTableConfig()
-        .setFormatVersion(ROCKSDB_FORMAT_VERSION)
-        .setBlockCache(cache)
-        .setFilterPolicy(new BloomFilter(10, false))
-        .setPartitionFilters(true)
-        .setCacheIndexAndFilterBlocks(false)
-        .setBlockSize(ROCKSDB_BLOCK_SIZE);
-  }
-
-  /***
    * Set Global options (DBOptions)
    *
    * @param configuration RocksDB configuration
    * @param stats The statistics object
    */
   private void setGlobalOptions(final RocksDBConfiguration configuration, final Statistics stats) {
-    options = new DBOptions();
-    options
-        .setCreateIfMissing(true)
-        .setMaxOpenFiles(configuration.getMaxOpenFiles())
-        .setStatistics(stats)
-        .setCreateMissingColumnFamilies(true)
-        .setLogFileTimeToRoll(TIME_TO_ROLL_LOG_FILE)
-        .setKeepLogFileNum(NUMBER_OF_LOG_FILES_TO_KEEP)
-        .setEnv(Env.getDefault().setBackgroundThreads(configuration.getBackgroundThreadCount()))
-        .setMaxTotalWalSize(WAL_MAX_TOTAL_SIZE)
-        .setRecycleLogFileNum(WAL_MAX_TOTAL_SIZE / EXPECTED_WAL_FILE_SIZE);
+    final Properties dbProps =
+        RocksDbNativeOptionStrings.parseDbOptionString(
+            configuration.getAdditionalDatabaseOptions().orElse(""));
+    final ConfigOptions cfgOpts = new ConfigOptions();
+    DBOptions dbOpts;
+    if (dbProps.isEmpty()) {
+      dbOpts = new DBOptions();
+    } else {
+      try {
+        dbOpts = DBOptions.getDBOptionsFromProps(cfgOpts, dbProps);
+      } catch (final IllegalArgumentException ex) {
+        LOG.warn(
+            "Invalid RocksDB DB options passed to getDBOptionsFromProps; using programmatic DB defaults. {}",
+            ex.getMessage());
+        dbOpts = null;
+      }
+      if (dbOpts == null) {
+        LOG.warn(
+            "RocksDB getDBOptionsFromProps returned null; using programmatic DB defaults. Check {} for invalid native keys.",
+            RocksDBCLIOptions.ADDITIONAL_DATABASE_OPTIONS);
+        dbOpts = new DBOptions();
+      }
+    }
+    options =
+        dbOpts
+            .setCreateIfMissing(true)
+            .setMaxOpenFiles(configuration.getMaxOpenFiles())
+            .setStatistics(stats)
+            .setCreateMissingColumnFamilies(true)
+            .setLogFileTimeToRoll(TIME_TO_ROLL_LOG_FILE)
+            .setKeepLogFileNum(NUMBER_OF_LOG_FILES_TO_KEEP)
+            .setEnv(Env.getDefault().setBackgroundThreads(configuration.getBackgroundThreadCount()))
+            .setMaxTotalWalSize(WAL_MAX_TOTAL_SIZE)
+            .setRecycleLogFileNum(WAL_MAX_TOTAL_SIZE / EXPECTED_WAL_FILE_SIZE);
   }
 
   /**

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
@@ -34,7 +34,6 @@ import org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksD
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -222,9 +221,7 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
     final RocksDbNativeOptionStrings.InsertionOrderedProperties cfProps =
         new RocksDbNativeOptionStrings.InsertionOrderedProperties();
     mergeBesuNativeColumnFamilyOptionsBeforeParse(cfProps, segment, configuration);
-    final List<String> userKeys = new ArrayList<>(userCfProps.stringPropertyNames());
-    Collections.sort(userKeys);
-    for (final String key : userKeys) {
+    for (final String key : userCfProps.stringPropertyNames()) {
       if (!BESU_MERGED_NATIVE_COLUMN_FAMILY_KEYS.contains(key)) {
         cfProps.setProperty(key, userCfProps.getProperty(key));
       }

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
@@ -254,11 +254,10 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
         configuration.isHighSpec() && segment.isEligibleToHighSpecFlag()
             ? ROCKSDB_BLOCKCACHE_SIZE_HIGH_SPEC
             : configuration.getCacheCapacity();
-    cfProps.setProperty("block_based_table_factory.index_type", "kTwoLevelIndexSearch");
     cfProps.setProperty(
         "block_based_table_factory.format_version", Integer.toString(ROCKSDB_FORMAT_VERSION));
     cfProps.setProperty("block_based_table_factory.filter_policy", "bloomfilter:10:false");
-    cfProps.setProperty("block_based_table_factory.partition_filters", "true");
+    cfProps.setProperty("block_based_table_factory.partition_filters", "false");
     cfProps.setProperty("block_based_table_factory.cache_index_and_filter_blocks", "false");
     cfProps.setProperty("block_based_table_factory.block_size", Long.toString(ROCKSDB_BLOCK_SIZE));
     cfProps.setProperty("block_based_table_factory.block_cache", Long.toString(blockCacheBytes));

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
@@ -49,6 +49,7 @@ import com.google.common.collect.Streams;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tuweni.bytes.Bytes;
 import org.rocksdb.AbstractRocksIterator;
+import org.rocksdb.BlockBasedTableConfig;
 import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.ColumnFamilyOptions;
@@ -64,6 +65,7 @@ import org.rocksdb.RocksDBException;
 import org.rocksdb.RocksIterator;
 import org.rocksdb.Statistics;
 import org.rocksdb.Status;
+import org.rocksdb.TableFormatConfig;
 import org.rocksdb.TransactionDBOptions;
 import org.rocksdb.WriteOptions;
 import org.slf4j.Logger;
@@ -100,7 +102,8 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
 
   private final WriteOptions tryDeleteOptions =
       new WriteOptions().setNoSlowdown(true).setIgnoreMissingColumnFamilies(true);
-  private final ReadOptions readOptions = new ReadOptions().setVerifyChecksums(false);
+  private final ReadOptions readOptions;
+  private final ReadOptions mmapReadOptions;
   private final MetricsSystem metricsSystem;
   private final RocksDBMetricsFactory rocksDBMetricsFactory;
 
@@ -152,6 +155,12 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
     this.configuration = configuration;
     this.metricsSystem = metricsSystem;
     this.rocksDBMetricsFactory = rocksDBMetricsFactory;
+    this.readOptions = new ReadOptions().setVerifyChecksums(false);
+    if (configuration.isMmapReadsBonsaiSlotTrieBranchEnabled()) {
+      this.mmapReadOptions = new ReadOptions().setVerifyChecksums(false).setFillCache(false);
+    } else {
+      this.mmapReadOptions = this.readOptions;
+    }
 
     try {
       trimmedSegments = new ArrayList<>(defaultSegments);
@@ -213,6 +222,10 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
     }
 
     final ColumnFamilyOptions columnOpts = columnFamilyOptionsFromNativeProperties(cfProps);
+    if (configuration.isMmapReadsBonsaiSlotTrieBranchEnabled()
+        && isMmapReadsTargetBonsaiSegment(segment)) {
+      applyMmapOptimizedTableFormat(columnOpts);
+    }
 
     columnOpts.setLevelCompactionDynamicLevelBytes(dynamicLevelCompaction);
     if (segment.containsStaticData()) {
@@ -242,18 +255,25 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
     cfProps.setProperty("block_based_table_factory.partition_filters", "false");
     cfProps.setProperty("block_based_table_factory.cache_index_and_filter_blocks", "false");
     cfProps.setProperty("block_based_table_factory.block_size", Long.toString(ROCKSDB_BLOCK_SIZE));
-    cfProps.setProperty("block_based_table_factory.block_cache", Long.toString(blockCacheBytes));
-    if (configuration.isMmapReadsBonsaiSlotTrieBranchEnabled()
-        && isMmapReadsTargetBonsaiSegment(segment)) {
-      cfProps.setProperty("block_based_table_factory.allow_mmap_reads", "true");
+    if (!(configuration.isMmapReadsBonsaiSlotTrieBranchEnabled()
+        && isMmapReadsTargetBonsaiSegment(segment))) {
+      cfProps.setProperty("block_based_table_factory.block_cache", Long.toString(blockCacheBytes));
     }
   }
 
-  private static boolean isMmapReadsTargetBonsaiSegment(final SegmentIdentifier segment) {
+  static boolean isMmapReadsTargetBonsaiSegment(final SegmentIdentifier segment) {
     final String n = segment.getName();
     return KeyValueSegmentIdentifier.ACCOUNT_STORAGE_STORAGE.name().equals(n)
         || KeyValueSegmentIdentifier.ACCOUNT_STORAGE_ARCHIVE.name().equals(n)
         || KeyValueSegmentIdentifier.TRIE_BRANCH_STORAGE.name().equals(n);
+  }
+
+  ReadOptions readOptionsFor(final SegmentIdentifier segment) {
+    if (configuration.isMmapReadsBonsaiSlotTrieBranchEnabled()
+        && isMmapReadsTargetBonsaiSegment(segment)) {
+      return mmapReadOptions;
+    }
+    return readOptions;
   }
 
   /**
@@ -320,6 +340,24 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
       base = new ColumnFamilyOptions();
     }
     return base.setTtl(0).setCompressionType(CompressionType.LZ4_COMPRESSION);
+  }
+
+  /**
+   * Disables the RocksDB block cache for mmap target column families so reads rely on OS page cache
+   * ({@link DBOptions#setAllowMmapReads} is set separately). {@code allow_mmap_reads} must not be
+   * passed in the native option string: RocksDB JNI rejects it and {@code
+   * getColumnFamilyOptionsFromProps} returns null.
+   */
+  private static void applyMmapOptimizedTableFormat(final ColumnFamilyOptions columnOpts) {
+    final TableFormatConfig existing = columnOpts.tableFormatConfig();
+    final BlockBasedTableConfig tableConfig;
+    if (existing instanceof BlockBasedTableConfig blockBasedTableConfig) {
+      tableConfig = blockBasedTableConfig;
+    } else {
+      tableConfig = new BlockBasedTableConfig();
+      columnOpts.setTableFormatConfig(tableConfig);
+    }
+    tableConfig.setNoBlockCache(true);
   }
 
   private static void configureBlobDBForSegment(
@@ -502,7 +540,8 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
     throwIfClosed();
 
     try (final OperationTimer.TimingContext ignored = metrics.getReadLatency().startTimer()) {
-      return Optional.ofNullable(getDB().get(safeColumnHandle(segment), readOptions, key));
+      return Optional.ofNullable(
+          getDB().get(safeColumnHandle(segment), readOptionsFor(segment), key));
     } catch (final RocksDBException e) {
       throw new StorageException(e);
     }
@@ -513,7 +552,7 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
       final SegmentIdentifier segmentIdentifier, final Bytes key) throws StorageException {
 
     try (final RocksIterator rocksIterator =
-        getDB().newIterator(safeColumnHandle(segmentIdentifier))) {
+        getDB().newIterator(safeColumnHandle(segmentIdentifier), readOptionsFor(segmentIdentifier))) {
       rocksIterator.seekForPrev(key.toArrayUnsafe());
       return Optional.of(rocksIterator)
           .filter(AbstractRocksIterator::isValid)
@@ -526,7 +565,7 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
       final SegmentIdentifier segmentIdentifier, final Bytes key) throws StorageException {
 
     try (final RocksIterator rocksIterator =
-        getDB().newIterator(safeColumnHandle(segmentIdentifier))) {
+        getDB().newIterator(safeColumnHandle(segmentIdentifier), readOptionsFor(segmentIdentifier))) {
       rocksIterator.seek(key.toArrayUnsafe());
       return Optional.of(rocksIterator)
           .filter(AbstractRocksIterator::isValid)
@@ -536,7 +575,8 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
 
   @Override
   public Stream<Pair<byte[], byte[]>> stream(final SegmentIdentifier segmentIdentifier) {
-    final RocksIterator rocksIterator = getDB().newIterator(safeColumnHandle(segmentIdentifier));
+    final RocksIterator rocksIterator =
+        getDB().newIterator(safeColumnHandle(segmentIdentifier), readOptionsFor(segmentIdentifier));
     rocksIterator.seekToFirst();
     return RocksDbIterator.create(rocksIterator).toStream();
   }
@@ -544,7 +584,8 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
   @Override
   public Stream<Pair<byte[], byte[]>> streamFromKey(
       final SegmentIdentifier segmentIdentifier, final byte[] startKey) {
-    final RocksIterator rocksIterator = getDB().newIterator(safeColumnHandle(segmentIdentifier));
+    final RocksIterator rocksIterator =
+        getDB().newIterator(safeColumnHandle(segmentIdentifier), readOptionsFor(segmentIdentifier));
     rocksIterator.seek(startKey);
     return RocksDbIterator.create(rocksIterator).toStream();
   }
@@ -553,7 +594,8 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
   public Stream<Pair<byte[], byte[]>> streamFromKey(
       final SegmentIdentifier segmentIdentifier, final byte[] startKey, final byte[] endKey) {
     final Bytes endKeyBytes = Bytes.wrap(endKey);
-    final RocksIterator rocksIterator = getDB().newIterator(safeColumnHandle(segmentIdentifier));
+    final RocksIterator rocksIterator =
+        getDB().newIterator(safeColumnHandle(segmentIdentifier), readOptionsFor(segmentIdentifier));
     rocksIterator.seek(startKey);
     return RocksDbIterator.create(rocksIterator)
         .toStream()
@@ -562,7 +604,8 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
 
   @Override
   public Stream<byte[]> streamKeys(final SegmentIdentifier segmentIdentifier) {
-    final RocksIterator rocksIterator = getDB().newIterator(safeColumnHandle(segmentIdentifier));
+    final RocksIterator rocksIterator =
+        getDB().newIterator(safeColumnHandle(segmentIdentifier), readOptionsFor(segmentIdentifier));
     rocksIterator.seekToFirst();
     return RocksDbIterator.create(rocksIterator).toStreamKeys();
   }
@@ -611,6 +654,10 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
       txOptions.close();
       options.close();
       tryDeleteOptions.close();
+      readOptions.close();
+      if (mmapReadOptions != readOptions) {
+        mmapReadOptions.close();
+      }
       columnHandlesBySegmentIdentifier.values().stream()
           .map(RocksDbSegmentIdentifier::get)
           .forEach(ColumnFamilyHandle::close);

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
@@ -388,7 +388,7 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
         dbOpts = new DBOptions();
       }
     }
-    options =
+    final DBOptions built =
         dbOpts
             .setCreateIfMissing(true)
             .setMaxOpenFiles(configuration.getMaxOpenFiles())
@@ -399,6 +399,10 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
             .setEnv(Env.getDefault().setBackgroundThreads(configuration.getBackgroundThreadCount()))
             .setMaxTotalWalSize(WAL_MAX_TOTAL_SIZE)
             .setRecycleLogFileNum(WAL_MAX_TOTAL_SIZE / EXPECTED_WAL_FILE_SIZE);
+    options =
+        configuration.isMmapReadsBonsaiSlotTrieBranchEnabled()
+            ? built.setAllowMmapReads(true)
+            : built;
   }
 
   /**

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
@@ -15,8 +15,8 @@
 package org.hyperledger.besu.plugin.services.storage.rocksdb.segmented;
 
 import static java.util.stream.Collectors.toUnmodifiableSet;
-import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.BLOCKCHAIN;
 
+import org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.exception.StorageException;
 import org.hyperledger.besu.plugin.services.metrics.OperationTimer;
@@ -243,6 +243,17 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
     cfProps.setProperty("block_based_table_factory.cache_index_and_filter_blocks", "false");
     cfProps.setProperty("block_based_table_factory.block_size", Long.toString(ROCKSDB_BLOCK_SIZE));
     cfProps.setProperty("block_based_table_factory.block_cache", Long.toString(blockCacheBytes));
+    if (configuration.isMmapReadsBonsaiSlotTrieBranchEnabled()
+        && isMmapReadsTargetBonsaiSegment(segment)) {
+      cfProps.setProperty("block_based_table_factory.allow_mmap_reads", "true");
+    }
+  }
+
+  private static boolean isMmapReadsTargetBonsaiSegment(final SegmentIdentifier segment) {
+    final String n = segment.getName();
+    return KeyValueSegmentIdentifier.ACCOUNT_STORAGE_STORAGE.name().equals(n)
+        || KeyValueSegmentIdentifier.ACCOUNT_STORAGE_ARCHIVE.name().equals(n)
+        || KeyValueSegmentIdentifier.TRIE_BRANCH_STORAGE.name().equals(n);
   }
 
   /**
@@ -339,7 +350,7 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
 
   private static boolean isStaticDataGarbageCollectionEnabled(
       final SegmentIdentifier segment, final RocksDBConfiguration configuration) {
-    if (BLOCKCHAIN.getName().equals(segment.getName())
+    if (KeyValueSegmentIdentifier.BLOCKCHAIN.getName().equals(segment.getName())
         && configuration.isBlockchainGarbageCollectionEnabled()) {
       return true;
     } else {

--- a/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/NearestKeyValueStorageTest.java
+++ b/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/NearestKeyValueStorageTest.java
@@ -73,6 +73,8 @@ public class NearestKeyValueStorageTest {
                     DEFAULT_ENABLE_READ_CACHE_FOR_SNAPSHOTS,
                     false,
                     Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
                     Optional.empty()),
             Arrays.asList(KeyValueSegmentIdentifier.values()),
             RocksDBMetricsFactory.PUBLIC_ROCKS_DB_METRICS);

--- a/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/NearestKeyValueStorageTest.java
+++ b/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/NearestKeyValueStorageTest.java
@@ -75,7 +75,8 @@ public class NearestKeyValueStorageTest {
                     Optional.empty(),
                     Optional.empty(),
                     Optional.empty(),
-                    Optional.empty()),
+                    Optional.empty(),
+                    false),
             Arrays.asList(KeyValueSegmentIdentifier.values()),
             RocksDBMetricsFactory.PUBLIC_ROCKS_DB_METRICS);
 

--- a/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBCLIOptionsTest.java
+++ b/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBCLIOptionsTest.java
@@ -21,6 +21,8 @@ import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration
 import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.DEFAULT_IS_HIGH_SPEC;
 import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.DEFAULT_MAX_OPEN_FILES;
 import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.IS_HIGH_SPEC;
+import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.ADDITIONAL_COLUMN_FAMILY_OPTIONS;
+import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.ADDITIONAL_DATABASE_OPTIONS;
 import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.MAX_OPEN_FILES_FLAG;
 
 import org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions;
@@ -103,5 +105,29 @@ public class RocksDBCLIOptionsTest {
     assertThat(configuration.getBackgroundThreadCount()).isEqualTo(DEFAULT_BACKGROUND_THREAD_COUNT);
     assertThat(configuration.getCacheCapacity()).isEqualTo(DEFAULT_CACHE_CAPACITY);
     assertThat(configuration.isHighSpec()).isEqualTo(Boolean.TRUE);
+  }
+
+  @Test
+  public void additionalColumnFamilyOptionsIncludesBlockTableKeys() {
+    final RocksDBCLIOptions options = RocksDBCLIOptions.create();
+    new CommandLine(options)
+        .parseArgs(
+            ADDITIONAL_COLUMN_FAMILY_OPTIONS,
+            "write_buffer_size=1000000;block_based_table_factory.prepopulate_block_cache=kFlushOnly;");
+
+    final RocksDBFactoryConfiguration configuration = options.toDomainObject();
+    assertThat(configuration.getAdditionalColumnFamilyOptions())
+        .hasValue(
+            "write_buffer_size=1000000;block_based_table_factory.prepopulate_block_cache=kFlushOnly;");
+  }
+
+  @Test
+  public void additionalDatabaseOptions() {
+    final RocksDBCLIOptions options = RocksDBCLIOptions.create();
+    new CommandLine(options)
+        .parseArgs(ADDITIONAL_DATABASE_OPTIONS, "max_file_opening_threads=16;");
+
+    final RocksDBFactoryConfiguration configuration = options.toDomainObject();
+    assertThat(configuration.getAdditionalDatabaseOptions()).hasValue("max_file_opening_threads=16;");
   }
 }

--- a/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBCLIOptionsTest.java
+++ b/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBCLIOptionsTest.java
@@ -15,14 +15,14 @@
 package org.hyperledger.besu.plugin.services.storage.rocksdb;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.ADDITIONAL_COLUMN_FAMILY_OPTIONS;
+import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.ADDITIONAL_DATABASE_OPTIONS;
 import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.CACHE_CAPACITY_FLAG;
 import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.DEFAULT_BACKGROUND_THREAD_COUNT;
 import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.DEFAULT_CACHE_CAPACITY;
 import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.DEFAULT_IS_HIGH_SPEC;
 import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.DEFAULT_MAX_OPEN_FILES;
 import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.IS_HIGH_SPEC;
-import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.ADDITIONAL_COLUMN_FAMILY_OPTIONS;
-import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.ADDITIONAL_DATABASE_OPTIONS;
 import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.MAX_OPEN_FILES_FLAG;
 
 import org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions;
@@ -124,10 +124,10 @@ public class RocksDBCLIOptionsTest {
   @Test
   public void additionalDatabaseOptions() {
     final RocksDBCLIOptions options = RocksDBCLIOptions.create();
-    new CommandLine(options)
-        .parseArgs(ADDITIONAL_DATABASE_OPTIONS, "max_file_opening_threads=16;");
+    new CommandLine(options).parseArgs(ADDITIONAL_DATABASE_OPTIONS, "max_file_opening_threads=16;");
 
     final RocksDBFactoryConfiguration configuration = options.toDomainObject();
-    assertThat(configuration.getAdditionalDatabaseOptions()).hasValue("max_file_opening_threads=16;");
+    assertThat(configuration.getAdditionalDatabaseOptions())
+        .hasValue("max_file_opening_threads=16;");
   }
 }

--- a/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBCLIOptionsTest.java
+++ b/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBCLIOptionsTest.java
@@ -21,9 +21,10 @@ import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration
 import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.DEFAULT_BACKGROUND_THREAD_COUNT;
 import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.DEFAULT_CACHE_CAPACITY;
 import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.DEFAULT_IS_HIGH_SPEC;
-import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.DEFAULT_MAX_OPEN_FILES;
+import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.DEFAULT_MMAP_READS_BONSAI_SLOT_TRIE_BRANCH;
 import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.IS_HIGH_SPEC;
 import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.MAX_OPEN_FILES_FLAG;
+import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.MMAP_READS_BONSAI_SLOT_TRIE_BRANCH_FLAG;
 
 import org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions;
 import org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBFactoryConfiguration;
@@ -43,8 +44,17 @@ public class RocksDBCLIOptionsTest {
     assertThat(configuration).isNotNull();
     assertThat(configuration.getBackgroundThreadCount()).isEqualTo(DEFAULT_BACKGROUND_THREAD_COUNT);
     assertThat(configuration.getCacheCapacity()).isEqualTo(DEFAULT_CACHE_CAPACITY);
-    assertThat(configuration.getMaxOpenFiles()).isEqualTo(DEFAULT_MAX_OPEN_FILES);
+    assertThat(configuration.getMaxOpenFiles()).isEqualTo(-1);
     assertThat(configuration.isHighSpec()).isEqualTo(DEFAULT_IS_HIGH_SPEC);
+    assertThat(configuration.isMmapReadsBonsaiSlotTrieBranchEnabled())
+        .isEqualTo(DEFAULT_MMAP_READS_BONSAI_SLOT_TRIE_BRANCH);
+  }
+
+  @Test
+  public void mmapReadsBonsaiSlotTrieBranchFlag() {
+    final RocksDBCLIOptions options = RocksDBCLIOptions.create();
+    new CommandLine(options).parseArgs(MMAP_READS_BONSAI_SLOT_TRIE_BRANCH_FLAG);
+    assertThat(options.toDomainObject().isMmapReadsBonsaiSlotTrieBranchEnabled()).isTrue();
   }
 
   @Test
@@ -60,7 +70,7 @@ public class RocksDBCLIOptionsTest {
     assertThat(configuration).isNotNull();
     assertThat(configuration.getBackgroundThreadCount()).isEqualTo(expectedBackgroundThreadCount);
     assertThat(configuration.getCacheCapacity()).isEqualTo(DEFAULT_CACHE_CAPACITY);
-    assertThat(configuration.getMaxOpenFiles()).isEqualTo(DEFAULT_MAX_OPEN_FILES);
+    assertThat(configuration.getMaxOpenFiles()).isEqualTo(-1);
     assertThat(configuration.isHighSpec()).isEqualTo(DEFAULT_IS_HIGH_SPEC);
   }
 
@@ -75,7 +85,7 @@ public class RocksDBCLIOptionsTest {
     assertThat(configuration).isNotNull();
     assertThat(configuration.getBackgroundThreadCount()).isEqualTo(DEFAULT_BACKGROUND_THREAD_COUNT);
     assertThat(configuration.getCacheCapacity()).isEqualTo(expectedCacheCapacity);
-    assertThat(configuration.getMaxOpenFiles()).isEqualTo(DEFAULT_MAX_OPEN_FILES);
+    assertThat(configuration.getMaxOpenFiles()).isEqualTo(-1);
     assertThat(configuration.isHighSpec()).isEqualTo(DEFAULT_IS_HIGH_SPEC);
   }
 

--- a/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDbNativeOptionStringsTest.java
+++ b/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDbNativeOptionStringsTest.java
@@ -88,4 +88,23 @@ public class RocksDbNativeOptionStringsTest {
       assertThat(opts).isNotNull();
     }
   }
+
+  @Test
+  public void
+      getColumnFamilyOptionsFromPropsAcceptsBesuStyleBlockTableKeysWithBlockCacheCapacity() {
+    RocksDbUtil.loadNativeLibrary();
+    final long cacheBytes = 8 * 1024 * 1024;
+    final Properties cfProps = new Properties();
+    cfProps.setProperty("block_based_table_factory.format_version", "5");
+    cfProps.setProperty("block_based_table_factory.filter_policy", "bloomfilter:10:false");
+    cfProps.setProperty("block_based_table_factory.partition_filters", "true");
+    cfProps.setProperty("block_based_table_factory.cache_index_and_filter_blocks", "false");
+    cfProps.setProperty("block_based_table_factory.block_size", "32768");
+    cfProps.setProperty("block_based_table_factory.block_cache", Long.toString(cacheBytes));
+    cfProps.setProperty("block_based_table_factory.prepopulate_block_cache", "kFlushOnly");
+    try (ColumnFamilyOptions opts =
+        ColumnFamilyOptions.getColumnFamilyOptionsFromProps(new ConfigOptions(), cfProps)) {
+      assertThat(opts).isNotNull();
+    }
+  }
 }

--- a/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDbNativeOptionStringsTest.java
+++ b/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDbNativeOptionStringsTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.plugin.services.storage.rocksdb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+import org.rocksdb.ColumnFamilyOptions;
+import org.rocksdb.ConfigOptions;
+import org.rocksdb.DBOptions;
+
+public class RocksDbNativeOptionStringsTest {
+
+  @Test
+  public void parseSemicolonKeyValueStringSplitsPairs() {
+    final var props =
+        RocksDbNativeOptionStrings.parseSemicolonKeyValueString("a=1;b=two;");
+    assertThat(props.getProperty("a")).isEqualTo("1");
+    assertThat(props.getProperty("b")).isEqualTo("two");
+  }
+
+  @Test
+  public void parseSemicolonKeyValueStringKeepsAllKeysIncludingBlockTable() {
+    final var props =
+        RocksDbNativeOptionStrings.parseSemicolonKeyValueString(
+            "write_buffer_size=1000000;block_based_table_factory.block_size=8192;block_based_table_factory.prepopulate_block_cache=kFlushOnly;ttl=0");
+    assertThat(props.getProperty("write_buffer_size")).isEqualTo("1000000");
+    assertThat(props.getProperty("ttl")).isEqualTo("0");
+    assertThat(props.getProperty("block_based_table_factory.prepopulate_block_cache"))
+        .isEqualTo("kFlushOnly");
+    assertThat(props.getProperty("block_based_table_factory.block_size")).isEqualTo("8192");
+  }
+
+  @Test
+  public void parseSemicolonKeyValueStringKeepsFormatVersionAndCompactionKeys() {
+    assertThat(
+            RocksDbNativeOptionStrings.parseSemicolonKeyValueString(
+                    "block_based_table_factory.format_version=5;")
+                .getProperty("block_based_table_factory.format_version"))
+        .isEqualTo("5");
+    assertThat(
+            RocksDbNativeOptionStrings.parseSemicolonKeyValueString(
+                    "level_compaction_dynamic_level_bytes=false;")
+                .getProperty("level_compaction_dynamic_level_bytes"))
+        .isEqualTo("false");
+    assertThat(
+            RocksDbNativeOptionStrings.parseSemicolonKeyValueString("enable_blob_files=true;")
+                .getProperty("enable_blob_files"))
+        .isEqualTo("true");
+    assertThat(
+            RocksDbNativeOptionStrings.parseSemicolonKeyValueString(
+                    "blob_garbage_collection_age_cutoff=0.25;")
+                .getProperty("blob_garbage_collection_age_cutoff"))
+        .isEqualTo("0.25");
+  }
+
+  @Test
+  public void getColumnFamilyOptionsFromPropsAcceptsNonEmptyNativeProperties() {
+    RocksDbUtil.loadNativeLibrary();
+    final Properties cfProps = new Properties();
+    cfProps.setProperty("ttl", "0");
+    cfProps.setProperty("compression", "kLZ4Compression");
+    try (ColumnFamilyOptions opts =
+        ColumnFamilyOptions.getColumnFamilyOptionsFromProps(new ConfigOptions(), cfProps)) {
+      assertThat(opts).isNotNull();
+    }
+  }
+
+  @Test
+  public void getDBOptionsFromPropsAcceptsNativeString() {
+    RocksDbUtil.loadNativeLibrary();
+    final Properties dbProps = new Properties();
+    dbProps.setProperty("max_file_opening_threads", "8");
+    try (DBOptions opts = DBOptions.getDBOptionsFromProps(new ConfigOptions(), dbProps)) {
+      assertThat(opts).isNotNull();
+    }
+  }
+}

--- a/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDbNativeOptionStringsTest.java
+++ b/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDbNativeOptionStringsTest.java
@@ -35,6 +35,12 @@ public class RocksDbNativeOptionStringsTest {
   }
 
   @Test
+  public void parseSemicolonKeyValueStringPreservesKeyOrderInStringPropertyNames() {
+    final var props = RocksDbNativeOptionStrings.parseSemicolonKeyValueString("z=1;a=2;m=3;");
+    assertThat(new ArrayList<>(props.stringPropertyNames())).containsExactly("z", "a", "m");
+  }
+
+  @Test
   public void parseSemicolonKeyValueStringKeepsAllKeysIncludingBlockTable() {
     final var props =
         RocksDbNativeOptionStrings.parseSemicolonKeyValueString(

--- a/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDbNativeOptionStringsTest.java
+++ b/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDbNativeOptionStringsTest.java
@@ -16,6 +16,8 @@ package org.hyperledger.besu.plugin.services.storage.rocksdb;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 
 import org.junit.jupiter.api.Test;
@@ -42,6 +44,25 @@ public class RocksDbNativeOptionStringsTest {
     assertThat(props.getProperty("block_based_table_factory.prepopulate_block_cache"))
         .isEqualTo("kFlushOnly");
     assertThat(props.getProperty("block_based_table_factory.block_size")).isEqualTo("8192");
+  }
+
+  @Test
+  public void insertionOrderedPropertiesKeepsBesuBlockTableKeyCallOrder() {
+    final RocksDbNativeOptionStrings.InsertionOrderedProperties cfProps =
+        new RocksDbNativeOptionStrings.InsertionOrderedProperties();
+    cfProps.setProperty("block_based_table_factory.index_type", "kTwoLevelIndexSearch");
+    cfProps.setProperty("block_based_table_factory.format_version", "5");
+    cfProps.setProperty("block_based_table_factory.filter_policy", "bloomfilter:10:false");
+    cfProps.setProperty("block_based_table_factory.partition_filters", "true");
+    cfProps.setProperty("block_based_table_factory.cache_index_and_filter_blocks", "false");
+    cfProps.setProperty("block_based_table_factory.block_size", "32768");
+    cfProps.setProperty("block_based_table_factory.block_cache", "8388608");
+    cfProps.setProperty("write_buffer_size", "123");
+    final List<String> names = new ArrayList<>(cfProps.stringPropertyNames());
+    assertThat(names.indexOf("block_based_table_factory.index_type"))
+        .isLessThan(names.indexOf("block_based_table_factory.partition_filters"));
+    assertThat(names.indexOf("block_based_table_factory.partition_filters"))
+        .isLessThan(names.indexOf("write_buffer_size"));
   }
 
   @Test
@@ -94,7 +115,9 @@ public class RocksDbNativeOptionStringsTest {
       getColumnFamilyOptionsFromPropsAcceptsBesuStyleBlockTableKeysWithBlockCacheCapacity() {
     RocksDbUtil.loadNativeLibrary();
     final long cacheBytes = 8 * 1024 * 1024;
-    final Properties cfProps = new Properties();
+    final RocksDbNativeOptionStrings.InsertionOrderedProperties cfProps =
+        new RocksDbNativeOptionStrings.InsertionOrderedProperties();
+    cfProps.setProperty("block_based_table_factory.index_type", "kTwoLevelIndexSearch");
     cfProps.setProperty("block_based_table_factory.format_version", "5");
     cfProps.setProperty("block_based_table_factory.filter_policy", "bloomfilter:10:false");
     cfProps.setProperty("block_based_table_factory.partition_filters", "true");

--- a/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDbNativeOptionStringsTest.java
+++ b/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDbNativeOptionStringsTest.java
@@ -27,8 +27,7 @@ public class RocksDbNativeOptionStringsTest {
 
   @Test
   public void parseSemicolonKeyValueStringSplitsPairs() {
-    final var props =
-        RocksDbNativeOptionStrings.parseSemicolonKeyValueString("a=1;b=two;");
+    final var props = RocksDbNativeOptionStrings.parseSemicolonKeyValueString("a=1;b=two;");
     assertThat(props.getProperty("a")).isEqualTo("1");
     assertThat(props.getProperty("b")).isEqualTo("two");
   }

--- a/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDbNativeOptionStringsTest.java
+++ b/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDbNativeOptionStringsTest.java
@@ -136,4 +136,20 @@ public class RocksDbNativeOptionStringsTest {
       assertThat(opts).isNotNull();
     }
   }
+
+  @Test
+  public void allowMmapReadsInNativeCfOptionStringInvalidatesParse() {
+    RocksDbUtil.loadNativeLibrary();
+    final RocksDbNativeOptionStrings.InsertionOrderedProperties cfProps =
+        new RocksDbNativeOptionStrings.InsertionOrderedProperties();
+    cfProps.setProperty("block_based_table_factory.format_version", "5");
+    cfProps.setProperty("block_based_table_factory.filter_policy", "bloomfilter:10:false");
+    cfProps.setProperty("block_based_table_factory.partition_filters", "false");
+    cfProps.setProperty("block_based_table_factory.cache_index_and_filter_blocks", "false");
+    cfProps.setProperty("block_based_table_factory.block_size", "32768");
+    cfProps.setProperty("block_based_table_factory.allow_mmap_reads", "true");
+    assertThat(
+            ColumnFamilyOptions.getColumnFamilyOptionsFromProps(new ConfigOptions(), cfProps))
+        .isNull();
+  }
 }

--- a/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/AdditionalColumnFamilyOptionsIntegrationTest.java
+++ b/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/AdditionalColumnFamilyOptionsIntegrationTest.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.plugin.services.storage.rocksdb.segmented;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
+import org.hyperledger.besu.plugin.services.storage.rocksdb.RocksDBMetricsFactory;
+import org.hyperledger.besu.plugin.services.storage.rocksdb.RocksDbUtil;
+import org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBConfigurationBuilder;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.rocksdb.ColumnFamilyDescriptor;
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.ColumnFamilyOptions;
+import org.rocksdb.CompressionType;
+import org.rocksdb.ConfigOptions;
+import org.rocksdb.DBOptions;
+import org.rocksdb.Env;
+import org.rocksdb.OptionsUtil;
+import org.rocksdb.RocksDB;
+
+/**
+ * Verifies additional column-family option strings against RocksDB and against Besu's storage
+ * wrapper. Memtable options such as {@code write_buffer_size} survive Besu's Java overlay; some
+ * block-table factory settings from the native string may be reset when Besu reapplies its table
+ * configuration in Java (see {@link #prepopulateBlockCacheFromNativeStringSurvivesWithoutBesuTableOverlay}).
+ *
+ * <p>Database-level strings are covered by {@link AdditionalDatabaseOptionsIntegrationTest}.
+ */
+public class AdditionalColumnFamilyOptionsIntegrationTest {
+
+  @Test
+  public void getColumnFamilyOptionsFromPropsThenBesuTtlAndLz4KeepsOtherNativeSettings()
+      throws Exception {
+    RocksDbUtil.loadNativeLibrary();
+    final Properties props = new Properties();
+    props.setProperty("write_buffer_size", "7654321");
+    props.setProperty("block_based_table_factory.prepopulate_block_cache", "kFlushOnly");
+    try (ColumnFamilyOptions opts =
+        ColumnFamilyOptions.getColumnFamilyOptionsFromProps(new ConfigOptions(), props)) {
+      assertThat(opts).isNotNull();
+      opts.setTtl(0).setCompressionType(CompressionType.LZ4_COMPRESSION);
+      assertThat(opts.writeBufferSize()).isEqualTo(7_654_321L);
+    }
+  }
+
+  @Test
+  public void prepopulateBlockCacheFromNativeStringSurvivesWithoutBesuTableOverlay(
+      @TempDir final Path dbDir) throws Exception {
+    RocksDbUtil.loadNativeLibrary();
+    final Properties props = new Properties();
+    props.setProperty("block_based_table_factory.prepopulate_block_cache", "kFlushOnly");
+
+    final List<ColumnFamilyHandle> handles = new ArrayList<>();
+    try (ColumnFamilyOptions cfOpts =
+            ColumnFamilyOptions.getColumnFamilyOptionsFromProps(new ConfigOptions(), props);
+        DBOptions dbOpts =
+            new DBOptions().setCreateIfMissing(true).setCreateMissingColumnFamilies(true);
+        RocksDB db =
+            RocksDB.open(
+                dbOpts,
+                dbDir.toString(),
+                List.of(new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY, cfOpts)),
+                handles)) {
+      assertThat(db).isNotNull();
+    } finally {
+      for (ColumnFamilyHandle h : handles) {
+        h.close();
+      }
+    }
+
+    final String optionsFileName =
+        OptionsUtil.getLatestOptionsFileName(dbDir.toString(), Env.getDefault());
+    final String content = Files.readString(dbDir.resolve(optionsFileName), StandardCharsets.UTF_8);
+    assertThat(content)
+        .containsIgnoringCase("prepopulate_block_cache")
+        .containsIgnoringCase("kFlushOnly");
+  }
+
+  @Test
+  public void additionalColumnFamilyOptionsAreVisibleInLiveDbAndOptionsFile(@TempDir final Path dbDir)
+      throws Exception {
+    RocksDbUtil.loadNativeLibrary();
+    final long writeBufferSize = 2_014_040L;
+    final var configuration =
+        new RocksDBConfigurationBuilder()
+            .databaseDir(dbDir)
+            .additionalColumnFamilyOptions(
+                Optional.of(
+                    "write_buffer_size="
+                        + writeBufferSize
+                        + ";block_based_table_factory.prepopulate_block_cache=kFlushOnly;"))
+            .build();
+
+    try (OptimisticRocksDBColumnarKeyValueStorage store =
+        new OptimisticRocksDBColumnarKeyValueStorage(
+            configuration,
+            List.of(
+                RocksDBColumnarKeyValueStorageTest.TestSegment.DEFAULT,
+                RocksDBColumnarKeyValueStorageTest.TestSegment.FOO),
+            List.of(),
+            new NoOpMetricsSystem(),
+            RocksDBMetricsFactory.PUBLIC_ROCKS_DB_METRICS)) {
+
+      final RocksDB db = store.getDB();
+      final var segmentRef =
+          store.columnHandlesBySegmentIdentifier.get(
+              RocksDBColumnarKeyValueStorageTest.TestSegment.DEFAULT);
+      assertThat(segmentRef).isNotNull();
+      final long liveWriteBuffer = db.getOptions(segmentRef.get()).writeBufferSize();
+      assertThat(liveWriteBuffer).isEqualTo(writeBufferSize);
+    }
+
+    final String optionsFileName =
+        OptionsUtil.getLatestOptionsFileName(dbDir.toString(), Env.getDefault());
+    final String optionsContent =
+        Files.readString(dbDir.resolve(optionsFileName), StandardCharsets.UTF_8);
+    assertThat(optionsContent).contains("write_buffer_size=" + writeBufferSize);
+    // Besu reapplies block table settings in Java; JNI resets prepopulate_block_cache to default.
+    assertThat(optionsContent).containsIgnoringCase("prepopulate_block_cache=kDisable");
+  }
+
+  @Test
+  public void unknownColumnFamilyOptionKeyFallsBackAndStorageStillOpens(@TempDir final Path dbDir)
+      throws Exception {
+    RocksDbUtil.loadNativeLibrary();
+    final var configuration =
+        new RocksDBConfigurationBuilder()
+            .databaseDir(dbDir)
+            .additionalColumnFamilyOptions(
+                Optional.of("besu_nonexistent_cf_option_xyz=1;"))
+            .build();
+
+    try (OptimisticRocksDBColumnarKeyValueStorage store =
+        new OptimisticRocksDBColumnarKeyValueStorage(
+            configuration,
+            List.of(
+                RocksDBColumnarKeyValueStorageTest.TestSegment.DEFAULT,
+                RocksDBColumnarKeyValueStorageTest.TestSegment.FOO),
+            List.of(),
+            new NoOpMetricsSystem(),
+            RocksDBMetricsFactory.PUBLIC_ROCKS_DB_METRICS)) {
+      assertThat(store.getDB()).isNotNull();
+    }
+
+    final String optionsFileName =
+        OptionsUtil.getLatestOptionsFileName(dbDir.toString(), Env.getDefault());
+    final String content = Files.readString(dbDir.resolve(optionsFileName), StandardCharsets.UTF_8);
+    assertThat(content).doesNotContain("besu_nonexistent_cf_option_xyz");
+  }
+
+  @Test
+  public void unknownCfKeyInStringInvalidatesEntireAdditionalColumnFamilyOptions(
+      @TempDir final Path dbDir) throws Exception {
+    RocksDbUtil.loadNativeLibrary();
+    final long requestedWriteBufferSize = 1_919_191L;
+    final var configuration =
+        new RocksDBConfigurationBuilder()
+            .databaseDir(dbDir)
+            .additionalColumnFamilyOptions(
+                Optional.of(
+                    "write_buffer_size="
+                        + requestedWriteBufferSize
+                        + ";besu_nonexistent_cf_option_xyz=1;"))
+            .build();
+
+    try (OptimisticRocksDBColumnarKeyValueStorage store =
+        new OptimisticRocksDBColumnarKeyValueStorage(
+            configuration,
+            List.of(
+                RocksDBColumnarKeyValueStorageTest.TestSegment.DEFAULT,
+                RocksDBColumnarKeyValueStorageTest.TestSegment.FOO),
+            List.of(),
+            new NoOpMetricsSystem(),
+            RocksDBMetricsFactory.PUBLIC_ROCKS_DB_METRICS)) {
+
+      final var segmentRef =
+          store.columnHandlesBySegmentIdentifier.get(
+              RocksDBColumnarKeyValueStorageTest.TestSegment.DEFAULT);
+      assertThat(segmentRef).isNotNull();
+      final long liveWriteBuffer = store.getDB().getOptions(segmentRef.get()).writeBufferSize();
+      assertThat(liveWriteBuffer).isNotEqualTo(requestedWriteBufferSize);
+      // Bare ColumnFamilyOptions default when getColumnFamilyOptionsFromProps returns null (RocksDB 9.7.x).
+      assertThat(liveWriteBuffer).isEqualTo(67_108_864L);
+    }
+  }
+}

--- a/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/AdditionalColumnFamilyOptionsIntegrationTest.java
+++ b/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/AdditionalColumnFamilyOptionsIntegrationTest.java
@@ -43,10 +43,9 @@ import org.rocksdb.RocksDB;
 
 /**
  * Verifies additional column-family option strings against RocksDB and against Besu's storage
- * wrapper. Memtable options such as {@code write_buffer_size} survive Besu's Java overlay; some
- * block-table factory settings from the native string may be reset when Besu reapplies its table
- * configuration in Java (see {@link
- * #prepopulateBlockCacheFromNativeStringSurvivesWithoutBesuTableOverlay}).
+ * wrapper. Besu merges its block-table defaults into the native option map before parsing, so user
+ * block-table keys such as {@code prepopulate_block_cache} are preserved alongside Besu's {@code
+ * format_version}, bloom filter, and block cache size.
  *
  * <p>Database-level strings are covered by {@link AdditionalDatabaseOptionsIntegrationTest}.
  */
@@ -139,8 +138,9 @@ public class AdditionalColumnFamilyOptionsIntegrationTest {
     final String optionsContent =
         Files.readString(dbDir.resolve(optionsFileName), StandardCharsets.UTF_8);
     assertThat(optionsContent).contains("write_buffer_size=" + writeBufferSize);
-    // Besu reapplies block table settings in Java; JNI resets prepopulate_block_cache to default.
-    assertThat(optionsContent).containsIgnoringCase("prepopulate_block_cache=kDisable");
+    assertThat(optionsContent)
+        .containsIgnoringCase("prepopulate_block_cache")
+        .containsIgnoringCase("kFlushOnly");
   }
 
   @Test

--- a/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/AdditionalColumnFamilyOptionsIntegrationTest.java
+++ b/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/AdditionalColumnFamilyOptionsIntegrationTest.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.plugin.services.storage.rocksdb.RocksDBMetricsFactory;
+import org.hyperledger.besu.plugin.services.storage.rocksdb.RocksDbSegmentIdentifier;
 import org.hyperledger.besu.plugin.services.storage.rocksdb.RocksDbUtil;
 import org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBConfigurationBuilder;
 
@@ -38,6 +39,7 @@ import org.rocksdb.CompressionType;
 import org.rocksdb.ConfigOptions;
 import org.rocksdb.DBOptions;
 import org.rocksdb.Env;
+import org.rocksdb.FlushOptions;
 import org.rocksdb.OptionsUtil;
 import org.rocksdb.RocksDB;
 
@@ -139,6 +141,62 @@ public class AdditionalColumnFamilyOptionsIntegrationTest {
         Files.readString(dbDir.resolve(optionsFileName), StandardCharsets.UTF_8);
     assertThat(optionsContent).contains("write_buffer_size=" + writeBufferSize);
     assertThat(optionsContent)
+        .containsIgnoringCase("prepopulate_block_cache")
+        .containsIgnoringCase("kFlushOnly");
+  }
+
+  /**
+   * Regression for native SIGSEGV in {@code PartitionedFilterBlockBuilder::DecideCutAFilterBlock}
+   * when {@code partition_filters=true} was applied without {@code index_type=kTwoLevelIndexSearch}
+   * on the incremental native options path (e.g. during WAL processing / flush). Besu applies
+   * block-table keys in a safe sequence on {@link
+   * org.hyperledger.besu.plugin.services.storage.rocksdb.RocksDbNativeOptionStrings.InsertionOrderedProperties}.
+   */
+  @Test
+  public void besuMergedBlockTableOptionsSurviveFlushAllColumnFamiliesWithoutNativeCrash(
+      @TempDir final Path dbDir) throws Exception {
+    RocksDbUtil.loadNativeLibrary();
+    final var configuration =
+        new RocksDBConfigurationBuilder()
+            .databaseDir(dbDir)
+            .cacheCapacity(2 * 1024 * 1024)
+            .additionalColumnFamilyOptions(
+                Optional.of(
+                    "write_buffer_size=65536;block_based_table_factory.prepopulate_block_cache=kFlushOnly;"))
+            .build();
+
+    try (OptimisticRocksDBColumnarKeyValueStorage store =
+        new OptimisticRocksDBColumnarKeyValueStorage(
+            configuration,
+            List.of(
+                RocksDBColumnarKeyValueStorageTest.TestSegment.DEFAULT,
+                RocksDBColumnarKeyValueStorageTest.TestSegment.FOO),
+            List.of(),
+            new NoOpMetricsSystem(),
+            RocksDBMetricsFactory.PUBLIC_ROCKS_DB_METRICS)) {
+
+      final RocksDB db = store.getDB();
+      final List<ColumnFamilyHandle> handles = new ArrayList<>();
+      for (final RocksDbSegmentIdentifier seg : store.columnHandlesBySegmentIdentifier.values()) {
+        handles.add(seg.get());
+      }
+      final byte[] value = new byte[512];
+      for (int i = 0; i < 200; i++) {
+        final byte[] key = String.format("k%06d", i).getBytes(StandardCharsets.UTF_8);
+        for (final ColumnFamilyHandle h : handles) {
+          db.put(h, key, value);
+        }
+      }
+      try (final FlushOptions flushOptions = new FlushOptions().setWaitForFlush(true)) {
+        db.flush(flushOptions, handles);
+      }
+    }
+
+    final String optionsFileName =
+        OptionsUtil.getLatestOptionsFileName(dbDir.toString(), Env.getDefault());
+    final String content = Files.readString(dbDir.resolve(optionsFileName), StandardCharsets.UTF_8);
+    assertThat(content).containsIgnoringCase("partition_filters");
+    assertThat(content)
         .containsIgnoringCase("prepopulate_block_cache")
         .containsIgnoringCase("kFlushOnly");
   }

--- a/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/AdditionalColumnFamilyOptionsIntegrationTest.java
+++ b/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/AdditionalColumnFamilyOptionsIntegrationTest.java
@@ -45,7 +45,8 @@ import org.rocksdb.RocksDB;
  * Verifies additional column-family option strings against RocksDB and against Besu's storage
  * wrapper. Memtable options such as {@code write_buffer_size} survive Besu's Java overlay; some
  * block-table factory settings from the native string may be reset when Besu reapplies its table
- * configuration in Java (see {@link #prepopulateBlockCacheFromNativeStringSurvivesWithoutBesuTableOverlay}).
+ * configuration in Java (see {@link
+ * #prepopulateBlockCacheFromNativeStringSurvivesWithoutBesuTableOverlay}).
  *
  * <p>Database-level strings are covered by {@link AdditionalDatabaseOptionsIntegrationTest}.
  */
@@ -100,8 +101,8 @@ public class AdditionalColumnFamilyOptionsIntegrationTest {
   }
 
   @Test
-  public void additionalColumnFamilyOptionsAreVisibleInLiveDbAndOptionsFile(@TempDir final Path dbDir)
-      throws Exception {
+  public void additionalColumnFamilyOptionsAreVisibleInLiveDbAndOptionsFile(
+      @TempDir final Path dbDir) throws Exception {
     RocksDbUtil.loadNativeLibrary();
     final long writeBufferSize = 2_014_040L;
     final var configuration =
@@ -149,8 +150,7 @@ public class AdditionalColumnFamilyOptionsIntegrationTest {
     final var configuration =
         new RocksDBConfigurationBuilder()
             .databaseDir(dbDir)
-            .additionalColumnFamilyOptions(
-                Optional.of("besu_nonexistent_cf_option_xyz=1;"))
+            .additionalColumnFamilyOptions(Optional.of("besu_nonexistent_cf_option_xyz=1;"))
             .build();
 
     try (OptimisticRocksDBColumnarKeyValueStorage store =
@@ -202,7 +202,8 @@ public class AdditionalColumnFamilyOptionsIntegrationTest {
       assertThat(segmentRef).isNotNull();
       final long liveWriteBuffer = store.getDB().getOptions(segmentRef.get()).writeBufferSize();
       assertThat(liveWriteBuffer).isNotEqualTo(requestedWriteBufferSize);
-      // Bare ColumnFamilyOptions default when getColumnFamilyOptionsFromProps returns null (RocksDB 9.7.x).
+      // Bare ColumnFamilyOptions default when getColumnFamilyOptionsFromProps returns null (RocksDB
+      // 9.7.x).
       assertThat(liveWriteBuffer).isEqualTo(67_108_864L);
     }
   }

--- a/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/AdditionalColumnFamilyOptionsIntegrationTest.java
+++ b/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/AdditionalColumnFamilyOptionsIntegrationTest.java
@@ -230,6 +230,22 @@ public class AdditionalColumnFamilyOptionsIntegrationTest {
   }
 
   @Test
+  public void mmapReadsWithNoBlockCacheNativeStringParses() throws Exception {
+    RocksDbUtil.loadNativeLibrary();
+    final Properties props = new Properties();
+    props.setProperty("block_based_table_factory.format_version", "5");
+    props.setProperty("block_based_table_factory.filter_policy", "bloomfilter:10:false");
+    props.setProperty("block_based_table_factory.partition_filters", "false");
+    props.setProperty("block_based_table_factory.cache_index_and_filter_blocks", "false");
+    props.setProperty("block_based_table_factory.block_size", "32768");
+    props.setProperty("block_based_table_factory.no_block_cache", "true");
+    try (ColumnFamilyOptions opts =
+        ColumnFamilyOptions.getColumnFamilyOptionsFromProps(new ConfigOptions(), props)) {
+      assertThat(opts).isNotNull();
+    }
+  }
+
+  @Test
   public void unknownCfKeyInStringInvalidatesEntireAdditionalColumnFamilyOptions(
       @TempDir final Path dbDir) throws Exception {
     RocksDbUtil.loadNativeLibrary();

--- a/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/AdditionalDatabaseOptionsIntegrationTest.java
+++ b/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/AdditionalDatabaseOptionsIntegrationTest.java
@@ -31,7 +31,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.rocksdb.Env;
 import org.rocksdb.OptionsUtil;
-import org.rocksdb.RocksDB;
 
 /** Integration tests for {@code --Xplugin-rocksdb-additional-database-options}. */
 public class AdditionalDatabaseOptionsIntegrationTest {

--- a/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/AdditionalDatabaseOptionsIntegrationTest.java
+++ b/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/AdditionalDatabaseOptionsIntegrationTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.plugin.services.storage.rocksdb.segmented;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
+import org.hyperledger.besu.plugin.services.storage.rocksdb.RocksDBMetricsFactory;
+import org.hyperledger.besu.plugin.services.storage.rocksdb.RocksDbUtil;
+import org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBConfigurationBuilder;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.rocksdb.Env;
+import org.rocksdb.OptionsUtil;
+import org.rocksdb.RocksDB;
+
+/** Integration tests for {@code --Xplugin-rocksdb-additional-database-options}. */
+public class AdditionalDatabaseOptionsIntegrationTest {
+
+  @Test
+  public void additionalDatabaseOptionsAreReflectedInOptionsFile(@TempDir final Path dbDir)
+      throws Exception {
+    RocksDbUtil.loadNativeLibrary();
+    final int maxFileOpeningThreads = 13;
+    final var configuration =
+        new RocksDBConfigurationBuilder()
+            .databaseDir(dbDir)
+            .additionalDatabaseOptions(
+                Optional.of("max_file_opening_threads=" + maxFileOpeningThreads + ";"))
+            .build();
+
+    try (OptimisticRocksDBColumnarKeyValueStorage store =
+        new OptimisticRocksDBColumnarKeyValueStorage(
+            configuration,
+            List.of(
+                RocksDBColumnarKeyValueStorageTest.TestSegment.DEFAULT,
+                RocksDBColumnarKeyValueStorageTest.TestSegment.FOO),
+            List.of(),
+            new NoOpMetricsSystem(),
+            RocksDBMetricsFactory.PUBLIC_ROCKS_DB_METRICS)) {
+      assertThat(store.getDB()).isNotNull();
+    }
+
+    final String optionsFileName =
+        OptionsUtil.getLatestOptionsFileName(dbDir.toString(), Env.getDefault());
+    final String content = Files.readString(dbDir.resolve(optionsFileName), StandardCharsets.UTF_8);
+    assertThat(content).contains("max_file_opening_threads=" + maxFileOpeningThreads);
+  }
+
+  @Test
+  public void unknownDatabaseOptionKeyFallsBackAndDbStillOpens(@TempDir final Path dbDir)
+      throws Exception {
+    RocksDbUtil.loadNativeLibrary();
+    final var configuration =
+        new RocksDBConfigurationBuilder()
+            .databaseDir(dbDir)
+            .additionalDatabaseOptions(
+                Optional.of("besu_nonexistent_db_option_xyz=not_a_valid_value;"))
+            .build();
+
+    try (OptimisticRocksDBColumnarKeyValueStorage store =
+        new OptimisticRocksDBColumnarKeyValueStorage(
+            configuration,
+            List.of(
+                RocksDBColumnarKeyValueStorageTest.TestSegment.DEFAULT,
+                RocksDBColumnarKeyValueStorageTest.TestSegment.FOO),
+            List.of(),
+            new NoOpMetricsSystem(),
+            RocksDBMetricsFactory.PUBLIC_ROCKS_DB_METRICS)) {
+      assertThat(store.getDB()).isNotNull();
+    }
+
+    final String optionsFileName =
+        OptionsUtil.getLatestOptionsFileName(dbDir.toString(), Env.getDefault());
+    final String content = Files.readString(dbDir.resolve(optionsFileName), StandardCharsets.UTF_8);
+    assertThat(content).doesNotContain("besu_nonexistent_db_option_xyz");
+  }
+
+  @Test
+  public void unknownDbKeyCombinedWithValidMaxFileOpeningThreadsDropsEntireNativeString(
+      @TempDir final Path dbDir) throws Exception {
+    RocksDbUtil.loadNativeLibrary();
+    final int maxFileOpeningThreads = 17;
+    final var configuration =
+        new RocksDBConfigurationBuilder()
+            .databaseDir(dbDir)
+            .additionalDatabaseOptions(
+                Optional.of(
+                    "max_file_opening_threads="
+                        + maxFileOpeningThreads
+                        + ";besu_nonexistent_db_option_xyz=1;"))
+            .build();
+
+    try (OptimisticRocksDBColumnarKeyValueStorage store =
+        new OptimisticRocksDBColumnarKeyValueStorage(
+            configuration,
+            List.of(
+                RocksDBColumnarKeyValueStorageTest.TestSegment.DEFAULT,
+                RocksDBColumnarKeyValueStorageTest.TestSegment.FOO),
+            List.of(),
+            new NoOpMetricsSystem(),
+            RocksDBMetricsFactory.PUBLIC_ROCKS_DB_METRICS)) {
+      assertThat(store.getDB()).isNotNull();
+    }
+
+    final String optionsFileName =
+        OptionsUtil.getLatestOptionsFileName(dbDir.toString(), Env.getDefault());
+    final String content = Files.readString(dbDir.resolve(optionsFileName), StandardCharsets.UTF_8);
+    assertThat(content).doesNotContain("besu_nonexistent_db_option_xyz");
+    // Invalid key makes getDBOptionsFromProps fail; Besu uses bare DBOptions for the whole string.
+    assertThat(content).doesNotContain("max_file_opening_threads=" + maxFileOpeningThreads);
+  }
+}


### PR DESCRIPTION
## PR description

Many valid ColumnFamilyOptions / block_based_table_factory.* keys exist in the C++ option registry but are missing or incomplete on rocksdbjni Java types. Passing everything through the native parser lets operators use --Xplugin-rocksdb-additional-column-family-options for any supported native key for the embedded RocksDB version, not only what Java exposes.


Column family (extra CF options):

```
besu --data-path=/data/besu \
  --Xplugin-rocksdb-additional-column-family-options="write_buffer_size=67108864;block_based_table_factory.prepopulate_block_cache=kFlushOnly"
```

Database-level (extra DB options):

```
besu --data-path=/data/besu \
  --Xplugin-rocksdb-additional-database-options="max_file_opening_threads=8"
```
you can also pass a property directly in the code

`cfProps.setProperty("block_based_table_factory.format_version", "5");`
## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


