### PR TITLE
bal- devnet-4: Reenable dynamic costPerStateByte calculation

### DIFF
--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/AbstractBlockProcessorIntegrationTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/AbstractBlockProcessorIntegrationTest.java
@@ -818,7 +818,7 @@ class AbstractBlockProcessorIntegrationTest {
 
     Block blockWithTransactions =
         createBlockWithTransactions(
-            "0x3912cef7496ffde5dc6822b2d268c582faeadcb261c66c80a333aca6f5da9de6",
+            "0x1f5501e9dccf8e5255e1fd4f4d0d215df77a979c60254813ac097bc3c4f0e673",
             Wei.of(5),
             transactionTransfer,
             getcontractBalanceTransaction,
@@ -886,7 +886,7 @@ class AbstractBlockProcessorIntegrationTest {
 
     Block blockWithTransactions =
         createBlockWithTransactions(
-            "0xb5b3d7b39b66b3e829b038d6ba9b38a3597cedd87df504828336dedb5f3e799f",
+            "0x2eeac8f0934e08deba88bea320eb0400101654cba1f10d5ff21d5f8186cb3789",
             Wei.of(5),
             transactionTransfer,
             sendEthFromContractTransaction,
@@ -953,7 +953,7 @@ class AbstractBlockProcessorIntegrationTest {
 
     Block blockWithTransactions =
         createBlockWithTransactions(
-            "0xf81c87537a0a166a48ede069bf50358163ae697d1005cbaa7e6083f22a60a2fb",
+            "0x7cf1e5035b25f95eb728b150992179afa5445bcdcba371ed16198ba3f909877e",
             Wei.of(5),
             transactionTransfer,
             getcontractBalanceTransaction,
@@ -1022,7 +1022,7 @@ class AbstractBlockProcessorIntegrationTest {
 
     Block blockWithTransactions =
         createBlockWithTransactions(
-            "0xf81c87537a0a166a48ede069bf50358163ae697d1005cbaa7e6083f22a60a2fb",
+            "0x7cf1e5035b25f95eb728b150992179afa5445bcdcba371ed16198ba3f909877e",
             Wei.of(5),
             transactionTransfer,
             sendEthFromContractTransaction,

--- a/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/Eip8037StateGasCostCalculator.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/Eip8037StateGasCostCalculator.java
@@ -82,18 +82,9 @@ public class Eip8037StateGasCostCalculator implements StateGasCostCalculator {
   /** Instantiates a new EIP-8037 state gas cost calculator. */
   public Eip8037StateGasCostCalculator() {}
 
-  /**
-   * Hardcoded cost per state byte for devnet-3. This value (1174) corresponds to a 100M block gas
-   * limit. The test framework cannot currently handle dynamic gas prices, so cpsb is treated as a
-   * fork constant. For devnet-4, the full EIP-8037 dynamic calculation will be restored.
-   */
-  static final long DEVNET_COST_PER_STATE_BYTE = 1174L;
-
   @Override
   public long costPerStateByte(final long blockGasLimit) {
-    // TODO(devnet-4): Restore dynamic cpsb calculation based on block gas limit:
-    // return costPerStateByteFromGasLimit(blockGasLimit);
-    return DEVNET_COST_PER_STATE_BYTE;
+    return costPerStateByteFromGasLimit(blockGasLimit);
   }
 
   /**

--- a/evm/src/test/java/org/hyperledger/besu/evm/gascalculator/Eip8037StateGasCostCalculatorTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/gascalculator/Eip8037StateGasCostCalculatorTest.java
@@ -24,18 +24,15 @@ class Eip8037StateGasCostCalculatorTest {
 
   private final Eip8037StateGasCostCalculator calculator = new Eip8037StateGasCostCalculator();
 
-  // --- Devnet-3: hardcoded cpsb tests ---
+  // --- Dynamic cpsb calculation tests ---
 
   @Test
-  void costPerStateByteReturnsHardcodedValue() {
-    // Devnet-3: cpsb is hardcoded to 1174 regardless of block gas limit
-    assertThat(calculator.costPerStateByte(36_000_000L)).isEqualTo(DEVNET_CPSB);
-    assertThat(calculator.costPerStateByte(60_000_000L)).isEqualTo(DEVNET_CPSB);
+  void costPerStateByteReturnsDynamicValue() {
+    assertThat(calculator.costPerStateByte(36_000_000L)).isEqualTo(150L);
+    assertThat(calculator.costPerStateByte(60_000_000L)).isEqualTo(662L);
     assertThat(calculator.costPerStateByte(100_000_000L)).isEqualTo(DEVNET_CPSB);
-    assertThat(calculator.costPerStateByte(0L)).isEqualTo(DEVNET_CPSB);
+    assertThat(calculator.costPerStateByte(0L)).isEqualTo(0L);
   }
-
-  // --- Dynamic cpsb calculation tests (for devnet-4 re-enablement) ---
 
   @Test
   void dynamicCostPerStateByteAt36MGasLimit() {

--- a/evm/src/test/java/org/hyperledger/besu/evm/operation/SStoreOperationTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/operation/SStoreOperationTest.java
@@ -215,7 +215,7 @@ class SStoreOperationTest {
 
     final long expectedStateGas =
         32L * new Eip8037StateGasCostCalculator().costPerStateByte(blockGasLimit);
-    assertThat(frame.getStateGasUsed()).isEqualTo(expectedStateGas); // 37,568
+    assertThat(frame.getStateGasUsed()).isEqualTo(expectedStateGas); // 4,800 at 36M gas limit
 
     // Second SSTORE: key=1, value=0 (nonzero -> 0, original=0 triggers state gas refund)
     frame.pushStackItem(UInt256.ZERO);
@@ -223,7 +223,7 @@ class SStoreOperationTest {
     final OperationResult result2 = operation.execute(frame, null);
     assertThat(result2.getHaltReason()).isNull();
 
-    // State gas refund (37,568) + regular SSTORE refund for 0->X->0 (2,800)
+    // State gas refund (4,800 at 36M) + regular SSTORE refund for 0->X->0 (2,800)
     assertThat(frame.getGasRefund()).isEqualTo(expectedStateGas + 2_800L);
     // stateGasUsed tracks gross consumption, not decremented by refunds
     assertThat(frame.getStateGasUsed()).isEqualTo(expectedStateGas);
@@ -280,7 +280,7 @@ class SStoreOperationTest {
     final SStoreOperation operation =
         new SStoreOperation(amsterdamCalc, SStoreOperation.EIP_1706_MINIMUM);
 
-    final long blockGasLimit = 36_000_000L;
+    final long blockGasLimit = 100_000_000L;
     final Address address = Address.fromHexString("0x18675309");
     final ToyWorld toyWorld = new ToyWorld();
 


### PR DESCRIPTION
## PR description
 
 Switches from returning a hard coded value to the correct dynamic calculation based on the block gas limit.
 
 Left in draft until we need to switch to bal- devnet-4


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


