### PR TITLE
Missing memory presence check

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/vm/DebugOperationTracer.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/vm/DebugOperationTracer.java
@@ -248,6 +248,7 @@ public class DebugOperationTracer extends AbstractDebugOperationTracer {
     } else if (frame.getMaybeUpdatedMemory().isEmpty()
         && lastFrame != null
         && lastFrame.getDepth() == frame.getDepth()
+        && lastFrame.getMemory().isPresent()
         && lastFrame.getMemory().get().length == frame.memoryWordSize()) {
       return lastFrame.getMemory();
     }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/vm/DebugOperationTracer.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/vm/DebugOperationTracer.java
@@ -245,12 +245,13 @@ public class DebugOperationTracer extends AbstractDebugOperationTracer {
   private Optional<Bytes[]> captureMemory(final MessageFrame frame) {
     if (!options.traceMemory() || frame.memoryWordSize() == 0) {
       return Optional.empty();
-    } else if (frame.getMaybeUpdatedMemory().isEmpty()
-        && lastFrame != null
-        && lastFrame.getDepth() == frame.getDepth()
-        && lastFrame.getMemory().isPresent()
-        && lastFrame.getMemory().get().length == frame.memoryWordSize()) {
-      return lastFrame.getMemory();
+    } else if (frame.getMaybeUpdatedMemory().isEmpty() && lastFrame != null) {
+      final Optional<Bytes[]> lastMemory = lastFrame.getMemory();
+      if (lastFrame.getDepth() == frame.getDepth()
+          && lastMemory.isPresent()
+          && lastMemory.get().length == frame.memoryWordSize()) {
+        return lastMemory;
+      }
     }
     return forceCaptureMem(frame);
   }


### PR DESCRIPTION
## PR description

Call lastFrame.getMemory().isPresent() before calling  lastFrame.getMemory().get()

### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


