### PR TITLE
feat: implement eth_getStorageValues RPC method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@ are provided with different values, using input as per the execution-apis spec i
 - Upgrade besu-native libraries version to 1.5.0. This fixes the issue of besu-native/secp256r1 exporting OpenSSL symbols in JVM space. [besu-native #308](https://github.com/besu-eth/besu-native/pull/308)
 
 ### Additions and Improvements
+- Add `eth_getStorageValues` JSON-RPC method for batched reads of multiple storage slots across multiple accounts in a single call [#10259](https://github.com/besu-eth/besu/pull/10259)
 - Add `transactionReceipts` subscription type to `eth_subscribe` that pushes all transaction receipts when a new block is added, with optional `transactionHashes` filter to receive receipts for specific transactions only [#10190](https://github.com/besu-eth/besu/pull/10190)
 - Add `enableMemory` parameter to `debug_traceTransaction` and `debug_traceBlockByNumber`. Defaults to `false`; memory is only included in trace output when explicitly enabled. The existing `disableMemory` parameter continues to work for backwards compatibility [#10169](https://github.com/besu-eth/besu/pull/10169)
 - `--net-restrict` now supports IPv6 CIDR notation (e.g. `fd00::/64`) in addition to IPv4, enabling subnet-based peer filtering in IPv6 and dual-stack deployments [#10028](https://github.com/besu-eth/besu/pull/10028)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,7 +114,6 @@ are provided with different values, using input as per the execution-apis spec i
 - Upgrade besu-native libraries version to 1.5.0. This fixes the issue of besu-native/secp256r1 exporting OpenSSL symbols in JVM space. [besu-native #308](https://github.com/besu-eth/besu-native/pull/308)
 
 ### Additions and Improvements
-- Add `eth_getStorageValues` JSON-RPC method for batched reads of multiple storage slots across multiple accounts in a single call [#10259](https://github.com/besu-eth/besu/pull/10259)
 - Add `transactionReceipts` subscription type to `eth_subscribe` that pushes all transaction receipts when a new block is added, with optional `transactionHashes` filter to receive receipts for specific transactions only [#10190](https://github.com/besu-eth/besu/pull/10190)
 - Add `enableMemory` parameter to `debug_traceTransaction` and `debug_traceBlockByNumber`. Defaults to `false`; memory is only included in trace output when explicitly enabled. The existing `disableMemory` parameter continues to work for backwards compatibility [#10169](https://github.com/besu-eth/besu/pull/10169)
 - `--net-restrict` now supports IPv6 CIDR notation (e.g. `fd00::/64`) in addition to IPv4, enabling subnet-based peer filtering in IPv6 and dual-stack deployments [#10028](https://github.com/besu-eth/besu/pull/10028)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fix `engine_forkchoiceUpdatedV1` now returns `-38003 INVALID_PAYLOAD_ATTRIBUTES` for invalid payload attribute timestamps (zero or not greater than head). [#10353](https://github.com/besu-eth/besu/pull/10353)
 
 ### Additions and Improvements
+- Add `eth_getStorageValues` JSON-RPC method for batched reads of multiple storage slots across multiple accounts in a single call [#10259](https://github.com/besu-eth/besu/pull/10259)
 - Add `enableReturnData` parameter to `debug_traceTransaction` and `debug_traceBlockByNumber`, and include `returnData` in `StructLog` when captured; the field is omitted when return data is empty or not captured. [#10172](https://github.com/besu-eth/besu/pull/10172)
 - Updated `Bouncycastle` to 1.84 and `maven-artifact` to 3.9.15 to resolve CVEs reported in those libraries. Besu's usage patterns are not affected by these vulnerabilities. [#10420](https://github.com/besu-eth/besu/pull/10420)
 ## 26.5.0

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/RpcMethod.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/RpcMethod.java
@@ -98,6 +98,7 @@ public enum RpcMethod {
   ETH_GET_MAX_PRIORITY_FEE_PER_GAS("eth_maxPriorityFeePerGas"),
   ETH_GET_PROOF("eth_getProof"),
   ETH_GET_STORAGE_AT("eth_getStorageAt"),
+  ETH_GET_STORAGE_VALUES("eth_getStorageValues"),
   ETH_GET_TRANSACTION_BY_BLOCK_HASH_AND_INDEX("eth_getTransactionByBlockHashAndIndex"),
   ETH_GET_TRANSACTION_BY_BLOCK_NUMBER_AND_INDEX("eth_getTransactionByBlockNumberAndIndex"),
   ETH_GET_TRANSACTION_BY_HASH("eth_getTransactionByHash"),

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetStorageValues.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetStorageValues.java
@@ -26,11 +26,13 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
+import org.hyperledger.besu.evm.account.Account;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.apache.tuweni.units.bigints.UInt256;
 
@@ -69,8 +71,12 @@ public class EthGetStorageValues extends AbstractBlockParameterOrBlockHashMethod
           "Invalid storage slots request parameter (index 0)", RpcErrorType.INVALID_PARAMS, e);
     }
 
+    // Validate and pre-parse all hex keys before opening the world state. Keeping validation
+    // outside the getAndMapWorldState lambda avoids its catch-all swallowing input errors.
+    final Map<Address, List<UInt256>> parsed = new HashMap<>(storageSlotsRequest.size());
     int totalSlots = 0;
-    for (final List<String> keys : storageSlotsRequest.values()) {
+    for (final Map.Entry<Address, List<String>> entry : storageSlotsRequest.entrySet()) {
+      final List<String> keys = entry.getValue();
       if (keys == null) {
         return new JsonRpcErrorResponse(
             request.getRequest().getId(),
@@ -85,6 +91,20 @@ public class EthGetStorageValues extends AbstractBlockParameterOrBlockHashMethod
                 "too many slots (max " + MAX_STORAGE_SLOTS + ")",
                 null));
       }
+      final List<UInt256> parsedKeys = new ArrayList<>(keys.size());
+      for (final String keyHex : keys) {
+        if (keyHex == null) {
+          throw new InvalidJsonRpcParameters(
+              "Invalid storage key parameter", RpcErrorType.INVALID_PARAMS);
+        }
+        try {
+          parsedKeys.add(UInt256.fromHexString(keyHex));
+        } catch (IllegalArgumentException e) {
+          throw new InvalidJsonRpcParameters(
+              "Invalid storage key parameter", RpcErrorType.INVALID_PARAMS, e);
+        }
+      }
+      parsed.put(entry.getKey(), parsedKeys);
     }
 
     if (totalSlots == 0) {
@@ -93,29 +113,29 @@ public class EthGetStorageValues extends AbstractBlockParameterOrBlockHashMethod
           new JsonRpcError(RpcErrorType.INVALID_PARAMS.getCode(), "empty request", null));
     }
 
-    final Map<String, List<String>> result = new HashMap<>();
-    for (final Map.Entry<Address, List<String>> entry : storageSlotsRequest.entrySet()) {
-      final Address address = entry.getKey();
-      final List<String> keys = entry.getValue();
-      final List<String> values = new ArrayList<>(keys.size());
-      for (final String keyHex : keys) {
-        if (keyHex == null) {
-          throw new InvalidJsonRpcParameters(
-              "Invalid storage key parameter", RpcErrorType.INVALID_PARAMS);
-        }
-        final UInt256 key;
-        try {
-          key = UInt256.fromHexString(keyHex);
-        } catch (IllegalArgumentException e) {
-          throw new InvalidJsonRpcParameters(
-              "Invalid storage key parameter", RpcErrorType.INVALID_PARAMS, e);
-        }
-        final UInt256 value =
-            blockchainQueries.get().storageAt(address, key, blockHash).orElse(UInt256.ZERO);
-        values.add(value.toHexString());
-      }
-      result.put(address.toHexString(), values);
-    }
-    return result;
+    return blockchainQueries
+        .get()
+        .getAndMapWorldState(
+            blockHash,
+            ws -> {
+              final Map<String, List<String>> result = new HashMap<>(parsed.size());
+              for (final Map.Entry<Address, List<UInt256>> entry : parsed.entrySet()) {
+                final Address address = entry.getKey();
+                final Account account = ws.get(address);
+                final List<UInt256> keys = entry.getValue();
+                final List<String> values = new ArrayList<>(keys.size());
+                for (final UInt256 key : keys) {
+                  final UInt256 value =
+                      (account == null) ? UInt256.ZERO : account.getStorageValue(key);
+                  values.add(value.toHexString());
+                }
+                result.put(address.toHexString(), values);
+              }
+              return Optional.<Object>of(result);
+            })
+        .orElseGet(
+            () ->
+                new JsonRpcErrorResponse(
+                    request.getRequest().getId(), RpcErrorType.WORLD_STATE_UNAVAILABLE));
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetStorageValues.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetStorageValues.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
+
+import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.BlockParameterOrBlockHash;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter.JsonRpcParameterException;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.StorageSlotsRequest;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
+import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.tuweni.units.bigints.UInt256;
+
+public class EthGetStorageValues extends AbstractBlockParameterOrBlockHashMethod {
+
+  private static final int MAX_STORAGE_SLOTS = 1024;
+
+  public EthGetStorageValues(final BlockchainQueries blockchainQueries) {
+    super(blockchainQueries);
+  }
+
+  @Override
+  public String getName() {
+    return RpcMethod.ETH_GET_STORAGE_VALUES.getMethodName();
+  }
+
+  @Override
+  protected BlockParameterOrBlockHash blockParameterOrBlockHash(
+      final JsonRpcRequestContext request) {
+    try {
+      return request.getRequiredParameter(1, BlockParameterOrBlockHash.class);
+    } catch (JsonRpcParameterException e) {
+      throw new InvalidJsonRpcParameters(
+          "Invalid block or block hash parameter (index 1)", RpcErrorType.INVALID_BLOCK_PARAMS, e);
+    }
+  }
+
+  @Override
+  protected Object resultByBlockHash(final JsonRpcRequestContext request, final Hash blockHash) {
+    final StorageSlotsRequest storageSlotsRequest;
+    try {
+      storageSlotsRequest = request.getRequiredParameter(0, StorageSlotsRequest.class);
+    } catch (JsonRpcParameterException e) {
+      throw new InvalidJsonRpcParameters(
+          "Invalid storage slots request parameter (index 0)", RpcErrorType.INVALID_PARAMS, e);
+    }
+
+    int totalSlots = 0;
+    for (final List<String> keys : storageSlotsRequest.values()) {
+      totalSlots += keys.size();
+      if (totalSlots > MAX_STORAGE_SLOTS) {
+        return new JsonRpcErrorResponse(
+            request.getRequest().getId(),
+            new JsonRpcError(
+                RpcErrorType.INVALID_PARAMS.getCode(),
+                "too many slots (max " + MAX_STORAGE_SLOTS + ")",
+                null));
+      }
+    }
+
+    if (totalSlots == 0) {
+      return new JsonRpcErrorResponse(
+          request.getRequest().getId(),
+          new JsonRpcError(RpcErrorType.INVALID_PARAMS.getCode(), "empty request", null));
+    }
+
+    final Map<String, List<String>> result = new HashMap<>();
+    for (final Map.Entry<Address, List<String>> entry : storageSlotsRequest.entrySet()) {
+      final Address address = entry.getKey();
+      final List<String> keys = entry.getValue();
+      final List<String> values = new ArrayList<>(keys.size());
+      for (final String keyHex : keys) {
+        final UInt256 key = UInt256.fromHexString(keyHex);
+        final UInt256 value =
+            blockchainQueries.get().storageAt(address, key, blockHash).orElse(UInt256.ZERO);
+        values.add(value.toHexString());
+      }
+      result.put(address.toHexString(), values);
+    }
+    return result;
+  }
+}

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetStorageValues.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetStorageValues.java
@@ -36,6 +36,7 @@ import org.apache.tuweni.units.bigints.UInt256;
 
 public class EthGetStorageValues extends AbstractBlockParameterOrBlockHashMethod {
 
+  /** Per-call cap on total storage slots, matches geth's {@code maxGetStorageSlots}. */
   static final int MAX_STORAGE_SLOTS = 1024;
 
   public EthGetStorageValues(final BlockchainQueries blockchainQueries) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetStorageValues.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetStorageValues.java
@@ -93,7 +93,13 @@ public class EthGetStorageValues extends AbstractBlockParameterOrBlockHashMethod
       final List<String> keys = entry.getValue();
       final List<String> values = new ArrayList<>(keys.size());
       for (final String keyHex : keys) {
-        final UInt256 key = UInt256.fromHexString(keyHex);
+        final UInt256 key;
+        try {
+          key = UInt256.fromHexString(keyHex);
+        } catch (IllegalArgumentException e) {
+          throw new InvalidJsonRpcParameters(
+              "Invalid storage key parameter", RpcErrorType.INVALID_PARAMS, e);
+        }
         final UInt256 value =
             blockchainQueries.get().storageAt(address, key, blockHash).orElse(UInt256.ZERO);
         values.add(value.toHexString());

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetStorageValues.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetStorageValues.java
@@ -36,7 +36,7 @@ import org.apache.tuweni.units.bigints.UInt256;
 
 public class EthGetStorageValues extends AbstractBlockParameterOrBlockHashMethod {
 
-  private static final int MAX_STORAGE_SLOTS = 1024;
+  static final int MAX_STORAGE_SLOTS = 1024;
 
   public EthGetStorageValues(final BlockchainQueries blockchainQueries) {
     super(blockchainQueries);
@@ -70,6 +70,11 @@ public class EthGetStorageValues extends AbstractBlockParameterOrBlockHashMethod
 
     int totalSlots = 0;
     for (final List<String> keys : storageSlotsRequest.values()) {
+      if (keys == null) {
+        return new JsonRpcErrorResponse(
+            request.getRequest().getId(),
+            new JsonRpcError(RpcErrorType.INVALID_PARAMS.getCode(), "null slot list", null));
+      }
       totalSlots += keys.size();
       if (totalSlots > MAX_STORAGE_SLOTS) {
         return new JsonRpcErrorResponse(
@@ -93,6 +98,10 @@ public class EthGetStorageValues extends AbstractBlockParameterOrBlockHashMethod
       final List<String> keys = entry.getValue();
       final List<String> values = new ArrayList<>(keys.size());
       for (final String keyHex : keys) {
+        if (keyHex == null) {
+          throw new InvalidJsonRpcParameters(
+              "Invalid storage key parameter", RpcErrorType.INVALID_PARAMS);
+        }
         final UInt256 key;
         try {
           key = UInt256.fromHexString(keyHex);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetStorageValues.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetStorageValues.java
@@ -80,7 +80,7 @@ public class EthGetStorageValues extends AbstractBlockParameterOrBlockHashMethod
       if (keys == null) {
         return new JsonRpcErrorResponse(
             request.getRequest().getId(),
-            new JsonRpcError(RpcErrorType.INVALID_PARAMS.getCode(), "null slot list", null));
+            new JsonRpcError(RpcErrorType.INVALID_PARAMS, "null slot list"));
       }
       totalSlots += keys.size();
       if (totalSlots > MAX_STORAGE_SLOTS) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetStorageValues.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetStorageValues.java
@@ -16,6 +16,7 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.datatypes.parameters.UInt256Parameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
@@ -71,12 +72,10 @@ public class EthGetStorageValues extends AbstractBlockParameterOrBlockHashMethod
           "Invalid storage slots request parameter (index 0)", RpcErrorType.INVALID_PARAMS, e);
     }
 
-    // Validate and pre-parse all hex keys before opening the world state. Keeping validation
-    // outside the getAndMapWorldState lambda avoids its catch-all swallowing input errors.
     final Map<Address, List<UInt256>> parsed = new HashMap<>(storageSlotsRequest.size());
     int totalSlots = 0;
-    for (final Map.Entry<Address, List<String>> entry : storageSlotsRequest.entrySet()) {
-      final List<String> keys = entry.getValue();
+    for (final Map.Entry<Address, List<UInt256Parameter>> entry : storageSlotsRequest.entrySet()) {
+      final List<UInt256Parameter> keys = entry.getValue();
       if (keys == null) {
         return new JsonRpcErrorResponse(
             request.getRequest().getId(),
@@ -92,17 +91,12 @@ public class EthGetStorageValues extends AbstractBlockParameterOrBlockHashMethod
                 null));
       }
       final List<UInt256> parsedKeys = new ArrayList<>(keys.size());
-      for (final String keyHex : keys) {
-        if (keyHex == null) {
+      for (final UInt256Parameter key : keys) {
+        if (key == null) {
           throw new InvalidJsonRpcParameters(
               "Invalid storage key parameter", RpcErrorType.INVALID_PARAMS);
         }
-        try {
-          parsedKeys.add(UInt256.fromHexString(keyHex));
-        } catch (IllegalArgumentException e) {
-          throw new InvalidJsonRpcParameters(
-              "Invalid storage key parameter", RpcErrorType.INVALID_PARAMS, e);
-        }
+        parsedKeys.add(key.getValue());
       }
       parsed.put(entry.getKey(), parsedKeys);
     }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/StorageSlotsRequest.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/StorageSlotsRequest.java
@@ -19,10 +19,7 @@ import org.hyperledger.besu.datatypes.Address;
 import java.util.HashMap;
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-
 /** Map of storage slot requests, indexed by address. */
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class StorageSlotsRequest extends HashMap<Address, List<String>> {
 
   /** Default constructor. */

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/StorageSlotsRequest.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/StorageSlotsRequest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters;
+
+import org.hyperledger.besu.datatypes.Address;
+
+import java.util.HashMap;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/** Map of storage slot requests, indexed by address. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class StorageSlotsRequest extends HashMap<Address, List<String>> {
+
+  /** Default constructor. */
+  public StorageSlotsRequest() {}
+}

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/StorageSlotsRequest.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/StorageSlotsRequest.java
@@ -15,12 +15,13 @@
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters;
 
 import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.datatypes.parameters.UInt256Parameter;
 
 import java.util.HashMap;
 import java.util.List;
 
 /** Map of storage slot requests, indexed by address. */
-public class StorageSlotsRequest extends HashMap<Address, List<String>> {
+public class StorageSlotsRequest extends HashMap<Address, List<UInt256Parameter>> {
 
   /** Default constructor. */
   public StorageSlotsRequest() {}

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EthJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EthJsonRpcMethods.java
@@ -42,6 +42,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.EthGetFilterLo
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.EthGetLogs;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.EthGetProof;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.EthGetStorageAt;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.EthGetStorageValues;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.EthGetTransactionByBlockHashAndIndex;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.EthGetTransactionByBlockNumberAndIndex;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.EthGetTransactionByHash;
@@ -166,6 +167,7 @@ public class EthJsonRpcMethods extends ApiGroupJsonRpcMethods {
             new EthGetFilterLogs(filterManager),
             new EthSyncing(synchronizer),
             new EthGetStorageAt(blockchainQueries),
+            new EthGetStorageValues(blockchainQueries),
             new EthSendRawTransaction(transactionPool),
             new EthSendTransaction(),
             new EthEstimateGas(blockchainQueries, transactionSimulator, apiConfiguration),

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetStorageValuesTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetStorageValuesTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
+import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
+import org.hyperledger.besu.ethereum.chain.Blockchain;
+import org.hyperledger.besu.ethereum.chain.ChainHead;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.apache.tuweni.units.bigints.UInt256;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class EthGetStorageValuesTest {
+
+  private static final Address ADDRESS_ONE =
+      Address.fromHexString("0x7dcd17433742f4c0ca53122ab541d0ba67fc27df");
+  private static final Address ADDRESS_TWO =
+      Address.fromHexString("0xc1cadaffffffffffffffffffffffffffffffffff");
+  private static final String SLOT_ZERO =
+      "0x0000000000000000000000000000000000000000000000000000000000000000";
+  private static final String SLOT_HIGH =
+      "0x0100000000000000000000000000000000000000000000000000000000000000";
+  private static final String VALUE_FORTY_TWO =
+      "0x000000000000000000000000000000000000000000000000000000000000002a";
+  private static final String VALUE_ZERO =
+      "0x0000000000000000000000000000000000000000000000000000000000000000";
+
+  private final BlockchainQueries blockchainQueries = mock(BlockchainQueries.class);
+  private final Blockchain blockchain = mock(Blockchain.class);
+  private final ChainHead chainHead = mock(ChainHead.class);
+  private final BlockHeader chainHeadHeader = mock(BlockHeader.class);
+
+  private EthGetStorageValues method;
+
+  @BeforeEach
+  public void setup() {
+    when(blockchainQueries.getBlockchain()).thenReturn(blockchain);
+    when(blockchain.getChainHead()).thenReturn(chainHead);
+    when(chainHead.getBlockHeader()).thenReturn(chainHeadHeader);
+    when(chainHeadHeader.getBlockHash()).thenReturn(Hash.ZERO);
+    method = new EthGetStorageValues(blockchainQueries);
+  }
+
+  @Test
+  public void shouldReturnCorrectMethodName() {
+    assertThat(method.getName()).isEqualTo("eth_getStorageValues");
+  }
+
+  @Test
+  public void shouldReturnEmptyRequestErrorWhenMapIsEmpty() {
+    final JsonRpcRequestContext request = requestWithParams(Map.of(), "latest");
+
+    final JsonRpcErrorResponse response = (JsonRpcErrorResponse) method.response(request);
+
+    assertThat(response.getError().getCode()).isEqualTo(-32602);
+    assertThat(response.getError().getMessage()).isEqualTo("empty request");
+  }
+
+  @Test
+  public void shouldReturnStorageValueForSingleAddress() {
+    when(blockchainQueries.storageAt(ADDRESS_ONE, UInt256.fromHexString(SLOT_ZERO), Hash.ZERO))
+        .thenReturn(Optional.of(UInt256.valueOf(42)));
+
+    final JsonRpcRequestContext request =
+        requestWithParams(Map.of(ADDRESS_ONE.toHexString(), List.of(SLOT_ZERO)), "latest");
+
+    final JsonRpcSuccessResponse response = (JsonRpcSuccessResponse) method.response(request);
+
+    @SuppressWarnings("unchecked")
+    final Map<String, List<String>> result = (Map<String, List<String>>) response.getResult();
+    assertThat(result).containsEntry(ADDRESS_ONE.toHexString(), List.of(VALUE_FORTY_TWO));
+  }
+
+  @Test
+  public void shouldReturnStorageValuesForMultipleAddresses() {
+    when(blockchainQueries.storageAt(ADDRESS_ONE, UInt256.fromHexString(SLOT_ZERO), Hash.ZERO))
+        .thenReturn(Optional.of(UInt256.valueOf(42)));
+    when(blockchainQueries.storageAt(ADDRESS_TWO, UInt256.fromHexString(SLOT_HIGH), Hash.ZERO))
+        .thenReturn(Optional.of(UInt256.ZERO));
+
+    final JsonRpcRequestContext request =
+        requestWithParams(
+            Map.of(
+                ADDRESS_ONE.toHexString(), List.of(SLOT_ZERO),
+                ADDRESS_TWO.toHexString(), List.of(SLOT_HIGH)),
+            "latest");
+
+    final JsonRpcSuccessResponse response = (JsonRpcSuccessResponse) method.response(request);
+
+    @SuppressWarnings("unchecked")
+    final Map<String, List<String>> result = (Map<String, List<String>>) response.getResult();
+    assertThat(result)
+        .containsEntry(ADDRESS_ONE.toHexString(), List.of(VALUE_FORTY_TWO))
+        .containsEntry(ADDRESS_TWO.toHexString(), List.of(VALUE_ZERO));
+  }
+
+  @Test
+  public void shouldReturnZeroForUnknownAccount() {
+    when(blockchainQueries.storageAt(ADDRESS_TWO, UInt256.fromHexString(SLOT_HIGH), Hash.ZERO))
+        .thenReturn(Optional.of(UInt256.ZERO));
+
+    final JsonRpcRequestContext request =
+        requestWithParams(Map.of(ADDRESS_TWO.toHexString(), List.of(SLOT_HIGH)), "latest");
+
+    final JsonRpcSuccessResponse response = (JsonRpcSuccessResponse) method.response(request);
+
+    @SuppressWarnings("unchecked")
+    final Map<String, List<String>> result = (Map<String, List<String>>) response.getResult();
+    assertThat(result).containsEntry(ADDRESS_TWO.toHexString(), List.of(VALUE_ZERO));
+  }
+
+  @Test
+  public void shouldReturnTooManySlotsErrorWhenOver1024() {
+    final String[] keys = new String[1025];
+    for (int i = 0; i < keys.length; i++) {
+      keys[i] = SLOT_ZERO;
+    }
+
+    final JsonRpcRequestContext request =
+        requestWithParams(Map.of(ADDRESS_ONE.toHexString(), List.of(keys)), "latest");
+
+    final JsonRpcErrorResponse response = (JsonRpcErrorResponse) method.response(request);
+
+    assertThat(response.getError().getCode()).isEqualTo(-32602);
+    assertThat(response.getError().getMessage()).isEqualTo("too many slots (max 1024)");
+  }
+
+  private JsonRpcRequestContext requestWithParams(
+      final Map<String, List<String>> requests, final String block) {
+    return new JsonRpcRequestContext(
+        new JsonRpcRequest("2.0", "eth_getStorageValues", new Object[] {requests, block}));
+  }
+}

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetStorageValuesTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetStorageValuesTest.java
@@ -16,6 +16,7 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -30,12 +31,15 @@ import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.chain.ChainHead;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.core.MutableWorldState;
+import org.hyperledger.besu.evm.account.Account;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 
 import org.apache.tuweni.units.bigints.UInt256;
 import org.junit.jupiter.api.BeforeEach;
@@ -60,6 +64,9 @@ public class EthGetStorageValuesTest {
   private final Blockchain blockchain = mock(Blockchain.class);
   private final ChainHead chainHead = mock(ChainHead.class);
   private final BlockHeader chainHeadHeader = mock(BlockHeader.class);
+  private final MutableWorldState worldState = mock(MutableWorldState.class);
+  private final Account accountOne = mock(Account.class);
+  private final Account accountTwo = mock(Account.class);
 
   private EthGetStorageValues method;
 
@@ -69,6 +76,13 @@ public class EthGetStorageValuesTest {
     when(blockchain.getChainHead()).thenReturn(chainHead);
     when(chainHead.getBlockHeader()).thenReturn(chainHeadHeader);
     when(chainHeadHeader.getBlockHash()).thenReturn(Hash.ZERO);
+    when(blockchainQueries.getAndMapWorldState(any(Hash.class), any()))
+        .thenAnswer(
+            invocation -> {
+              @SuppressWarnings("unchecked")
+              Function<MutableWorldState, Optional<Object>> mapper = invocation.getArgument(1);
+              return mapper.apply(worldState);
+            });
     method = new EthGetStorageValues(blockchainQueries);
   }
 
@@ -89,8 +103,9 @@ public class EthGetStorageValuesTest {
 
   @Test
   public void shouldReturnStorageValueForSingleAddress() {
-    when(blockchainQueries.storageAt(ADDRESS_ONE, UInt256.fromHexString(SLOT_ZERO), Hash.ZERO))
-        .thenReturn(Optional.of(UInt256.valueOf(42)));
+    when(worldState.get(ADDRESS_ONE)).thenReturn(accountOne);
+    when(accountOne.getStorageValue(UInt256.fromHexString(SLOT_ZERO)))
+        .thenReturn(UInt256.valueOf(42));
 
     final JsonRpcRequestContext request =
         requestWithParams(Map.of(ADDRESS_ONE.toHexString(), List.of(SLOT_ZERO)), "latest");
@@ -104,10 +119,11 @@ public class EthGetStorageValuesTest {
 
   @Test
   public void shouldReturnStorageValuesForMultipleAddresses() {
-    when(blockchainQueries.storageAt(ADDRESS_ONE, UInt256.fromHexString(SLOT_ZERO), Hash.ZERO))
-        .thenReturn(Optional.of(UInt256.valueOf(42)));
-    when(blockchainQueries.storageAt(ADDRESS_TWO, UInt256.fromHexString(SLOT_HIGH), Hash.ZERO))
-        .thenReturn(Optional.of(UInt256.ZERO));
+    when(worldState.get(ADDRESS_ONE)).thenReturn(accountOne);
+    when(worldState.get(ADDRESS_TWO)).thenReturn(accountTwo);
+    when(accountOne.getStorageValue(UInt256.fromHexString(SLOT_ZERO)))
+        .thenReturn(UInt256.valueOf(42));
+    when(accountTwo.getStorageValue(UInt256.fromHexString(SLOT_HIGH))).thenReturn(UInt256.ZERO);
 
     final JsonRpcRequestContext request =
         requestWithParams(
@@ -127,9 +143,6 @@ public class EthGetStorageValuesTest {
 
   @Test
   public void shouldReturnZeroForUnknownAccount() {
-    when(blockchainQueries.storageAt(ADDRESS_TWO, UInt256.fromHexString(SLOT_HIGH), Hash.ZERO))
-        .thenReturn(Optional.empty());
-
     final JsonRpcRequestContext request =
         requestWithParams(Map.of(ADDRESS_TWO.toHexString(), List.of(SLOT_HIGH)), "latest");
 
@@ -192,9 +205,9 @@ public class EthGetStorageValuesTest {
     when(specificHeader.getBlockHash()).thenReturn(specificBlockHash);
     when(blockchainQueries.getBlockHeaderByHash(specificBlockHash))
         .thenReturn(Optional.of(specificHeader));
-    when(blockchainQueries.storageAt(
-            ADDRESS_ONE, UInt256.fromHexString(SLOT_ZERO), specificBlockHash))
-        .thenReturn(Optional.of(UInt256.valueOf(42)));
+    when(worldState.get(ADDRESS_ONE)).thenReturn(accountOne);
+    when(accountOne.getStorageValue(UInt256.fromHexString(SLOT_ZERO)))
+        .thenReturn(UInt256.valueOf(42));
 
     final JsonRpcRequestContext request =
         requestWithParams(

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetStorageValuesTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetStorageValuesTest.java
@@ -124,7 +124,7 @@ public class EthGetStorageValuesTest {
   @Test
   public void shouldReturnZeroForUnknownAccount() {
     when(blockchainQueries.storageAt(ADDRESS_TWO, UInt256.fromHexString(SLOT_HIGH), Hash.ZERO))
-        .thenReturn(Optional.of(UInt256.ZERO));
+        .thenReturn(Optional.empty());
 
     final JsonRpcRequestContext request =
         requestWithParams(Map.of(ADDRESS_TWO.toHexString(), List.of(SLOT_HIGH)), "latest");

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetStorageValuesTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetStorageValuesTest.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -22,6 +23,7 @@ import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
@@ -156,5 +158,15 @@ public class EthGetStorageValuesTest {
       final Map<String, List<String>> requests, final String block) {
     return new JsonRpcRequestContext(
         new JsonRpcRequest("2.0", "eth_getStorageValues", new Object[] {requests, block}));
+  }
+
+  @Test
+  public void shouldThrowInvalidJsonRpcParametersForMalformedSlotHex() {
+    final JsonRpcRequestContext request =
+        requestWithParams(Map.of(ADDRESS_ONE.toHexString(), List.of("0xzz")), "latest");
+
+    assertThatThrownBy(() -> method.response(request))
+        .isInstanceOf(InvalidJsonRpcParameters.class)
+        .hasMessageContaining("Invalid storage key parameter");
   }
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetStorageValuesTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetStorageValuesTest.java
@@ -229,4 +229,18 @@ public class EthGetStorageValuesTest {
         .isInstanceOf(InvalidJsonRpcParameters.class)
         .hasMessageContaining("Invalid storage key parameter");
   }
+
+  @Test
+  public void shouldReturnWorldStateUnavailableErrorWhenStateMissing() {
+    when(blockchainQueries.getAndMapWorldState(any(Hash.class), any()))
+        .thenReturn(Optional.empty());
+
+    final JsonRpcRequestContext request =
+        requestWithParams(Map.of(ADDRESS_ONE.toHexString(), List.of(SLOT_ZERO)), "latest");
+
+    final JsonRpcErrorResponse response = (JsonRpcErrorResponse) method.response(request);
+
+    assertThat(response.getError().getCode()).isEqualTo(-32000);
+    assertThat(response.getError().getMessage()).isEqualTo("World state unavailable");
+  }
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetStorageValuesTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetStorageValuesTest.java
@@ -31,6 +31,8 @@ import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.chain.ChainHead;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -139,8 +141,8 @@ public class EthGetStorageValuesTest {
   }
 
   @Test
-  public void shouldReturnTooManySlotsErrorWhenOver1024() {
-    final String[] keys = new String[1025];
+  public void shouldReturnTooManySlotsErrorWhenOverLimit() {
+    final String[] keys = new String[EthGetStorageValues.MAX_STORAGE_SLOTS + 1];
     for (int i = 0; i < keys.length; i++) {
       keys[i] = SLOT_ZERO;
     }
@@ -164,6 +166,51 @@ public class EthGetStorageValuesTest {
   public void shouldThrowInvalidJsonRpcParametersForMalformedSlotHex() {
     final JsonRpcRequestContext request =
         requestWithParams(Map.of(ADDRESS_ONE.toHexString(), List.of("0xzz")), "latest");
+
+    assertThatThrownBy(() -> method.response(request))
+        .isInstanceOf(InvalidJsonRpcParameters.class)
+        .hasMessageContaining("Invalid storage key parameter");
+  }
+
+  @Test
+  public void shouldReturnInvalidParamsWhenSlotListIsNull() {
+    final Map<String, List<String>> params = new HashMap<>();
+    params.put(ADDRESS_ONE.toHexString(), null);
+    final JsonRpcRequestContext request = requestWithParams(params, "latest");
+
+    final JsonRpcErrorResponse response = (JsonRpcErrorResponse) method.response(request);
+
+    assertThat(response.getError().getCode()).isEqualTo(-32602);
+    assertThat(response.getError().getMessage()).isEqualTo("null slot list");
+  }
+
+  @Test
+  public void shouldReturnStorageValueByBlockHash() {
+    final Hash specificBlockHash =
+        Hash.fromHexString("0xb73cee02246c6f32ac0f459934e89102c2ce904d966a4fc2ab6309c3e104b9cb");
+    final BlockHeader specificHeader = mock(BlockHeader.class);
+    when(specificHeader.getBlockHash()).thenReturn(specificBlockHash);
+    when(blockchainQueries.getBlockHeaderByHash(specificBlockHash))
+        .thenReturn(Optional.of(specificHeader));
+    when(blockchainQueries.storageAt(
+            ADDRESS_ONE, UInt256.fromHexString(SLOT_ZERO), specificBlockHash))
+        .thenReturn(Optional.of(UInt256.valueOf(42)));
+
+    final JsonRpcRequestContext request =
+        requestWithParams(
+            Map.of(ADDRESS_ONE.toHexString(), List.of(SLOT_ZERO)), specificBlockHash.toHexString());
+
+    final JsonRpcSuccessResponse response = (JsonRpcSuccessResponse) method.response(request);
+
+    @SuppressWarnings("unchecked")
+    final Map<String, List<String>> result = (Map<String, List<String>>) response.getResult();
+    assertThat(result).containsEntry(ADDRESS_ONE.toHexString(), List.of(VALUE_FORTY_TWO));
+  }
+
+  @Test
+  public void shouldThrowInvalidJsonRpcParametersWhenSlotKeyIsNull() {
+    final JsonRpcRequestContext request =
+        requestWithParams(Map.of(ADDRESS_ONE.toHexString(), Arrays.asList("0x0", null)), "latest");
 
     assertThatThrownBy(() -> method.response(request))
         .isInstanceOf(InvalidJsonRpcParameters.class)

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetStorageValuesTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetStorageValuesTest.java
@@ -118,6 +118,25 @@ public class EthGetStorageValuesTest {
   }
 
   @Test
+  public void shouldReturnMultipleStorageValuesForSingleAddress() {
+    when(worldState.get(ADDRESS_ONE)).thenReturn(accountOne);
+    when(accountOne.getStorageValue(UInt256.fromHexString(SLOT_ZERO)))
+        .thenReturn(UInt256.valueOf(42));
+    when(accountOne.getStorageValue(UInt256.fromHexString(SLOT_HIGH))).thenReturn(UInt256.ZERO);
+
+    final JsonRpcRequestContext request =
+        requestWithParams(
+            Map.of(ADDRESS_ONE.toHexString(), List.of(SLOT_ZERO, SLOT_HIGH)), "latest");
+
+    final JsonRpcSuccessResponse response = (JsonRpcSuccessResponse) method.response(request);
+
+    @SuppressWarnings("unchecked")
+    final Map<String, List<String>> result = (Map<String, List<String>>) response.getResult();
+    assertThat(result)
+        .containsEntry(ADDRESS_ONE.toHexString(), List.of(VALUE_FORTY_TWO, VALUE_ZERO));
+  }
+
+  @Test
   public void shouldReturnStorageValuesForMultipleAddresses() {
     when(worldState.get(ADDRESS_ONE)).thenReturn(accountOne);
     when(worldState.get(ADDRESS_TWO)).thenReturn(accountTwo);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetStorageValuesTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetStorageValuesTest.java
@@ -31,7 +31,7 @@ import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.chain.ChainHead;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
-import org.hyperledger.besu.ethereum.core.MutableWorldState;
+import org.hyperledger.besu.plugin.services.worldstate.MutableWorldState;
 import org.hyperledger.besu.evm.account.Account;
 
 import java.util.Arrays;
@@ -194,7 +194,7 @@ public class EthGetStorageValuesTest {
     final JsonRpcErrorResponse response = (JsonRpcErrorResponse) method.response(request);
 
     assertThat(response.getError().getCode()).isEqualTo(-32602);
-    assertThat(response.getError().getMessage()).isEqualTo("null slot list");
+    assertThat(response.getError().getData()).isEqualTo("null slot list");
   }
 
   @Test

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetStorageValuesTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetStorageValuesTest.java
@@ -31,8 +31,8 @@ import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.chain.ChainHead;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
-import org.hyperledger.besu.plugin.services.worldstate.MutableWorldState;
 import org.hyperledger.besu.evm.account.Account;
+import org.hyperledger.besu.plugin.services.worldstate.MutableWorldState;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -182,7 +182,7 @@ public class EthGetStorageValuesTest {
 
     assertThatThrownBy(() -> method.response(request))
         .isInstanceOf(InvalidJsonRpcParameters.class)
-        .hasMessageContaining("Invalid storage key parameter");
+        .hasMessageContaining("Invalid storage slots request parameter (index 0)");
   }
 
   @Test

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getStorageValues_blockHash.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getStorageValues_blockHash.json
@@ -1,0 +1,24 @@
+{
+  "request": {
+    "id": 341,
+    "jsonrpc": "2.0",
+    "method": "eth_getStorageValues",
+    "params": [
+      {
+        "0x6295ee1b4f6dd65047762f924ecd367c17eabf8f": ["0x2", "0x3"]
+      },
+      "0xb73cee02246c6f32ac0f459934e89102c2ce904d966a4fc2ab6309c3e104b9cb"
+    ]
+  },
+  "response": {
+    "jsonrpc": "2.0",
+    "id": 341,
+    "result": {
+      "0x6295ee1b4f6dd65047762f924ecd367c17eabf8f": [
+        "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffee",
+        "0xaabbccffffffffffffffffffffffffffffffffffffffffffffffffffffffffee"
+      ]
+    }
+  },
+  "statusCode": 200
+}

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getStorageValues_blockNumber.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getStorageValues_blockNumber.json
@@ -1,0 +1,25 @@
+{
+  "request": {
+    "id": 341,
+    "jsonrpc": "2.0",
+    "method": "eth_getStorageValues",
+    "params": [
+      {
+        "0x6295ee1b4f6dd65047762f924ecd367c17eabf8f": ["0x0", "0x1", "0x4"]
+      },
+      "0x19"
+    ]
+  },
+  "response": {
+    "jsonrpc": "2.0",
+    "id": 341,
+    "result": {
+      "0x6295ee1b4f6dd65047762f924ecd367c17eabf8f": [
+        "0x000000000000000000000000000000000000000000000000000000000008fa01",
+        "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffee",
+        "0xaabbccffffffffffffffffffffffffffffffffffffffffffffffffffffffffee"
+      ]
+    }
+  },
+  "statusCode": 200
+}

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getStorageValues_emptyRequest.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getStorageValues_emptyRequest.json
@@ -1,0 +1,20 @@
+{
+  "request": {
+    "id": 341,
+    "jsonrpc": "2.0",
+    "method": "eth_getStorageValues",
+    "params": [
+      {},
+      "latest"
+    ]
+  },
+  "response": {
+    "jsonrpc": "2.0",
+    "id": 341,
+    "error": {
+      "code": -32602,
+      "message": "empty request"
+    }
+  },
+  "statusCode": 200
+}

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getStorageValues_invalidBlockHash.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getStorageValues_invalidBlockHash.json
@@ -1,0 +1,22 @@
+{
+  "request": {
+    "id": 341,
+    "jsonrpc": "2.0",
+    "method": "eth_getStorageValues",
+    "params": [
+      {
+        "0x6295ee1b4f6dd65047762f924ecd367c17eabf8f": ["0x0"]
+      },
+      "0xb73cee02246c6f32ac0f459934e89102c2ce904d966a4fc2ab6309c3e104b9cb1234"
+    ]
+  },
+  "response": {
+    "jsonrpc": "2.0",
+    "id": 341,
+    "error": {
+      "code": -32602,
+      "message": "Invalid block param (block not found)"
+    }
+  },
+  "statusCode": 200
+}

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getStorageValues_latest.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getStorageValues_latest.json
@@ -1,0 +1,23 @@
+{
+  "request": {
+    "id": 341,
+    "jsonrpc": "2.0",
+    "method": "eth_getStorageValues",
+    "params": [
+      {
+        "0x6295ee1b4f6dd65047762f924ecd367c17eabf8f": ["0x4"]
+      },
+      "latest"
+    ]
+  },
+  "response": {
+    "jsonrpc": "2.0",
+    "id": 341,
+    "result": {
+      "0x6295ee1b4f6dd65047762f924ecd367c17eabf8f": [
+        "0xaabbccffffffffffffffffffffffffffffffffffffffffffffffffffffffffee"
+      ]
+    }
+  },
+  "statusCode": 200
+}

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getStorageValues_unknownAccount.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getStorageValues_unknownAccount.json
@@ -1,0 +1,24 @@
+{
+  "request": {
+    "id": 341,
+    "jsonrpc": "2.0",
+    "method": "eth_getStorageValues",
+    "params": [
+      {
+        "0xdeaddeaddeaddeaddeaddeaddeaddeaddeaddead": ["0x0", "0x1"]
+      },
+      "latest"
+    ]
+  },
+  "response": {
+    "jsonrpc": "2.0",
+    "id": 341,
+    "result": {
+      "0xdeaddeaddeaddeaddeaddeaddeaddeaddeaddead": [
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "0x0000000000000000000000000000000000000000000000000000000000000000"
+      ]
+    }
+  },
+  "statusCode": 200
+}


### PR DESCRIPTION
Added the `eth_getStorageValues` JSON-RPC method, a batched version of `eth_getStorageAt` that reads multiple storage slots across multiple accounts in a single call.

### What changed

- New `EthGetStorageValues` method extending `AbstractBlockParameterOrBlockHashMethod`
- New `StorageSlotsRequest` parameter class (`HashMap<Address, List<String>>`) 
- Registered in `RpcMethod` enum and `EthJsonRpcMethods`
- Unit tests covering single address, multiple addresses, unknown accounts, empty request, and the slot cap

## Fixed Issue(s)

Fixes 4 failing Hive rpc-compat tests for `eth_getStorageValues`:
https://hive.ethpandaops.io/#/test/generic/1776233102-b0ae09a940116cc8abb883b9505fa1e9
fixes #10282 

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [x] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)
