### PR TITLE
fix(discv5): downgrade overly verbose DiscV5 log statements from debug to trace

### DIFF
--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/discv5/PeerDiscoveryAgentFactoryV5.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/discv5/PeerDiscoveryAgentFactoryV5.java
@@ -248,7 +248,7 @@ public final class PeerDiscoveryAgentFactoryV5 implements PeerDiscoveryAgentFact
           return peerPermissions.isPermitted(
               localNode.get(), remotePeer, PeerPermissions.Action.DISCOVERY_ALLOW_IN_PEER_TABLE);
         } catch (final RuntimeException e) {
-          LOG.debug("DiscV5: Rejecting peer with malformed NodeRecord", e);
+          LOG.trace("DiscV5: Rejecting peer with malformed NodeRecord", e);
           return false;
         }
       }

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/discv5/PeerDiscoveryAgentV5.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/discv5/PeerDiscoveryAgentV5.java
@@ -161,7 +161,7 @@ public final class PeerDiscoveryAgentV5 implements PeerDiscoveryAgent {
   @Override
   public CompletableFuture<Integer> start(final int tcpPort) {
     if (!isEnabled()) {
-      LOG.debug("DiscV5 peer discovery is disabled; not starting agent");
+      LOG.trace("DiscV5 peer discovery is disabled; not starting agent");
       return CompletableFuture.completedFuture(0);
     }
     if (stopped.get()) {
@@ -201,7 +201,7 @@ public final class PeerDiscoveryAgentV5 implements PeerDiscoveryAgent {
               } catch (final RejectedExecutionException e) {
                 // Benign: stop() shut down the scheduler between the stopped check and the
                 // schedule call. The agent is stopping so there is nothing to schedule.
-                LOG.debug("Scheduler already shut down; skipping discovery tick scheduling", e);
+                LOG.trace("Scheduler already shut down; skipping discovery tick scheduling", e);
               }
               if (stopped.get()) {
                 throw new IllegalStateException(
@@ -232,7 +232,7 @@ public final class PeerDiscoveryAgentV5 implements PeerDiscoveryAgent {
                 try {
                   system.stop();
                 } catch (final Exception e) {
-                  LOG.debug("Error while stopping discovery system after failed start", e);
+                  LOG.trace("Error while stopping discovery system after failed start", e);
                 }
                 discoverySystem.set(null);
               }


### PR DESCRIPTION
## Summary

Fixes #9691

Downgrades four `LOG.debug(...)` calls in the DiscV5 peer discovery code to `LOG.trace(...)`. These fire on every normal operational event making `DEBUG` output noisy in real deployments and obscuring genuine debug signals.

**Files changed:**

- `PeerDiscoveryAgentV5.java` — 3 statements: disabled-agent, scheduler-shutdown race, stop-on-failed-start
- `PeerDiscoveryAgentFactoryV5.java` — 1 statement: malformed NodeRecord rejection

## Test plan

- [ ] Existing unit/integration tests pass unchanged (no functional change)
- [ ] `./gradlew :ethereum:p2p:test` passes