### PR TITLE
Make engineNewPayloadV5 to follow the current standard for this type of methods

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayload.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayload.java
@@ -15,7 +15,6 @@
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine;
 
 import static java.util.stream.Collectors.toList;
-import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.AMSTERDAM;
 import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.ExecutionEngineJsonRpcMethod.EngineStatus.ACCEPTED;
 import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.ExecutionEngineJsonRpcMethod.EngineStatus.INVALID;
 import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.ExecutionEngineJsonRpcMethod.EngineStatus.INVALID_BLOCK_HASH;
@@ -52,6 +51,7 @@ import org.hyperledger.besu.ethereum.core.Difficulty;
 import org.hyperledger.besu.ethereum.core.Request;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.core.Withdrawal;
+import org.hyperledger.besu.ethereum.core.encoding.BlockAccessListDecoder;
 import org.hyperledger.besu.ethereum.core.encoding.EncodingContext;
 import org.hyperledger.besu.ethereum.core.encoding.TransactionDecoder;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeers;
@@ -62,6 +62,7 @@ import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
 import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
 import org.hyperledger.besu.ethereum.mainnet.block.access.list.BlockAccessList;
 import org.hyperledger.besu.ethereum.mainnet.feemarket.ExcessBlobGasCalculator;
+import org.hyperledger.besu.ethereum.rlp.BytesValueRLPInput;
 import org.hyperledger.besu.ethereum.rlp.RLPException;
 import org.hyperledger.besu.ethereum.trie.MerkleTrieException;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
@@ -91,8 +92,6 @@ public abstract class AbstractEngineNewPayload extends ExecutionEngineJsonRpcMet
   private final EthPeers ethPeers;
   private long lastExecutionTimeInNs = 0L;
 
-  protected final Optional<Long> amsterdamMilestone;
-
   public AbstractEngineNewPayload(
       final Vertx vertx,
       final ProtocolSchedule protocolSchedule,
@@ -109,8 +108,6 @@ public abstract class AbstractEngineNewPayload extends ExecutionEngineJsonRpcMet
         "execution_time_head",
         "The execution time of the last block (head)",
         this::getLastExecutionTime);
-
-    this.amsterdamMilestone = protocolSchedule.milestoneFor(AMSTERDAM);
   }
 
   @Override
@@ -229,13 +226,13 @@ public abstract class AbstractEngineNewPayload extends ExecutionEngineJsonRpcMet
     final Optional<BlockAccessList> maybeBlockAccessList;
     try {
       maybeBlockAccessList = extractBlockAccessList(blockParam);
-    } catch (final InvalidBlockAccessListException e) {
+    } catch (final Exception e) {
       return respondWithInvalid(
           reqId,
           blockParam,
           mergeCoordinator.getLatestValidAncestor(blockParam.getParentHash()).orElse(null),
           INVALID,
-          e.getMessage());
+          "Invalid block access list encoding");
     }
 
     if (mergeContext.get().isSyncing()) {
@@ -522,19 +519,17 @@ public abstract class AbstractEngineNewPayload extends ExecutionEngineJsonRpcMet
     return ValidationResult.valid();
   }
 
-  protected Optional<BlockAccessList> extractBlockAccessList(
-      final EnginePayloadParameter payloadParameter) throws InvalidBlockAccessListException {
-    return Optional.empty();
-  }
+  private Optional<BlockAccessList> extractBlockAccessList(
+      final EnginePayloadParameter payloadParameter) {
+    final String blockAccessList = payloadParameter.getBlockAccessList();
 
-  protected static class InvalidBlockAccessListException extends Exception {
-    InvalidBlockAccessListException(final String message) {
-      super(message);
+    if (blockAccessList == null) {
+      return Optional.empty();
     }
 
-    InvalidBlockAccessListException(final String message, final Throwable cause) {
-      super(message, cause);
-    }
+    return Optional.of(
+        BlockAccessListDecoder.decode(
+            new BytesValueRLPInput(Bytes.fromHexString(blockAccessList), false)));
   }
 
   protected ValidationResult<RpcErrorType> validateBlobs(

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV5.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV5.java
@@ -21,21 +21,18 @@ import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.EnginePayloadParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
-import org.hyperledger.besu.ethereum.core.encoding.BlockAccessListDecoder;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeers;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
-import org.hyperledger.besu.ethereum.mainnet.block.access.list.BlockAccessList;
-import org.hyperledger.besu.ethereum.rlp.BytesValueRLPInput;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 
 import java.util.List;
 import java.util.Optional;
 
 import io.vertx.core.Vertx;
-import org.apache.tuweni.bytes.Bytes;
 
 public class EngineNewPayloadV5 extends AbstractEngineNewPayload {
+  private final Optional<Long> amsterdamMilestone;
 
   public EngineNewPayloadV5(
       final Vertx vertx,
@@ -53,6 +50,7 @@ public class EngineNewPayloadV5 extends AbstractEngineNewPayload {
         ethPeers,
         engineCallListener,
         metricsSystem);
+    this.amsterdamMilestone = timestampSchedule.milestoneFor(AMSTERDAM);
   }
 
   @Override
@@ -85,28 +83,12 @@ public class EngineNewPayloadV5 extends AbstractEngineNewPayload {
     } else if (payloadParameter.getSlotNumber() == null) {
       return ValidationResult.invalid(
           RpcErrorType.INVALID_SLOT_NUMBER_PARAMS, "Missing slot number field");
+    } else if (payloadParameter.getBlockAccessList() == null
+        || payloadParameter.getBlockAccessList().isEmpty()) {
+      return ValidationResult.invalid(
+          RpcErrorType.INVALID_BLOCK_ACCESS_LIST_PARAMS, "Missing block access list field");
     }
     return ValidationResult.valid();
-  }
-
-  @Override
-  protected Optional<BlockAccessList> extractBlockAccessList(
-      final EnginePayloadParameter payloadParameter) throws InvalidBlockAccessListException {
-    final String blockAccessList = payloadParameter.getBlockAccessList();
-    if (blockAccessList == null || blockAccessList.isEmpty()) {
-      throw new InvalidBlockAccessListException("Missing block access list field");
-    }
-    final Bytes encoded;
-    try {
-      encoded = Bytes.fromHexString(blockAccessList);
-    } catch (final IllegalArgumentException e) {
-      throw new InvalidBlockAccessListException("Invalid block access list encoding", e);
-    }
-    try {
-      return Optional.of(BlockAccessListDecoder.decode(new BytesValueRLPInput(encoded, false)));
-    } catch (final RuntimeException e) {
-      throw new InvalidBlockAccessListException("Invalid block access list encoding", e);
-    }
   }
 
   @Override

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/RpcErrorType.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/RpcErrorType.java
@@ -63,6 +63,8 @@ public enum RpcErrorType implements RpcMethodError {
   INVALID_EXECUTION_REQUESTS_PARAMS(INVALID_PARAMS_ERROR_CODE, "Invalid execution requests params"),
   INVALID_SLOT_NUMBER_PARAMS(
       INVALID_PARAMS_ERROR_CODE, "Invalid slot number params (missing or invalid)"),
+  INVALID_BLOCK_ACCESS_LIST_PARAMS(
+      INVALID_PARAMS_ERROR_CODE, "Invalid block access list params (missing or invalid)"),
   INVALID_EXTRA_DATA_PARAMS(INVALID_PARAMS_ERROR_CODE, "Invalid extra data params"),
   INVALID_FILTER_PARAMS(INVALID_PARAMS_ERROR_CODE, "Invalid filter params"),
   INVALID_HASH_RATE_PARAMS(INVALID_PARAMS_ERROR_CODE, "Invalid hash rate params"),

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV5Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV5Test.java
@@ -18,6 +18,8 @@ import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.AMSTERDAM;
 import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.ExecutionEngineJsonRpcMethod.EngineStatus.INVALID;
+import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineTestSupport.fromErrorResp;
+import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType.INVALID_BLOCK_ACCESS_LIST_PARAMS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -33,6 +35,7 @@ import org.hyperledger.besu.ethereum.BlockProcessingOutputs;
 import org.hyperledger.besu.ethereum.BlockProcessingResult;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.EnginePayloadParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.WithdrawalParameter;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.EnginePayloadStatusResult;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
@@ -123,10 +126,10 @@ public class EngineNewPayloadV5Test extends EngineNewPayloadV4Test {
 
     final JsonRpcResponse resp = resp(super.mockEnginePayload(header, emptyList(), null, null));
 
-    final EnginePayloadStatusResult result = fromSuccessResp(resp);
-    assertThat(result.getStatusAsString()).isEqualTo(INVALID.name());
-    assertThat(result.getError()).isEqualTo("Missing block access list field");
-    assertThat(result.getLatestValidHash()).isEmpty();
+    final JsonRpcError jsonRpcError = fromErrorResp(resp);
+    assertThat(jsonRpcError.getCode()).isEqualTo(INVALID_BLOCK_ACCESS_LIST_PARAMS.getCode());
+    assertThat(jsonRpcError.getMessage()).isEqualTo(INVALID_BLOCK_ACCESS_LIST_PARAMS.getMessage());
+    assertThat(jsonRpcError.getData()).isEqualTo("Missing block access list field");
     verify(engineCallListener, times(1)).executionEngineCalled();
   }
 


### PR DESCRIPTION
## PR description

While working on FOCIL, that require a new version (V6) of the `engine_newPayload` method, I found that for the current way the versioning is implemented, i.e. each new version extends `AbstractEngineNewPayload` and not the previous version, will result in V6 not including BAL support, so I refactored V5 to adapt BAL the current _de facto standard_ (not that I like it, because it is a bit confusing, so it could benefit from a refactor, but this is a larger task)

@mirgee @matkt could you please review?

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


