### PR TITLE
fix: fix DefaultPeerId comparator

### DIFF
--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/peers/DefaultPeerId.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/peers/DefaultPeerId.java
@@ -50,8 +50,7 @@ public class DefaultPeerId implements PeerId {
   @Override
   public boolean equals(final Object o) {
     if (this == o) return true;
-    if (o == null || o.getClass().isAssignableFrom(this.getClass())) return false;
-    final DefaultPeerId that = (DefaultPeerId) o;
+    if (!(o instanceof DefaultPeerId that)) return false;
     return Objects.equals(id, that.id);
   }
 

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/peers/DefaultPeerIdTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/peers/DefaultPeerIdTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.p2p.peers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.junit.jupiter.api.Test;
+
+public class DefaultPeerIdTest {
+
+  private static final Bytes ID_1 = Bytes.fromHexString("0x1234");
+  private static final Bytes ID_2 = Bytes.fromHexString("0x5678");
+
+  @Test
+  public void equals_sameId_returnsTrue() {
+    final DefaultPeerId a = new DefaultPeerId(ID_1);
+    final DefaultPeerId b = new DefaultPeerId(ID_1);
+    assertThat(a).isEqualTo(b);
+  }
+
+  @Test
+  public void equals_differentId_returnsFalse() {
+    final DefaultPeerId a = new DefaultPeerId(ID_1);
+    final DefaultPeerId b = new DefaultPeerId(ID_2);
+    assertThat(a).isNotEqualTo(b);
+  }
+
+  @Test
+  public void equals_null_returnsFalse() {
+    final DefaultPeerId a = new DefaultPeerId(ID_1);
+    assertThat(a).isNotEqualTo(null);
+  }
+
+  @Test
+  public void equals_differentType_returnsFalse() {
+    final DefaultPeerId a = new DefaultPeerId(ID_1);
+    assertThat(a).isNotEqualTo("not-a-peer-id");
+  }
+
+  @Test
+  public void hashCode_sameId_returnsSameHash() {
+    final DefaultPeerId a = new DefaultPeerId(ID_1);
+    final DefaultPeerId b = new DefaultPeerId(ID_1);
+    assertThat(a.hashCode()).isEqualTo(b.hashCode());
+  }
+}


### PR DESCRIPTION
## PR description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


