### PR TITLE
Feature add block import trace to eth simulate

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthSimulateV1.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthSimulateV1.java
@@ -156,9 +156,10 @@ public class EthSimulateV1 extends AbstractBlockParameterOrBlockHashMethod {
   }
 
   private Object process(final BlockHeader header, final SimulateV1Parameter simulateV1Parameter) {
-    var blockImportTracer = simulateV1Parameter.isTraceBlockImport()
-        ? blockImportTracerProvider.getBlockImportTracer(header)
-        : OperationTracer.NO_TRACING;
+    var blockImportTracer =
+        simulateV1Parameter.isTraceBlockImport()
+            ? blockImportTracerProvider.getBlockImportTracer(header)
+            : OperationTracer.NO_TRACING;
 
     final List<BlockSimulationResult> simulationResults =
         blockSimulator.process(header, simulateV1Parameter, blockImportTracer);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthSimulateV1.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthSimulateV1.java
@@ -40,6 +40,10 @@ import org.hyperledger.besu.ethereum.transaction.BlockSimulator;
 import org.hyperledger.besu.ethereum.transaction.TransactionSimulator;
 import org.hyperledger.besu.ethereum.transaction.exceptions.BlockStateCallError;
 import org.hyperledger.besu.ethereum.transaction.exceptions.BlockStateCallException;
+import org.hyperledger.besu.evm.tracing.OperationTracer;
+import org.hyperledger.besu.plugin.ServiceManager;
+import org.hyperledger.besu.plugin.services.BlockImportTracerProvider;
+import org.hyperledger.besu.plugin.services.tracer.BlockAwareOperationTracer;
 
 import java.util.List;
 import java.util.Optional;
@@ -52,8 +56,10 @@ public class EthSimulateV1 extends AbstractBlockParameterOrBlockHashMethod {
 
   private final BlockSimulator blockSimulator;
   private final ProtocolSchedule protocolSchedule;
+  private final BlockImportTracerProvider blockImportTracerProvider;
 
   public EthSimulateV1(
+      final ServiceManager serviceManager,
       final BlockchainQueries blockchainQueries,
       final ProtocolSchedule protocolSchedule,
       final TransactionSimulator transactionSimulator,
@@ -69,6 +75,12 @@ public class EthSimulateV1 extends AbstractBlockParameterOrBlockHashMethod {
             miningConfiguration,
             blockchainQueries.getBlockchain(),
             apiConfiguration.getGasCap());
+
+    this.blockImportTracerProvider =
+        Optional.ofNullable(serviceManager)
+            .flatMap(mgr -> mgr.getService(BlockImportTracerProvider.class))
+            // if block import tracer provider is not specified by plugin, default to no tracing
+            .orElse(__ -> BlockAwareOperationTracer.NO_TRACING);
   }
 
   @VisibleForTesting
@@ -79,6 +91,7 @@ public class EthSimulateV1 extends AbstractBlockParameterOrBlockHashMethod {
     super(blockchainQueries);
     this.protocolSchedule = protocolSchedule;
     this.blockSimulator = blockSimulator;
+    this.blockImportTracerProvider = __ -> BlockAwareOperationTracer.NO_TRACING;
   }
 
   @Override
@@ -143,8 +156,13 @@ public class EthSimulateV1 extends AbstractBlockParameterOrBlockHashMethod {
   }
 
   private Object process(final BlockHeader header, final SimulateV1Parameter simulateV1Parameter) {
+    var blockImportTracer = simulateV1Parameter.isTraceBlockImport()
+        ? blockImportTracerProvider.getBlockImportTracer(header)
+        : OperationTracer.NO_TRACING;
+
     final List<BlockSimulationResult> simulationResults =
-        blockSimulator.process(header, simulateV1Parameter);
+        blockSimulator.process(header, simulateV1Parameter, blockImportTracer);
+
     return simulationResults.stream()
         .map(
             result ->

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/SimulateV1Parameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/SimulateV1Parameter.java
@@ -23,13 +23,21 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class SimulateV1Parameter extends BlockSimulationParameter {
 
+  private final boolean traceBlockImport;
+
   @JsonCreator
   public SimulateV1Parameter(
       @JsonProperty("blockStateCalls") final List<JsonBlockStateCallParameter> blockStateCalls,
       @JsonProperty("validation") final boolean validation,
       @JsonProperty("traceTransfers") final boolean traceTransfers,
       @JsonProperty("returnFullTransactions") final boolean returnFullTransactions,
-      @JsonProperty("returnTrieLog") final boolean returnTrieLog) {
+      @JsonProperty("returnTrieLog") final boolean returnTrieLog,
+      @JsonProperty("traceBlockImport") final boolean traceBlockImport) {
     super(blockStateCalls, validation, traceTransfers, returnFullTransactions, returnTrieLog);
+    this.traceBlockImport = traceBlockImport;
+  }
+
+  public boolean isTraceBlockImport() {
+    return traceBlockImport;
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EthJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EthJsonRpcMethods.java
@@ -71,6 +71,7 @@ import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Capability;
 import org.hyperledger.besu.ethereum.transaction.TransactionSimulator;
+import org.hyperledger.besu.plugin.ServiceManager;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 
 import java.util.Map;
@@ -92,6 +93,7 @@ public class EthJsonRpcMethods extends ApiGroupJsonRpcMethods {
   private final ApiConfiguration apiConfiguration;
   private final GenesisConfigOptions genesisConfigOptions;
   private final TransactionSimulator transactionSimulator;
+  private final ServiceManager serviceManager;
   private final MetricsSystem metricsSystem;
 
   public EthJsonRpcMethods(
@@ -106,6 +108,7 @@ public class EthJsonRpcMethods extends ApiGroupJsonRpcMethods {
       final ApiConfiguration apiConfiguration,
       final GenesisConfigOptions genesisConfigOptions,
       final TransactionSimulator transactionSimulator,
+      final ServiceManager serviceManager,
       final MetricsSystem metricsSystem) {
     this.blockchainQueries = blockchainQueries;
     this.synchronizer = synchronizer;
@@ -118,6 +121,7 @@ public class EthJsonRpcMethods extends ApiGroupJsonRpcMethods {
     this.apiConfiguration = apiConfiguration;
     this.genesisConfigOptions = genesisConfigOptions;
     this.transactionSimulator = transactionSimulator;
+    this.serviceManager = serviceManager;
     this.metricsSystem = metricsSystem;
   }
 
@@ -173,6 +177,7 @@ public class EthJsonRpcMethods extends ApiGroupJsonRpcMethods {
             new EthBlobBaseFee(blockchainQueries.getBlockchain(), protocolSchedule),
             new EthMaxPriorityFeePerGas(blockchainQueries),
             new EthSimulateV1(
+                serviceManager,
                 blockchainQueries,
                 protocolSchedule,
                 transactionSimulator,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/JsonRpcMethodsFactory.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/JsonRpcMethodsFactory.java
@@ -136,6 +136,7 @@ public class JsonRpcMethodsFactory {
                   apiConfiguration,
                   genesisConfigOptions,
                   transactionSimulator,
+                  protocolContext.getPluginServiceManager(),
                   metricsSystem),
               new NetJsonRpcMethods(
                   p2pNetwork,

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthSimulateV1Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthSimulateV1Test.java
@@ -39,13 +39,13 @@ import org.hyperledger.besu.ethereum.transaction.TransactionSimulator;
 import org.hyperledger.besu.ethereum.transaction.exceptions.BlockStateCallError;
 import org.hyperledger.besu.ethereum.transaction.exceptions.BlockStateCallException;
 import org.hyperledger.besu.evm.precompile.PrecompileContractRegistry;
+import org.hyperledger.besu.evm.tracing.OperationTracer;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.hyperledger.besu.evm.tracing.OperationTracer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -145,7 +145,8 @@ public class EthSimulateV1Test {
   public void shouldNotReturnInvalidParamsWhenInputAndDataHaveDifferentValues() {
     setupMethodWithMockSimulator();
     setupBlockchainForLatest();
-    when(blockSimulator.process(any(BlockHeader.class), any(), any(OperationTracer.class))).thenReturn(List.of());
+    when(blockSimulator.process(any(BlockHeader.class), any(), any(OperationTracer.class)))
+        .thenReturn(List.of());
 
     // Reproduces issue #9960: both input and data provided with different values.
     // Other EL clients (Geth, Nethermind, Reth, Erigon) accept this and use input.
@@ -168,7 +169,8 @@ public class EthSimulateV1Test {
 
     final ArgumentCaptor<BlockSimulationParameter> captor =
         ArgumentCaptor.forClass(BlockSimulationParameter.class);
-    verify(blockSimulator).process(any(BlockHeader.class), captor.capture(), any(OperationTracer.class));
+    verify(blockSimulator)
+        .process(any(BlockHeader.class), captor.capture(), any(OperationTracer.class));
     final Bytes payload =
         captor.getValue().getBlockStateCalls().get(0).getCalls().get(0).getPayload().orElseThrow();
     assertThat(payload).isEqualTo(Bytes.fromHexString("0xDEADBEEF"));

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthSimulateV1Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthSimulateV1Test.java
@@ -45,6 +45,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.tuweni.bytes.Bytes;
+import org.hyperledger.besu.evm.tracing.OperationTracer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -76,6 +77,7 @@ public class EthSimulateV1Test {
   public void setUp() {
     method =
         new EthSimulateV1(
+            null,
             blockchainQueries,
             protocolSchedule,
             transactionSimulator,
@@ -107,7 +109,7 @@ public class EthSimulateV1Test {
   public void shouldReturnInvalidParamsWhenUpfrontCostExceedsBalanceWithValidation() {
     setupMethodWithMockSimulator();
     setupBlockchainForLatest();
-    when(blockSimulator.process(any(BlockHeader.class), any()))
+    when(blockSimulator.process(any(BlockHeader.class), any(), any(OperationTracer.class)))
         .thenThrow(
             new BlockStateCallException(
                 "Upfront cost exceeds balance", BlockStateCallError.UPFRONT_COST_EXCEEDS_BALANCE));
@@ -125,7 +127,7 @@ public class EthSimulateV1Test {
   public void shouldReturnOriginalErrorCodeWhenUpfrontCostExceedsBalanceWithoutValidation() {
     setupMethodWithMockSimulator();
     setupBlockchainForLatest();
-    when(blockSimulator.process(any(BlockHeader.class), any()))
+    when(blockSimulator.process(any(BlockHeader.class), any(), any(OperationTracer.class)))
         .thenThrow(
             new BlockStateCallException(
                 "Upfront cost exceeds balance", BlockStateCallError.UPFRONT_COST_EXCEEDS_BALANCE));
@@ -143,7 +145,7 @@ public class EthSimulateV1Test {
   public void shouldNotReturnInvalidParamsWhenInputAndDataHaveDifferentValues() {
     setupMethodWithMockSimulator();
     setupBlockchainForLatest();
-    when(blockSimulator.process(any(BlockHeader.class), any())).thenReturn(List.of());
+    when(blockSimulator.process(any(BlockHeader.class), any(), any(OperationTracer.class))).thenReturn(List.of());
 
     // Reproduces issue #9960: both input and data provided with different values.
     // Other EL clients (Geth, Nethermind, Reth, Erigon) accept this and use input.
@@ -166,7 +168,7 @@ public class EthSimulateV1Test {
 
     final ArgumentCaptor<BlockSimulationParameter> captor =
         ArgumentCaptor.forClass(BlockSimulationParameter.class);
-    verify(blockSimulator).process(any(BlockHeader.class), captor.capture());
+    verify(blockSimulator).process(any(BlockHeader.class), captor.capture(), any(OperationTracer.class));
     final Bytes payload =
         captor.getValue().getBlockStateCalls().get(0).getCalls().get(0).getPayload().orElseThrow();
     assertThat(payload).isEqualTo(Bytes.fromHexString("0xDEADBEEF"));
@@ -202,7 +204,7 @@ public class EthSimulateV1Test {
   }
 
   private SimulateV1Parameter simulateParameter(final boolean validation) {
-    return new SimulateV1Parameter(List.of(), validation, false, false, false);
+    return new SimulateV1Parameter(List.of(), validation, false, false, false, false);
   }
 
   private JsonRpcRequestContext ethSimulateV1Request(

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthSimulateV1TrielogTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthSimulateV1TrielogTest.java
@@ -90,6 +90,7 @@ public class EthSimulateV1TrielogTest {
 
     method =
         new EthSimulateV1(
+            null,
             blockchainQueries,
             protocolSchedule,
             new TransactionSimulator(
@@ -115,7 +116,7 @@ public class EthSimulateV1TrielogTest {
 
     // Create simulation parameter with returnTrieLog = true
     SimulateV1Parameter simulateV1Parameter =
-        new SimulateV1Parameter(List.of(blockStateCall), false, false, false, true);
+        new SimulateV1Parameter(List.of(blockStateCall), false, false, false, true, false);
 
     JsonRpcRequestContext request =
         new JsonRpcRequestContext(
@@ -166,7 +167,7 @@ public class EthSimulateV1TrielogTest {
 
     // Create simulation parameter with returnTrieLog = false
     SimulateV1Parameter simulateV1Parameter =
-        new SimulateV1Parameter(List.of(blockStateCall), false, false, false, false);
+        new SimulateV1Parameter(List.of(blockStateCall), false, false, false, false, false);
 
     JsonRpcRequestContext request =
         new JsonRpcRequestContext(
@@ -199,7 +200,7 @@ public class EthSimulateV1TrielogTest {
         new JsonBlockStateCallParameter(List.of(callParameter1, callParameter2), null, null);
 
     SimulateV1Parameter simulateV1Parameter =
-        new SimulateV1Parameter(List.of(blockStateCall), false, false, false, true);
+        new SimulateV1Parameter(List.of(blockStateCall), false, false, false, true, false);
 
     JsonRpcRequestContext request =
         new JsonRpcRequestContext(

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/SimulateV1ParameterTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/SimulateV1ParameterTest.java
@@ -38,7 +38,7 @@ public class SimulateV1ParameterTest {
       final List<JsonBlockStateCallParameter> blockStateCalls,
       final BlockStateCallError expectedError) {
     SimulateV1Parameter simulateV1Parameter =
-        new SimulateV1Parameter(blockStateCalls, false, false, false, false);
+        new SimulateV1Parameter(blockStateCalls, false, false, false, false, false);
     Optional<BlockStateCallError> maybeValidationError =
         simulateV1Parameter.validate(VALID_PRECOMPILE_ADDRESSES);
     assertThat(maybeValidationError).isPresent();

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/BlockSimulator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/BlockSimulator.java
@@ -67,6 +67,7 @@ import org.hyperledger.besu.evm.tracing.EthTransferLogOperationTracer;
 import org.hyperledger.besu.evm.tracing.OperationTracer;
 import org.hyperledger.besu.evm.worldstate.WorldUpdater;
 import org.hyperledger.besu.plugin.data.BlockOverrides;
+import org.hyperledger.besu.plugin.services.tracer.BlockAwareOperationTracer;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -79,6 +80,8 @@ import java.util.function.Supplier;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Simulates the execution of a block, processing transactions and applying state overrides. This
@@ -90,6 +93,8 @@ import org.apache.tuweni.bytes.Bytes32;
  * header, transaction receipts, and other relevant information.
  */
 public class BlockSimulator {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BlockSimulator.class);
 
   private static final TransactionValidationParams STRICT_VALIDATION_PARAMS =
       TransactionValidationParams.blockSimulatorStrict();
@@ -280,8 +285,15 @@ public class BlockSimulator {
             ws,
             protocolSpec,
             blockHashLookup,
-            OperationTracer.NO_TRACING,
+            operationTracer,
             Optional.empty());
+
+    // if operationTracer is block-aware, trace start block
+    if (operationTracer instanceof BlockAwareOperationTracer blockTracer) {
+      LOG.trace("traceStartBlock sim for {}", overridenBaseBlockHeader.getNumber());
+      blockTracer.traceStartBlock(
+          ws, overridenBaseBlockHeader, overridenBaseBlockHeader.getCoinbase());
+    }
 
     protocolSpec
         .getPreExecutionProcessor()
@@ -340,14 +352,22 @@ public class BlockSimulator {
       rewardUpdater.commit();
     }
 
-    return createFinalBlock(
-        overridenBaseBlockHeader,
-        blockStateCallSimulationResult,
-        blockOverrides,
-        protocolSpec,
-        ws,
-        maybeRequests,
-        returnTrieLog);
+    var finalBlock =
+        createFinalBlock(
+            overridenBaseBlockHeader,
+            blockStateCallSimulationResult,
+            blockOverrides,
+            protocolSpec,
+            ws,
+            maybeRequests,
+            returnTrieLog);
+
+    if (operationTracer instanceof BlockAwareOperationTracer blockTracer) {
+      LOG.trace("traceEndBlock sim for {}", finalBlock.getBlockHeader().getNumber());
+      blockTracer.traceEndBlock(finalBlock.getBlockHeader(), finalBlock.getBlockBody());
+    }
+
+    return finalBlock;
   }
 
   protected BlockStateCallSimulationResult processTransactions(

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/BlockSimulator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/BlockSimulator.java
@@ -51,7 +51,6 @@ import org.hyperledger.besu.ethereum.mainnet.block.access.list.AccessLocationTra
 import org.hyperledger.besu.ethereum.mainnet.block.access.list.BlockAccessList.BlockAccessListBuilder;
 import org.hyperledger.besu.ethereum.mainnet.block.access.list.BlockAccessListFactory;
 import org.hyperledger.besu.ethereum.mainnet.feemarket.BaseFeeMarket;
-import org.hyperledger.besu.ethereum.mainnet.feemarket.ExcessBlobGasCalculator;
 import org.hyperledger.besu.ethereum.mainnet.feemarket.FeeMarket;
 import org.hyperledger.besu.ethereum.mainnet.requests.RequestProcessingContext;
 import org.hyperledger.besu.ethereum.mainnet.requests.RequestProcessorCoordinator;
@@ -289,15 +288,17 @@ public class BlockSimulator {
             Optional.empty());
 
     // if operationTracer is block-aware, traceStart and hold onto the option ref for traceEnd
-    var maybeBlockAwareOperationTracer = Optional.of(operationTracer)
-        .filter(z -> z instanceof BlockAwareOperationTracer)
-        .map(BlockAwareOperationTracer.class::cast);
+    var maybeBlockAwareOperationTracer =
+        Optional.of(operationTracer)
+            .filter(z -> z instanceof BlockAwareOperationTracer)
+            .map(BlockAwareOperationTracer.class::cast);
 
-    maybeBlockAwareOperationTracer.ifPresent(tracer -> {
-      LOG.trace("traceStartBlock sim for {}", overridenBaseBlockHeader.toLogString());
-      tracer.traceStartBlock(
-          ws, overridenBaseBlockHeader, overridenBaseBlockHeader.getCoinbase());
-    });
+    maybeBlockAwareOperationTracer.ifPresent(
+        tracer -> {
+          LOG.trace("traceStartBlock sim for {}", overridenBaseBlockHeader.toLogString());
+          tracer.traceStartBlock(
+              ws, overridenBaseBlockHeader, overridenBaseBlockHeader.getCoinbase());
+        });
 
     protocolSpec
         .getPreExecutionProcessor()
@@ -579,10 +580,11 @@ public class BlockSimulator {
     Block block = new Block(finalBlockHeader, new BlockBody(transactions, List.of(), withdrawals));
 
     // if we have a block-aware operation tracer, trace end block here
-    maybeBlockAwareOperationTracer.ifPresent(tracer -> {
-      LOG.trace("traceEndBlock sim for {}", blockHeader.toLogString());
-      tracer.traceEndBlock(blockHeader, block.getBody());
-    });
+    maybeBlockAwareOperationTracer.ifPresent(
+        tracer -> {
+          LOG.trace("traceEndBlock sim for {}", blockHeader.toLogString());
+          tracer.traceEndBlock(blockHeader, block.getBody());
+        });
 
     if (returnTrieLog && ws instanceof PathBasedWorldState) {
       // if requested and path-based worldstate, return result with trielog and serializer:
@@ -684,8 +686,7 @@ public class BlockSimulator {
 
     // Cancun+: excessBlobGas
     if (newProtocolSpec.getFeeMarket().implementsBlobFee()) {
-      builder.excessBlobGas(
-          calculateExcessBlobGasForParent(newProtocolSpec, header));
+      builder.excessBlobGas(calculateExcessBlobGasForParent(newProtocolSpec, header));
     } else {
       builder.excessBlobGas(null);
       builder.blobGasUsed(null);

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/BlockSimulator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/BlockSimulator.java
@@ -288,12 +288,16 @@ public class BlockSimulator {
             operationTracer,
             Optional.empty());
 
-    // if operationTracer is block-aware, trace start block
-    if (operationTracer instanceof BlockAwareOperationTracer blockTracer) {
-      LOG.trace("traceStartBlock sim for {}", overridenBaseBlockHeader.getNumber());
-      blockTracer.traceStartBlock(
+    // if operationTracer is block-aware, traceStart and hold onto the option ref for traceEnd
+    var maybeBlockAwareOperationTracer = Optional.of(operationTracer)
+        .filter(z -> z instanceof BlockAwareOperationTracer)
+        .map(BlockAwareOperationTracer.class::cast);
+
+    maybeBlockAwareOperationTracer.ifPresent(tracer -> {
+      LOG.trace("traceStartBlock sim for {}", overridenBaseBlockHeader.toLogString());
+      tracer.traceStartBlock(
           ws, overridenBaseBlockHeader, overridenBaseBlockHeader.getCoinbase());
-    }
+    });
 
     protocolSpec
         .getPreExecutionProcessor()
@@ -360,12 +364,8 @@ public class BlockSimulator {
             protocolSpec,
             ws,
             maybeRequests,
+            maybeBlockAwareOperationTracer,
             returnTrieLog);
-
-    if (operationTracer instanceof BlockAwareOperationTracer blockTracer) {
-      LOG.trace("traceEndBlock sim for {}", finalBlock.getBlockHeader().getNumber());
-      blockTracer.traceEndBlock(finalBlock.getBlockHeader(), finalBlock.getBlockBody());
-    }
 
     return finalBlock;
   }
@@ -536,6 +536,7 @@ public class BlockSimulator {
       final ProtocolSpec protocolSpec,
       final MutableWorldState ws,
       final Optional<List<Request>> maybeRequests,
+      final Optional<BlockAwareOperationTracer> maybeBlockAwareOperationTracer,
       final boolean returnTrieLog) {
 
     List<Transaction> transactions = simResult.getTransactions();
@@ -576,6 +577,12 @@ public class BlockSimulator {
         isShanghaiPlus ? Optional.of(List.of()) : Optional.empty();
 
     Block block = new Block(finalBlockHeader, new BlockBody(transactions, List.of(), withdrawals));
+
+    // if we have a block-aware operation tracer, trace end block here
+    maybeBlockAwareOperationTracer.ifPresent(tracer -> {
+      LOG.trace("traceEndBlock sim for {}", blockHeader.toLogString());
+      tracer.traceEndBlock(blockHeader, block.getBody());
+    });
 
     if (returnTrieLog && ws instanceof PathBasedWorldState) {
       // if requested and path-based worldstate, return result with trielog and serializer:
@@ -678,7 +685,7 @@ public class BlockSimulator {
     // Cancun+: excessBlobGas
     if (newProtocolSpec.getFeeMarket().implementsBlobFee()) {
       builder.excessBlobGas(
-          ExcessBlobGasCalculator.calculateExcessBlobGasForParent(newProtocolSpec, header));
+          calculateExcessBlobGasForParent(newProtocolSpec, header));
     } else {
       builder.excessBlobGas(null);
       builder.blobGasUsed(null);


### PR DESCRIPTION
## PR description

This feature enables block tracing during eth_simulateV1 via an optional boolean parameter.  This feature accomodates merkle proving of forced-transaction-inclusion in linea via shomei

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->





### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


