### PR TITLE
fix(jsonrpc): return EIP-55 checksummed addresses across JSON-RPC responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - BFT option `xemptyblockperiodseconds` has been taken out of experimental and been renamed `emptyblockperiodseconds`. The old config option is deprecated and will be removed in a future release.
 
 ### Bug fixes
+- `eth_getBlockBy*`, `eth_getTransactionBy*`, `eth_getTransactionReceipt`, `eth_getLogs`, `txpool_content`, `txpool_contentFrom`, and `engine_getPayloadV*` now return Ethereum addresses in EIP-55 mixed-case checksum format instead of lowercase, aligning with the execution-apis spec and the behaviour of Geth and Reth. [#10327](https://github.com/besu-eth/besu/pull/10327)
 - Fix data race in `SyncDurationMetrics` where the backing `HashMap` was mutated from multiple sync threads in parallel, causing missing or zero `sync_duration` samples. [#10277](https://github.com/besu-eth/besu/pull/10277)
 
 ### Additions and Improvements

--- a/datatypes/src/main/java/org/hyperledger/besu/datatypes/Address.java
+++ b/datatypes/src/main/java/org/hyperledger/besu/datatypes/Address.java
@@ -22,6 +22,7 @@ import org.hyperledger.besu.ethereum.rlp.RLP;
 import org.hyperledger.besu.ethereum.rlp.RLPException;
 import org.hyperledger.besu.ethereum.rlp.RLPInput;
 
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ExecutionException;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -236,6 +237,28 @@ public class Address extends BytesHolder {
                   out.writeLongScalar(nonce);
                   out.endList();
                 })));
+  }
+
+  /**
+   * Returns the EIP-55 mixed-case checksum encoding of this address.
+   *
+   * @return checksummed address string, e.g. {@code 0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed}
+   */
+  public String toChecksumString() {
+    final String hex = getBytes().toHexString().substring(2);
+    final byte[] hashBytes =
+        keccak256(Bytes.wrap(hex.getBytes(StandardCharsets.US_ASCII))).toArray();
+    final StringBuilder sb = new StringBuilder("0x");
+    for (int i = 0; i < hex.length(); i++) {
+      final char c = hex.charAt(i);
+      if (Character.isDigit(c)) {
+        sb.append(c);
+      } else {
+        final int hashNibble = (hashBytes[i / 2] >> (i % 2 == 0 ? 4 : 0)) & 0xF;
+        sb.append(hashNibble >= 8 ? Character.toUpperCase(c) : c);
+      }
+    }
+    return sb.toString();
   }
 
   /**

--- a/datatypes/src/test/java/org/hyperledger/besu/datatypes/AddressTest.java
+++ b/datatypes/src/test/java/org/hyperledger/besu/datatypes/AddressTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.datatypes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Locale;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class AddressTest {
+
+  // EIP-55 test vectors from https://eips.ethereum.org/EIPS/eip-55
+  @ParameterizedTest
+  @CsvSource({
+    "0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed",
+    "0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359",
+    "0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB",
+    "0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb",
+    "0x52908400098527886E0F7030069857D2E4169EE7",
+    "0x8617E340B3D01FA5F11F306F4090FD50E238070D",
+  })
+  void toChecksumStringMatchesEip55(final String checksummed) {
+    final Address address = Address.fromHexString(checksummed.toLowerCase(Locale.ROOT));
+    assertThat(address.toChecksumString()).isEqualTo(checksummed);
+  }
+}

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/BlockResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/BlockResult.java
@@ -122,7 +122,7 @@ public class BlockResult implements JsonRpcResult {
     this.transactionsRoot = header.getTransactionsRoot().toString();
     this.stateRoot = header.getStateRoot().toString();
     this.receiptsRoot = header.getReceiptsRoot().toString();
-    this.miner = header.getCoinbase().toString();
+    this.miner = header.getCoinbase().toChecksumString();
     this.difficulty = Quantity.create(header.getDifficulty());
     this.totalDifficulty =
         totalDifficulty != null && !header.getDifficulty().isZero()

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/EngineGetPayloadResultV1.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/EngineGetPayloadResultV1.java
@@ -68,7 +68,7 @@ public class EngineGetPayloadResultV1 {
     this.gasUsed = Quantity.create(header.getGasUsed());
     this.timestamp = Quantity.create(header.getTimestamp());
     this.transactions = transactions;
-    this.feeRecipient = header.getCoinbase().toString();
+    this.feeRecipient = header.getCoinbase().toChecksumString();
     this.prevRandao = header.getPrevRandao().map(Bytes32::toHexString).orElse(null);
   }
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/EngineGetPayloadResultV2.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/EngineGetPayloadResultV2.java
@@ -88,7 +88,7 @@ public class EngineGetPayloadResultV2 {
       this.gasUsed = Quantity.create(header.getGasUsed());
       this.timestamp = Quantity.create(header.getTimestamp());
       this.transactions = transactions;
-      this.feeRecipient = header.getCoinbase().toString();
+      this.feeRecipient = header.getCoinbase().toChecksumString();
       this.prevRandao = header.getPrevRandao().map(Bytes32::toHexString).orElse(null);
       this.withdrawals =
           withdrawals

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/EngineGetPayloadResultV3.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/EngineGetPayloadResultV3.java
@@ -103,7 +103,7 @@ public class EngineGetPayloadResultV3 {
       this.gasUsed = Quantity.create(header.getGasUsed());
       this.timestamp = Quantity.create(header.getTimestamp());
       this.transactions = transactions;
-      this.feeRecipient = header.getCoinbase().toString();
+      this.feeRecipient = header.getCoinbase().toChecksumString();
       this.prevRandao = header.getPrevRandao().map(Bytes32::toHexString).orElse(null);
       this.withdrawals =
           withdrawals

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/EngineGetPayloadResultV4.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/EngineGetPayloadResultV4.java
@@ -117,7 +117,7 @@ public class EngineGetPayloadResultV4 {
       this.gasUsed = Quantity.create(header.getGasUsed());
       this.timestamp = Quantity.create(header.getTimestamp());
       this.transactions = transactions;
-      this.feeRecipient = header.getCoinbase().toString();
+      this.feeRecipient = header.getCoinbase().toChecksumString();
       this.prevRandao = header.getPrevRandao().map(Bytes32::toHexString).orElse(null);
       this.withdrawals =
           withdrawals

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/EngineGetPayloadResultV5.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/EngineGetPayloadResultV5.java
@@ -116,7 +116,7 @@ public class EngineGetPayloadResultV5 {
       this.gasUsed = Quantity.create(header.getGasUsed());
       this.timestamp = Quantity.create(header.getTimestamp());
       this.transactions = transactions;
-      this.feeRecipient = header.getCoinbase().toString();
+      this.feeRecipient = header.getCoinbase().toChecksumString();
       this.prevRandao = header.getPrevRandao().map(Bytes32::toHexString).orElse(null);
       this.withdrawals =
           withdrawals

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/EngineGetPayloadResultV6.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/EngineGetPayloadResultV6.java
@@ -145,7 +145,7 @@ public class EngineGetPayloadResultV6 {
       this.gasUsed = Quantity.create(header.getGasUsed());
       this.timestamp = Quantity.create(header.getTimestamp());
       this.transactions = transactions;
-      this.feeRecipient = header.getCoinbase().toString();
+      this.feeRecipient = header.getCoinbase().toChecksumString();
       this.prevRandao = header.getPrevRandao().map(Bytes32::toHexString).orElse(null);
       this.withdrawals =
           withdrawals

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/LogResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/LogResult.java
@@ -56,7 +56,7 @@ public class LogResult implements JsonRpcResult {
     this.blockTimestamp = Quantity.create(logWithMetadata.getBlockTimestamp());
     this.transactionHash = logWithMetadata.getTransactionHash().toString();
     this.transactionIndex = Quantity.create(logWithMetadata.getTransactionIndex());
-    this.address = logWithMetadata.getLogger().toString();
+    this.address = logWithMetadata.getLogger().toChecksumString();
     this.data = logWithMetadata.getData().toString();
     this.topics = new ArrayList<>(logWithMetadata.getTopics().size());
     this.removed = logWithMetadata.isRemoved();

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/TransactionBaseResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/TransactionBaseResult.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.results;
 
 import org.hyperledger.besu.datatypes.AccessListEntry;
+import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.BytesHolder;
 import org.hyperledger.besu.datatypes.TransactionType;
 import org.hyperledger.besu.datatypes.Wei;
@@ -101,7 +102,7 @@ public class TransactionBaseResult implements TransactionResult {
     this.accessList =
         transaction.getAccessList().orElse(transactionType.supportsAccessList() ? List.of() : null);
     this.chainId = transaction.getChainId().map(Quantity::create).orElse(null);
-    this.from = transaction.getSender().toString();
+    this.from = transaction.getSender().toChecksumString();
     this.gas = Quantity.create(transaction.getGasLimit());
     this.maxPriorityFeePerGas =
         transaction.getMaxPriorityFeePerGas().map(Wei::toShortHexString).orElse(null);
@@ -120,7 +121,7 @@ public class TransactionBaseResult implements TransactionResult {
     this.hash = transaction.getHash().toString();
     this.input = transaction.getPayload().toString();
     this.nonce = Quantity.create(transaction.getNonce());
-    this.to = transaction.getTo().map(a -> a.getBytes().toHexString()).orElse(null);
+    this.to = transaction.getTo().map(Address::toChecksumString).orElse(null);
     if (transactionType == TransactionType.FRONTIER) {
       this.type = Quantity.create(0);
       this.yParity = null;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/TransactionReceiptLogResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/TransactionReceiptLogResult.java
@@ -57,7 +57,7 @@ public class TransactionReceiptLogResult {
       final long blockTimestamp,
       final int transactionIndex,
       final int logIndex) {
-    this.address = log.getLogger().toString();
+    this.address = log.getLogger().toChecksumString();
     this.topics = new ArrayList<>(log.getTopics().size());
 
     for (final LogTopic topic : log.getTopics()) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/TransactionReceiptResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/TransactionReceiptResult.java
@@ -15,7 +15,6 @@
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.results;
 
 import org.hyperledger.besu.datatypes.Address;
-import org.hyperledger.besu.datatypes.BytesHolder;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.Log;
 import org.hyperledger.besu.datatypes.TransactionType;
@@ -78,9 +77,9 @@ public abstract class TransactionReceiptResult {
     this.receipt = receiptWithMetadata.getReceipt();
     this.blockHash = receiptWithMetadata.getBlockHash().toString();
     this.blockNumber = Quantity.create(receiptWithMetadata.getBlockNumber());
-    this.contractAddress = txn.contractAddress().map(Address::toString).orElse(null);
+    this.contractAddress = txn.contractAddress().map(Address::toChecksumString).orElse(null);
     this.cumulativeGasUsed = Quantity.create(receipt.getCumulativeGasUsed());
-    this.from = txn.getSender().toString();
+    this.from = txn.getSender().toChecksumString();
     this.gasUsed = Quantity.create(receiptWithMetadata.getGasUsed());
     this.blobGasUsed = receiptWithMetadata.getBlobGasUsed().map(Quantity::create).orElse(null);
     this.blobGasPrice = receiptWithMetadata.getBlobGasPrice().map(Quantity::create).orElse(null);
@@ -97,7 +96,7 @@ public abstract class TransactionReceiptResult {
             receiptWithMetadata.getTransactionIndex(),
             receiptWithMetadata.getLogIndexOffset());
     this.logsBloom = receipt.getBloomFilter().toString();
-    this.to = txn.getTo().map(BytesHolder::getBytes).map(Bytes::toHexString).orElse(null);
+    this.to = txn.getTo().map(Address::toChecksumString).orElse(null);
     this.transactionHash = txn.getHash().toString();
     this.transactionIndex = Quantity.create(receiptWithMetadata.getTransactionIndex());
     this.revertReason = receipt.getRevertReason().map(Bytes::toString).orElse(null);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/pending/PendingTransactionDetailResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/pending/PendingTransactionDetailResult.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.pending;
 
+import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.TransactionType;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.JsonRpcResult;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.Quantity;
@@ -55,13 +56,13 @@ public class PendingTransactionDetailResult implements JsonRpcResult {
 
   public PendingTransactionDetailResult(final Transaction tx) {
     TransactionType transactionType = tx.getType();
-    this.from = tx.getSender().toString();
+    this.from = tx.getSender().toChecksumString();
     this.gas = Quantity.create(tx.getGasLimit());
     this.gasPrice = tx.getGasPrice().map(Quantity::create).orElse(null);
     this.hash = tx.getHash().toString();
     this.input = tx.getPayload().toString();
     this.nonce = Quantity.create(tx.getNonce());
-    this.to = tx.getTo().map(a -> a.getBytes().toHexString()).orElse(null);
+    this.to = tx.getTo().map(Address::toChecksumString).orElse(null);
     if (transactionType == TransactionType.FRONTIER) {
       this.type = Quantity.create(0);
       this.yParity = null;


### PR DESCRIPTION
Closes #10325

## What changed and why

While investigating the `txpool_content` hive failure, I noticed that Besu returns Ethereum addresses as plain lowercase hex across most JSON-RPC responses. The execution-apis spec and both Geth and Reth use EIP-55 mixed-case checksum encoding, so this puts Besu out of step with the ecosystem and is the root cause of several `rpc-compat` hive failures.

The fix is straightforward: add `Address#toChecksumString()` implementing the EIP-55 algorithm (keccak256 the lowercase hex, uppercase each letter whose corresponding hash nibble is ≥ 8), then apply it in every result class that serialises an address field.

**Affected methods and fields:**

| Method(s) | Field(s) |
|---|---|
| `eth_getBlockByHash`, `eth_getBlockByNumber` | `miner`, `coinbase` |
| `eth_getTransactionByHash`, `eth_getTransactionByBlockHash*`, `eth_getTransactionByBlockNumber*` | `from`, `to` |
| `eth_getTransactionReceipt` | `from`, `to`, `contractAddress` |
| `eth_getLogs` / receipt log entries | `address` |
| `txpool_content`, `txpool_contentFrom` | sender map keys, `from`, `to` |
| `eth_subscribe` (newPendingTransactions full) | `from`, `to` |
| `engine_getPayloadV1`–`V6` | `feeRecipient` |

## Test plan

- [ ] `AddressTest#toChecksumStringMatchesEip55` passes for all six EIP-55 reference vectors from the spec
- [ ] Existing JSON-RPC result unit tests still pass
- [ ] `eth_getBlockByNumber`, `eth_getTransactionByHash`, `eth_getTransactionReceipt`, `eth_getLogs` responses show checksummed addresses