### PR TITLE
feat(debug): add enableReturnData param and returnData field 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fix `engine_forkchoiceUpdatedV1` now returns `-38003 INVALID_PAYLOAD_ATTRIBUTES` for invalid payload attribute timestamps (zero or not greater than head). [#10353](https://github.com/besu-eth/besu/pull/10353)
 
 ### Additions and Improvements
+- Add `enableReturnData` parameter to `debug_traceTransaction` and `debug_traceBlockByNumber`, and include `returnData` in `StructLog` when captured; the field is omitted when return data is empty or not captured. [#10172](https://github.com/besu-eth/besu/pull/10172)
 
 ## 26.5.0
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/TransactionTraceParams.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/TransactionTraceParams.java
@@ -71,6 +71,13 @@ public interface TransactionTraceParams {
 
   @JsonProperty(value = "limit")
   @Nullable Integer limit();
+  
+  @JsonProperty(value = "enableReturnData")
+  @Nullable Boolean enableReturnDataNullable();
+
+  default boolean enableReturnData() {
+    return Boolean.TRUE.equals(enableReturnDataNullable());
+  }
 
   @JsonProperty("tracer")
   @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -134,6 +141,8 @@ public interface TransactionTraceParams {
     }
     if (limit() != null) {
       builder.limit(limit());
+    if (enableReturnDataNullable() != null) {
+      builder.traceReturnData(enableReturnData());
     }
     var opCodeTracerConfig = builder.traceOpcodes(opcodes()).build();
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/TransactionTraceParams.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/TransactionTraceParams.java
@@ -71,7 +71,7 @@ public interface TransactionTraceParams {
 
   @JsonProperty(value = "limit")
   @Nullable Integer limit();
-  
+
   @JsonProperty(value = "enableReturnData")
   @Nullable Boolean enableReturnDataNullable();
 
@@ -141,6 +141,7 @@ public interface TransactionTraceParams {
     }
     if (limit() != null) {
       builder.limit(limit());
+    }
     if (enableReturnDataNullable() != null) {
       builder.traceReturnData(enableReturnData());
     }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/StructLog.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/StructLog.java
@@ -41,6 +41,7 @@ public class StructLog {
   private final String[] stack;
   private final Object storage;
   private final String reason;
+  private final String returnData;
 
   public StructLog(final TraceFrame traceFrame) {
     depth = traceFrame.getDepth() + 1;
@@ -64,6 +65,7 @@ public class StructLog {
 
     storage = traceFrame.getStorage().map(StructLog::formatStorage).orElse(null);
     reason = traceFrame.getRevertReason().map(bytes -> toCompactHex(bytes, true)).orElse(null);
+    returnData = traceFrame.getReturnData().map(Bytes::toHexString).orElse(null);
   }
 
   private static Map<String, String> formatStorage(final Map<UInt256, UInt256> storage) {
@@ -143,6 +145,12 @@ public class StructLog {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   public String reason() {
     return reason;
+  }
+
+  @JsonGetter("returnData")
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public String returnData() {
+    return returnData;
   }
 
   @Override

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/StructLog.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/StructLog.java
@@ -27,7 +27,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
 
-@JsonPropertyOrder({"pc", "op", "gas", "gasCost", "depth", "refund", "stack", "memory", "storage"})
+@JsonPropertyOrder({"pc", "op", "gas", "gasCost", "depth", "refund", "stack", "memory", "returnData", "storage"})
 public class StructLog {
 
   private static final char[] hexChars = "0123456789abcdef".toCharArray();

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/StructLog.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/StructLog.java
@@ -27,7 +27,18 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
 
-@JsonPropertyOrder({"pc", "op", "gas", "gasCost", "depth", "refund", "stack", "memory", "returnData", "storage"})
+@JsonPropertyOrder({
+  "pc",
+  "op",
+  "gas",
+  "gasCost",
+  "depth",
+  "refund",
+  "stack",
+  "memory",
+  "returnData",
+  "storage"
+})
 public class StructLog {
 
   private static final char[] hexChars = "0123456789abcdef".toCharArray();

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/TransactionTraceParamsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/TransactionTraceParamsTest.java
@@ -138,4 +138,36 @@ public class TransactionTraceParamsTest {
     assertThatThrownBy(() -> MAPPER.readValue("{\"limit\": -1}", TransactionTraceParams.class))
         .hasMessageContaining("limit must be >= 0, got: -1");
   }
+
+  @Test
+  public void enableReturnDataTrueShouldSetTraceReturnData() throws Exception {
+    final TransactionTraceParams params =
+        MAPPER.readValue("{\"enableReturnData\": true}", TransactionTraceParams.class);
+    final OpCodeTracerConfig config = params.traceOptions().opCodeTracerConfig();
+
+    assertThat(config.traceReturnData())
+        .describedAs("enableReturnData: true should set traceReturnData to true")
+        .isTrue();
+  }
+
+  @Test
+  public void enableReturnDataFalseShouldSetTraceReturnDataFalse() throws Exception {
+    final TransactionTraceParams params =
+        MAPPER.readValue("{\"enableReturnData\": false}", TransactionTraceParams.class);
+    final OpCodeTracerConfig config = params.traceOptions().opCodeTracerConfig();
+
+    assertThat(config.traceReturnData())
+        .describedAs("enableReturnData: false should set traceReturnData to false")
+        .isFalse();
+  }
+
+  @Test
+  public void missingEnableReturnDataShouldDefaultToFalse() throws Exception {
+    final TransactionTraceParams params = MAPPER.readValue("{}", TransactionTraceParams.class);
+    final OpCodeTracerConfig config = params.traceOptions().opCodeTracerConfig();
+
+    assertThat(config.traceReturnData())
+        .describedAs("traceReturnData should default to false when enableReturnData is absent")
+        .isFalse();
+  }
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/StructLogTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/StructLogTest.java
@@ -251,16 +251,7 @@ public class StructLogTest {
 
   @Test
   public void returnDataShouldBePresentWhenCaptured() {
-    when(traceFrame.getDepth()).thenReturn(0);
-    when(traceFrame.getGasRemaining()).thenReturn(0L);
-    when(traceFrame.getGasCost()).thenReturn(OptionalLong.empty());
-    when(traceFrame.getGasRefund()).thenReturn(0L);
-    when(traceFrame.getMemory()).thenReturn(Optional.empty());
-    when(traceFrame.getOpcode()).thenReturn("PUSH1");
-    when(traceFrame.getPc()).thenReturn(0);
-    when(traceFrame.getStack()).thenReturn(Optional.empty());
-    when(traceFrame.getStorage()).thenReturn(Optional.empty());
-    when(traceFrame.getRevertReason()).thenReturn(Optional.empty());
+    setupMinimalTraceFrameForReturnDataTests();
     when(traceFrame.getReturnData()).thenReturn(Optional.of(Bytes.fromHexString("0xdeadbeef")));
 
     final StructLog log = new StructLog(traceFrame);
@@ -270,16 +261,7 @@ public class StructLogTest {
 
   @Test
   public void returnDataShouldBeNullWhenNotCaptured() {
-    when(traceFrame.getDepth()).thenReturn(0);
-    when(traceFrame.getGasRemaining()).thenReturn(0L);
-    when(traceFrame.getGasCost()).thenReturn(OptionalLong.empty());
-    when(traceFrame.getGasRefund()).thenReturn(0L);
-    when(traceFrame.getMemory()).thenReturn(Optional.empty());
-    when(traceFrame.getOpcode()).thenReturn("PUSH1");
-    when(traceFrame.getPc()).thenReturn(0);
-    when(traceFrame.getStack()).thenReturn(Optional.empty());
-    when(traceFrame.getStorage()).thenReturn(Optional.empty());
-    when(traceFrame.getRevertReason()).thenReturn(Optional.empty());
+    setupMinimalTraceFrameForReturnDataTests();
     when(traceFrame.getReturnData()).thenReturn(Optional.empty());
 
     final StructLog log = new StructLog(traceFrame);
@@ -289,6 +271,16 @@ public class StructLogTest {
 
   @Test
   public void returnDataShouldBeAbsentFromJsonWhenNotCaptured() throws Exception {
+    setupMinimalTraceFrameForReturnDataTests();
+    when(traceFrame.getReturnData()).thenReturn(Optional.empty());
+
+    final StructLog log = new StructLog(traceFrame);
+    final String json = objectMapper.writeValueAsString(log);
+
+    assertThat(json).doesNotContain("returnData");
+  }
+
+  private void setupMinimalTraceFrameForReturnDataTests() {
     when(traceFrame.getDepth()).thenReturn(0);
     when(traceFrame.getGasRemaining()).thenReturn(0L);
     when(traceFrame.getGasCost()).thenReturn(OptionalLong.empty());
@@ -299,11 +291,5 @@ public class StructLogTest {
     when(traceFrame.getStack()).thenReturn(Optional.empty());
     when(traceFrame.getStorage()).thenReturn(Optional.empty());
     when(traceFrame.getRevertReason()).thenReturn(Optional.empty());
-    when(traceFrame.getReturnData()).thenReturn(Optional.empty());
-
-    final StructLog log = new StructLog(traceFrame);
-    final String json = objectMapper.writeValueAsString(log);
-
-    assertThat(json).doesNotContain("returnData");
   }
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/StructLogTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/StructLogTest.java
@@ -246,4 +246,64 @@ public class StructLogTest {
     String result = StructLog.toCompactHex(bytes, true);
     assertEquals("0x102030405060708090a", result, "Expected correct hex output for large data");
   }
+
+  // --- returnData tests ---
+
+  @Test
+  public void returnDataShouldBePresentWhenCaptured() {
+    when(traceFrame.getDepth()).thenReturn(0);
+    when(traceFrame.getGasRemaining()).thenReturn(0L);
+    when(traceFrame.getGasCost()).thenReturn(OptionalLong.empty());
+    when(traceFrame.getGasRefund()).thenReturn(0L);
+    when(traceFrame.getMemory()).thenReturn(Optional.empty());
+    when(traceFrame.getOpcode()).thenReturn("PUSH1");
+    when(traceFrame.getPc()).thenReturn(0);
+    when(traceFrame.getStack()).thenReturn(Optional.empty());
+    when(traceFrame.getStorage()).thenReturn(Optional.empty());
+    when(traceFrame.getRevertReason()).thenReturn(Optional.empty());
+    when(traceFrame.getReturnData()).thenReturn(Optional.of(Bytes.fromHexString("0xdeadbeef")));
+
+    final StructLog log = new StructLog(traceFrame);
+
+    assertThat(log.returnData()).isEqualTo("0xdeadbeef");
+  }
+
+  @Test
+  public void returnDataShouldBeNullWhenNotCaptured() {
+    when(traceFrame.getDepth()).thenReturn(0);
+    when(traceFrame.getGasRemaining()).thenReturn(0L);
+    when(traceFrame.getGasCost()).thenReturn(OptionalLong.empty());
+    when(traceFrame.getGasRefund()).thenReturn(0L);
+    when(traceFrame.getMemory()).thenReturn(Optional.empty());
+    when(traceFrame.getOpcode()).thenReturn("PUSH1");
+    when(traceFrame.getPc()).thenReturn(0);
+    when(traceFrame.getStack()).thenReturn(Optional.empty());
+    when(traceFrame.getStorage()).thenReturn(Optional.empty());
+    when(traceFrame.getRevertReason()).thenReturn(Optional.empty());
+    when(traceFrame.getReturnData()).thenReturn(Optional.empty());
+
+    final StructLog log = new StructLog(traceFrame);
+
+    assertThat(log.returnData()).isNull();
+  }
+
+  @Test
+  public void returnDataShouldBeAbsentFromJsonWhenNotCaptured() throws Exception {
+    when(traceFrame.getDepth()).thenReturn(0);
+    when(traceFrame.getGasRemaining()).thenReturn(0L);
+    when(traceFrame.getGasCost()).thenReturn(OptionalLong.empty());
+    when(traceFrame.getGasRefund()).thenReturn(0L);
+    when(traceFrame.getMemory()).thenReturn(Optional.empty());
+    when(traceFrame.getOpcode()).thenReturn("PUSH1");
+    when(traceFrame.getPc()).thenReturn(0);
+    when(traceFrame.getStack()).thenReturn(Optional.empty());
+    when(traceFrame.getStorage()).thenReturn(Optional.empty());
+    when(traceFrame.getRevertReason()).thenReturn(Optional.empty());
+    when(traceFrame.getReturnData()).thenReturn(Optional.empty());
+
+    final StructLog log = new StructLog(traceFrame);
+    final String json = objectMapper.writeValueAsString(log);
+
+    assertThat(json).doesNotContain("returnData");
+  }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/vm/DebugOperationTracer.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/vm/DebugOperationTracer.java
@@ -86,6 +86,8 @@ public class DebugOperationTracer extends AbstractDebugOperationTracer {
                             && currentOperation instanceof AbstractCreateOperation
                         ? forceCaptureMem(frame)
                         : Optional.empty());
+    final Optional<Bytes> returnData = captureReturnData(frame);
+    final Optional<Bytes[]> memory = captureMemory(frame);
     final Optional<Bytes[]> stackPostExecution = captureStack(frame);
 
     if (!traceFrames.isEmpty()) {
@@ -122,6 +124,7 @@ public class DebugOperationTracer extends AbstractDebugOperationTracer {
             .setValue(frame.getApparentValue())
             .setInputData(inputData)
             .setOutputData(outputData)
+            .setReturnData(returnData)
             .setStack(preExecutionStack)
             .setMemory(memory)
             .setStorage(storage)
@@ -232,6 +235,14 @@ public class DebugOperationTracer extends AbstractDebugOperationTracer {
             .setVirtualOperation(true)
             .build();
     traceFrames.add(traceFrame);
+  }
+
+
+  private Optional<Bytes> captureReturnData(final MessageFrame frame) {
+    if (!options.traceReturnData()) {
+      return Optional.empty();
+    }
+    return Optional.of(frame.getReturnData());
   }
 
   private Optional<Map<UInt256, UInt256>> captureStorage(final MessageFrame frame) {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/vm/DebugOperationTracer.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/vm/DebugOperationTracer.java
@@ -87,7 +87,6 @@ public class DebugOperationTracer extends AbstractDebugOperationTracer {
                         ? forceCaptureMem(frame)
                         : Optional.empty());
     final Optional<Bytes> returnData = captureReturnData(frame);
-    final Optional<Bytes[]> memory = captureMemory(frame);
     final Optional<Bytes[]> stackPostExecution = captureStack(frame);
 
     if (!traceFrames.isEmpty()) {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/vm/DebugOperationTracer.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/vm/DebugOperationTracer.java
@@ -237,7 +237,6 @@ public class DebugOperationTracer extends AbstractDebugOperationTracer {
     traceFrames.add(traceFrame);
   }
 
-
   private Optional<Bytes> captureReturnData(final MessageFrame frame) {
     if (!options.traceReturnData()) {
       return Optional.empty();

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/vm/DebugOperationTracer.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/vm/DebugOperationTracer.java
@@ -241,7 +241,8 @@ public class DebugOperationTracer extends AbstractDebugOperationTracer {
     if (!options.traceReturnData()) {
       return Optional.empty();
     }
-    return Optional.of(frame.getReturnData());
+    final Bytes returnData = frame.getReturnData();
+    return (returnData == null || returnData.isEmpty()) ? Optional.empty() : Optional.of(returnData);
   }
 
   private Optional<Map<UInt256, UInt256>> captureStorage(final MessageFrame frame) {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/vm/DebugOperationTracer.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/vm/DebugOperationTracer.java
@@ -241,7 +241,9 @@ public class DebugOperationTracer extends AbstractDebugOperationTracer {
       return Optional.empty();
     }
     final Bytes returnData = frame.getReturnData();
-    return (returnData == null || returnData.isEmpty()) ? Optional.empty() : Optional.of(returnData);
+    return (returnData == null || returnData.isEmpty())
+        ? Optional.empty()
+        : Optional.of(returnData);
   }
 
   private Optional<Map<UInt256, UInt256>> captureStorage(final MessageFrame frame) {

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/vm/DebugOperationTracerTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/vm/DebugOperationTracerTest.java
@@ -223,6 +223,41 @@ class DebugOperationTracerTest {
   }
 
   @Test
+  void shouldRecordReturnDataWhenEnabled() {
+    final MessageFrame frame = validMessageFrame();
+    frame.setReturnData(Bytes.fromHexString("0xdeadbeef"));
+    final TraceFrame traceFrame =
+        traceFrame(
+            frame,
+            OpCodeTracerConfigBuilder.createFrom(OpCodeTracerConfig.DEFAULT)
+                .traceStorage(false)
+                .traceMemory(false)
+                .traceStack(false)
+                .traceReturnData(true)
+                .build(),
+            false);
+    assertThat(traceFrame.getReturnData()).isPresent();
+    assertThat(traceFrame.getReturnData().get()).isEqualTo(Bytes.fromHexString("0xdeadbeef"));
+  }
+
+  @Test
+  void shouldNotRecordReturnDataWhenDisabled() {
+    final MessageFrame frame = validMessageFrame();
+    frame.setReturnData(Bytes.fromHexString("0xdeadbeef"));
+    final TraceFrame traceFrame =
+        traceFrame(
+            frame,
+            OpCodeTracerConfigBuilder.createFrom(OpCodeTracerConfig.DEFAULT)
+                .traceStorage(false)
+                .traceMemory(false)
+                .traceStack(false)
+                .traceReturnData(false)
+                .build(),
+            false);
+    assertThat(traceFrame.getReturnData()).isEmpty();
+  }
+
+  @Test
   void shouldNotAddGasWhenDisabled() {
     final TraceFrame traceFrame =
         traceFrame(

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/vm/DebugOperationTracerTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/vm/DebugOperationTracerTest.java
@@ -225,14 +225,12 @@ class DebugOperationTracerTest {
   @Test
   void shouldRecordReturnDataWhenEnabled() {
     final MessageFrame frame = validMessageFrame();
+    setupStorageForCapture(frame);
     frame.setReturnData(Bytes.fromHexString("0xdeadbeef"));
     final TraceFrame traceFrame =
         traceFrame(
             frame,
             OpCodeTracerConfigBuilder.createFrom(OpCodeTracerConfig.DEFAULT)
-                .traceStorage(false)
-                .traceMemory(false)
-                .traceStack(false)
                 .traceReturnData(true)
                 .build(),
             false);
@@ -243,14 +241,12 @@ class DebugOperationTracerTest {
   @Test
   void shouldNotRecordEmptyReturnDataWhenEnabled() {
     final MessageFrame frame = validMessageFrame();
+    setupStorageForCapture(frame);
     frame.setReturnData(Bytes.EMPTY);
     final TraceFrame traceFrame =
         traceFrame(
             frame,
             OpCodeTracerConfigBuilder.createFrom(OpCodeTracerConfig.DEFAULT)
-                .traceStorage(false)
-                .traceMemory(false)
-                .traceStack(false)
                 .traceReturnData(true)
                 .build(),
             false);
@@ -260,14 +256,12 @@ class DebugOperationTracerTest {
   @Test
   void shouldNotRecordReturnDataWhenDisabled() {
     final MessageFrame frame = validMessageFrame();
+    setupStorageForCapture(frame);
     frame.setReturnData(Bytes.fromHexString("0xdeadbeef"));
     final TraceFrame traceFrame =
         traceFrame(
             frame,
             OpCodeTracerConfigBuilder.createFrom(OpCodeTracerConfig.DEFAULT)
-                .traceStorage(false)
-                .traceMemory(false)
-                .traceStack(false)
                 .traceReturnData(false)
                 .build(),
             false);

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/vm/DebugOperationTracerTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/vm/DebugOperationTracerTest.java
@@ -239,7 +239,7 @@ class DebugOperationTracerTest {
   }
 
   @Test
-  void shouldNotRecordEmptyReturnDataWhenEnabled() {
+  void shouldRecordEmptyReturnDataWhenEnabled() {
     final MessageFrame frame = validMessageFrame();
     setupStorageForCapture(frame);
     frame.setReturnData(Bytes.EMPTY);

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/vm/DebugOperationTracerTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/vm/DebugOperationTracerTest.java
@@ -241,6 +241,23 @@ class DebugOperationTracerTest {
   }
 
   @Test
+  void shouldNotRecordEmptyReturnDataWhenEnabled() {
+    final MessageFrame frame = validMessageFrame();
+    frame.setReturnData(Bytes.EMPTY);
+    final TraceFrame traceFrame =
+        traceFrame(
+            frame,
+            OpCodeTracerConfigBuilder.createFrom(OpCodeTracerConfig.DEFAULT)
+                .traceStorage(false)
+                .traceMemory(false)
+                .traceStack(false)
+                .traceReturnData(true)
+                .build(),
+            false);
+    assertThat(traceFrame.getReturnData()).isEmpty();
+  }
+
+  @Test
   void shouldNotRecordReturnDataWhenDisabled() {
     final MessageFrame frame = validMessageFrame();
     frame.setReturnData(Bytes.fromHexString("0xdeadbeef"));

--- a/evm/src/main/java/org/hyperledger/besu/evm/tracing/TraceFrame.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/tracing/TraceFrame.java
@@ -68,6 +68,7 @@ public class TraceFrame {
 
   private final Optional<SoftFailureReason> softFailureReason;
   private final OptionalLong gasAvailableForChildCall;
+  private final Optional<Bytes> returnData;
 
   /** Private constructor - only accessible through Builder */
   private TraceFrame(final Builder builder) {
@@ -103,6 +104,7 @@ public class TraceFrame {
     this.precompileOutputData = builder.precompileOutputData;
     this.softFailureReason = builder.softFailureReason;
     this.gasAvailableForChildCall = builder.gasAvailableForChildCall;
+    this.returnData = builder.returnData;
   }
 
   /**
@@ -158,6 +160,7 @@ public class TraceFrame {
     private Optional<Bytes> precompileOutputData = Optional.empty();
     private Optional<SoftFailureReason> softFailureReason = Optional.empty();
     private OptionalLong gasAvailableForChildCall = OptionalLong.empty();
+    private Optional<Bytes> returnData = Optional.empty();
 
     /** Default constructor */
     public Builder() {}
@@ -200,6 +203,7 @@ public class TraceFrame {
       this.precompileOutputData = traceFrame.precompileOutputData;
       this.softFailureReason = traceFrame.softFailureReason;
       this.gasAvailableForChildCall = traceFrame.gasAvailableForChildCall;
+      this.returnData = traceFrame.returnData;
     }
 
     /**
@@ -576,6 +580,17 @@ public class TraceFrame {
     }
 
     /**
+     * Sets the return data buffer captured after the opcode executed.
+     *
+     * @param returnData the return data buffer contents
+     * @return this builder instance for method chaining
+     */
+    public Builder setReturnData(final Optional<Bytes> returnData) {
+      this.returnData = returnData;
+      return this;
+    }
+
+    /**
      * Builds the TraceFrame instance.
      *
      * @return the constructed TraceFrame
@@ -872,6 +887,15 @@ public class TraceFrame {
    */
   public OptionalLong getGasAvailableForChildCall() {
     return gasAvailableForChildCall;
+  }
+
+  /**
+   * Return data buffer at the time this opcode was traced.
+   *
+   * @return the return data buffer, or empty if not captured
+   */
+  public Optional<Bytes> getReturnData() {
+    return returnData;
   }
 
   @Override

--- a/evm/src/main/java/org/hyperledger/besu/evm/tracing/TraceFrame.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/tracing/TraceFrame.java
@@ -910,6 +910,7 @@ public class TraceFrame {
         .add("stack", stack)
         .add("memory", memory)
         .add("storage", storage)
+        .add("returnData", returnData)
         .toString();
   }
 }


### PR DESCRIPTION

## PR description

Add `enableReturnData` param and `returnData` field 

Part of aligning Besu's debug RPC endpoints with the [execution-apis spec](https://github.com/ethereum/execution-apis/pull/762).

**What changed:**
- `TransactionTraceParams` — new optional `enableReturnData` boolean param (default `false`)
- `DebugOperationTracer` — captures `frame.getReturnData()` per opcode when enabled
- `TraceFrame` — carries the captured return data buffer through the trace pipeline
- `StructLog` — serializes `returnData` as a hex string; field is omitted from JSON when not enabled

**Behaviour:**
- When `enableReturnData: false` (default) — no change to existing responses
- When `enableReturnData: true` — each StructLog entry includes a `returnData` field containing the EVM return data buffer (populated after CALL/CREATE/etc.) as a `0x`-prefixed hex string

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Refs #10115 

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


