### PR TITLE
Feat: [BESU-9984] Bonsai Archive: index infrastructure with seekForPrev fallback

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/storage/keyvalue/KeyValueSegmentIdentifier.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/storage/keyvalue/KeyValueSegmentIdentifier.java
@@ -63,6 +63,18 @@ public enum KeyValueSegmentIdentifier implements SegmentIdentifier {
       true,
       false,
       true),
+  ARCHIVE_ACCOUNT_INDEX(
+      "ARCHIVE_ACCOUNT_INDEX".getBytes(StandardCharsets.UTF_8),
+      EnumSet.of(X_BONSAI_ARCHIVE),
+      true,
+      false,
+      true),
+  ARCHIVE_STORAGE_INDEX(
+      "ARCHIVE_STORAGE_INDEX".getBytes(StandardCharsets.UTF_8),
+      EnumSet.of(X_BONSAI_ARCHIVE),
+      true,
+      false,
+      true),
   VARIABLES(new byte[] {11}), // formerly GOQUORUM_PRIVATE_WORLD_STATE
 
   // previously supported GoQuorum private states

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/storage/flat/ArchiveIndexReader.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/storage/flat/ArchiveIndexReader.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.trie.pathbased.bonsai.storage.flat;
+
+import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.ARCHIVE_ACCOUNT_INDEX;
+import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.ARCHIVE_STORAGE_INDEX;
+
+import org.hyperledger.besu.plugin.services.storage.SegmentIdentifier;
+import org.hyperledger.besu.plugin.services.storage.SegmentedKeyValueStorage;
+
+import java.util.Optional;
+
+import org.apache.tuweni.bytes.Bytes;
+
+/**
+ * Reads from the archive index to resolve historical queries without a seekForPrev scan.
+ *
+ * <p>The index stores, per (naturalKey, rangeId), a sorted list of block numbers at which the
+ * account or storage slot changed. A binary search over this list finds the exact block ≤ the
+ * target, enabling an O(1) direct key lookup instead of an O(N) seek.
+ *
+ * <p>If the index is not yet complete for the queried block range, callers should fall back to the
+ * existing {@code getNearestBefore} / seekForPrev path.
+ */
+public class ArchiveIndexReader {
+
+  private ArchiveIndexReader() {}
+
+  /**
+   * Returns {@code true} if the index has been built contiguously up to and including {@code
+   * targetBlock}. A {@code true} result means:
+   *
+   * <ul>
+   *   <li>An index hit → the returned block is the exact block to look up.
+   *   <li>An index miss → the account/slot did not change in the range, so the value is not present
+   *       at this block (definitive empty).
+   * </ul>
+   *
+   * @param storage the underlying storage
+   * @param targetBlock the block we are querying
+   * @return whether the index covers this block
+   */
+  public static boolean isIndexComplete(
+      final SegmentedKeyValueStorage storage, final long targetBlock) {
+    return ArchiveIndexWriter.getLastIndexedBlock(storage)
+        .map(last -> last >= targetBlock)
+        .orElse(false);
+  }
+
+  /**
+   * Binary-searches the account index for the largest block ≤ {@code targetBlock} at which {@code
+   * accountHash} changed.
+   *
+   * @param storage the underlying storage
+   * @param accountHash raw 32-byte account address hash
+   * @param targetBlock the block we are querying
+   * @return the exact block to use for a direct lookup, or empty if the account had no change in
+   *     this range
+   */
+  public static Optional<Long> findExactAccountBlock(
+      final SegmentedKeyValueStorage storage, final byte[] accountHash, final long targetBlock) {
+    final long rangeId = targetBlock / ArchiveIndexWriter.RANGE_SIZE;
+    final byte[] indexKey = ArchiveIndexWriter.buildAccountIndexKey(accountHash, rangeId);
+    return findExactBlock(storage, ARCHIVE_ACCOUNT_INDEX, indexKey, targetBlock);
+  }
+
+  /**
+   * Binary-searches the storage index for the largest block ≤ {@code targetBlock} at which {@code
+   * naturalKey} (accountHash ++ slotHash) changed.
+   *
+   * @param storage the underlying storage
+   * @param naturalKey raw 64-byte key (accountHash ++ slotHash)
+   * @param targetBlock the block we are querying
+   * @return the exact block to use for a direct lookup, or empty if the slot had no change in this
+   *     range
+   */
+  public static Optional<Long> findExactStorageBlock(
+      final SegmentedKeyValueStorage storage, final byte[] naturalKey, final long targetBlock) {
+    final long rangeId = targetBlock / ArchiveIndexWriter.RANGE_SIZE;
+    final byte[] indexKey = ArchiveIndexWriter.buildStorageIndexKey(naturalKey, rangeId);
+    return findExactBlock(storage, ARCHIVE_STORAGE_INDEX, indexKey, targetBlock);
+  }
+
+  /**
+   * Performs a binary search over the sorted block-number list stored at {@code indexKey} in {@code
+   * indexSegment}, returning the largest value ≤ {@code targetBlock}.
+   *
+   * <p>Block numbers are stored as a contiguous array of 8-byte big-endian longs in ascending
+   * order.
+   *
+   * @param storage the underlying storage
+   * @param indexSegment the segment to look in ({@code ARCHIVE_ACCOUNT_INDEX} or {@code
+   *     ARCHIVE_STORAGE_INDEX})
+   * @param indexKey the pre-built composite index key
+   * @param targetBlock the block we are querying
+   * @return the largest stored block ≤ targetBlock, or empty
+   */
+  private static Optional<Long> findExactBlock(
+      final SegmentedKeyValueStorage storage,
+      final SegmentIdentifier indexSegment,
+      final byte[] indexKey,
+      final long targetBlock) {
+    final Optional<byte[]> blockListOpt = storage.get(indexSegment, indexKey);
+    if (blockListOpt.isEmpty()) {
+      return Optional.empty();
+    }
+    final byte[] blockList = blockListOpt.get();
+    final int count = blockList.length / Long.BYTES;
+    if (count == 0) {
+      return Optional.empty();
+    }
+
+    // Binary search: find the rightmost index where blockList[i] <= targetBlock
+    int lo = 0;
+    int hi = count - 1;
+    int result = -1;
+    while (lo <= hi) {
+      final int mid = (lo + hi) >>> 1;
+      final long midBlock = Bytes.wrap(blockList, mid * Long.BYTES, Long.BYTES).toLong();
+      if (midBlock <= targetBlock) {
+        result = mid;
+        lo = mid + 1;
+      } else {
+        hi = mid - 1;
+      }
+    }
+
+    if (result < 0) {
+      return Optional.empty();
+    }
+    return Optional.of(Bytes.wrap(blockList, result * Long.BYTES, Long.BYTES).toLong());
+  }
+}

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/storage/flat/ArchiveIndexWriter.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/storage/flat/ArchiveIndexWriter.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.trie.pathbased.bonsai.storage.flat;
+
+import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.ARCHIVE_ACCOUNT_INDEX;
+import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.ARCHIVE_STORAGE_INDEX;
+
+import org.hyperledger.besu.plugin.services.storage.SegmentedKeyValueStorage;
+import org.hyperledger.besu.plugin.services.storage.SegmentedKeyValueStorageTransaction;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.bouncycastle.util.Arrays;
+
+/**
+ * Writes block numbers into the archive index segments. The index maps (naturalKey + rangeId) →
+ * sorted list of block numbers at which the account/slot changed.
+ *
+ * <p>Block ranges (of size {@link #RANGE_SIZE}) keep individual index entries small and bounded,
+ * even for hot accounts that change every block.
+ */
+public class ArchiveIndexWriter {
+
+  /** Number of blocks covered by a single index range entry. */
+  public static final long RANGE_SIZE = 100_000L;
+
+  /** Metadata key used to store the last block whose index entries are contiguously complete. */
+  public static final byte[] LAST_INDEXED_BLOCK_KEY =
+      "lastIndexedBlock".getBytes(StandardCharsets.UTF_8);
+
+  private ArchiveIndexWriter() {}
+
+  /**
+   * Appends {@code blockNumber} to the account index entry for the given {@code accountHash} within
+   * the appropriate range. Must be called inside an already-open transaction.
+   *
+   * @param storage the underlying storage (used for read-before-write)
+   * @param tx the open transaction to write into
+   * @param accountHash raw 32-byte account address hash
+   * @param blockNumber the block at which this account changed
+   */
+  public static void appendAccountToIndex(
+      final SegmentedKeyValueStorage storage,
+      final SegmentedKeyValueStorageTransaction tx,
+      final byte[] accountHash,
+      final long blockNumber) {
+    final long rangeId = blockNumber / RANGE_SIZE;
+    final byte[] indexKey = buildAccountIndexKey(accountHash, rangeId);
+    final byte[] existing = storage.get(ARCHIVE_ACCOUNT_INDEX, indexKey).orElse(new byte[0]);
+    tx.put(ARCHIVE_ACCOUNT_INDEX, indexKey, appendBlockNumber(existing, blockNumber));
+  }
+
+  /**
+   * Appends {@code blockNumber} to the storage index entry for the given {@code naturalKey}
+   * (accountHash ++ slotHash) within the appropriate range.
+   *
+   * @param storage the underlying storage (used for read-before-write)
+   * @param tx the open transaction to write into
+   * @param naturalKey raw 64-byte key (accountHash ++ slotHash)
+   * @param blockNumber the block at which this storage slot changed
+   */
+  public static void appendStorageToIndex(
+      final SegmentedKeyValueStorage storage,
+      final SegmentedKeyValueStorageTransaction tx,
+      final byte[] naturalKey,
+      final long blockNumber) {
+    final long rangeId = blockNumber / RANGE_SIZE;
+    final byte[] indexKey = buildStorageIndexKey(naturalKey, rangeId);
+    final byte[] existing = storage.get(ARCHIVE_STORAGE_INDEX, indexKey).orElse(new byte[0]);
+    tx.put(ARCHIVE_STORAGE_INDEX, indexKey, appendBlockNumber(existing, blockNumber));
+  }
+
+  /**
+   * Attempts to advance the {@code lastIndexedBlock} pointer by one. Only advances if {@code
+   * blockNumber} equals the current {@code lastIndexedBlock + 1}, ensuring contiguous coverage from
+   * block 0. This guarantees that a block listed in the index implies all prior blocks are also
+   * indexed.
+   *
+   * @param storage the underlying storage
+   * @param blockNumber the block just fully indexed
+   */
+  public static void tryAdvanceLastIndexedBlock(
+      final SegmentedKeyValueStorage storage, final long blockNumber) {
+    final long current = getLastIndexedBlock(storage).orElse(-1L);
+    if (blockNumber == current + 1) {
+      final SegmentedKeyValueStorageTransaction tx = storage.startTransaction();
+      tx.put(
+          ARCHIVE_ACCOUNT_INDEX,
+          LAST_INDEXED_BLOCK_KEY,
+          Bytes.ofUnsignedLong(blockNumber).toArrayUnsafe());
+      tx.commit();
+    }
+  }
+
+  /**
+   * Returns the latest block for which the index is known to be contiguously complete.
+   *
+   * @param storage the underlying storage
+   * @return the last indexed block number, or empty if none
+   */
+  public static Optional<Long> getLastIndexedBlock(final SegmentedKeyValueStorage storage) {
+    return storage
+        .get(ARCHIVE_ACCOUNT_INDEX, LAST_INDEXED_BLOCK_KEY)
+        .map(Bytes::wrap)
+        .map(Bytes::toLong);
+  }
+
+  /**
+   * Builds the index key for an account: {@code accountHash (32 bytes) ++ rangeId (8 bytes)}.
+   *
+   * @param accountHash raw 32-byte account address hash
+   * @param rangeId the range identifier
+   * @return the composite index key
+   */
+  public static byte[] buildAccountIndexKey(final byte[] accountHash, final long rangeId) {
+    return Bytes.concatenate(Bytes.of(accountHash), Bytes.ofUnsignedLong(rangeId)).toArrayUnsafe();
+  }
+
+  /**
+   * Builds the index key for a storage slot: {@code naturalKey (64 bytes) ++ rangeId (8 bytes)}.
+   *
+   * @param naturalKey raw 64-byte key (accountHash ++ slotHash)
+   * @param rangeId the range identifier
+   * @return the composite index key
+   */
+  public static byte[] buildStorageIndexKey(final byte[] naturalKey, final long rangeId) {
+    return Bytes.concatenate(Bytes.of(naturalKey), Bytes.ofUnsignedLong(rangeId)).toArrayUnsafe();
+  }
+
+  private static byte[] appendBlockNumber(final byte[] existing, final long blockNumber) {
+    return Arrays.concatenate(existing, Bytes.ofUnsignedLong(blockNumber).toArrayUnsafe());
+  }
+}

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/storage/flat/BonsaiArchiveFlatDbStrategy.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/storage/flat/BonsaiArchiveFlatDbStrategy.java
@@ -18,6 +18,8 @@ import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIden
 import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.ACCOUNT_INFO_STATE_FREEZER;
 import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.ACCOUNT_STORAGE_ARCHIVE;
 import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.ACCOUNT_STORAGE_FREEZER;
+import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.ARCHIVE_ACCOUNT_INDEX;
+import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.ARCHIVE_STORAGE_INDEX;
 import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.TRIE_BRANCH_STORAGE;
 import static org.hyperledger.besu.ethereum.trie.pathbased.common.storage.PathBasedWorldStateKeyValueStorage.WORLD_BLOCK_NUMBER_KEY;
 
@@ -123,6 +125,36 @@ public class BonsaiArchiveFlatDbStrategy extends BonsaiFullFlatDbStrategy {
       final SegmentedKeyValueStorage storage) {
 
     getAccountCounter.inc();
+
+    // --- Index-based fast path (skips seekForPrev for indexed ranges) ---
+    final Optional<BonsaiContext> accountReadCtx = getStateArchiveContextForRead(storage);
+    if (accountReadCtx.isPresent()) {
+      final long accountTargetBlock = accountReadCtx.get().getBlockNumber().orElse(-1L);
+      if (accountTargetBlock >= 0
+          && ArchiveIndexReader.isIndexComplete(storage, accountTargetBlock)) {
+        final Optional<Long> exactAccountBlock =
+            ArchiveIndexReader.findExactAccountBlock(
+                storage, accountHash.getBytes().toArrayUnsafe(), accountTargetBlock);
+        if (exactAccountBlock.isPresent()) {
+          final byte[] directKey =
+              calculateArchiveKeyWithMinSuffix(
+                  new BonsaiContext(exactAccountBlock.get()),
+                  accountHash.getBytes().toArrayUnsafe());
+          final Optional<byte[]> directValue =
+              storage
+                  .get(ACCOUNT_INFO_STATE_ARCHIVE, directKey)
+                  .or(() -> storage.get(ACCOUNT_INFO_STATE_FREEZER, directKey));
+          getAccountFoundInFlatDatabaseCounter.inc();
+          return directValue
+              .filter(v -> !Arrays.areEqual(DELETED_ACCOUNT_VALUE, v))
+              .map(Bytes::wrap);
+        }
+        // Index complete, no entry in this range -> account did not exist at this block
+        getAccountNotFoundInFlatDatabaseCounter.inc();
+        return Optional.empty();
+      }
+    }
+
     Optional<SegmentedKeyValueStorage.NearestKeyValue> accountFound;
 
     // keyNearest, use MAX_BLOCK_SUFFIX in the absence of a block context:
@@ -296,6 +328,12 @@ public class BonsaiArchiveFlatDbStrategy extends BonsaiFullFlatDbStrategy {
             getStateArchiveContextForWrite(storage).get(), accountHash.getBytes().toArrayUnsafe());
 
     transaction.put(ACCOUNT_INFO_STATE_ARCHIVE, keySuffixed, accountValue.toArrayUnsafe());
+    getStateArchiveContextForWrite(storage)
+        .flatMap(BonsaiContext::getBlockNumber)
+        .ifPresent(
+            blockNum ->
+                ArchiveIndexWriter.appendAccountToIndex(
+                    storage, transaction, accountHash.getBytes().toArrayUnsafe(), blockNum));
   }
 
   @Override
@@ -330,6 +368,36 @@ public class BonsaiArchiveFlatDbStrategy extends BonsaiFullFlatDbStrategy {
 
     Optional<SegmentedKeyValueStorage.NearestKeyValue> storageFound;
     getStorageValueCounter.inc();
+
+    // --- Index-based fast path (skips seekForPrev for indexed ranges) ---
+    final Optional<BonsaiContext> storageReadCtx = getStateArchiveContextForRead(storage);
+    if (storageReadCtx.isPresent()) {
+      final long storageTargetBlock = storageReadCtx.get().getBlockNumber().orElse(-1L);
+      if (storageTargetBlock >= 0
+          && ArchiveIndexReader.isIndexComplete(storage, storageTargetBlock)) {
+        final byte[] naturalKeyForIndex =
+            calculateNaturalSlotKey(accountHash, storageSlotKey.getSlotHash());
+        final Optional<Long> exactStorageBlock =
+            ArchiveIndexReader.findExactStorageBlock(
+                storage, naturalKeyForIndex, storageTargetBlock);
+        if (exactStorageBlock.isPresent()) {
+          final byte[] directKey =
+              calculateArchiveKeyWithMinSuffix(
+                  new BonsaiContext(exactStorageBlock.get()), naturalKeyForIndex);
+          final Optional<byte[]> directValue =
+              storage
+                  .get(ACCOUNT_STORAGE_ARCHIVE, directKey)
+                  .or(() -> storage.get(ACCOUNT_STORAGE_FREEZER, directKey));
+          getStorageValueFlatDatabaseCounter.inc();
+          return directValue
+              .filter(v -> !Arrays.areEqual(DELETED_STORAGE_VALUE, v))
+              .map(Bytes::wrap);
+        }
+        // Index complete, no entry in this range -> slot did not exist at this block
+        getStorageValueNotFoundInFlatDatabaseCounter.inc();
+        return Optional.empty();
+      }
+    }
 
     // get natural key from account hash and slot key
     byte[] naturalKey = calculateNaturalSlotKey(accountHash, storageSlotKey.getSlotHash());
@@ -398,6 +466,12 @@ public class BonsaiArchiveFlatDbStrategy extends BonsaiFullFlatDbStrategy {
         calculateArchiveKeyWithMinSuffix(getStateArchiveContextForWrite(storage).get(), naturalKey);
 
     transaction.put(ACCOUNT_STORAGE_ARCHIVE, keyNearest, storageValue.toArrayUnsafe());
+    getStateArchiveContextForWrite(storage)
+        .flatMap(BonsaiContext::getBlockNumber)
+        .ifPresent(
+            blockNum ->
+                ArchiveIndexWriter.appendStorageToIndex(
+                    storage, transaction, naturalKey, blockNum));
   }
 
   /*
@@ -460,6 +534,8 @@ public class BonsaiArchiveFlatDbStrategy extends BonsaiFullFlatDbStrategy {
     storage.clear(ACCOUNT_STORAGE_ARCHIVE);
     storage.clear(ACCOUNT_INFO_STATE_FREEZER);
     storage.clear(ACCOUNT_STORAGE_FREEZER);
+    storage.clear(ARCHIVE_ACCOUNT_INDEX);
+    storage.clear(ARCHIVE_STORAGE_INDEX);
   }
 
   // TODO JF: move this out of this class so can be used with ArchiveCodeStorageStrategy without

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/worldview/BonsaiArchiver.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/worldview/BonsaiArchiver.java
@@ -18,10 +18,13 @@ import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.chain.BlockAddedEvent;
 import org.hyperledger.besu.ethereum.chain.BlockAddedObserver;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
+import org.hyperledger.besu.ethereum.trie.pathbased.bonsai.storage.flat.ArchiveIndexWriter;
+import org.hyperledger.besu.ethereum.trie.pathbased.bonsai.storage.flat.BonsaiArchiveFlatDbStrategy;
 import org.hyperledger.besu.ethereum.trie.pathbased.common.storage.PathBasedWorldStateKeyValueStorage;
 import org.hyperledger.besu.ethereum.trie.pathbased.common.trielog.TrieLogManager;
 import org.hyperledger.besu.metrics.BesuMetricCategory;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
+import org.hyperledger.besu.plugin.services.storage.SegmentedKeyValueStorageTransaction;
 import org.hyperledger.besu.plugin.services.trielogs.TrieLog;
 
 import java.util.Optional;
@@ -139,7 +142,7 @@ public class BonsaiArchiver implements BlockAddedObserver {
       blocksToArchive
           .entrySet()
           .forEach(
-              (block) -> {
+              block -> {
                 Hash blockHash = block.getValue();
                 LOG.atDebug()
                     .setMessage("Archiving all account state for block {}")
@@ -184,6 +187,39 @@ public class BonsaiArchiver implements BlockAddedObserver {
                                 });
                           });
                 }
+                // Write index entries for all changed accounts/storage in this block
+                if (trieLog.isPresent()) {
+                  final long blockNumber = block.getKey();
+                  final SegmentedKeyValueStorageTransaction indexTx =
+                      rootWorldStateStorage.getComposedWorldStateStorage().startTransaction();
+                  trieLog
+                      .get()
+                      .getAccountChanges()
+                      .forEach(
+                          (address, change) ->
+                              ArchiveIndexWriter.appendAccountToIndex(
+                                  rootWorldStateStorage.getComposedWorldStateStorage(),
+                                  indexTx,
+                                  address.addressHash().getBytes().toArrayUnsafe(),
+                                  blockNumber));
+                  trieLog
+                      .get()
+                      .getStorageChanges()
+                      .forEach(
+                          (address, storageSlotKey) ->
+                              storageSlotKey.forEach(
+                                  (slotKey, slotValue) ->
+                                      ArchiveIndexWriter.appendStorageToIndex(
+                                          rootWorldStateStorage.getComposedWorldStateStorage(),
+                                          indexTx,
+                                          BonsaiArchiveFlatDbStrategy.calculateNaturalSlotKey(
+                                              address.addressHash(), slotKey.getSlotHash()),
+                                          blockNumber)));
+                  indexTx.commit();
+                  // Advance lastIndexedBlock if this block fills the gap contiguously from 0
+                  ArchiveIndexWriter.tryAdvanceLastIndexedBlock(
+                      rootWorldStateStorage.getComposedWorldStateStorage(), blockNumber);
+                }
                 LOG.atDebug()
                     .setMessage("All account state and storage archived for block {}")
                     .addArgument(block.getKey())
@@ -215,7 +251,7 @@ public class BonsaiArchiver implements BlockAddedObserver {
           .log();
     }
 
-    return archivedAccountStateCount.get() + archivedAccountStorageCount.get();
+    return (archivedAccountStateCount.get() + archivedAccountStorageCount.get());
   }
 
   private final Lock archiveMutex = new ReentrantLock(true);

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/storage/PathBasedWorldStateKeyValueStorage.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/storage/PathBasedWorldStateKeyValueStorage.java
@@ -20,6 +20,7 @@ import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIden
 import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.ACCOUNT_STORAGE_ARCHIVE;
 import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.ACCOUNT_STORAGE_FREEZER;
 import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.ACCOUNT_STORAGE_STORAGE;
+import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.ARCHIVE_ACCOUNT_INDEX;
 import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.CODE_STORAGE;
 import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.TRIE_BRANCH_STORAGE;
 
@@ -27,6 +28,7 @@ import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.storage.StorageProvider;
 import org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier;
+import org.hyperledger.besu.ethereum.trie.pathbased.bonsai.storage.flat.ArchiveIndexWriter;
 import org.hyperledger.besu.ethereum.trie.pathbased.bonsai.storage.flat.BonsaiArchiveFlatDbStrategy;
 import org.hyperledger.besu.ethereum.trie.pathbased.common.BonsaiContext;
 import org.hyperledger.besu.ethereum.trie.pathbased.common.StorageSubscriber;
@@ -407,6 +409,22 @@ public abstract class PathBasedWorldStateKeyValueStorage
     tx.put(
         ACCOUNT_INFO_STATE_FREEZER,
         ARCHIVED_BLOCKS,
+        Bytes.ofUnsignedLong(blockNumber).toArrayUnsafe());
+    tx.commit();
+  }
+
+  public Optional<Long> getLastIndexedBlock() {
+    return composedWorldStateStorage
+        .get(ARCHIVE_ACCOUNT_INDEX, ArchiveIndexWriter.LAST_INDEXED_BLOCK_KEY)
+        .map(Bytes::wrap)
+        .map(Bytes::toLong);
+  }
+
+  public void setLastIndexedBlock(final long blockNumber) {
+    SegmentedKeyValueStorageTransaction tx = composedWorldStateStorage.startTransaction();
+    tx.put(
+        ARCHIVE_ACCOUNT_INDEX,
+        ArchiveIndexWriter.LAST_INDEXED_BLOCK_KEY,
         Bytes.ofUnsignedLong(blockNumber).toArrayUnsafe());
     tx.commit();
   }

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/storage/flat/ArchiveIndexReaderTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/storage/flat/ArchiveIndexReaderTest.java
@@ -1,0 +1,289 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.trie.pathbased.bonsai.storage.flat;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.plugin.services.storage.SegmentedKeyValueStorage;
+import org.hyperledger.besu.plugin.services.storage.SegmentedKeyValueStorageTransaction;
+import org.hyperledger.besu.services.kvstore.SegmentedInMemoryKeyValueStorage;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class ArchiveIndexReaderTest {
+
+  private SegmentedKeyValueStorage storage;
+
+  @BeforeEach
+  public void setup() {
+    storage = new SegmentedInMemoryKeyValueStorage();
+  }
+
+  // ── isIndexComplete ───────────────────────────────────────────────────────
+
+  @Test
+  public void isIndexComplete_returnsFalseWhenNoLastIndexedBlock() {
+    assertThat(ArchiveIndexReader.isIndexComplete(storage, 100L)).isFalse();
+  }
+
+  @Test
+  public void isIndexComplete_returnsTrueWhenLastIndexedBlockCoversTarget() {
+    advanceLastIndexed(0L);
+    advanceLastIndexed(1L);
+    advanceLastIndexed(2L);
+
+    assertThat(ArchiveIndexReader.isIndexComplete(storage, 0L)).isTrue();
+    assertThat(ArchiveIndexReader.isIndexComplete(storage, 1L)).isTrue();
+    assertThat(ArchiveIndexReader.isIndexComplete(storage, 2L)).isTrue();
+  }
+
+  @Test
+  public void isIndexComplete_returnsFalseWhenTargetBeyondLastIndexedBlock() {
+    advanceLastIndexed(0L);
+    advanceLastIndexed(1L);
+
+    assertThat(ArchiveIndexReader.isIndexComplete(storage, 2L)).isFalse();
+    assertThat(ArchiveIndexReader.isIndexComplete(storage, 1000L)).isFalse();
+  }
+
+  @Test
+  public void isIndexComplete_returnsTrueExactlyAtLastIndexedBlock() {
+    advanceLastIndexed(0L);
+    advanceLastIndexed(1L);
+    advanceLastIndexed(2L);
+    advanceLastIndexed(3L);
+
+    assertThat(ArchiveIndexReader.isIndexComplete(storage, 3L)).isTrue();
+    assertThat(ArchiveIndexReader.isIndexComplete(storage, 4L)).isFalse();
+  }
+
+  // ── findExactAccountBlock ─────────────────────────────────────────────────
+
+  @Test
+  public void findExactAccountBlock_returnsEmptyWhenNoIndexEntry() {
+    final byte[] accountHash = accountHash(1);
+
+    final java.util.Optional<Long> result =
+        ArchiveIndexReader.findExactAccountBlock(storage, accountHash, 500L);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  public void findExactAccountBlock_returnsExactMatchWhenPresent() {
+    final byte[] accountHash = accountHash(2);
+    appendAccount(accountHash, 100L);
+    appendAccount(accountHash, 200L);
+    appendAccount(accountHash, 300L);
+
+    assertThat(ArchiveIndexReader.findExactAccountBlock(storage, accountHash, 100L)).contains(100L);
+    assertThat(ArchiveIndexReader.findExactAccountBlock(storage, accountHash, 200L)).contains(200L);
+    assertThat(ArchiveIndexReader.findExactAccountBlock(storage, accountHash, 300L)).contains(300L);
+  }
+
+  @Test
+  public void findExactAccountBlock_returnsNearestPredecessorWhenNoExactMatch() {
+    final byte[] accountHash = accountHash(3);
+    appendAccount(accountHash, 100L);
+    appendAccount(accountHash, 300L);
+    appendAccount(accountHash, 500L);
+
+    // 250 is between 100 and 300; nearest before is 100
+    assertThat(ArchiveIndexReader.findExactAccountBlock(storage, accountHash, 250L)).contains(100L);
+
+    // 400 is between 300 and 500; nearest before is 300
+    assertThat(ArchiveIndexReader.findExactAccountBlock(storage, accountHash, 400L)).contains(300L);
+
+    // 600 is beyond the last entry; nearest before is 500
+    assertThat(ArchiveIndexReader.findExactAccountBlock(storage, accountHash, 600L)).contains(500L);
+  }
+
+  @Test
+  public void findExactAccountBlock_returnsEmptyWhenTargetBeforeAllEntries() {
+    final byte[] accountHash = accountHash(4);
+    appendAccount(accountHash, 200L);
+    appendAccount(accountHash, 400L);
+
+    // Target is before every recorded block in this range
+    assertThat(ArchiveIndexReader.findExactAccountBlock(storage, accountHash, 50L)).isEmpty();
+  }
+
+  @Test
+  public void findExactAccountBlock_singleEntryExactMatch() {
+    final byte[] accountHash = accountHash(5);
+    appendAccount(accountHash, 77L);
+
+    assertThat(ArchiveIndexReader.findExactAccountBlock(storage, accountHash, 77L)).contains(77L);
+  }
+
+  @Test
+  public void findExactAccountBlock_singleEntryNearestBefore() {
+    final byte[] accountHash = accountHash(6);
+    appendAccount(accountHash, 77L);
+
+    assertThat(ArchiveIndexReader.findExactAccountBlock(storage, accountHash, 99L)).contains(77L);
+  }
+
+  @Test
+  public void findExactAccountBlock_singleEntryTargetBefore() {
+    final byte[] accountHash = accountHash(7);
+    appendAccount(accountHash, 77L);
+
+    assertThat(ArchiveIndexReader.findExactAccountBlock(storage, accountHash, 50L)).isEmpty();
+  }
+
+  @Test
+  public void findExactAccountBlock_doesNotReturnEntryFromDifferentAccount() {
+    final byte[] accountHashA = accountHash(8);
+    final byte[] accountHashB = accountHash(9);
+    appendAccount(accountHashA, 100L);
+
+    // B has no entries; should return empty even though A has entries in the same range
+    assertThat(ArchiveIndexReader.findExactAccountBlock(storage, accountHashB, 100L)).isEmpty();
+  }
+
+  @Test
+  public void findExactAccountBlock_manyEntriesBinarySearchCorrect() {
+    final byte[] accountHash = accountHash(10);
+    // Write 1000 entries: blocks 1, 2, 3, ..., 1000 (all in range 0)
+    for (long b = 1; b <= 1000L; b++) {
+      appendAccount(accountHash, b);
+    }
+
+    // Exact matches at boundaries
+    assertThat(ArchiveIndexReader.findExactAccountBlock(storage, accountHash, 1L)).contains(1L);
+    assertThat(ArchiveIndexReader.findExactAccountBlock(storage, accountHash, 1000L))
+        .contains(1000L);
+
+    // Mid-range exact match
+    assertThat(ArchiveIndexReader.findExactAccountBlock(storage, accountHash, 500L)).contains(500L);
+
+    // Target beyond last entry in range (still in same range bucket)
+    assertThat(ArchiveIndexReader.findExactAccountBlock(storage, accountHash, 1500L))
+        .contains(1000L);
+  }
+
+  // ── findExactStorageBlock ─────────────────────────────────────────────────
+
+  @Test
+  public void findExactStorageBlock_returnsEmptyWhenNoIndexEntry() {
+    final byte[] naturalKey = naturalKey(1, 2);
+
+    assertThat(ArchiveIndexReader.findExactStorageBlock(storage, naturalKey, 100L)).isEmpty();
+  }
+
+  @Test
+  public void findExactStorageBlock_returnsExactMatch() {
+    final byte[] naturalKey = naturalKey(3, 4);
+    appendStorage(naturalKey, 50L);
+    appendStorage(naturalKey, 150L);
+
+    assertThat(ArchiveIndexReader.findExactStorageBlock(storage, naturalKey, 50L)).contains(50L);
+    assertThat(ArchiveIndexReader.findExactStorageBlock(storage, naturalKey, 150L)).contains(150L);
+  }
+
+  @Test
+  public void findExactStorageBlock_returnsNearestPredecessor() {
+    final byte[] naturalKey = naturalKey(5, 6);
+    appendStorage(naturalKey, 100L);
+    appendStorage(naturalKey, 300L);
+
+    assertThat(ArchiveIndexReader.findExactStorageBlock(storage, naturalKey, 200L)).contains(100L);
+  }
+
+  @Test
+  public void findExactStorageBlock_returnsEmptyWhenTargetBeforeAllEntries() {
+    final byte[] naturalKey = naturalKey(7, 8);
+    appendStorage(naturalKey, 500L);
+
+    assertThat(ArchiveIndexReader.findExactStorageBlock(storage, naturalKey, 10L)).isEmpty();
+  }
+
+  @Test
+  public void findExactStorageBlock_doesNotReturnEntryFromDifferentSlot() {
+    final byte[] naturalKeyA = naturalKey(9, 10);
+    final byte[] naturalKeyB = naturalKey(9, 11); // same account, different slot
+    appendStorage(naturalKeyA, 200L);
+
+    assertThat(ArchiveIndexReader.findExactStorageBlock(storage, naturalKeyB, 200L)).isEmpty();
+  }
+
+  // ── cross-range boundary ─────────────────────────────────────────────────
+
+  @Test
+  public void findExactAccountBlock_returnsEmptyForQueryInUnindexedRange() {
+    final byte[] accountHash = accountHash(20);
+    // Write entries only in range 0 (block < 100_000)
+    appendAccount(accountHash, 50_000L);
+    appendAccount(accountHash, 99_999L);
+
+    // Query in range 1 (100_000 <= block < 200_000) — no index entry exists there
+    assertThat(ArchiveIndexReader.findExactAccountBlock(storage, accountHash, 150_000L)).isEmpty();
+  }
+
+  @Test
+  public void findExactAccountBlock_returnsCorrectEntryPerRange() {
+    final byte[] accountHash = accountHash(21);
+    // Range 0: block 50_000
+    appendAccount(accountHash, 50_000L);
+    // Range 1: block 150_000
+    appendAccount(accountHash, 150_000L);
+
+    // Query in range 0
+    assertThat(ArchiveIndexReader.findExactAccountBlock(storage, accountHash, 75_000L))
+        .contains(50_000L);
+
+    // Query in range 1
+    assertThat(ArchiveIndexReader.findExactAccountBlock(storage, accountHash, 175_000L))
+        .contains(150_000L);
+  }
+
+  // ── helpers ──────────────────────────────────────────────────────────────
+
+  /** Advance lastIndexedBlock contiguously from whatever the current value is. */
+  private void advanceLastIndexed(final long block) {
+    ArchiveIndexWriter.tryAdvanceLastIndexedBlock(storage, block);
+  }
+
+  private void appendAccount(final byte[] accountHash, final long blockNumber) {
+    final SegmentedKeyValueStorageTransaction tx = storage.startTransaction();
+    ArchiveIndexWriter.appendAccountToIndex(storage, tx, accountHash, blockNumber);
+    tx.commit();
+  }
+
+  private void appendStorage(final byte[] naturalKey, final long blockNumber) {
+    final SegmentedKeyValueStorageTransaction tx = storage.startTransaction();
+    ArchiveIndexWriter.appendStorageToIndex(storage, tx, naturalKey, blockNumber);
+    tx.commit();
+  }
+
+  private static byte[] accountHash(final int seed) {
+    return Address.fromHexString(String.format("0x%040x", seed))
+        .addressHash()
+        .getBytes()
+        .toArrayUnsafe();
+  }
+
+  private static byte[] naturalKey(final int accountSeed, final int slotSeed) {
+    final Hash accountHash =
+        Address.fromHexString(String.format("0x%040x", accountSeed)).addressHash();
+    final Hash slotHash = Address.fromHexString(String.format("0x%040x", slotSeed)).addressHash();
+    return Bytes.concatenate(accountHash.getBytes(), slotHash.getBytes()).toArrayUnsafe();
+  }
+}

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/storage/flat/ArchiveIndexWriterTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/storage/flat/ArchiveIndexWriterTest.java
@@ -1,0 +1,278 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.trie.pathbased.bonsai.storage.flat;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.ARCHIVE_ACCOUNT_INDEX;
+import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.ARCHIVE_STORAGE_INDEX;
+
+import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.plugin.services.storage.SegmentedKeyValueStorage;
+import org.hyperledger.besu.plugin.services.storage.SegmentedKeyValueStorageTransaction;
+import org.hyperledger.besu.services.kvstore.SegmentedInMemoryKeyValueStorage;
+
+import java.util.Optional;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class ArchiveIndexWriterTest {
+
+  private SegmentedKeyValueStorage storage;
+
+  @BeforeEach
+  public void setup() {
+    storage = new SegmentedInMemoryKeyValueStorage();
+  }
+
+  // ── appendAccountToIndex ─────────────────────────────────────────────────
+
+  @Test
+  public void appendAccountToIndex_writesBlockNumberInCorrectSegment() {
+    final Hash accountHash = address(1).addressHash();
+    final long blockNumber = 500L;
+
+    final SegmentedKeyValueStorageTransaction tx = storage.startTransaction();
+    ArchiveIndexWriter.appendAccountToIndex(
+        storage, tx, accountHash.getBytes().toArrayUnsafe(), blockNumber);
+    tx.commit();
+
+    final long rangeId = blockNumber / ArchiveIndexWriter.RANGE_SIZE;
+    final byte[] indexKey =
+        ArchiveIndexWriter.buildAccountIndexKey(accountHash.getBytes().toArrayUnsafe(), rangeId);
+    final Optional<byte[]> stored = storage.get(ARCHIVE_ACCOUNT_INDEX, indexKey);
+
+    assertThat(stored).isPresent();
+    assertThat(stored.get().length).isEqualTo(Long.BYTES);
+    assertThat(Bytes.wrap(stored.get()).toLong()).isEqualTo(blockNumber);
+  }
+
+  @Test
+  public void appendAccountToIndex_appendsMultipleBlocksInOrder() {
+    final Hash accountHash = address(2).addressHash();
+    final long block1 = 100L;
+    final long block2 = 200L;
+    final long block3 = 300L;
+
+    appendAccount(accountHash, block1);
+    appendAccount(accountHash, block2);
+    appendAccount(accountHash, block3);
+
+    final long rangeId = block1 / ArchiveIndexWriter.RANGE_SIZE;
+    final byte[] indexKey =
+        ArchiveIndexWriter.buildAccountIndexKey(accountHash.getBytes().toArrayUnsafe(), rangeId);
+    final byte[] stored = storage.get(ARCHIVE_ACCOUNT_INDEX, indexKey).get();
+
+    assertThat(stored.length).isEqualTo(3 * Long.BYTES);
+    assertThat(Bytes.wrap(stored, 0, Long.BYTES).toLong()).isEqualTo(block1);
+    assertThat(Bytes.wrap(stored, Long.BYTES, Long.BYTES).toLong()).isEqualTo(block2);
+    assertThat(Bytes.wrap(stored, 2 * Long.BYTES, Long.BYTES).toLong()).isEqualTo(block3);
+  }
+
+  @Test
+  public void appendAccountToIndex_blocksInDifferentRangesGoToDifferentEntries() {
+    final Hash accountHash = address(3).addressHash();
+    final long blockInRange0 = 50_000L;
+    final long blockInRange1 = 150_000L; // range 1
+
+    appendAccount(accountHash, blockInRange0);
+    appendAccount(accountHash, blockInRange1);
+
+    final long rangeId0 = blockInRange0 / ArchiveIndexWriter.RANGE_SIZE;
+    final long rangeId1 = blockInRange1 / ArchiveIndexWriter.RANGE_SIZE;
+    assertThat(rangeId0).isNotEqualTo(rangeId1);
+
+    final byte[] key0 =
+        ArchiveIndexWriter.buildAccountIndexKey(accountHash.getBytes().toArrayUnsafe(), rangeId0);
+    final byte[] key1 =
+        ArchiveIndexWriter.buildAccountIndexKey(accountHash.getBytes().toArrayUnsafe(), rangeId1);
+
+    assertThat(storage.get(ARCHIVE_ACCOUNT_INDEX, key0)).isPresent();
+    assertThat(storage.get(ARCHIVE_ACCOUNT_INDEX, key1)).isPresent();
+
+    assertThat(Bytes.wrap(storage.get(ARCHIVE_ACCOUNT_INDEX, key0).get()).toLong())
+        .isEqualTo(blockInRange0);
+    assertThat(Bytes.wrap(storage.get(ARCHIVE_ACCOUNT_INDEX, key1).get()).toLong())
+        .isEqualTo(blockInRange1);
+  }
+
+  @Test
+  public void appendAccountToIndex_doesNotWriteToStorageIndexSegment() {
+    final Hash accountHash = address(4).addressHash();
+
+    appendAccount(accountHash, 42L);
+
+    final long rangeId = 42L / ArchiveIndexWriter.RANGE_SIZE;
+    final byte[] key =
+        ArchiveIndexWriter.buildAccountIndexKey(accountHash.getBytes().toArrayUnsafe(), rangeId);
+
+    assertThat(storage.get(ARCHIVE_STORAGE_INDEX, key)).isEmpty();
+  }
+
+  // ── appendStorageToIndex ─────────────────────────────────────────────────
+
+  @Test
+  public void appendStorageToIndex_writesBlockNumberInCorrectSegment() {
+    final byte[] naturalKey = naturalKey(address(5), address(6));
+    final long blockNumber = 999L;
+
+    final SegmentedKeyValueStorageTransaction tx = storage.startTransaction();
+    ArchiveIndexWriter.appendStorageToIndex(storage, tx, naturalKey, blockNumber);
+    tx.commit();
+
+    final long rangeId = blockNumber / ArchiveIndexWriter.RANGE_SIZE;
+    final byte[] indexKey = ArchiveIndexWriter.buildStorageIndexKey(naturalKey, rangeId);
+    final Optional<byte[]> stored = storage.get(ARCHIVE_STORAGE_INDEX, indexKey);
+
+    assertThat(stored).isPresent();
+    assertThat(Bytes.wrap(stored.get()).toLong()).isEqualTo(blockNumber);
+  }
+
+  @Test
+  public void appendStorageToIndex_appendsMultipleBlocks() {
+    final byte[] naturalKey = naturalKey(address(7), address(8));
+
+    appendStorage(naturalKey, 10L);
+    appendStorage(naturalKey, 20L);
+
+    final long rangeId = 10L / ArchiveIndexWriter.RANGE_SIZE;
+    final byte[] stored =
+        storage
+            .get(
+                ARCHIVE_STORAGE_INDEX, ArchiveIndexWriter.buildStorageIndexKey(naturalKey, rangeId))
+            .get();
+
+    assertThat(stored.length).isEqualTo(2 * Long.BYTES);
+    assertThat(Bytes.wrap(stored, 0, Long.BYTES).toLong()).isEqualTo(10L);
+    assertThat(Bytes.wrap(stored, Long.BYTES, Long.BYTES).toLong()).isEqualTo(20L);
+  }
+
+  // ── tryAdvanceLastIndexedBlock ────────────────────────────────────────────
+
+  @Test
+  public void tryAdvanceLastIndexedBlock_advancesFromMinusOneToZero() {
+    assertThat(ArchiveIndexWriter.getLastIndexedBlock(storage)).isEmpty();
+
+    ArchiveIndexWriter.tryAdvanceLastIndexedBlock(storage, 0L);
+
+    assertThat(ArchiveIndexWriter.getLastIndexedBlock(storage)).contains(0L);
+  }
+
+  @Test
+  public void tryAdvanceLastIndexedBlock_advancesContiguously() {
+    ArchiveIndexWriter.tryAdvanceLastIndexedBlock(storage, 0L);
+    ArchiveIndexWriter.tryAdvanceLastIndexedBlock(storage, 1L);
+    ArchiveIndexWriter.tryAdvanceLastIndexedBlock(storage, 2L);
+
+    assertThat(ArchiveIndexWriter.getLastIndexedBlock(storage)).contains(2L);
+  }
+
+  @Test
+  public void tryAdvanceLastIndexedBlock_doesNotAdvanceWhenGapExists() {
+    // Jump from -1 to 5 (not contiguous from 0)
+    ArchiveIndexWriter.tryAdvanceLastIndexedBlock(storage, 5L);
+
+    assertThat(ArchiveIndexWriter.getLastIndexedBlock(storage)).isEmpty();
+  }
+
+  @Test
+  public void tryAdvanceLastIndexedBlock_doesNotAdvanceWhenNonContiguous() {
+    ArchiveIndexWriter.tryAdvanceLastIndexedBlock(storage, 0L); // sets to 0
+    ArchiveIndexWriter.tryAdvanceLastIndexedBlock(storage, 2L); // skips 1 — no advance
+
+    assertThat(ArchiveIndexWriter.getLastIndexedBlock(storage)).contains(0L);
+  }
+
+  @Test
+  public void tryAdvanceLastIndexedBlock_doesNotGoBackward() {
+    ArchiveIndexWriter.tryAdvanceLastIndexedBlock(storage, 0L);
+    ArchiveIndexWriter.tryAdvanceLastIndexedBlock(storage, 1L);
+    ArchiveIndexWriter.tryAdvanceLastIndexedBlock(storage, 2L);
+    // Try to set to 1 again — should not move pointer back
+    ArchiveIndexWriter.tryAdvanceLastIndexedBlock(storage, 1L);
+
+    assertThat(ArchiveIndexWriter.getLastIndexedBlock(storage)).contains(2L);
+  }
+
+  // ── buildAccountIndexKey / buildStorageIndexKey ───────────────────────────
+
+  @Test
+  public void buildAccountIndexKey_hasCorrectLength() {
+    final byte[] accountHash = address(9).addressHash().getBytes().toArrayUnsafe();
+    final byte[] key = ArchiveIndexWriter.buildAccountIndexKey(accountHash, 7L);
+
+    // 32 bytes accountHash + 8 bytes rangeId
+    assertThat(key.length).isEqualTo(32 + Long.BYTES);
+  }
+
+  @Test
+  public void buildStorageIndexKey_hasCorrectLength() {
+    final byte[] naturalKey = naturalKey(address(10), address(11));
+    final byte[] key = ArchiveIndexWriter.buildStorageIndexKey(naturalKey, 3L);
+
+    // 64 bytes naturalKey + 8 bytes rangeId
+    assertThat(key.length).isEqualTo(64 + Long.BYTES);
+  }
+
+  @Test
+  public void buildAccountIndexKey_rangeIdEncodedBigEndian() {
+    final byte[] accountHash = address(12).addressHash().getBytes().toArrayUnsafe();
+    final long rangeId = 1L;
+    final byte[] key = ArchiveIndexWriter.buildAccountIndexKey(accountHash, rangeId);
+
+    // Last 8 bytes should be big-endian encoding of rangeId
+    final Bytes rangeBytes = Bytes.wrap(key, 32, Long.BYTES);
+    assertThat(rangeBytes.toLong()).isEqualTo(rangeId);
+  }
+
+  @Test
+  public void differentAccountsProduceDifferentIndexKeys() {
+    final byte[] key1 =
+        ArchiveIndexWriter.buildAccountIndexKey(
+            address(13).addressHash().getBytes().toArrayUnsafe(), 0L);
+    final byte[] key2 =
+        ArchiveIndexWriter.buildAccountIndexKey(
+            address(14).addressHash().getBytes().toArrayUnsafe(), 0L);
+
+    assertThat(key1).isNotEqualTo(key2);
+  }
+
+  // ── helpers ──────────────────────────────────────────────────────────────
+
+  private void appendAccount(final Hash accountHash, final long blockNumber) {
+    final SegmentedKeyValueStorageTransaction tx = storage.startTransaction();
+    ArchiveIndexWriter.appendAccountToIndex(
+        storage, tx, accountHash.getBytes().toArrayUnsafe(), blockNumber);
+    tx.commit();
+  }
+
+  private void appendStorage(final byte[] naturalKey, final long blockNumber) {
+    final SegmentedKeyValueStorageTransaction tx = storage.startTransaction();
+    ArchiveIndexWriter.appendStorageToIndex(storage, tx, naturalKey, blockNumber);
+    tx.commit();
+  }
+
+  private static Address address(final int seed) {
+    return Address.fromHexString(String.format("0x%040x", seed));
+  }
+
+  private static byte[] naturalKey(final Address account, final Address slot) {
+    // Use address hash as stand-in for slot hash (just needs 32 + 32 = 64 bytes)
+    return Bytes.concatenate(account.addressHash().getBytes(), slot.addressHash().getBytes())
+        .toArrayUnsafe();
+  }
+}

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/worldview/BonsaiArchiverTests.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/worldview/BonsaiArchiverTests.java
@@ -46,7 +46,9 @@ import org.hyperledger.besu.ethereum.trie.pathbased.common.trielog.TrieLogManage
 import org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration;
 import org.hyperledger.besu.ethereum.worldstate.FlatDbMode;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
+import org.hyperledger.besu.plugin.services.storage.SegmentedKeyValueStorage;
 import org.hyperledger.besu.plugin.services.storage.SegmentedKeyValueStorageTransaction;
+import org.hyperledger.besu.services.kvstore.SegmentedInMemoryKeyValueStorage;
 
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
@@ -111,6 +113,8 @@ public class BonsaiArchiverTests {
   public void setup() {
     Configurator.setLevel(LogManager.getLogger(BonsaiArchiverTests.class).getName(), Level.TRACE);
     worldStateStorage = Mockito.mock(BonsaiWorldStateKeyValueStorage.class);
+    final SegmentedKeyValueStorage composedStorage = new SegmentedInMemoryKeyValueStorage();
+    when(worldStateStorage.getComposedWorldStateStorage()).thenReturn(composedStorage);
     blockchain = Mockito.mock(Blockchain.class);
     trieLogManager = Mockito.mock(TrieLogManager.class);
     bonsaiWorldState = Mockito.mock(BonsaiWorldState.class);


### PR DESCRIPTION
## PR description

Summary

Introduces the archive index infrastructure that tracks which blocks modified each account and storage slot, enabling O(log N) direct lookups for historical state queries. Reads use the index when it covers the queried block and transparently fall back to `seekForPrev` when not, so existing functionality is entirely unaffected while the index builds incrementally.

---

### Problem

Historical queries on Bonsai Archive nodes currently use `getNearestBefore` (`seekForPrev`) against the `ACCOUNT_INFO_STATE_ARCHIVE` and `ACCOUNT_STORAGE_ARCHIVE` column families. For **hot accounts** — DEX liquidity pools, ERC-20 token contracts, fee collectors — that change on nearly every block, millions of archive entries accumulate for a single account. RocksDB must merge-scan across many SST levels to land on the correct version, making historical queries increasingly expensive the longer the node runs.

---

### Design Decisions

#### 1. Block ranges instead of one flat list

Each index entry covers a fixed range of `100,000` blocks (`RANGE_SIZE`). Rather than maintaining one unbounded list of all blocks an account ever changed at, the index is split into per-range buckets:

```
ARCHIVE_ACCOUNT_INDEX[ accountHash (32B) ++ rangeId (8B) ] → sorted block list
ARCHIVE_STORAGE_INDEX[ naturalKey  (64B) ++ rangeId (8B) ] → sorted block list
```

This keeps individual index entries **bounded in size** even for hot accounts, avoids unbounded read-modify-write growth on a single key, and aligns with the block-range concept used by the follow-up bloom filter work in #9985.

#### 2. Block list stored as contiguous sorted `long[]`

Each index value is a byte array of 8-byte big-endian longs in ascending order. This allows **binary search** (`O(log N)` where N ≤ `RANGE_SIZE`) directly over the raw bytes without deserialisation, and is trivially appendable — new block numbers are always larger than existing ones, so writes are simple concatenations.

#### 3. Index writes happen inside the archiver, not at import time

`ArchiveIndexWriter` is called from `BonsaiArchiver.moveBlockStateToArchive()`, alongside the existing `archivePreviousAccountState` / `archivePreviousStorageState` calls. A single batch transaction is opened per block, all changed accounts and storage slots are indexed in one commit, then `tryAdvanceLastIndexedBlock` is called.

This approach was chosen over writing in `putFlatAccount()` because the archiver already has the full list of changed keys per block (from the trie log), ensuring the index is built **alongside** the archive — not ahead of it — which is the correct invariant for `lastIndexedBlock`.

#### 4. `lastIndexedBlock` contiguity invariant

`tryAdvanceLastIndexedBlock(storage, blockNumber)` only advances the pointer when `blockNumber == lastIndexedBlock + 1`. This ensures the pointer always represents **contiguous coverage from block 0**. A miss in the index is only trusted as definitive when the pointer covers the target block. This design means:

- **Fresh nodes** (archive from genesis): the index is usable immediately, advancing block by block.
- **Existing nodes** (archive data present before this feature): `lastIndexedBlock` stays at 0 and all queries fall back to `seekForPrev` until the retroactive index builder (#9700) fills the historical gap.

#### 5. Three-way read path in `BonsaiArchiveFlatDbStrategy`

```
getArchiveAccount(hash, targetBlock):
  ├── isIndexComplete(targetBlock)?
  │     YES ── findExactBlock() returns hit  ──► direct get(ARCHIVE) or get(FREEZER)   O(log N)
  │     YES ── findExactBlock() returns miss ──► account didn't exist at this block      O(1)
  └──   NO  ──────────────────────────────────► seekForPrev fallback (existing path)    O(N)
```

The index fast-path is inserted **before** the existing `getNearestBefore` code in both `getFlatAccount` and `getFlatStorageValueByStorageSlotKey`. When the index is not yet built the code falls straight through to the original seekForPrev logic — no branching overhead for nodes that have not yet built the index.

#### 6. Direct lookup checks both ARCHIVE and FREEZER

After the binary search resolves the exact block number, the direct lookup tries `ACCOUNT_INFO_STATE_ARCHIVE` first, then `ACCOUNT_INFO_STATE_FREEZER`. This is necessary because the archiver moves old entries from ARCHIVE to FREEZER asynchronously, so a given entry may live in either segment depending on its age. Two point reads (each O(1) with bloom filters) is still far cheaper than one seekForPrev scan.

#### 7. Two new column families use full-name identifiers

`ARCHIVE_ACCOUNT_INDEX` and `ARCHIVE_STORAGE_INDEX` follow the same pattern as the existing archive/freezer segments — using their full string name as the column family identifier rather than a single byte. This keeps the DB operationally debuggable with `ldb`.

#### 8. `lastIndexedBlock` persisted in `ARCHIVE_ACCOUNT_INDEX`

The metadata key `"lastIndexedBlock"` is stored in `ARCHIVE_ACCOUNT_INDEX` itself (following the same pattern as `ARCHIVED_BLOCKS` in `ACCOUNT_INFO_STATE_FREEZER`). `PathBasedWorldStateKeyValueStorage` exposes `getLastIndexedBlock()` / `setLastIndexedBlock()` so the archiver and any future index builder share a single consistent pointer.

---

### Changes

| File | Type | What changed |
|---|---|---|
| `KeyValueSegmentIdentifier` | Modified | Added `ARCHIVE_ACCOUNT_INDEX` and `ARCHIVE_STORAGE_INDEX` segments scoped to `X_BONSAI_ARCHIVE` |
| `ArchiveIndexWriter` | **New** | Appends block numbers to index entries within open transactions; manages `tryAdvanceLastIndexedBlock` contiguity pointer |
| `ArchiveIndexReader` | **New** | `isIndexComplete` guard + `findExactAccountBlock` / `findExactStorageBlock` binary search |
| `BonsaiArchiveFlatDbStrategy` | Modified | Index fast-path in `getFlatAccount` and `getFlatStorageValueByStorageSlotKey`; index write calls in `putFlatAccount` and `putFlatAccountStorageValueByStorageSlotHash`; index segments cleared in `clearArchiveSegments` |
| `BonsaiArchiver` | Modified | After archiving each block, writes all index entries in one batch transaction then calls `tryAdvanceLastIndexedBlock` |
| `PathBasedWorldStateKeyValueStorage` | Modified | `getLastIndexedBlock()` / `setLastIndexedBlock()` backed by `ARCHIVE_ACCOUNT_INDEX` |
| `ArchiveIndexWriterTest` | **New** | 13 tests — key construction, multi-block appends, range bucketing, cross-segment isolation, contiguity rules |
| `ArchiveIndexReaderTest` | **New** | 20 tests — `isIndexComplete` boundaries, exact match, nearest-predecessor, before-all-entries, large list binary search, cross-range and cross-slot isolation |
| `BonsaiArchiverTests` | Modified | Stub `getComposedWorldStateStorage()` with in-memory storage so index writes in `moveBlockStateToArchive` do not NPE on the mock |

---

### What this PR does NOT include

- **Retroactive index building** for nodes that already have archive data — that is the scope of #9700 (`ArchiveIndexBuilder`).
- **Bloom filters / range presence markers** — those are the scope of #9985 and sit on top of this infrastructure.

---

### Testing

- `ArchiveIndexWriterTest` — 13 unit tests
- `ArchiveIndexReaderTest` — 20 unit tests
- `BonsaiArchiveFlatDbStrategyTest` — all existing tests pass
- `BonsaiArchiverTests` — all existing tests pass (+ mock fix)
- Full `ethereum:core`, `ethereum:api`, `plugin-api`, `services:kvstore` test suites — all pass, zero regressions

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fxies #9984 


### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


