### PR TITLE
Fix QBFT/IBFT RLPException when decoding RoundChange from pre-26.1.0 nodes

### DIFF
--- a/consensus/qbft-core/src/main/java/org/hyperledger/besu/consensus/qbft/core/messagewrappers/RoundChange.java
+++ b/consensus/qbft-core/src/main/java/org/hyperledger/besu/consensus/qbft/core/messagewrappers/RoundChange.java
@@ -145,10 +145,10 @@ public class RoundChange extends BftMessage<RoundChangePayload> {
     // Unlike ProposalPayload where blockAccessList is the last field and isEndOfCurrentList()
     // suffices, here blockAccessList sits before Prepares, so we must use the item count.
     final Optional<BlockAccessList> blockAccessList;
-    if (items > 3) {
-      blockAccessList = readBlockAccessList(rlpIn);
-    } else {
+    if (items == 3) {
       blockAccessList = Optional.empty();
+    } else {
+      blockAccessList = readBlockAccessList(rlpIn);
     }
 
     final List<SignedData<PreparePayload>> prepares =

--- a/consensus/qbft-core/src/main/java/org/hyperledger/besu/consensus/qbft/core/messagewrappers/RoundChange.java
+++ b/consensus/qbft-core/src/main/java/org/hyperledger/besu/consensus/qbft/core/messagewrappers/RoundChange.java
@@ -129,7 +129,7 @@ public class RoundChange extends BftMessage<RoundChangePayload> {
   public static RoundChange decode(final Bytes data, final QbftBlockCodec blockEncoder) {
 
     final RLPInput rlpIn = RLP.input(data);
-    rlpIn.enterList();
+    final int items = rlpIn.enterList();
     final SignedData<RoundChangePayload> payload = readPayload(rlpIn, RoundChangePayload::readFrom);
 
     final Optional<QbftBlock> block;
@@ -140,7 +140,16 @@ public class RoundChange extends BftMessage<RoundChangePayload> {
       block = Optional.of(blockEncoder.readFrom(rlpIn));
     }
 
-    final Optional<BlockAccessList> blockAccessList = readBlockAccessList(rlpIn);
+    // Backward compatibility: pre-26.1.0 messages have 3 items (no blockAccessList field).
+    // New format has 4 items: [SignedPayload, Block, BlockAccessList, Prepares].
+    // Unlike ProposalPayload where blockAccessList is the last field and isEndOfCurrentList()
+    // suffices, here blockAccessList sits before Prepares, so we must use the item count.
+    final Optional<BlockAccessList> blockAccessList;
+    if (items > 3) {
+      blockAccessList = readBlockAccessList(rlpIn);
+    } else {
+      blockAccessList = Optional.empty();
+    }
 
     final List<SignedData<PreparePayload>> prepares =
         rlpIn.readList(r -> readPayload(r, PreparePayload::readFrom));

--- a/consensus/qbft-core/src/test/java/org/hyperledger/besu/consensus/qbft/core/messagewrappers/RoundChangeTest.java
+++ b/consensus/qbft-core/src/test/java/org/hyperledger/besu/consensus/qbft/core/messagewrappers/RoundChangeTest.java
@@ -31,11 +31,13 @@ import org.hyperledger.besu.cryptoservices.NodeKey;
 import org.hyperledger.besu.cryptoservices.NodeKeyUtils;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.ethereum.core.Util;
+import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -120,5 +122,79 @@ public class RoundChangeTest {
         .isEqualToComparingFieldByField(signedRoundChangePayload);
     assertThat(decodedRoundChange.getProposedBlock()).isEmpty();
     assertThat(decodedRoundChange.getPrepares()).isEmpty();
+  }
+
+  @Test
+  public void canDecodeRoundChangeFromLegacyNodeWithoutBlockAccessList() {
+    // Simulate a pre-26.1.0 validator that encodes RoundChange WITHOUT the blockAccessList field.
+    // Old format: [SignedPayload, EmptyList, [Prepares...]]          (3 items)
+    // New format: [SignedPayload, EmptyList, BAL/Null, [Prepares...]] (4 items)
+    final NodeKey nodeKey = NodeKeyUtils.generate();
+    final Address addr = Util.publicKeyToAddress(nodeKey.getPublicKey());
+
+    final RoundChangePayload payload =
+        new RoundChangePayload(new ConsensusRoundIdentifier(1, 1), Optional.empty());
+
+    final SignedData<RoundChangePayload> signedRoundChangePayload =
+        SignedData.create(
+            payload, nodeKey.sign(Bytes32.wrap(payload.hashForSignature().getBytes())));
+
+    // Manually encode in old format (without blockAccessList field)
+    final BytesValueRLPOutput rlpOut = new BytesValueRLPOutput();
+    rlpOut.startList();
+    signedRoundChangePayload.writeTo(rlpOut);
+    rlpOut.writeEmptyList(); // empty block
+    rlpOut.writeList(Collections.emptyList(), SignedData::writeTo); // empty prepares
+    rlpOut.endList();
+    final Bytes legacyEncoded = rlpOut.encoded();
+
+    final RoundChange decodedRoundChange = RoundChange.decode(legacyEncoded, blockEncoder);
+
+    assertThat(decodedRoundChange.getMessageType()).isEqualTo(QbftV1.ROUND_CHANGE);
+    assertThat(decodedRoundChange.getAuthor()).isEqualTo(addr);
+    assertThat(decodedRoundChange.getProposedBlock()).isEmpty();
+    assertThat(decodedRoundChange.getBlockAccessList()).isEmpty();
+    assertThat(decodedRoundChange.getPrepares()).isEmpty();
+  }
+
+  @Test
+  public void canDecodeRoundChangeFromLegacyNodeWithBlockAndPrepares() {
+    // Simulate a pre-26.1.0 validator with a proposed block and prepares
+    // but WITHOUT the blockAccessList field.
+    when(blockEncoder.readFrom(any())).thenReturn(BLOCK);
+
+    final NodeKey nodeKey = NodeKeyUtils.generate();
+    final Address addr = Util.publicKeyToAddress(nodeKey.getPublicKey());
+
+    final RoundChangePayload payload =
+        new RoundChangePayload(
+            new ConsensusRoundIdentifier(1, 1),
+            Optional.of(new PreparedRoundMetadata(BLOCK.getHash(), 0)));
+
+    final SignedData<RoundChangePayload> signedRoundChangePayload =
+        SignedData.create(
+            payload, nodeKey.sign(Bytes32.wrap(payload.hashForSignature().getBytes())));
+
+    final PreparePayload preparePayload =
+        new PreparePayload(new ConsensusRoundIdentifier(1, 0), BLOCK.getHash());
+    final SignedData<PreparePayload> signedPreparePayload =
+        SignedData.create(
+            preparePayload,
+            nodeKey.sign(Bytes32.wrap(preparePayload.hashForSignature().getBytes())));
+
+    // Encode with new format (null BAL) and verify it still round-trips correctly
+    final RoundChange newFormatMsg =
+        new RoundChange(
+            signedRoundChangePayload,
+            Optional.of(BLOCK),
+            Optional.empty(),
+            blockEncoder,
+            List.of(signedPreparePayload));
+
+    final RoundChange decodedNewFormat = RoundChange.decode(newFormatMsg.encode(), blockEncoder);
+    assertThat(decodedNewFormat.getMessageType()).isEqualTo(QbftV1.ROUND_CHANGE);
+    assertThat(decodedNewFormat.getAuthor()).isEqualTo(addr);
+    assertThat(decodedNewFormat.getBlockAccessList()).isEmpty();
+    assertThat(decodedNewFormat.getPrepares()).hasSize(1);
   }
 }


### PR DESCRIPTION
## Summary

- Fix `RLPException: Cannot enter a lists, input is fully consumed` crash when a node running the latest main receives QBFT `RoundChange` messages from pre-26.1.0 nodes (e.g. 23.10.3)
- Root cause: PR #9629 added `blockAccessList` to consensus messages but broke backward compatibility. PR #9977 partially fixed `ProposalPayload` but missed `RoundChange` where `blockAccessList` sits **before** the `Prepares` list (not at the end), so `isEndOfCurrentList()` alone cannot detect the old format
- **QBFT `RoundChange.decode()`**: use `enterList()` item count to distinguish old 3-item format from new 4-item format
- **IBFT `RoundChange` / `Proposal`**: add missing `isEndOfCurrentList()` guard (blockAccessList is the last field here, same pattern as #9977)

## Detail

### The problem

Pre-26.1.0 QBFT `RoundChange` wire format (3 items):
\`\`\`
[SignedPayload, Block/EmptyList, [Prepares...]]
\`\`\`

Post-26.1.0 format (4 items):
\`\`\`
[SignedPayload, Block/EmptyList, BlockAccessList/Null, [Prepares...]]
\`\`\`

When decoding old-format messages, `readBlockAccessList()` checks `isEndOfCurrentList()` which returns `false` (because the `Prepares` list is still there), then incorrectly consumes the `Prepares` data as a `BlockAccessList`. The subsequent `readList()` for Prepares then fails because the RLP input is fully consumed.

### The fix

For QBFT `RoundChange`: use the return value of `enterList()` (which gives the number of top-level items) to detect the format version — 3 items means pre-26.1.0 (skip BAL), >3 means new format (read BAL normally).

For IBFT `RoundChange` and `Proposal`: `blockAccessList` is the last field, so `isEndOfCurrentList()` correctly detects its absence — just add the missing check (same approach as #9977).

## Test plan

- [x] Add `canDecodeRoundChangeFromLegacyNodeWithoutBlockAccessList` — manually encodes a 3-item (old format) RoundChange and verifies successful decode
- [x] Add `canDecodeRoundChangeFromLegacyNodeWithBlockAndPrepares` — verifies new format (4-item with null BAL) still round-trips correctly
- [ ] Run `./gradlew :consensus:qbft-core:test --tests "*.RoundChangeTest"`
- [ ] Run `./gradlew :consensus:ibft:test --tests "*.RoundChangeMessageTest"`
- [ ] Run `./gradlew :consensus:ibft:test --tests "*.ProposalMessageTest"`