### PR TITLE
Fix snap/2 BAL message wire format per EIP-8189

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/snap/SnapServer.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/snap/SnapServer.java
@@ -46,6 +46,7 @@ import org.hyperledger.besu.ethereum.worldstate.FlatDbMode;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateStorageCoordinator;
 import org.hyperledger.besu.plugin.services.BesuEvents;
 
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -242,11 +243,18 @@ class SnapServer implements BesuEvents.InitialSyncCompletionListener {
 
     final GetBlockAccessListsMessage getBlockAccessLists =
         GetBlockAccessListsMessage.readFrom(message);
-    final Iterable<Hash> blockHashes = getBlockAccessLists.blockHashes(true);
+    final GetBlockAccessListsMessage.BlockHashes request = getBlockAccessLists.blockHashes(true);
+    final List<Hash> blockHashes = request.hashes();
+    // EIP-8189: honor the client's requested soft size limit, capped at our own MAX_RESPONSE_SIZE.
+    final int clientRequestedBytes =
+        request.responseBytes().signum() <= 0
+            ? MAX_RESPONSE_SIZE
+            : request.responseBytes().min(BigInteger.valueOf(MAX_RESPONSE_SIZE)).intValue();
 
-    int responseSizeEstimate = RLP.MAX_PREFIX_SIZE;
+    int responseSizeEstimate = RLP.MAX_PREFIX_SIZE + RLP.MAX_PREFIX_SIZE; // outer + inner list
     final BytesValueRLPOutput rlp = new BytesValueRLPOutput();
-    rlp.startList();
+    rlp.startList(); // response wrapper
+    rlp.startList(); // inner list of BALs (EIP-8189 wire format)
 
     final Optional<Blockchain> maybeBlockchain =
         protocolContext.map(ProtocolContext::getBlockchain);
@@ -262,24 +270,27 @@ class SnapServer implements BesuEvents.InitialSyncCompletionListener {
 
         final Optional<BlockAccessList> maybeBlockAccessList =
             blockchain.getBlockAccessList(blockHash);
-        final BytesValueRLPOutput balOutput = new BytesValueRLPOutput();
         if (maybeBlockAccessList.isPresent()) {
+          final BytesValueRLPOutput balOutput = new BytesValueRLPOutput();
           BlockAccessListEncoder.encode(maybeBlockAccessList.get(), balOutput);
+          final int encodedSize = balOutput.encodedSize();
+          if (responseSizeEstimate + encodedSize > clientRequestedBytes) {
+            break;
+          }
+          responseSizeEstimate += encodedSize;
+          rlp.writeRaw(balOutput.encoded());
         } else {
-          // Empty lists are returned for blocks where the BAL is unavailable.
-          balOutput.startList();
-          balOutput.endList();
+          // EIP-8189: unavailable BALs are returned as the RLP empty string (0x80).
+          if (responseSizeEstimate + 1 > clientRequestedBytes) {
+            break;
+          }
+          responseSizeEstimate += 1;
+          rlp.writeBytes(Bytes.EMPTY);
         }
-
-        final int encodedSize = balOutput.encodedSize();
-        if (responseSizeEstimate + encodedSize > MAX_RESPONSE_SIZE) {
-          break;
-        }
-        responseSizeEstimate += encodedSize;
-        rlp.writeRaw(balOutput.encoded());
       }
     }
-    rlp.endList();
+    rlp.endList(); // inner list
+    rlp.endList(); // response wrapper
 
     return BlockAccessListsMessage.createUnsafe(rlp.encoded());
   }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/messages/snap/BlockAccessListsMessage.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/messages/snap/BlockAccessListsMessage.java
@@ -14,16 +14,31 @@
  */
 package org.hyperledger.besu.ethereum.eth.messages.snap;
 
-import org.hyperledger.besu.ethereum.eth.messages.BlockAccessListsMessageData;
+import org.hyperledger.besu.ethereum.core.encoding.BlockAccessListDecoder;
+import org.hyperledger.besu.ethereum.core.encoding.BlockAccessListEncoder;
 import org.hyperledger.besu.ethereum.mainnet.block.access.list.BlockAccessList;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.AbstractSnapMessageData;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.MessageData;
+import org.hyperledger.besu.ethereum.rlp.BytesValueRLPInput;
+import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
+import org.hyperledger.besu.ethereum.rlp.RLPInput;
 
 import java.math.BigInteger;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
 
+/**
+ * snap/2 BlockAccessLists (0x09) per EIP-8189.
+ *
+ * <p>Wire format: {@code [request-id: P, [block-access-list₁, block-access-list₂, ...]]}.
+ *
+ * <p>Unavailable BALs are encoded as the RLP empty string ({@code 0x80}) at their positional
+ * index, not as an empty list.
+ */
 public final class BlockAccessListsMessage extends AbstractSnapMessageData {
 
   public BlockAccessListsMessage(final Bytes data) {
@@ -48,8 +63,21 @@ public final class BlockAccessListsMessage extends AbstractSnapMessageData {
 
   public static BlockAccessListsMessage create(
       final Optional<BigInteger> requestId, final Iterable<BlockAccessList> blockAccessLists) {
-    return new BlockAccessListsMessage(
-        BlockAccessListsMessageData.encode(requestId, blockAccessLists));
+    final BytesValueRLPOutput output = new BytesValueRLPOutput();
+    output.startList();
+    requestId.ifPresent(output::writeBigIntegerScalar);
+    output.startList();
+    for (final BlockAccessList bal : blockAccessLists) {
+      if (bal == null || bal.isEmpty()) {
+        // EIP-8189: unavailable BALs are encoded as the RLP empty string (0x80).
+        output.writeBytes(Bytes.EMPTY);
+      } else {
+        BlockAccessListEncoder.encode(bal, output);
+      }
+    }
+    output.endList();
+    output.endList();
+    return new BlockAccessListsMessage(output.encoded());
   }
 
   /**
@@ -74,6 +102,46 @@ public final class BlockAccessListsMessage extends AbstractSnapMessageData {
   }
 
   public Iterable<BlockAccessList> blockAccessLists(final boolean withRequestId) {
-    return BlockAccessListsMessageData.decode(data, withRequestId);
+    return () ->
+        new Iterator<>() {
+          private final RLPInput input = new BytesValueRLPInput(data, false);
+          private boolean initialized = false;
+
+          private void ensureInitialized() {
+            if (!initialized) {
+              input.enterList();
+              if (withRequestId) {
+                input.skipNext();
+              }
+              input.enterList();
+              initialized = true;
+            }
+          }
+
+          @Override
+          public boolean hasNext() {
+            ensureInitialized();
+            return !input.isEndOfCurrentList();
+          }
+
+          @Override
+          public BlockAccessList next() {
+            ensureInitialized();
+            if (!hasNext()) {
+              throw new NoSuchElementException();
+            }
+            // EIP-8189: a positional entry is either a BAL (RLP list) or the empty-string
+            // sentinel (0x80) for "unavailable". The sentinel decodes to an empty BAL.
+            if (input.nextIsList()) {
+              return BlockAccessListDecoder.decode(input.readAsRlp());
+            }
+            final Bytes raw = input.readBytes();
+            if (!raw.isEmpty()) {
+              throw new IllegalStateException(
+                  "Unexpected non-list, non-empty-string entry in BlockAccessLists response");
+            }
+            return new BlockAccessList(List.of());
+          }
+        };
   }
 }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/messages/snap/GetBlockAccessListsMessage.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/messages/snap/GetBlockAccessListsMessage.java
@@ -15,16 +15,29 @@
 package org.hyperledger.besu.ethereum.eth.messages.snap;
 
 import org.hyperledger.besu.datatypes.Hash;
-import org.hyperledger.besu.ethereum.eth.messages.GetBlockAccessListsMessageData;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.AbstractSnapMessageData;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.MessageData;
+import org.hyperledger.besu.ethereum.rlp.BytesValueRLPInput;
+import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
+import org.hyperledger.besu.ethereum.rlp.RLPInput;
 
 import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
+import org.immutables.value.Value;
 
+/**
+ * snap/2 GetBlockAccessLists (0x08) per EIP-8189.
+ *
+ * <p>Wire format: {@code [request-id: P, [blockhash₁: B_32, blockhash₂: B_32, ...], bytes: P]}.
+ */
 public final class GetBlockAccessListsMessage extends AbstractSnapMessageData {
+
+  /** EIP-8189 recommended soft response limit for BlockAccessLists (2 MiB). */
+  public static final BigInteger DEFAULT_RESPONSE_BYTES = BigInteger.valueOf(2L * 1024 * 1024);
 
   public GetBlockAccessListsMessage(final Bytes data) {
     super(data);
@@ -42,19 +55,27 @@ public final class GetBlockAccessListsMessage extends AbstractSnapMessageData {
     return new GetBlockAccessListsMessage(message.getData());
   }
 
-  public static GetBlockAccessListsMessage create(final Iterable<Hash> blockHashes) {
-    return create(Optional.empty(), blockHashes);
+  public static GetBlockAccessListsMessage create(final List<Hash> blockHashes) {
+    return create(Optional.empty(), blockHashes, DEFAULT_RESPONSE_BYTES);
   }
 
   public static GetBlockAccessListsMessage create(
-      final Optional<BigInteger> requestId, final Iterable<Hash> blockHashes) {
-    return new GetBlockAccessListsMessage(
-        GetBlockAccessListsMessageData.encode(requestId, blockHashes));
+      final Optional<BigInteger> requestId,
+      final List<Hash> blockHashes,
+      final BigInteger responseBytes) {
+    final BytesValueRLPOutput tmp = new BytesValueRLPOutput();
+    tmp.startList();
+    requestId.ifPresent(tmp::writeBigIntegerScalar);
+    tmp.writeList(blockHashes, (hash, rlpOutput) -> rlpOutput.writeBytes(hash.getBytes()));
+    tmp.writeBigIntegerScalar(responseBytes);
+    tmp.endList();
+    return new GetBlockAccessListsMessage(tmp.encoded());
   }
 
   @Override
   protected Bytes wrap(final BigInteger requestId) {
-    return create(Optional.of(requestId), blockHashes(false)).getData();
+    final BlockHashes decoded = blockHashes(false);
+    return create(Optional.of(requestId), decoded.hashes(), decoded.responseBytes()).getData();
   }
 
   @Override
@@ -62,7 +83,28 @@ public final class GetBlockAccessListsMessage extends AbstractSnapMessageData {
     return SnapV2.GET_BLOCK_ACCESS_LISTS;
   }
 
-  public Iterable<Hash> blockHashes(final boolean withRequestId) {
-    return GetBlockAccessListsMessageData.decode(data, withRequestId);
+  public BlockHashes blockHashes(final boolean withRequestId) {
+    final List<Hash> hashes = new ArrayList<>();
+    final RLPInput input = new BytesValueRLPInput(data, false);
+    input.enterList();
+    if (withRequestId) {
+      input.skipNext();
+    }
+    input.enterList();
+    while (!input.isEndOfCurrentList()) {
+      hashes.add(Hash.wrap(input.readBytes32()));
+    }
+    input.leaveList();
+    final BigInteger responseBytes = input.readBigIntegerScalar();
+    input.leaveList();
+    return ImmutableBlockHashes.builder().hashes(hashes).responseBytes(responseBytes).build();
+  }
+
+  @Value.Immutable
+  public interface BlockHashes {
+
+    List<Hash> hashes();
+
+    BigInteger responseBytes();
   }
 }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/messages/snap/BlockAccessListsMessageTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/messages/snap/BlockAccessListsMessageTest.java
@@ -23,6 +23,7 @@ import org.hyperledger.besu.ethereum.p2p.rlpx.wire.RawMessage;
 import java.math.BigInteger;
 import java.util.List;
 
+import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
 
 public class BlockAccessListsMessageTest {
@@ -47,5 +48,21 @@ public class BlockAccessListsMessageTest {
 
     final BlockAccessListsMessage message = BlockAccessListsMessage.readFrom(raw);
     assertThat(message.blockAccessLists(false)).isEmpty();
+  }
+
+  @Test
+  public void wireFormatMatchesEip8189() {
+    // EIP-8189 (no request-id): [ [ 0x80 ] ] — outer wrapper list containing an inner list
+    // whose single entry is the RLP empty-string sentinel for an unavailable BAL.
+    final BlockAccessListsMessage message =
+        BlockAccessListsMessage.create(List.of(new BlockAccessList(List.of())));
+
+    assertThat(message.getData()).isEqualTo(Bytes.fromHexString("0xc2c180"));
+
+    // And the decoder rehydrates the empty-string sentinel as an empty BlockAccessList.
+    final BlockAccessListsMessage decoded =
+        BlockAccessListsMessage.readFrom(
+            new RawMessage(SnapV2.BLOCK_ACCESS_LISTS, message.getData()));
+    assertThat(decoded.blockAccessLists(false)).containsExactly(new BlockAccessList(List.of()));
   }
 }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/messages/snap/GetBlockAccessListsMessageTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/messages/snap/GetBlockAccessListsMessageTest.java
@@ -19,11 +19,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.MessageData;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.RawMessage;
+import org.hyperledger.besu.ethereum.rlp.BytesValueRLPInput;
+import org.hyperledger.besu.ethereum.rlp.RLPInput;
 
 import java.math.BigInteger;
 import java.util.List;
-import java.util.stream.StreamSupport;
+import java.util.Optional;
 
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
 
@@ -40,9 +43,11 @@ public class GetBlockAccessListsMessageTest {
     final MessageData raw = new RawMessage(SnapV2.GET_BLOCK_ACCESS_LISTS, wrapped.getData());
 
     final GetBlockAccessListsMessage message = GetBlockAccessListsMessage.readFrom(raw);
+    final GetBlockAccessListsMessage.BlockHashes decoded = message.blockHashes(true);
 
-    assertThat(StreamSupport.stream(message.blockHashes(true).spliterator(), false))
-        .containsExactlyElementsOf(blockHashes);
+    assertThat(decoded.hashes()).containsExactlyElementsOf(blockHashes);
+    assertThat(decoded.responseBytes())
+        .isEqualTo(GetBlockAccessListsMessage.DEFAULT_RESPONSE_BYTES);
   }
 
   @Test
@@ -51,6 +56,29 @@ public class GetBlockAccessListsMessageTest {
     final MessageData raw = new RawMessage(SnapV2.GET_BLOCK_ACCESS_LISTS, initialMessage.getData());
     final GetBlockAccessListsMessage message = GetBlockAccessListsMessage.readFrom(raw);
 
-    assertThat(message.blockHashes(false)).isEmpty();
+    assertThat(message.blockHashes(false).hashes()).isEmpty();
+  }
+
+  @Test
+  public void wireFormatMatchesEip8189() {
+    // EIP-8189 wire format for GetBlockAccessLists (without request-id):
+    //   [ [hash1, hash2, ...], bytes ]
+    final Hash h1 = Hash.wrap(Bytes32.fromHexString("0x" + "11".repeat(32)));
+    final Hash h2 = Hash.wrap(Bytes32.fromHexString("0x" + "22".repeat(32)));
+    final BigInteger requestedBytes = BigInteger.valueOf(65536);
+
+    final GetBlockAccessListsMessage message =
+        GetBlockAccessListsMessage.create(Optional.empty(), List.of(h1, h2), requestedBytes);
+
+    // Decode the raw RLP bytes directly and assert the structure is [ [hash1, hash2], bytes ].
+    final Bytes encoded = message.getData();
+    final RLPInput in = new BytesValueRLPInput(encoded, false);
+    in.enterList();
+    in.enterList();
+    assertThat(in.readBytes32()).isEqualTo(h1.getBytes());
+    assertThat(in.readBytes32()).isEqualTo(h2.getBytes());
+    in.leaveList();
+    assertThat(in.readBigIntegerScalar()).isEqualTo(requestedBytes);
+    in.leaveList();
   }
 }


### PR DESCRIPTION
## Summary                                                                    
  Fix snap/2 `GetBlockAccessLists` / `BlockAccessLists` wire format per EIP-8189:                                                                     
  - nest hash list inside outer frame + add `bytes` soft-limit field (request)  
  - nest BAL list inside outer frame (response)                                 
  - encode unavailable BALs as RLP empty string `0x80` (was empty list `0xC0`)  
  - server honors client `bytes`, capped at 2 MiB                               
                                                                                
  Interops with geth's snap/2 (PR [ethereum/go-ethereum#34626](https://github.com/ethereum/go-ethereum/pull/34626)).                                     
                                                                                
  ## Test plan                                                    
  - [x] `./gradlew :ethereum:eth:test` — 104/104 snap-related tests pass
  - [x] New `wireFormatMatchesEip8189` tests lock the RLP byte layout    