### PR TITLE
fix(referencetests): upgrade execution-spec-tests to v5.4.0 and handle expected exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Add EIP-7981 to Amsterdam [#10388](https://github.com/besu-eth/besu/pull/10388)
 - Bonsai Archive storage now uses Bonsai for head and Bonsai for near head improving performance for head queries [#10192](https://github.com/besu-eth/besu/pull/10192)
 - Added `eth_capabilities` JSON-RPC method that returns the node's data-serving capabilities, including chain head and per-resource availability flags [#10322](https://github.com/besu-eth/besu/pull/10322)
+- Upgrade execution-spec-tests to v5.4.0 and fix test harness to correctly handle blocks with expected exceptions [#10287](https://github.com/besu-eth/besu/issues/10287)
 
 ## 26.5.0
 

--- a/ethereum/referencetests/build.gradle
+++ b/ethereum/referencetests/build.gradle
@@ -316,7 +316,7 @@ dependencies {
   // the following will be resolved via custom ivy repository declared in root build.gradle
   referenceTestImplementation(
     group: 'ethereum', name: 'execution-spec-tests',
-    version: 'v5.3.0', classifier: 'fixtures_develop', ext: 'tar.gz'
+    version: 'v5.4.0', classifier: 'fixtures_develop', ext: 'tar.gz'
     )
   devnetTarConfig(
     group: 'ethereum', name: 'execution-spec-tests',

--- a/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/BlockchainReferenceTestCaseSpec.java
+++ b/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/BlockchainReferenceTestCaseSpec.java
@@ -305,6 +305,10 @@ public class BlockchainReferenceTestCaseSpec {
         blockValid = false;
       }
 
+      if (expectException != null || expectExceptionALL != null) {
+        blockValid = false;
+      }
+
       this.valid = blockValid;
       this.transactionSequence = transactionSequence;
       this.blockAccessList = blockAccessList;

--- a/ethereum/referencetests/src/main/resources/block-exception-mapping.json
+++ b/ethereum/referencetests/src/main/resources/block-exception-mapping.json
@@ -89,6 +89,11 @@
     "_comment_tx_sender": "Transaction sender errors",
     "TransactionException.SENDER_NOT_EOA":                       "transaction invalid Sender 0x[0-9a-f]+ has deployed code and so is not authorized to send transactions",
 
+    "_comment_tx_type_pre_fork": "Transaction type not supported on this fork — Besu emits the same error for all unsupported types",
+    "TransactionException.TYPE_NOT_SUPPORTED":                     "transaction invalid Transaction type \\w+ is invalid, accepted transaction types are|replay protected signatures is not supported",
+    "TransactionException.TYPE_1_TX_PRE_FORK":                     "transaction invalid Transaction type \\w+ is invalid, accepted transaction types are|replay protected signatures is not supported",
+    "TransactionException.TYPE_2_TX_PRE_FORK":                     "transaction invalid Transaction type \\w+ is invalid, accepted transaction types are|replay protected signatures is not supported",
+
     "_comment_tx_blob": "Blob transaction (EIP-4844) errors — type 3 tx specific validations",
     "TR_TypeNotSupportedBlob":                                   "Transaction type BLOB is invalid, accepted transaction types are|replay protected signatures is not supported",
     "TransactionException.TYPE_3_TX_BLOB_COUNT_EXCEEDED":        "Blob transaction has too many blobs: \\d+|Invalid Blob Count: \\d+|Header validation failed \\(",

--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -2128,9 +2128,9 @@
             <sha256 value="741530c88f6a48c15184d1504316c02c3a76c2322c410a04b643a85185dc62e9" origin="Manual"/>
          </artifact>
       </component>
-      <component group="ethereum" name="execution-spec-tests" version="v5.3.0">
-         <artifact name="execution-spec-tests-v5.3.0-fixtures_develop.tar.gz">
-            <sha256 value="5dd08fee0fb41bc2a59bc4ab1dc75b19723fc71fe6af2f855454d3283fba09b9" origin="Manual"/>
+      <component group="ethereum" name="execution-spec-tests" version="v5.4.0">
+         <artifact name="execution-spec-tests-v5.4.0-fixtures_develop.tar.gz">
+            <sha256 value="3e2b02d49fe903eda4fd8caca5cbf0d139c470e97e1de9a85299b1b034f97099" origin="Manual"/>
          </artifact>
       </component>
       <component group="info.picocli" name="picocli" version="4.7.6">


### PR DESCRIPTION
## Description

Closes #10287

Upgrades `execution-spec-tests` from v5.3.0 to v5.4.0. The new release introduces test fixtures for [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930) and [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) typed transactions that are expected to be **rejected** on pre-fork chains (e.g. type-1 `ACCESS_LIST` on Frontier/Homestead, type-2 `EIP1559` on pre-London forks).

These tests exposed a bug in the test harness: `CandidateBlock.isValid()` only evaluated structural validity (parseable RLP + non-null header/txs/uncles) and did not consider the `expectException` / `expectExceptionALL` fields. This caused assertions to fail because Besu's core validation correctly rejected the invalid blocks, but the test harness still expected them to be valid.

### Changes

1. **`BlockchainReferenceTestCaseSpec.java`** — Mark blocks as invalid when the fixture specifies `expectException` or `expectExceptionALL`. These fields explicitly indicate that the block is expected to fail validation.

2. **`block-exception-mapping.json`** — Add regex mapping for `TransactionException.TYPE_NOT_SUPPORTED`, matching the Besu error message `Transaction type <TYPE> is invalid, accepted transaction types are <LIST>` produced by `MainnetTransactionValidator`.

3. **`build.gradle`** — Bump version pin from `v5.3.0` to `v5.4.0`.

4. **`verification-metadata.xml`** — Update SHA-256 hash for the new fixture tarball.

### Root Cause

Besu's `MainnetTransactionValidator` already correctly rejects unsupported transaction types with `INVALID_TRANSACTION_FORMAT`. The bug was localized to the test expectation logic:

\\\java
// Before: only structural checks
blockValid = (rlp parses) && (header/txs/uncles non-null)

// After: also considers fixture's expected-exception annotation
if (expectException != null || expectExceptionALL != null) {
    blockValid = false;
}
\\\

Without this check, the assertion `assertThat(imported).isEqualTo(candidateBlock.isValid())` failed because `imported=false` (Besu correctly rejected) but `candidateBlock.isValid()=true` (harness didn't check expectException).