### PR TITLE
Add contributor call agenda issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/contributor-call.md
+++ b/.github/ISSUE_TEMPLATE/contributor-call.md
@@ -2,8 +2,8 @@
 name: Contributor Call Agenda
 about: agenda for the Besu contributor call
 title: 'YYYY-MM-DD Contributor Call'
-labels: 'agenda'
-assignees: 'jflo'
+labels: [agenda]
+assignees: [jflo]
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/contributor-call.md
+++ b/.github/ISSUE_TEMPLATE/contributor-call.md
@@ -1,0 +1,21 @@
+---
+name: Contributor Call Agenda
+about: agenda for the Besu contributor call
+title: 'YYYY-MM-DD Contributor Call'
+labels: 'agenda'
+assignees: 'jflo'
+
+---
+
+### Housekeeping
+
+- [Antitrust Policy](https://www.linuxfoundation.org/legal/antitrust-policy) notice
+- This meeting is being recorded, transcribed, and machine summarized
+- Please mute unless speaking
+- If you have a question use the raise hand feature
+
+### Agenda Items
+
+1. **[Topic 1]** — [Brief description]
+2. **[Topic 2]** — [Brief description]
+3. **[Topic 3]** — [Brief description]

--- a/.github/ISSUE_TEMPLATE/contributor-call.md
+++ b/.github/ISSUE_TEMPLATE/contributor-call.md
@@ -1,6 +1,6 @@
 ---
 name: Contributor Call Agenda
-about: agenda for the Besu contributor call
+about: Agenda for the Besu contributor call
 title: 'YYYY-MM-DD Contributor Call'
 labels: [agenda]
 assignees: [jflo]


### PR DESCRIPTION
## Summary
- Adds a new GitHub issue template for Besu contributor call agendas
- Includes standard housekeeping boilerplate (antitrust notice, recording disclosure, mute/raise-hand reminders)
- Pre-fills 3 agenda item placeholders for the creator to fill in
- Auto-assigns to jflo and applies the `agenda` label

## Test plan
- [ ] Verify the template appears in the issue creation chooser at https://github.com/besu-eth/besu/issues/new/choose
- [ ] Create a test issue using the template and confirm formatting looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)