### PR TITLE
Add EIP-7976 to Amsterdam

### DIFF
--- a/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/AmsterdamGasCalculator.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/AmsterdamGasCalculator.java
@@ -14,6 +14,8 @@
  */
 package org.hyperledger.besu.evm.gascalculator;
 
+import static org.hyperledger.besu.evm.internal.Words.clampedAdd;
+
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Transaction;
 import org.hyperledger.besu.datatypes.Wei;
@@ -22,6 +24,7 @@ import org.hyperledger.besu.evm.frame.MessageFrame;
 
 import java.util.function.Supplier;
 
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
 
 /**
@@ -34,9 +37,13 @@ import org.apache.tuweni.units.bigints.UInt256;
  *
  * <UL>
  *   <LI>EIP-7928: gas cost per item for block access list size limit
+ *   <LI>EIP-7976: calldata floor cost raised to 64 gas per byte
  * </UL>
  */
 public class AmsterdamGasCalculator extends OsakaGasCalculator {
+
+  // EIP-7976: floor cost of 64 gas per calldata byte (zero and non-zero alike)
+  private static final long TOTAL_COST_FLOOR_PER_BYTE = 64L;
 
   // EIP-8037: New regular gas constants for Amsterdam
   private static final long TX_CREATE_COST = 9_000L;
@@ -94,6 +101,13 @@ public class AmsterdamGasCalculator extends OsakaGasCalculator {
   @Override
   public long getBlockAccessListItemCost() {
     return BLOCK_ACCESS_LIST_ITEM_COST;
+  }
+
+  @Override
+  public long transactionFloorCost(final Bytes transactionPayload, final long payloadZeroBytes) {
+    // EIP-7976: uniform 64 gas per calldata byte, so zero/non-zero split is irrelevant.
+    return clampedAdd(
+        getMinimumTransactionCost(), transactionPayload.size() * TOTAL_COST_FLOOR_PER_BYTE);
   }
 
   // --- EIP-8037 Gas Cost Overrides ---

--- a/evm/src/test/java/org/hyperledger/besu/evm/gascalculator/AmsterdamGasCalculatorTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/gascalculator/AmsterdamGasCalculatorTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.evm.gascalculator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.junit.jupiter.api.Test;
+
+class AmsterdamGasCalculatorTest {
+
+  private final AmsterdamGasCalculator amsterdamGasCalculator = new AmsterdamGasCalculator();
+
+  @Test
+  void transactionFloorCostShouldBeAtLeastTransactionBaseCost() {
+    // floor cost = 21000 (base cost) + 0
+    assertThat(amsterdamGasCalculator.transactionFloorCost(Bytes.EMPTY, 0)).isEqualTo(21000L);
+    // EIP-7976: floor cost = 21000 + 256 * 64 (uniform per-byte floor)
+    assertThat(amsterdamGasCalculator.transactionFloorCost(Bytes.repeat((byte) 0x0, 256), 256))
+        .isEqualTo(37384L);
+    // EIP-7976: non-zero bytes priced identically to zero bytes for the floor
+    assertThat(amsterdamGasCalculator.transactionFloorCost(Bytes.repeat((byte) 0x1, 256), 0))
+        .isEqualTo(37384L);
+    // 11-byte mixed payload: 21000 + 11 * 64 = 21704
+    assertThat(
+            amsterdamGasCalculator.transactionFloorCost(
+                Bytes.fromHexString("0x0001000100010001000101"), 5))
+        .isEqualTo(21704L);
+  }
+}


### PR DESCRIPTION
## PR description

Add https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7976.md to Amsterdam

Blocked until we move to bal-devnet-4

### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


