### PR TITLE
feat(plugin-api): expose Besu node version and commit hash via BesuConfiguration

### DIFF
--- a/app/src/main/java/org/hyperledger/besu/services/BesuConfigurationImpl.java
+++ b/app/src/main/java/org/hyperledger/besu/services/BesuConfigurationImpl.java
@@ -21,6 +21,7 @@ import org.hyperledger.besu.ethereum.core.MiningConfiguration;
 import org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration;
 import org.hyperledger.besu.plugin.services.BesuConfiguration;
 import org.hyperledger.besu.plugin.services.storage.DataStorageFormat;
+import org.hyperledger.besu.util.BesuVersionUtils;
 
 import java.nio.file.Path;
 import java.util.Optional;
@@ -133,6 +134,16 @@ public class BesuConfigurationImpl implements BesuConfiguration {
   public org.hyperledger.besu.plugin.services.storage.DataStorageConfiguration
       getDataStorageConfiguration() {
     return new DataStoreConfigurationImpl(dataStorageConfiguration);
+  }
+
+  @Override
+  public String getBesuVersion() {
+    return BesuVersionUtils.shortVersion();
+  }
+
+  @Override
+  public String getBesuCommitHash() {
+    return BesuVersionUtils.commit();
   }
 
   /**

--- a/app/src/test/java/org/hyperledger/besu/services/BesuConfigurationImplTest.java
+++ b/app/src/test/java/org/hyperledger/besu/services/BesuConfigurationImplTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class BesuConfigurationImplTest {
+
+  @Test
+  void getBesuVersion_returnsNonEmptyString() {
+    BesuConfigurationImpl config = new BesuConfigurationImpl();
+    String version = config.getBesuVersion();
+    assertThat(version).isNotNull();
+    assertThat(version).isNotEmpty();
+  }
+
+  @Test
+  void getBesuCommitHash_returnsNonEmptyString() {
+    BesuConfigurationImpl config = new BesuConfigurationImpl();
+    String commit = config.getBesuCommitHash();
+    assertThat(commit).isNotNull();
+    assertThat(commit).isNotEmpty();
+  }
+}

--- a/app/src/test/java/org/hyperledger/besu/services/BesuConfigurationImplTest.java
+++ b/app/src/test/java/org/hyperledger/besu/services/BesuConfigurationImplTest.java
@@ -16,23 +16,21 @@ package org.hyperledger.besu.services;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.hyperledger.besu.util.BesuVersionUtils;
+
 import org.junit.jupiter.api.Test;
 
 class BesuConfigurationImplTest {
 
   @Test
-  void getBesuVersion_returnsNonEmptyString() {
+  void getBesuVersion_delegatesToBesuVersionUtils() {
     BesuConfigurationImpl config = new BesuConfigurationImpl();
-    String version = config.getBesuVersion();
-    assertThat(version).isNotNull();
-    assertThat(version).isNotEmpty();
+    assertThat(config.getBesuVersion()).isEqualTo(BesuVersionUtils.shortVersion());
   }
 
   @Test
-  void getBesuCommitHash_returnsNonEmptyString() {
+  void getBesuCommitHash_delegatesToBesuVersionUtils() {
     BesuConfigurationImpl config = new BesuConfigurationImpl();
-    String commit = config.getBesuCommitHash();
-    assertThat(commit).isNotNull();
-    assertThat(commit).isNotEmpty();
+    assertThat(config.getBesuCommitHash()).isEqualTo(BesuVersionUtils.commit());
   }
 }

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -71,7 +71,7 @@ Calculated : ${currentHash}
 tasks.register('checkAPIChanges', FileStateChecker) {
   description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
   files = sourceSets.main.allJava.files
-  knownHash = '/z6HqXUJiqnSTy6/KHXGXYbf9/Ww4Q3fpN3H2KF3FFw='
+  knownHash = '4vItngNeppIRII2rFbvadnol4Whng6fPz4+Iytl2+sg='
 }
 check.dependsOn('checkAPIChanges')
 

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -71,7 +71,7 @@ Calculated : ${currentHash}
 tasks.register('checkAPIChanges', FileStateChecker) {
   description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
   files = sourceSets.main.allJava.files
-  knownHash = 'fDkUshUOXLQDBHsugUujwwJkJtYVYnqipuScb8CIof0='
+  knownHash = '/z6HqXUJiqnSTy6/KHXGXYbf9/Ww4Q3fpN3H2KF3FFw='
 }
 check.dependsOn('checkAPIChanges')
 

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/BesuConfiguration.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/BesuConfiguration.java
@@ -104,20 +104,22 @@ public interface BesuConfiguration extends BesuService {
   /**
    * Returns the version of the running Besu node.
    *
-   * <p>The format follows semantic versioning: {@code "MAJOR.MINOR.PATCH"} for release builds
-   * (e.g., {@code "25.3.0"}) or {@code "MAJOR.MINOR.PATCH-qualifier"} for development builds
-   * (e.g., {@code "25.3.1-dev-ac23d311"}).
+   * <p>This is a human-readable version string. For release builds, it is typically a semantic
+   * version such as {@code "25.3.0"}. Development builds may include a qualifier, e.g. {@code
+   * "25.3.1-dev-ac23d311"}.
    *
    * <p>Available during all plugin lifecycle phases ({@code register} through {@code stop}).
    *
-   * @return the Besu node version string, never null
+   * @return the Besu node version string
    */
   String getBesuVersion();
 
   /**
    * Returns the git commit hash of the running Besu build.
    *
-   * @return the short git commit hash, never null
+   * <p>Available during all plugin lifecycle phases ({@code register} through {@code stop}).
+   *
+   * @return the git commit hash
    */
   String getBesuCommitHash();
 }

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/BesuConfiguration.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/BesuConfiguration.java
@@ -100,4 +100,24 @@ public interface BesuConfiguration extends BesuService {
    */
   @Unstable
   DataStorageConfiguration getDataStorageConfiguration();
+
+  /**
+   * Returns the version of the running Besu node.
+   *
+   * <p>The format follows semantic versioning: {@code "MAJOR.MINOR.PATCH"} for release builds
+   * (e.g., {@code "25.3.0"}) or {@code "MAJOR.MINOR.PATCH-qualifier"} for development builds
+   * (e.g., {@code "25.3.1-dev-ac23d311"}).
+   *
+   * <p>Available during all plugin lifecycle phases ({@code register} through {@code stop}).
+   *
+   * @return the Besu node version string, never null
+   */
+  String getBesuVersion();
+
+  /**
+   * Returns the git commit hash of the running Besu build.
+   *
+   * @return the short git commit hash, never null
+   */
+  String getBesuCommitHash();
 }


### PR DESCRIPTION
## Summary
- Add `getBesuVersion()` and `getBesuCommitHash()` to `BesuConfiguration`
- Implementation in `BesuConfigurationImpl` delegates to `BesuVersionUtils`
- Enables plugins to query the Besu node version at runtime

## Motivation
While `PluginVerifier` provides build-time version compatibility checking via the artifact catalog, plugins have no way to access the node version at runtime through the plugin API. This limits plugins from performing their own compatibility checks, including version info in diagnostics, or adapting behavior to node capabilities.

The only indirect workaround is calling `RpcEndpointService.call("web3_clientVersion", ...)`, but this has significant limitations:
- **Lifecycle restriction**: `call()` throws if invoked before `beforeExternalServices()` completes
- **Namespace dependency**: requires the `WEB3` RPC namespace to be enabled
- **Not first-class**: goes through the full JSON-RPC dispatch layer for a simple data lookup


Fixes #10226

## Changes
- Added `getBesuVersion()` to `BesuConfiguration` -- returns `BesuVersionUtils.shortVersion()`
- Added `getBesuCommitHash()` to `BesuConfiguration` -- returns `BesuVersionUtils.commit()`
- Updated `checkAPIChanges` known hash
- Added `BesuConfigurationImplTest` with tests for both methods

## Test plan
- [ ] `BesuConfigurationImplTest` verifies non-null, non-empty return values
- [ ] `checkAPIChanges` hash updated
- [ ] `./gradlew :plugin-api:build` passes
- [ ] `./gradlew :app:test` passes
