### PR TITLE
DebugOperationTracer #10115 - 10 : storage snapshot timing 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Bug fixes
 - Fix `engine_forkchoiceUpdatedV1` now returns `-38003 INVALID_PAYLOAD_ATTRIBUTES` for invalid payload attribute timestamps (zero or not greater than head). [#10353](https://github.com/besu-eth/besu/pull/10353)
+- Fix `debug_trace*` `storage` field to emit only for SLOAD/SSTORE opcodes showing the single slot touched, matching the execution-apis spec and geth behaviour [#10176](https://github.com/besu-eth/besu/pull/10176)
 
 ### Additions and Improvements
 - Add `eth_getStorageValues` JSON-RPC method for batched reads of multiple storage slots across multiple accounts in a single call [#10259](https://github.com/besu-eth/besu/pull/10259)
@@ -59,11 +60,11 @@
 - Enforce that `blob_versioned_hashes` match the supplied blobs [#10278](https://github.com/besu-eth/besu/pull/10278)
 - Restrict no-reorg behavior to the prefix of the known finalized chain (per execution-apis #786) [#10335](https://github.com/besu-eth/besu/pull/10335)
 - `eth_getFilterLogs`: cache the chain head once when resolving default `latest..latest` bounds, so a block arriving between the two reads no longer expands the queried range into `[N, N+1]` and returns extra logs. [#10368](https://github.com/besu-eth/besu/pull/10368)
+- `eth_getFilterLogs`: cache the chain head once when resolving default `latest..latest` bounds, so a block arriving between the two reads no longer expands the queried range into `[N, N+1]` and returns extra logs.
 
 ### Additions and Improvements
 - The option to set a different block period for empty BFT blocks (`emptyblockperiodseconds`) is no longer experimental. The experimental flag `xemptyblockperiodseconds` will be removed in a future release. [#10264](https://github.com/besu-eth/besu/pull/10264)
 - Release worker threads after engine API timeout to avoid blocking subsequent requests [#10311](https://github.com/besu-eth/besu/pull/10311)
-- `debug_trace*`: add optional `limit` parameter to cap opcode trace capture after N steps (`0` keeps unlimited behavior); negative values are rejected as invalid params (`-32602`). [#10176](https://github.com/besu-eth/besu/pull/10176)
 - `evmtool blocktest --verbose` flag, default off, removes noise from output [#10348](https://github.com/besu-eth/besu/pull/10348)
 - Bound precompile result caches to the semantic-prefix slice and apply a 16 MB byte-weight cap per cache, providing a uniform memory ceiling across all 14 precompile caches [#10350](https://github.com/besu-eth/besu/pull/10350)
 - Lazy RLP decoding of `GetBlockBodies` messages reduces memory and CPU spent on dropped requests [#10342](https://github.com/besu-eth/besu/pull/10342)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 ### Additions and Improvements
 - The option to set a different block period for empty BFT blocks (`emptyblockperiodseconds`) is no longer experimental. The experimental flag `xemptyblockperiodseconds` will be removed in a future release. [#10264](https://github.com/besu-eth/besu/pull/10264)
 - Release worker threads after engine API timeout to avoid blocking subsequent requests [#10311](https://github.com/besu-eth/besu/pull/10311)
+- `debug_trace*`: add optional `limit` parameter to cap opcode trace capture after N steps (`0` keeps unlimited behavior); negative values are rejected as invalid params (`-32602`). [#10176](https://github.com/besu-eth/besu/pull/10176)
 - `evmtool blocktest --verbose` flag, default off, removes noise from output [#10348](https://github.com/besu-eth/besu/pull/10348)
 - Bound precompile result caches to the semantic-prefix slice and apply a 16 MB byte-weight cap per cache, providing a uniform memory ceiling across all 14 precompile caches [#10350](https://github.com/besu-eth/besu/pull/10350)
 - Lazy RLP decoding of `GetBlockBodies` messages reduces memory and CPU spent on dropped requests [#10342](https://github.com/besu-eth/besu/pull/10342)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,6 @@
 - Enforce that `blob_versioned_hashes` match the supplied blobs [#10278](https://github.com/besu-eth/besu/pull/10278)
 - Restrict no-reorg behavior to the prefix of the known finalized chain (per execution-apis #786) [#10335](https://github.com/besu-eth/besu/pull/10335)
 - `eth_getFilterLogs`: cache the chain head once when resolving default `latest..latest` bounds, so a block arriving between the two reads no longer expands the queried range into `[N, N+1]` and returns extra logs. [#10368](https://github.com/besu-eth/besu/pull/10368)
-- `eth_getFilterLogs`: cache the chain head once when resolving default `latest..latest` bounds, so a block arriving between the two reads no longer expands the queried range into `[N, N+1]` and returns extra logs.
 
 ### Additions and Improvements
 - The option to set a different block period for empty BFT blocks (`emptyblockperiodseconds`) is no longer experimental. The experimental flag `xemptyblockperiodseconds` will be removed in a future release. [#10264](https://github.com/besu-eth/besu/pull/10264)

--- a/ethereum/core/src/integration-test/java/org/hyperledger/besu/ethereum/vm/TraceTransactionIntegrationTest.java
+++ b/ethereum/core/src/integration-test/java/org/hyperledger/besu/ethereum/vm/TraceTransactionIntegrationTest.java
@@ -158,21 +158,21 @@ public class TraceTransactionIntegrationTest {
 
     assertThat(result.isSuccessful()).isTrue();
 
-    // No storage changes before the SSTORE call.
+    // Non-storage opcodes produce no storage entry (per execution-apis spec).
     TraceFrame frame = tracer.getTraceFrames().get(170);
     assertThat(frame.getOpcode()).isEqualTo("DUP6");
+    assertThat(frame.getStorage()).isEmpty();
 
-    // Storage changes show up in the SSTORE frame.
+    // Storage is emitted only for the SSTORE frame, showing the single slot touched.
     frame = tracer.getTraceFrames().get(171);
     assertThat(frame.getOpcode()).isEqualTo("SSTORE");
     assertStorageContainsExactly(
         frame, entry("0x01", "0x6261720000000000000000000000000000000000000000000000000000000006"));
 
-    // And storage changes are still present in future frames.
+    // After SSTORE, non-storage opcodes produce no storage entry (per execution-apis spec).
     frame = tracer.getTraceFrames().get(172);
     assertThat(frame.getOpcode()).isEqualTo("PUSH2");
-    assertStorageContainsExactly(
-        frame, entry("0x01", "0x6261720000000000000000000000000000000000000000000000000000000006"));
+    assertThat(frame.getStorage()).isEmpty();
   }
 
   @Test

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/vm/DebugOperationTracer.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/vm/DebugOperationTracer.java
@@ -60,9 +60,11 @@ public class DebugOperationTracer extends AbstractDebugOperationTracer {
   @Override
   public void tracePreExecution(final MessageFrame frame) {
     super.tracePreExecution(frame);
+    final Operation currentOperation = frame.getCurrentOperation();
+    final String operationName = currentOperation != null ? currentOperation.getName() : null;
     if (traceOpcode
         && options.traceStorage()
-        && "SLOAD".equals(frame.getCurrentOperation().getName())
+        && "SLOAD".equals(operationName)
         && frame.stackSize() > 0) {
       preExecutionStorageKey = Optional.of(UInt256.fromBytes(frame.getStackItem(0)));
     } else {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/vm/DebugOperationTracer.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/vm/DebugOperationTracer.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.ethereum.vm;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.evm.Code;
-import org.hyperledger.besu.evm.ModificationNotAllowedException;
 import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.operation.AbstractCreateOperation;
@@ -42,6 +41,7 @@ public class DebugOperationTracer extends AbstractDebugOperationTracer {
   private List<TraceFrame> traceFrames = new ArrayList<>();
   private TraceFrame lastFrame;
 
+  private Optional<UInt256> preExecutionStorageKey = Optional.empty();
   private Bytes inputData;
   private int stepCount;
   private boolean limitReached;
@@ -55,6 +55,19 @@ public class DebugOperationTracer extends AbstractDebugOperationTracer {
    */
   public DebugOperationTracer(final OpCodeTracerConfig options, final boolean recordChildCallGas) {
     super(options, recordChildCallGas);
+  }
+
+  @Override
+  public void tracePreExecution(final MessageFrame frame) {
+    super.tracePreExecution(frame);
+    if (traceOpcode
+        && options.traceStorage()
+        && "SLOAD".equals(frame.getCurrentOperation().getName())
+        && frame.stackSize() > 0) {
+      preExecutionStorageKey = Optional.of(UInt256.fromBytes(frame.getStackItem(0)));
+    } else {
+      preExecutionStorageKey = Optional.empty();
+    }
   }
 
   @Override
@@ -99,7 +112,8 @@ public class DebugOperationTracer extends AbstractDebugOperationTracer {
       return;
     }
 
-    final Optional<Map<UInt256, UInt256>> storage = captureStorage(frame);
+    final Optional<Map<UInt256, UInt256>> storage =
+        captureStorage(frame, currentOperation, operationResult);
     final Optional<Map<Address, Wei>> maybeRefunds =
         frame.getRefunds().isEmpty() ? Optional.empty() : Optional.of(frame.getRefunds());
     final long thisGasCost = computeGasCost(currentOperation, operationResult, frame);
@@ -246,20 +260,43 @@ public class DebugOperationTracer extends AbstractDebugOperationTracer {
         : Optional.of(returnData);
   }
 
-  private Optional<Map<UInt256, UInt256>> captureStorage(final MessageFrame frame) {
+  private Optional<Map<UInt256, UInt256>> captureStorage(
+      final MessageFrame frame,
+      final Operation currentOperation,
+      final OperationResult operationResult) {
     if (!options.traceStorage()) {
       return Optional.empty();
     }
-    try {
-      Map<UInt256, UInt256> updatedStorage =
-          frame.getWorldUpdater().getAccount(frame.getRecipientAddress()).getUpdatedStorage();
-      if (updatedStorage.isEmpty()) return Optional.empty();
-      final Map<UInt256, UInt256> storageContents = new TreeMap<>(updatedStorage);
-
-      return Optional.of(storageContents);
-    } catch (final ModificationNotAllowedException e) {
-      return Optional.of(new TreeMap<>());
+    // Per execution-apis spec, the storage field is only emitted for SLOAD and SSTORE opcodes,
+    // showing only the single slot touched by that specific operation.
+    final String opName = currentOperation.getName();
+    if ("SSTORE".equals(opName)) {
+      // SStoreOperation calls frame.storageWasUpdated(key, newValue) on success;
+      // empty if SSTORE halted (e.g. insufficient gas), which is correct.
+      return frame
+          .getMaybeUpdatedStorage()
+          .map(
+              entry -> {
+                final Map<UInt256, UInt256> map = new TreeMap<>();
+                map.put(entry.getOffset(), UInt256.fromBytes(entry.getValue()));
+                return map;
+              });
     }
+    if ("SLOAD".equals(opName) && operationResult.getHaltReason() == null) {
+      // preExecutionStorageKey holds the slot key captured before the opcode ran;
+      // after SLOAD executes the loaded value sits at the top of the stack.
+      return preExecutionStorageKey.flatMap(
+          key -> {
+            if (frame.stackSize() == 0) {
+              return Optional.empty();
+            }
+            final UInt256 loadedValue = UInt256.fromBytes(frame.getStackItem(0));
+            final Map<UInt256, UInt256> map = new TreeMap<>();
+            map.put(key, loadedValue);
+            return Optional.of(map);
+          });
+    }
+    return Optional.empty();
   }
 
   private Optional<Bytes[]> captureMemory(final MessageFrame frame) {
@@ -297,6 +334,7 @@ public class DebugOperationTracer extends AbstractDebugOperationTracer {
     lastFrame = null;
     stepCount = 0;
     limitReached = false;
+    preExecutionStorageKey = Optional.empty();
   }
 
   public List<TraceFrame> copyTraceFrames() {

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/vm/DebugOperationTracerTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/vm/DebugOperationTracerTest.java
@@ -15,8 +15,6 @@
 package org.hyperledger.besu.ethereum.vm;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
@@ -25,7 +23,6 @@ import org.hyperledger.besu.ethereum.core.ExecutionContextTestFixture;
 import org.hyperledger.besu.ethereum.core.MessageFrameTestFixture;
 import org.hyperledger.besu.ethereum.referencetests.ReferenceTestBlockchain;
 import org.hyperledger.besu.evm.EVM;
-import org.hyperledger.besu.evm.account.MutableAccount;
 import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.CancunGasCalculator;
@@ -39,9 +36,7 @@ import org.hyperledger.besu.evm.tracing.TraceFrame;
 import org.hyperledger.besu.evm.worldstate.WorldUpdater;
 
 import java.util.List;
-import java.util.Map;
 import java.util.OptionalLong;
-import java.util.TreeMap;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
@@ -82,6 +77,30 @@ class DebugOperationTracerTest {
       };
 
   private final CallOperation callOperation = new CallOperation(new CancunGasCalculator());
+
+  private static final UInt256 SLOAD_RETURNED_VALUE =
+      UInt256.fromHexString("0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc");
+
+  private final Operation SSTORE_OPERATION =
+      new AbstractOperation(0x55, "SSTORE", 2, 0, null) {
+        @Override
+        public OperationResult execute(final MessageFrame frame, final EVM evm) {
+          final UInt256 key = UInt256.fromBytes(frame.popStackItem());
+          final UInt256 value = UInt256.fromBytes(frame.popStackItem());
+          frame.storageWasUpdated(key, value);
+          return new OperationResult(5000L, null);
+        }
+      };
+
+  private final Operation SLOAD_OPERATION =
+      new AbstractOperation(0x54, "SLOAD", 1, 1, null) {
+        @Override
+        public OperationResult execute(final MessageFrame frame, final EVM evm) {
+          frame.popStackItem(); // consume the key
+          frame.pushStackItem(SLOAD_RETURNED_VALUE); // push the loaded value
+          return new OperationResult(2100L, null);
+        }
+      };
 
   @Test
   void shouldRecordProgramCounter() {
@@ -192,20 +211,60 @@ class DebugOperationTracerTest {
   }
 
   @Test
-  void shouldRecordStorageWhenEnabled() {
+  void shouldRecordStorageForSstoreWhenEnabled() {
     final MessageFrame frame = validMessageFrame();
-    final Map<UInt256, UInt256> updatedStorage = setupStorageForCapture(frame);
-    final TraceFrame traceFrame =
-        traceFrame(
-            frame,
+    final UInt256 storageKey = UInt256.fromHexString("0x01");
+    final UInt256 storageValue = UInt256.fromHexString("0xdeadbeef");
+    frame.pushStackItem(storageValue); // value (popped second by SSTORE)
+    frame.pushStackItem(storageKey); // key   (popped first  by SSTORE)
+    final DebugOperationTracer tracer =
+        new DebugOperationTracer(
             OpCodeTracerConfigBuilder.createFrom(OpCodeTracerConfig.DEFAULT)
                 .traceStorage(true)
                 .traceMemory(false)
                 .traceStack(false)
                 .build(),
             false);
+    traceFrame(frame, tracer, SSTORE_OPERATION);
+    final TraceFrame traceFrame = getOnlyTraceFrame(tracer);
     assertThat(traceFrame.getStorage()).isPresent();
-    assertThat(traceFrame.getStorage()).contains(updatedStorage);
+    assertThat(traceFrame.getStorage().get()).hasSize(1);
+    assertThat(traceFrame.getStorage().get()).containsEntry(storageKey, storageValue);
+  }
+
+  @Test
+  void shouldRecordStorageForSloadWhenEnabled() {
+    final MessageFrame frame = validMessageFrame();
+    final UInt256 storageKey = UInt256.fromHexString("0x02");
+    frame.pushStackItem(storageKey); // key (popped by SLOAD)
+    final DebugOperationTracer tracer =
+        new DebugOperationTracer(
+            OpCodeTracerConfigBuilder.createFrom(OpCodeTracerConfig.DEFAULT)
+                .traceStorage(true)
+                .traceMemory(false)
+                .traceStack(false)
+                .build(),
+            false);
+    traceFrame(frame, tracer, SLOAD_OPERATION);
+    final TraceFrame traceFrame = getOnlyTraceFrame(tracer);
+    assertThat(traceFrame.getStorage()).isPresent();
+    assertThat(traceFrame.getStorage().get()).hasSize(1);
+    assertThat(traceFrame.getStorage().get()).containsEntry(storageKey, SLOAD_RETURNED_VALUE);
+  }
+
+  @Test
+  void shouldNotRecordStorageForNonStorageOpcodeWhenEnabled() {
+    // storage is only emitted for SLOAD/SSTORE; non-storage opcodes produce empty storage
+    final TraceFrame traceFrame =
+        traceFrame(
+            validMessageFrame(),
+            OpCodeTracerConfigBuilder.createFrom(OpCodeTracerConfig.DEFAULT)
+                .traceStorage(true)
+                .traceMemory(false)
+                .traceStack(false)
+                .build(),
+            false);
+    assertThat(traceFrame.getStorage()).isEmpty();
   }
 
   @Test
@@ -323,7 +382,6 @@ class DebugOperationTracerTest {
   @Test
   void shouldCaptureFrameWhenExceptionalHaltOccurs() {
     final MessageFrame frame = validMessageFrame();
-    final Map<UInt256, UInt256> updatedStorage = setupStorageForCapture(frame);
 
     final DebugOperationTracer tracer =
         new DebugOperationTracer(
@@ -340,7 +398,7 @@ class DebugOperationTracerTest {
     final TraceFrame traceFrame = getOnlyTraceFrame(tracer);
     assertThat(traceFrame.getExceptionalHaltReason())
         .contains(ExceptionalHaltReason.INSUFFICIENT_GAS);
-    assertThat(traceFrame.getStorage()).contains(updatedStorage);
+    assertThat(traceFrame.getStorage()).isEmpty();
   }
 
   @Test
@@ -589,23 +647,6 @@ class DebugOperationTracerTest {
     return frame;
   }
 
-  private Map<UInt256, UInt256> setupStorageForCapture(final MessageFrame frame) {
-    final MutableAccount account = mock(MutableAccount.class);
-    when(worldUpdater.getAccount(frame.getRecipientAddress())).thenReturn(account);
-
-    final Map<UInt256, UInt256> updatedStorage = new TreeMap<>();
-    updatedStorage.put(UInt256.ZERO, UInt256.valueOf(233));
-    updatedStorage.put(UInt256.ONE, UInt256.valueOf(2424));
-    when(account.getUpdatedStorage()).thenReturn(updatedStorage);
-    final Bytes32 word1 = Bytes32.fromHexString("0x01");
-    final Bytes32 word2 = Bytes32.fromHexString("0x02");
-    final Bytes32 word3 = Bytes32.fromHexString("0x03");
-    frame.writeMemory(0, 32, word1);
-    frame.writeMemory(32, 32, word2);
-    frame.writeMemory(64, 32, word3);
-    return updatedStorage;
-  }
-
   private static DebugOperationTracer createDebugOperationTracerWithMemory() {
     final OpCodeTracerConfig config =
         OpCodeTracerConfigBuilder.createFrom(OpCodeTracerConfig.DEFAULT)
@@ -614,5 +655,14 @@ class DebugOperationTracerTest {
             .traceStorage(false)
             .build();
     return new DebugOperationTracer(config, false);
+  }
+
+  private void setupStorageForCapture(final MessageFrame frame) {
+    final Bytes32 word1 = Bytes32.fromHexString("0x01");
+    final Bytes32 word2 = Bytes32.fromHexString("0x02");
+    final Bytes32 word3 = Bytes32.fromHexString("0x03");
+    frame.writeMemory(0, 32, word1);
+    frame.writeMemory(32, 32, word2);
+    frame.writeMemory(64, 32, word3);
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/tracing/TraceFrame.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/tracing/TraceFrame.java
@@ -375,8 +375,8 @@ public class TraceFrame {
     /**
      * Sets the storage entry touched by this operation.
      *
-     * <p>Per the execution-apis spec, this field is only populated for SLOAD and SSTORE
-     * opcodes and contains solely the single slot accessed or written by that operation.
+     * <p>Per the execution-apis spec, this field is only populated for SLOAD and SSTORE opcodes and
+     * contains solely the single slot accessed or written by that operation.
      *
      * @param storage the storage slot touched, as an optional single-entry map of slot key to
      *     value; empty for all opcodes other than SLOAD and SSTORE
@@ -733,9 +733,9 @@ public class TraceFrame {
   /**
    * Returns the storage slot touched by this operation.
    *
-   * <p>Per the execution-apis spec, this field is only populated for SLOAD and SSTORE opcodes
-   * and contains solely the single slot accessed or written by that operation. Empty for all
-   * other opcodes.
+   * <p>Per the execution-apis spec, this field is only populated for SLOAD and SSTORE opcodes and
+   * contains solely the single slot accessed or written by that operation. Empty for all other
+   * opcodes.
    *
    * @return an optional single-entry map of slot key to value, present only for SLOAD/SSTORE
    */

--- a/evm/src/main/java/org/hyperledger/besu/evm/tracing/TraceFrame.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/tracing/TraceFrame.java
@@ -373,9 +373,13 @@ public class TraceFrame {
     }
 
     /**
-     * Sets the storage for this operation.
+     * Sets the storage entry touched by this operation.
      *
-     * @param storage the storage as an optional map of UInt256 keys and values
+     * <p>Per the execution-apis spec, this field is only populated for SLOAD and SSTORE
+     * opcodes and contains solely the single slot accessed or written by that operation.
+     *
+     * @param storage the storage slot touched, as an optional single-entry map of slot key to
+     *     value; empty for all opcodes other than SLOAD and SSTORE
      * @return this builder instance for method chaining
      */
     public Builder setStorage(final Optional<Map<UInt256, UInt256>> storage) {
@@ -727,9 +731,13 @@ public class TraceFrame {
   }
 
   /**
-   * data storage slots and values
+   * Returns the storage slot touched by this operation.
    *
-   * @return data storage slots and values
+   * <p>Per the execution-apis spec, this field is only populated for SLOAD and SSTORE opcodes
+   * and contains solely the single slot accessed or written by that operation. Empty for all
+   * other opcodes.
+   *
+   * @return an optional single-entry map of slot key to value, present only for SLOAD/SSTORE
    */
   public Optional<Map<UInt256, UInt256>> getStorage() {
     return storage;


### PR DESCRIPTION
## PR description

**Problem**

The `storage` field in debug trace struct logs was being emitted on **every opcode**, not just storage-touching ones. The root cause was in `DebugOperationTracer.captureStorage()`:

getUpdatedStorage()` returns  "all storage slots written so far in the transaction"  — it accumulates across opcodes. So once any `SSTORE` executed, every subsequent frame (ADD, PUSH, JUMP, etc.) included the full dirty-storage map. This diverges from geth and the execution-apis spec, as highlighted in the [ethPandaOps trace comparison report](https://investigations.ethpandaops.io/2026-01/trace-comparisons/).

### Approach & Reasoning

The spec says: emit `storage` only for `SLOAD` and `SSTORE`, showing only the **single slot** touched by that operation.

**For SSTORE** this was straightforward — `SStoreOperation` already calls `frame.storageWasUpdated(key, newValue)` on success, which sets `frame.getMaybeUpdatedStorage()`. That's exactly the one slot we need. No extra tracking required.

**For SLOAD** it was trickier. `SLoadOperation` doesn't call `storageWasUpdated` (it's a read, not a write), so `getMaybeUpdatedStorage()` is always empty for it. Two pieces of data are needed: the slot **key** and the **loaded value**.

- The key sits at the top of the stack *before* execution (SLOAD pops it). So it must be captured in `tracePreExecution()` before the opcode runs — introducing the `preExecutionStorageKey` field.
- The loaded value is pushed to the top of the stack *after* execution, so `frame.getStackItem(0)` in `tracePostExecution()` gives it directly.

This approach deliberately avoids depending on `options.traceStack()` being enabled — the key is captured independently of stack tracing, so storage capture works correctly regardless of what other trace flags the caller set.

One edge case considered: if SLOAD halts (e.g. OOG), the value was never pushed, so the stack top would be wrong. This is guarded by checking `operationResult.getHaltReason() == null` before reading the stack — matching what geth does (no storage entry on a halted SLOAD).

Tests

All 21 tests in `DebugOperationTracerTest` pass, including the 3 new ones:
- `shouldRecordStorageForSstoreWhenEnabled` — verifies single-slot map with correct key/value
- `shouldRecordStorageForSloadWhenEnabled` — verifies key captured pre-execution, value captured post-execution
- `shouldNotRecordStorageForNonStorageOpcodeWhenEnabled` — verifies MUL (and any non-storage opcode) emits empty storage even when `traceStorage=true

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Refs #10115 - 10 : storage snapshot timing 


### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [x] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


