### PR TITLE
Exclude IntelliJ bin/default output from Spotless shell script check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -261,7 +261,7 @@ configure(allprojects - project(':platform')) {
     // Below this line are currently only license header tasks
     format 'ShellScripts', {
       target '**/*.sh'
-      targetExclude '**/src/reference-test/**', '**/src/main/generated/**', '**/src/test/generated/**', '**/src/jmh/generated/**'
+      targetExclude '**/src/reference-test/**', '**/src/main/generated/**', '**/src/test/generated/**', '**/src/jmh/generated/**', '**/bin/default/**'
       trimTrailingWhitespace()
       endWithNewline()
 


### PR DESCRIPTION
When IntelliJ syncs a Gradle project without build delegation, it copies processed resources (including reference test shell scripts from the submodule) into bin/default/. Spotless then finds these copies and incorrectly flags them for missing license headers, while CI never sees bin/default/ since it runs bare Gradle.

Add '**/bin/default/**' to the ShellScripts targetExclude, matching the existing pattern used for other generated/external content.

