### PR TITLE
fix: add registerCliOptions() lifecycle hook for early CLI option bin…

### DIFF
--- a/acceptance-tests/detached-test-plugins/src/main/java/org/hyperledger/besu/tests/acceptance/plugins/TestPicoCLIPlugin.java
+++ b/acceptance-tests/detached-test-plugins/src/main/java/org/hyperledger/besu/tests/acceptance/plugins/TestPicoCLIPlugin.java
@@ -57,6 +57,11 @@ public class TestPicoCLIPlugin implements BesuPlugin {
   private File callbackDir;
 
   @Override
+  public void registerCliOptions(final PicoCLIOptions options) {
+    options.addPicoCLIOptions("test", this);
+  }
+
+  @Override
   public void register(final ServiceManager context) {
     LOG.info("Registering.  Test Option is '{}'", testOption);
     state = "registering";
@@ -65,10 +70,6 @@ public class TestPicoCLIPlugin implements BesuPlugin {
       state = "failregister";
       throw new RuntimeException("I was told to fail at registration");
     }
-
-    context
-        .getService(PicoCLIOptions.class)
-        .ifPresent(picoCLIOptions -> picoCLIOptions.addPicoCLIOptions("test", this));
 
     callbackDir = new File(System.getProperty("besu.plugins.dir", "plugins"));
     writeSignal("registered");

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ThreadBesuNodeRunner.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ThreadBesuNodeRunner.java
@@ -608,8 +608,15 @@ public class ThreadBesuNodeRunner implements BesuNodeRunner {
               .pluginsDir(pluginsPath)
               .requestedPluginsInfo(requestedPlugins.stream().map(PluginInfo::new).toList())
               .build());
+      // register plugin CLI options before registering plugins
+      besuPluginContext.registerPluginCliOptions();
+      final String[] args = extraCLIOptions.toArray(new String[0]);
+      // parse so plugin CLI options are available during registration
+      commandLine.parseArgs(args);
       besuPluginContext.registerPlugins();
-      commandLine.parseArgs(extraCLIOptions.toArray(new String[0]));
+      // backward compat: re-parse for plugins that still register options in register().
+      // remove this second parseArgs() call once all plugins migrate to registerCliOptions().
+      commandLine.parseArgs(args);
 
       // register built-in plugins
       new RocksDBPlugin().register(besuPluginContext);

--- a/acceptance-tests/tests/src/acceptanceTest/java/org/hyperledger/besu/tests/acceptance/plugins/PicoCLIOptionsPluginTest.java
+++ b/acceptance-tests/tests/src/acceptanceTest/java/org/hyperledger/besu/tests/acceptance/plugins/PicoCLIOptionsPluginTest.java
@@ -50,9 +50,9 @@ public class PicoCLIOptionsPluginTest extends AcceptanceTestBase {
         node.homeDirectory().resolve("plugins/pluginLifecycle.registered");
     waitForFile(registrationFile);
 
-    // this assert is false as CLI will not be parsed at this point
+    // this assert is true as CLI will be parsed at this point
     assertThat(Files.readAllLines(registrationFile).stream().anyMatch(s -> s.contains(MAGIC_WORDS)))
-        .isFalse();
+        .isTrue();
   }
 
   @Test

--- a/app/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/app/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -861,9 +861,15 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
         suppressInfoLog();
       }
       besuPluginContext.initialize(PluginsConfigurationOptions.fromCommandLine(commandLine));
+      // register plugin CLI options before registering plugins
+      besuPluginContext.registerPluginCliOptions();
+      final String[] args = parseResult.originalArgs().toArray(new String[0]);
+      // re-parse so plugin CLI options are available during registration
+      commandLine.parseArgs(args);
       besuPluginContext.registerPlugins();
       commandLine.setExecutionStrategy(nextStep);
-      return commandLine.execute(parseResult.originalArgs().toArray(new String[0]));
+      // execute() re-parses args, which also covers options registered during register()
+      return commandLine.execute(args);
     };
   }
 

--- a/app/src/main/java/org/hyperledger/besu/services/BesuPluginContextImpl.java
+++ b/app/src/main/java/org/hyperledger/besu/services/BesuPluginContextImpl.java
@@ -21,6 +21,7 @@ import org.hyperledger.besu.ethereum.core.plugins.PluginConfiguration;
 import org.hyperledger.besu.plugin.BesuPlugin;
 import org.hyperledger.besu.plugin.ServiceManager;
 import org.hyperledger.besu.plugin.services.BesuService;
+import org.hyperledger.besu.plugin.services.PicoCLIOptions;
 import org.hyperledger.besu.plugin.services.PluginVersionsProvider;
 
 import java.io.IOException;
@@ -80,6 +81,7 @@ public class BesuPluginContextImpl implements ServiceManager, PluginVersionsProv
   private final Map<Class<?>, ? super BesuService> serviceRegistry = new ConcurrentHashMap<>();
 
   private List<BesuPlugin> detectedPlugins = new ArrayList<>();
+  private boolean pluginsDetected;
   private List<String> requestedPlugins = new ArrayList<>();
 
   private final List<BesuPlugin> registeredPlugins = new ArrayList<>();
@@ -124,7 +126,40 @@ public class BesuPluginContextImpl implements ServiceManager, PluginVersionsProv
         state == Lifecycle.UNINITIALIZED,
         "Besu plugins have already been initialized. Cannot register additional plugins.");
     this.config = config;
+    pluginsDetected = false;
     state = Lifecycle.INITIALIZED;
+  }
+
+  /**
+    * Registers command line options for detected plugins by calling
+    * {@link BesuPlugin#registerCliOptions(PicoCLIOptions)} on each plugin.
+    *
+    * @throws IllegalStateException if the system is not in the INITIALIZED state.
+   */
+  public void registerPluginCliOptions() {
+    checkState(
+        state == Lifecycle.INITIALIZED,
+        "Besu plugins must be in INITIALIZED state to register CLI options.");
+
+    if (config.isExternalPluginsEnabled()) {
+      detectedPlugins = detectPlugins(config);
+      pluginsDetected = true;
+
+      getService(PicoCLIOptions.class)
+          .ifPresent(
+              cliOptions -> {
+                for (final BesuPlugin plugin : detectedPlugins) {
+                  try {
+                    plugin.registerCliOptions(cliOptions);
+                  } catch (final Exception e) {
+                    LOG.error(
+                        "Error registering CLI options for plugin of type {}.",
+                        plugin.getClass().getName(),
+                        e);
+                  }
+                }
+              });
+    }
   }
 
   /**
@@ -141,7 +176,10 @@ public class BesuPluginContextImpl implements ServiceManager, PluginVersionsProv
     state = Lifecycle.REGISTERING;
 
     if (config.isExternalPluginsEnabled()) {
-      detectedPlugins = detectPlugins(config);
+      if (!pluginsDetected) {
+        detectedPlugins = detectPlugins(config);
+        pluginsDetected = true;
+      }
 
       if (config.getRequestedPlugins().isEmpty()) {
         // If no plugins were specified, register all detected plugins

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/BesuPlugin.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/BesuPlugin.java
@@ -14,6 +14,8 @@
  */
 package org.hyperledger.besu.plugin;
 
+import org.hyperledger.besu.plugin.services.PicoCLIOptions;
+
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
@@ -49,6 +51,18 @@ public interface BesuPlugin {
    * @param context the context that provides access to Besu services.
    */
   void register(ServiceManager context);
+
+  /**
+   * Called before {@link #register(ServiceManager)}. Plugins should use this callback to register
+   * any command line options required via the PicoCLIOptions service.
+   *
+   * <p>Options registered in this callback are parsed before {@code register()} is called.
+   *
+   * <p>If not overridden this method does nothing for convenience.
+   *
+   * @param options the service used to register command line options.
+   */
+  default void registerCliOptions(final PicoCLIOptions options) {}
 
   /**
    * Called once when besu has loaded configuration but before external services have been started


### PR DESCRIPTION
## PR description

Adds a new `registerCliOptions(PicoCLIOptions)` lifecycle hook to `BesuPlugin`, called **before** `register()`. This allows plugins to declare CLI options early so they are parsed and available by the time `register()` runs.

### Problem

Plugins that register CLI options via `PicoCLIOptions.addPicoCLIOptions()` inside `register()` cannot read those option values during registration — the command line hasn't been parsed yet at that point. This forces plugins to defer any config-dependent logic to `beforeExternalServices()` or `start()`, even when it logically belongs in `register()`.

### Solution

New startup sequence:

```
initialize()
  → registerCliOptions()   ← NEW: plugins declare CLI options here
  → parseArgs()            ← options are now bound
  → register()             ← plugins can read option values
  → ...
```

**This change is fully backward compatible.** Plugins that still register options inside `register()` continue to work because:
- In `BesuCommand`: `commandLine.execute()` re-parses args after `register()`.
- In `ThreadBesuNodeRunner`: an explicit second `parseArgs()` call after `register()` handles the same case.

To drop backward compatibility in the future, remove the second `parseArgs()` in `ThreadBesuNodeRunner` (marked with a comment) and optionally add a guard in `PicoCLIOptionsImpl` to reject late option registration.

### Changes

| File | Change |
|------|--------|
| `BesuPlugin.java` | Added `default void registerCliOptions(PicoCLIOptions)` |
| `BesuPluginContextImpl.java` | Added `registerPluginCliOptions()` method; `registerPlugins()` skips re-detection if plugins were already detected |
| `BesuCommand.java` | Calls `registerPluginCliOptions()` + `parseArgs()` before `registerPlugins()` |
| `ThreadBesuNodeRunner.java` | Same reordering + second `parseArgs()` for backward compat |
| `TestPicoCLIPlugin.java` | Migrated to use `registerCliOptions()` instead of registering options in `register()` |
| `PicoCLIOptionsPluginTest.java` | Flipped `shouldRegister()` assertion from `isFalse()` to `isTrue()` (option value is now available during registration) |

## Fixed Issue(s)

fixes #2703

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)
