### PR TITLE
Limit bonsai head roll-forward distance

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/provider/PathBasedWorldStateProvider.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/provider/PathBasedWorldStateProvider.java
@@ -205,6 +205,33 @@ public abstract class PathBasedWorldStateProvider implements WorldStateArchive {
    * @return the full world state, if available
    */
   private Optional<MutableWorldState> getFullWorldStateFromHead(final Hash blockHash) {
+    final Optional<BlockHeader> maybeHeadHeader =
+        blockchain.getBlockHeader(headWorldState.blockHash()).map(BlockHeader.class::cast);
+    final Optional<BlockHeader> maybeTargetHeader =
+        blockchain.getBlockHeader(blockHash).map(BlockHeader.class::cast);
+    if (maybeHeadHeader.isPresent() && maybeTargetHeader.isPresent()) {
+      final long rollingDistance =
+          maybeTargetHeader.get().getNumber() - maybeHeadHeader.get().getNumber();
+      final long maxLayers = trieLogManager.getMaxLayersToLoad();
+      if (maxLayers > 0 && rollingDistance >= maxLayers) {
+        LOG.warn(
+            "Bonsai head world state is {} blocks behind target block {} (head at block {})."
+                + " This exceeds the maximum roll-forward limit of {}."
+                + " The node cannot validate new blocks until the world state is resynced.",
+            rollingDistance,
+            maybeTargetHeader.get().getNumber(),
+            maybeHeadHeader.get().getNumber(),
+            maxLayers);
+        return Optional.empty();
+      } else if (rollingDistance > 1) {
+        LOG.warn(
+            "Rolling bonsai head world state {} blocks forward to block {} (from block {})."
+                + " This may indicate the world state is falling behind chain head.",
+            rollingDistance,
+            maybeTargetHeader.get().getNumber(),
+            maybeHeadHeader.get().getNumber());
+      }
+    }
     return rollFullWorldStateToBlockHash(headWorldState, blockHash);
   }
 
@@ -293,6 +320,15 @@ public abstract class PathBasedWorldStateProvider implements WorldStateArchive {
             targetBlockHash = targetHeader.getBlockHash();
             persistedBlockHash = persistedHeader.getBlockHash();
           }
+        }
+
+        // log a warning when a non-trivial roll is required
+        if (rollForwards.size() + rollBacks.size() > 1) {
+          LOG.warn(
+              "Bonsai world state roll: {} rollbacks, {} roll-forwards to reach block {}",
+              rollBacks.size(),
+              rollForwards.size(),
+              blockHash);
         }
 
         // attempt the state rolling

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/BonsaiWorldStateProviderTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/BonsaiWorldStateProviderTest.java
@@ -125,6 +125,28 @@ class BonsaiWorldStateProviderTest {
   }
 
   @Test
+  void shouldReturnEmptyWhenRollForwardExceedsMaxLayersInHeadPath() {
+    bonsaiWorldStateArchive = createBonsaiWorldStateProvider();
+
+    when(trieLogManager.getMaxLayersToLoad()).thenReturn(512L);
+
+    // treat the initial head world state hash as block 0
+    final Hash headHash = ((BonsaiWorldState) bonsaiWorldStateArchive.getWorldState()).blockHash();
+    final BlockHeader genesis = blockBuilder.number(0).buildHeader();
+    final BlockHeader blockHeader512 =
+        blockBuilder.number(512).parentHash(genesis.getHash()).buildHeader();
+
+    when(blockchain.getBlockHeader(headHash)).thenReturn(Optional.of(genesis));
+    when(blockchain.getBlockHeader(blockHeader512.getHash()))
+        .thenReturn(Optional.of(blockHeader512));
+
+    // distance 512 >= maxLayersToLoad 512 → should abort and return empty
+    assertThat(
+            bonsaiWorldStateArchive.getWorldState(withBlockHeaderAndUpdateNodeHead(blockHeader512)))
+        .isEmpty();
+  }
+
+  @Test
   void shouldReturnEmptyWhenLoadingMoreThanMaxLayersBack() {
     bonsaiWorldStateArchive =
         new BonsaiWorldStateProvider(


### PR DESCRIPTION
When the bonsai persisted world state falls far behind chain head (e.g. due to repeated OOM crashes), rollFullWorldStateToBlockHash attempts to replay all accumulated trie logs into memory before applying any. This can cause OOM, which restarts the node with a cold cache.

Two changes to mitigate this:

1. Add a roll-forward distance limit in getFullWorldStateFromHead: if the gap between the persisted head state and the target block meets or exceeds maxLayersToLoad (default 512), return Optional.empty() with a WARN log. The CL receives SYNCING rather than the engine hanging.

2. Log a WARN in rollFullWorldStateToBlockHash when a non-trivial roll is required (>1 trie log), showing rollback and roll-forward counts. In normal operation this path should rarely be taken; the log makes any deviation immediately visible in production.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


