### PR TITLE
Exclude IntelliJ generated dir from spotless solidity

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -269,7 +269,7 @@ configure(allprojects - project(':platform')) {
     }
     format 'Solidity', {
       target '**/*.sol'
-      targetExclude '**/src/reference-test/**', '**/src/main/generated/**', '**/src/test/generated/**', '**/src/jmh/generated/**'
+      targetExclude '**/src/reference-test/**', '**/src/main/generated/**', '**/src/test/generated/**', '**/src/jmh/generated/**', '**/bin/default/**'
       trimTrailingWhitespace()
       endWithNewline()
 


### PR DESCRIPTION
Similar to https://github.com/besu-eth/besu/pull/10210 but for solidity instead of shell checks