### PR TITLE
Path-based world state: batch trie-log rolls to cut memory use

### DIFF
--- a/consensus/merge/build.gradle
+++ b/consensus/merge/build.gradle
@@ -63,4 +63,6 @@ dependencies {
   testImplementation 'org.mockito:mockito-core'
   testImplementation 'org.mockito:mockito-junit-jupiter'
   testImplementation project(':ethereum:core')
+  testImplementation project(path: ':ethereum:eth', configuration: 'testArtifacts')
+  testImplementation project(path: ':ethereum:eth', configuration: 'testSupportArtifacts')
 }

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
@@ -714,14 +714,14 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
     MutableBlockchain blockchain = protocolContext.getBlockchain();
     final Optional<BlockHeader> newFinalized = blockchain.getBlockHeader(finalizedBlockHash);
 
-    if (newHead.getNumber() < blockchain.getChainHeadBlockNumber()
+    /*if (newHead.getNumber() < blockchain.getChainHeadBlockNumber()
         && isDescendantOf(newHead, blockchain.getChainHeadHeader())) {
       LOG.atDebug()
           .setMessage("Ignoring update to old head {}")
           .addArgument(newHead::toLogString)
           .log();
       return ForkchoiceResult.withIgnoreUpdateToOldHead(newHead);
-    }
+    }*/
 
     final Optional<Hash> latestValid = getLatestValidAncestor(newHead);
 

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
@@ -16,7 +16,6 @@ package org.hyperledger.besu.consensus.merge.blockcreation;
 
 import static java.util.stream.Collectors.joining;
 import static org.hyperledger.besu.consensus.merge.blockcreation.MergeMiningCoordinator.ForkchoiceResult.Status.INVALID;
-import static org.hyperledger.besu.ethereum.trie.pathbased.common.provider.WorldStateQueryParams.withBlockHeaderAndUpdateNodeHead;
 
 import org.hyperledger.besu.config.NetworkDefinition;
 import org.hyperledger.besu.consensus.merge.MergeContext;
@@ -49,6 +48,8 @@ import org.hyperledger.besu.ethereum.mainnet.HeaderValidationMode;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.block.access.list.BlockAccessList;
 import org.hyperledger.besu.ethereum.trie.MerkleTrieException;
+import org.hyperledger.besu.ethereum.trie.pathbased.common.provider.TrieLogLayerBudgetExceededException;
+import org.hyperledger.besu.ethereum.trie.pathbased.common.provider.WorldStateQueryParams;
 import org.hyperledger.besu.plugin.services.exception.StorageException;
 
 import java.io.PrintWriter;
@@ -711,21 +712,20 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
   @Override
   public ForkchoiceResult updateForkChoice(
       final BlockHeader newHead, final Hash finalizedBlockHash, final Hash safeBlockHash) {
-    MutableBlockchain blockchain = protocolContext.getBlockchain();
+    final MutableBlockchain blockchain = protocolContext.getBlockchain();
     final Optional<BlockHeader> newFinalized = blockchain.getBlockHeader(finalizedBlockHash);
 
-    /*if (newHead.getNumber() < blockchain.getChainHeadBlockNumber()
-        && isDescendantOf(newHead, blockchain.getChainHeadHeader())) {
+    if (isForkchoiceToCanonicalAncestorBelowTip(newHead, blockchain)) {
       LOG.atDebug()
-          .setMessage("Ignoring update to old head {}")
+          .setMessage("Declining forkchoice rewind to canonical ancestor {}")
           .addArgument(newHead::toLogString)
           .log();
-      return ForkchoiceResult.withIgnoreUpdateToOldHead(newHead);
-    }*/
+      return ForkchoiceResult.withDeclinedCanonicalRewind(newHead);
+    }
 
     final Optional<Hash> latestValid = getLatestValidAncestor(newHead);
-
-    Optional<BlockHeader> parentOfNewHead = blockchain.getBlockHeader(newHead.getParentHash());
+    final Optional<BlockHeader> parentOfNewHead =
+        blockchain.getBlockHeader(newHead.getParentHash());
     if (parentOfNewHead.isPresent()
         && Long.compareUnsigned(newHead.getTimestamp(), parentOfNewHead.get().getTimestamp())
             <= 0) {
@@ -733,18 +733,41 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
           INVALID, "new head timestamp not greater than parent", latestValid);
     }
 
-    if (!setNewHead(blockchain, newHead)) {
-      LOG.warn("Failed to move world state to new head {}", newHead.toLogString());
-      return ForkchoiceResult.withFailure(INVALID, "Failed to set new head", latestValid);
-    }
+    final ForkchoiceResult forkchoiceResult =
+        setNewHead(blockchain, latestValid, newFinalized, newHead);
 
-    // set and persist the new finalized block if it is present
+    return switch (forkchoiceResult.getStatus()) {
+      case VALID ->
+          applyForkchoiceFinalizedAndSafe(blockchain, newFinalized, safeBlockHash, newHead);
+      case DECLINED_CANONICAL_REWIND -> {
+        startBackwardSyncAfterTrieLogBudgetExceeded(newHead);
+        yield ForkchoiceResult.withSyncing();
+      }
+      default -> forkchoiceResult;
+    };
+  }
+
+  /**
+   * Forkchoice head is on the canonical chain but strictly below the execution chain tip —
+   * rewinding to it would be a reorg; Besu keeps the tip and signals this to the engine layer
+   * separately.
+   */
+  private boolean isForkchoiceToCanonicalAncestorBelowTip(
+      final BlockHeader newHead, final MutableBlockchain blockchain) {
+    return newHead.getNumber() < blockchain.getChainHeadBlockNumber()
+        && isDescendantOf(newHead, blockchain.getChainHeadHeader());
+  }
+
+  private ForkchoiceResult applyForkchoiceFinalizedAndSafe(
+      final MutableBlockchain blockchain,
+      final Optional<BlockHeader> newFinalized,
+      final Hash safeBlockHash,
+      final BlockHeader newHead) {
     newFinalized.ifPresent(
         blockHeader -> {
           blockchain.setFinalized(blockHeader.getHash());
           mergeContext.setFinalized(blockHeader);
         });
-
     blockchain
         .getBlockHeader(safeBlockHash)
         .ifPresent(
@@ -752,49 +775,100 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
               blockchain.setSafeBlock(safeBlockHash);
               mergeContext.setSafeBlock(newSafeBlock);
             });
-
     return ForkchoiceResult.withResult(newFinalized, Optional.of(newHead));
   }
 
-  private boolean setNewHead(final MutableBlockchain blockchain, final BlockHeader newHead) {
+  private void startBackwardSyncAfterTrieLogBudgetExceeded(final BlockHeader newHead) {
+    LOG.atInfo()
+        .setMessage(
+            "Trie-log roll plan ops exceeds max layers; triggering backward sync for head {}")
+        .addArgument(newHead::toLogString)
+        .log();
+    protocolContext
+        .getBlockchain()
+        .getBlockByHash(newHead.getHash())
+        .map(this::appendNewPayloadToSync)
+        .orElseGet(() -> backwardSyncContext.syncBackwardsUntil(newHead.getHash()))
+        .whenComplete(
+            (result, error) -> {
+              if (error != null) {
+                LOG.error(
+                    "Backward sync after trie-log layer budget exceeded failed for head {}",
+                    newHead.toLogString(),
+                    error);
+              }
+            });
+  }
+
+  private ForkchoiceResult setNewHead(
+      final MutableBlockchain blockchain,
+      final Optional<Hash> latestValid,
+      final Optional<BlockHeader> newFinalized,
+      final BlockHeader newHead) {
 
     if (newHead.getHash().equals(blockchain.getChainHeadHash())) {
       LOG.atDebug()
           .setMessage("Nothing to do new head {} is already chain head")
           .addArgument(newHead::toLogString)
           .log();
-      return true;
+      return ForkchoiceResult.withResult(newFinalized, Optional.of(newHead));
     }
 
-    if (moveWorldStateTo(newHead)) {
-      if (newHead.getParentHash().equals(blockchain.getChainHeadHash())) {
-        LOG.atDebug()
-            .setMessage(
-                "Forwarding chain head to the block {} saved from a previous newPayload invocation")
-            .addArgument(newHead::toLogString)
-            .log();
-        return blockchain.forwardToBlock(newHead);
-      } else {
-        LOG.atDebug()
-            .setMessage("New head {} is a chain reorg, rewind chain head to it")
-            .addArgument(newHead::toLogString)
-            .log();
-        return blockchain.rewindToBlock(newHead.getHash());
-      }
+    final boolean worldStateMoved;
+    try {
+      worldStateMoved = moveWorldStateTo(newHead);
+    } catch (final TrieLogLayerBudgetExceededException e) {
+      return ForkchoiceResult.withDeclinedCanonicalRewind(newHead);
     }
-    LOG.atDebug()
-        .setMessage("Failed to move the worldstate forward to hash {}, not moving chain head")
-        .addArgument(newHead::toLogString)
-        .log();
-    return false;
+
+    if (!worldStateMoved) {
+      LOG.atDebug()
+          .setMessage("Failed to move the worldstate forward to hash {}, not moving chain head")
+          .addArgument(newHead::toLogString)
+          .log();
+      return ForkchoiceResult.withFailure(
+          INVALID, "Failed to move the worldstate forward to hash", latestValid);
+    }
+
+    final boolean chainHeadUpdated;
+    if (newHead.getParentHash().equals(blockchain.getChainHeadHash())) {
+      LOG.atDebug()
+          .setMessage(
+              "Forwarding chain head to the block {} saved from a previous newPayload invocation")
+          .addArgument(newHead::toLogString)
+          .log();
+      chainHeadUpdated = blockchain.forwardToBlock(newHead);
+    } else {
+      LOG.atDebug()
+          .setMessage("New head {} is a chain reorg, rewind chain head to it")
+          .addArgument(newHead::toLogString)
+          .log();
+      chainHeadUpdated = blockchain.rewindToBlock(newHead.getHash());
+    }
+
+    if (!chainHeadUpdated) {
+      LOG.atDebug()
+          .setMessage("Failed to advance chain head to {}, not moving chain head")
+          .addArgument(newHead::toLogString)
+          .log();
+      return ForkchoiceResult.withFailure(
+          INVALID, "Failed to move the worldstate forward to hash", latestValid);
+    }
+
+    return ForkchoiceResult.withResult(newFinalized, Optional.of(newHead));
   }
 
-  private boolean moveWorldStateTo(final BlockHeader newHead) {
-    Optional<MutableWorldState> newWorldState =
+  private boolean moveWorldStateTo(final BlockHeader newHead)
+      throws TrieLogLayerBudgetExceededException {
+    final Optional<MutableWorldState> newWorldState =
         protocolContext
             .getWorldStateArchive()
-            .getWorldState(withBlockHeaderAndUpdateNodeHead(newHead));
-
+            .getWorldState(
+                WorldStateQueryParams.newBuilder()
+                    .withBlockHeader(newHead)
+                    .withShouldWorldStateUpdateHead(true)
+                    .withEnforceTrieRollLayerBudget(true)
+                    .build());
     newWorldState.ifPresentOrElse(
         mutableWorldState ->
             LOG.atDebug()

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
@@ -737,8 +737,10 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
         setNewHead(blockchain, latestValid, newFinalized, newHead);
 
     return switch (forkchoiceResult.getStatus()) {
-      case VALID ->
-          applyForkchoiceFinalizedAndSafe(blockchain, newFinalized, safeBlockHash, newHead);
+      case VALID -> {
+        applyForkchoiceFinalizedAndSafe(blockchain, newFinalized, safeBlockHash);
+        yield forkchoiceResult;
+      }
       case DECLINED_CANONICAL_REWIND -> {
         startBackwardSyncAfterTrieLogBudgetExceeded(newHead);
         yield ForkchoiceResult.withSyncing();
@@ -758,11 +760,10 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
         && isDescendantOf(newHead, blockchain.getChainHeadHeader());
   }
 
-  private ForkchoiceResult applyForkchoiceFinalizedAndSafe(
+  private void applyForkchoiceFinalizedAndSafe(
       final MutableBlockchain blockchain,
       final Optional<BlockHeader> newFinalized,
-      final Hash safeBlockHash,
-      final BlockHeader newHead) {
+      final Hash safeBlockHash) {
     newFinalized.ifPresent(
         blockHeader -> {
           blockchain.setFinalized(blockHeader.getHash());
@@ -775,7 +776,6 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
               blockchain.setSafeBlock(safeBlockHash);
               mergeContext.setSafeBlock(newSafeBlock);
             });
-    return ForkchoiceResult.withResult(newFinalized, Optional.of(newHead));
   }
 
   private void startBackwardSyncAfterTrieLogBudgetExceeded(final BlockHeader newHead) {

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeMiningCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeMiningCoordinator.java
@@ -14,7 +14,7 @@
  */
 package org.hyperledger.besu.consensus.merge.blockcreation;
 
-import static org.hyperledger.besu.consensus.merge.blockcreation.MergeMiningCoordinator.ForkchoiceResult.Status.IGNORE_UPDATE_TO_OLD_HEAD;
+import static org.hyperledger.besu.consensus.merge.blockcreation.MergeMiningCoordinator.ForkchoiceResult.Status.DECLINED_CANONICAL_REWIND;
 import static org.hyperledger.besu.consensus.merge.blockcreation.MergeMiningCoordinator.ForkchoiceResult.Status.VALID;
 
 import org.hyperledger.besu.datatypes.Address;
@@ -205,8 +205,16 @@ public interface MergeMiningCoordinator extends MiningCoordinator {
       INVALID,
       /** Invalid payload attributes status. */
       INVALID_PAYLOAD_ATTRIBUTES,
-      /** Ignore update to old head status. */
-      IGNORE_UPDATE_TO_OLD_HEAD
+      /**
+       * Forkchoice head is a canonical ancestor of the execution tip; EL declines rewinding to it
+       * (no reorg).
+       */
+      DECLINED_CANONICAL_REWIND,
+      /**
+       * Fork choice deferred (e.g. path-based trie roll exceeds layer budget, backward sync
+       * started); engine API should return {@code SYNCING}.
+       */
+      SYNCING
     }
 
     private final Status status;
@@ -247,18 +255,18 @@ public interface MergeMiningCoordinator extends MiningCoordinator {
     }
 
     /**
-     * Create forkchoice result with ignore update to old head.
+     * Forkchoice requested a canonical ancestor below the current tip; chain head is unchanged.
      *
-     * @param oldHead the old head
+     * @param requestedHead the forkchoice head block header
      * @return the forkchoice result
      */
-    public static ForkchoiceResult withIgnoreUpdateToOldHead(final BlockHeader oldHead) {
+    public static ForkchoiceResult withDeclinedCanonicalRewind(final BlockHeader requestedHead) {
       return new ForkchoiceResult(
-          IGNORE_UPDATE_TO_OLD_HEAD,
+          DECLINED_CANONICAL_REWIND,
           Optional.empty(),
           Optional.empty(),
           Optional.empty(),
-          Optional.of(oldHead.getHash()));
+          Optional.of(requestedHead.getHash()));
     }
 
     /**
@@ -271,6 +279,16 @@ public interface MergeMiningCoordinator extends MiningCoordinator {
     public static ForkchoiceResult withResult(
         final Optional<BlockHeader> newFinalized, final Optional<BlockHeader> newHead) {
       return new ForkchoiceResult(VALID, Optional.empty(), newFinalized, newHead, Optional.empty());
+    }
+
+    /**
+     * Fork choice is deferred or blocked; caller should surface engine SYNCING without payload id.
+     *
+     * @return syncing forkchoice result
+     */
+    public static ForkchoiceResult withSyncing() {
+      return new ForkchoiceResult(
+          Status.SYNCING, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
     }
 
     /**

--- a/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinatorForkchoiceBackwardSyncIntegrationTest.java
+++ b/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinatorForkchoiceBackwardSyncIntegrationTest.java
@@ -1,0 +1,479 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.consensus.merge.blockcreation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hyperledger.besu.ethereum.core.InMemoryKeyValueStorageProvider.createBonsaiInMemoryWorldStateArchive;
+import static org.hyperledger.besu.ethereum.core.InMemoryKeyValueStorageProvider.createInMemoryBlockchain;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.hyperledger.besu.config.MergeConfiguration;
+import org.hyperledger.besu.consensus.merge.MergeProtocolSchedule;
+import org.hyperledger.besu.consensus.merge.PostMergeContext;
+import org.hyperledger.besu.consensus.merge.blockcreation.MergeMiningCoordinator.ForkchoiceResult;
+import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.BlockProcessingResult;
+import org.hyperledger.besu.ethereum.ProtocolContext;
+import org.hyperledger.besu.ethereum.chain.BadBlockManager;
+import org.hyperledger.besu.ethereum.chain.GenesisState;
+import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
+import org.hyperledger.besu.ethereum.core.Block;
+import org.hyperledger.besu.ethereum.core.BlockBody;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
+import org.hyperledger.besu.ethereum.core.Difficulty;
+import org.hyperledger.besu.ethereum.core.ImmutableMiningConfiguration;
+import org.hyperledger.besu.ethereum.core.ImmutableMiningConfiguration.MutableInitValues;
+import org.hyperledger.besu.ethereum.core.MiningConfiguration;
+import org.hyperledger.besu.ethereum.eth.manager.EthContext;
+import org.hyperledger.besu.ethereum.eth.manager.EthProtocolManager;
+import org.hyperledger.besu.ethereum.eth.manager.EthProtocolManagerTestBuilder;
+import org.hyperledger.besu.ethereum.eth.manager.EthProtocolManagerTestUtil;
+import org.hyperledger.besu.ethereum.eth.manager.EthScheduler;
+import org.hyperledger.besu.ethereum.eth.manager.peertask.PeerTaskExecutor;
+import org.hyperledger.besu.ethereum.eth.manager.peertask.task.GetBodiesFromPeerTask;
+import org.hyperledger.besu.ethereum.eth.manager.peertask.task.GetBodiesFromPeerTaskExecutorAnswer;
+import org.hyperledger.besu.ethereum.eth.manager.peertask.task.GetHeadersFromPeerTask;
+import org.hyperledger.besu.ethereum.eth.manager.peertask.task.GetHeadersFromPeerTaskExecutorAnswer;
+import org.hyperledger.besu.ethereum.eth.sync.SynchronizerConfiguration;
+import org.hyperledger.besu.ethereum.eth.sync.backwardsync.BackwardChain;
+import org.hyperledger.besu.ethereum.eth.sync.backwardsync.BackwardSyncContext;
+import org.hyperledger.besu.ethereum.eth.sync.backwardsync.BackwardSyncContextTest;
+import org.hyperledger.besu.ethereum.eth.sync.state.SyncState;
+import org.hyperledger.besu.ethereum.eth.transactions.BlobCache;
+import org.hyperledger.besu.ethereum.eth.transactions.ImmutableTransactionPoolConfiguration;
+import org.hyperledger.besu.ethereum.eth.transactions.TransactionBroadcaster;
+import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
+import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolConfiguration;
+import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolMetrics;
+import org.hyperledger.besu.ethereum.eth.transactions.sorter.BaseFeePendingTransactionsSorter;
+import org.hyperledger.besu.ethereum.mainnet.BalConfiguration;
+import org.hyperledger.besu.ethereum.mainnet.HeaderValidationMode;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
+import org.hyperledger.besu.ethereum.mainnet.feemarket.BaseFeeMarket;
+import org.hyperledger.besu.ethereum.mainnet.feemarket.FeeMarket;
+import org.hyperledger.besu.ethereum.trie.pathbased.bonsai.BonsaiWorldStateProvider;
+import org.hyperledger.besu.ethereum.trie.pathbased.bonsai.cache.CodeCache;
+import org.hyperledger.besu.ethereum.trie.pathbased.common.provider.TrieLogLayerBudgetExceededException;
+import org.hyperledger.besu.ethereum.trie.pathbased.common.provider.WorldStateQueryParams;
+import org.hyperledger.besu.ethereum.worldstate.ImmutablePathBasedExtraStorageConfiguration;
+import org.hyperledger.besu.ethereum.worldstate.PathBasedExtraStorageConfiguration;
+import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
+import org.hyperledger.besu.evm.internal.EvmConfiguration;
+import org.hyperledger.besu.metrics.StubMetricsSystem;
+import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
+import org.hyperledger.besu.testutil.TestClock;
+import org.hyperledger.besu.util.number.Fraction;
+
+import java.time.ZoneId;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+/**
+ * Integration coverage for {@link MergeCoordinator#updateForkChoice} with a real {@link
+ * BackwardSyncContext}, {@link EthProtocolManager}, and {@link PeerTaskExecutor} answers (mirrored
+ * remote chain), plus the trie-log budget path returning {@link ForkchoiceResult.Status#SYNCING}.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class MergeCoordinatorForkchoiceBackwardSyncIntegrationTest
+    implements MergeGenesisConfigHelper {
+
+  /** Large budget so trie-log rolls during chain construction stay well under the limit. */
+  private static final long BONSAI_TRIE_LOG_LAYERS_FOR_TESTS = 512L;
+
+  private static final int COMMON_POST_TERMINAL_BLOCKS = 5;
+  private static final int SHORT_BRANCH_BLOCKS = 2;
+  private static final int LONG_BRANCH_BLOCKS = 12;
+
+  @Mock private PeerTaskExecutor peerTaskExecutor;
+  @Mock private SyncState syncState;
+
+  private final PostMergeContext mergeContext = new PostMergeContext();
+  private ProtocolSchedule protocolSchedule;
+  private GenesisState genesisState;
+  private final BlockHeaderTestFixture headerGenerator = new BlockHeaderTestFixture();
+  private BaseFeeMarket feeMarket;
+  private final Address coinbase =
+      genesisAllocations(getPosGenesisConfig()).findFirst().orElseThrow();
+  private final MiningConfiguration miningConfiguration =
+      ImmutableMiningConfiguration.builder()
+          .mutableInitValues(MutableInitValues.builder().coinbase(coinbase).build())
+          .build();
+
+  private MutableBlockchain blockchain;
+  private MutableBlockchain remoteBlockchain;
+  private WorldStateArchive worldStateArchive;
+  private WorldStateArchive remoteWorldStateArchive;
+  private ProtocolContext protocolContext;
+  private ProtocolContext remoteProtocolContext;
+  private BadBlockManager badBlockManager;
+  private EthScheduler ethScheduler;
+
+  @BeforeEach
+  void setUp() {
+    MergeConfiguration.setMergeEnabled(false);
+    badBlockManager = new BadBlockManager();
+    protocolSchedule =
+        MergeProtocolSchedule.create(
+            getPosGenesisConfig().getConfigOptions(),
+            false,
+            MiningConfiguration.MINING_DISABLED,
+            badBlockManager,
+            false,
+            BalConfiguration.DEFAULT,
+            new NoOpMetricsSystem(),
+            EvmConfiguration.DEFAULT);
+    genesisState =
+        GenesisState.fromConfig(getPosGenesisConfig(), protocolSchedule, new CodeCache());
+    feeMarket = FeeMarket.london(0, genesisState.getBlock().getHeader().getBaseFee());
+    MergeConfiguration.setMergeEnabled(true);
+
+    blockchain = createInMemoryBlockchain(genesisState.getBlock());
+    remoteBlockchain = createInMemoryBlockchain(genesisState.getBlock());
+    final PathBasedExtraStorageConfiguration pathConfig =
+        ImmutablePathBasedExtraStorageConfiguration.builder()
+            .from(PathBasedExtraStorageConfiguration.DEFAULT)
+            .maxLayersToLoad(BONSAI_TRIE_LOG_LAYERS_FOR_TESTS)
+            .build();
+    worldStateArchive =
+        createBonsaiInMemoryWorldStateArchive(
+            blockchain, EvmConfiguration.DEFAULT, null, pathConfig);
+    remoteWorldStateArchive =
+        createBonsaiInMemoryWorldStateArchive(
+            remoteBlockchain, EvmConfiguration.DEFAULT, null, pathConfig);
+
+    mergeContext.setTerminalTotalDifficulty(
+        Difficulty.of(
+            getPosGenesisConfig()
+                .getConfigOptions()
+                .getTerminalTotalDifficulty()
+                .orElseThrow()
+                .toBigInteger()
+                .longValueExact()));
+    mergeContext.setSyncState(syncState);
+    when(syncState.hasReachedTerminalDifficulty()).thenReturn(Optional.of(Boolean.TRUE));
+    when(syncState.isInitialSyncPhaseDone()).thenReturn(true);
+    when(syncState.isInSync()).thenReturn(true);
+
+    protocolContext =
+        new ProtocolContext.Builder()
+            .withBlockchain(blockchain)
+            .withWorldStateArchive(worldStateArchive)
+            .withConsensusContext(mergeContext)
+            .withBadBlockManager(badBlockManager)
+            .build();
+
+    final var localMutable = worldStateArchive.getWorldState();
+    genesisState.writeStateTo(localMutable);
+    localMutable.persist(genesisState.getBlock().getHeader());
+
+    remoteProtocolContext =
+        new ProtocolContext.Builder()
+            .withBlockchain(remoteBlockchain)
+            .withWorldStateArchive(remoteWorldStateArchive)
+            .withConsensusContext(mergeContext)
+            .withBadBlockManager(badBlockManager)
+            .build();
+    final var remoteMutable = remoteWorldStateArchive.getWorldState();
+    genesisState.writeStateTo(remoteMutable);
+    remoteMutable.persist(genesisState.getBlock().getHeader());
+
+    blockchain.observeBlockAdded(
+        event ->
+            blockchain
+                .getTotalDifficultyByHash(event.getHeader().getHash())
+                .ifPresent(mergeContext::setIsPostMerge));
+    remoteBlockchain.observeBlockAdded(
+        event ->
+            remoteBlockchain
+                .getTotalDifficultyByHash(event.getHeader().getHash())
+                .ifPresent(mergeContext::setIsPostMerge));
+
+    ethScheduler = new EthScheduler(2, 2, 2, new NoOpMetricsSystem());
+  }
+
+  @AfterEach
+  void tearDown() {
+    MergeConfiguration.setMergeEnabled(false);
+  }
+
+  @Test
+  void deepForkReorgCompletes() throws Exception {
+    final MergeCoordinator coordinator =
+        newMergeCoordinatorWithBackwardSync(BackwardSyncContextTest.inMemoryBackwardChain());
+
+    final Block firstPos = new Block(firstPostGenesisHeader(), BlockBody.empty());
+    importAndForkchoiceToHead(coordinator, firstPos);
+    mirrorBlockToRemote(firstPos);
+
+    for (int i = 0; i < COMMON_POST_TERMINAL_BLOCKS; i++) {
+      final Block b = nextEmptyBlock(blockchain.getChainHeadHeader());
+      importAndForkchoiceToHead(coordinator, b);
+      mirrorBlockToRemote(b);
+    }
+    final Hash forkParentHash = blockchain.getChainHeadHash();
+
+    Block shortTip = null;
+    for (int i = 0; i < SHORT_BRANCH_BLOCKS; i++) {
+      final Block b = nextEmptyBlock(blockchain.getChainHeadHeader());
+      importAndForkchoiceToHead(coordinator, b);
+      mirrorBlockToRemote(b);
+      shortTip = b;
+    }
+
+    BlockHeader longBranchParent = blockchain.getBlockHeader(forkParentHash).orElseThrow();
+    Block longTip = null;
+    for (int i = 0; i < LONG_BRANCH_BLOCKS; i++) {
+      final Block b = nextEmptyBlock(longBranchParent);
+      rememberOnly(coordinator, b);
+      mirrorBlockToRemote(b);
+      longTip = b;
+      longBranchParent = b.getHeader();
+    }
+
+    assertThat(shortTip).isNotNull();
+    assertThat(longTip).isNotNull();
+    assertThat(blockchain.getChainHeadHash()).isEqualTo(shortTip.getHash());
+
+    final BlockHeader longOnChain =
+        protocolContext.getBlockchain().getBlockByHash(longTip.getHash()).orElseThrow().getHeader();
+    final ForkchoiceResult res = coordinator.updateForkChoice(longOnChain, Hash.ZERO, Hash.ZERO);
+    assertThat(res.getStatus()).isEqualTo(ForkchoiceResult.Status.VALID);
+    assertThat(blockchain.getChainHeadHash()).isEqualTo(longTip.getHash());
+  }
+
+  @Test
+  void forkchoiceReturnsSyncingAndStartsBackwardSyncWhenTrieLogRollBudgetExceeded() {
+    final BonsaiWorldStateProvider spyArchive = spy((BonsaiWorldStateProvider) worldStateArchive);
+    final AtomicReference<Hash> trieBudgetExceededWhenRollingTo = new AtomicReference<>();
+    protocolContext =
+        new ProtocolContext.Builder()
+            .withBlockchain(blockchain)
+            .withWorldStateArchive(spyArchive)
+            .withConsensusContext(mergeContext)
+            .withBadBlockManager(badBlockManager)
+            .build();
+    final var localMutable = spyArchive.getWorldState();
+    genesisState.writeStateTo(localMutable);
+    localMutable.persist(genesisState.getBlock().getHeader());
+
+    doAnswer(
+            invocation -> {
+              final WorldStateQueryParams params = invocation.getArgument(0);
+              final Hash failAt = trieBudgetExceededWhenRollingTo.get();
+              if (params.shouldEnforceTrieRollLayerBudget()
+                  && params.shouldWorldStateUpdateHead()
+                  && failAt != null
+                  && failAt.equals(params.getBlockHash())) {
+                throw new TrieLogLayerBudgetExceededException(100, 4);
+              }
+              return invocation.callRealMethod();
+            })
+        .when(spyArchive)
+        .getWorldState(any(WorldStateQueryParams.class));
+
+    final BackwardChain backwardChain = BackwardSyncContextTest.inMemoryBackwardChain();
+    final EthContext ethContext = createEthContextAndWirePeers();
+    final BackwardSyncContext backwardSyncContext =
+        spy(
+            new BackwardSyncContext(
+                protocolContext,
+                protocolSchedule,
+                SynchronizerConfiguration.builder().build(),
+                new NoOpMetricsSystem(),
+                ethContext,
+                syncState,
+                backwardChain,
+                1,
+                25));
+    final MergeCoordinator coordinator = newMergeCoordinator(ethContext, backwardSyncContext);
+
+    final Block firstPos = new Block(firstPostGenesisHeader(), BlockBody.empty());
+    importAndForkchoiceToHead(coordinator, firstPos);
+
+    final Block b1 = nextEmptyBlock(blockchain.getChainHeadHeader());
+    importAndForkchoiceToHead(coordinator, b1);
+
+    final Block b2 = nextEmptyBlock(blockchain.getChainHeadHeader());
+    trieBudgetExceededWhenRollingTo.set(b2.getHash());
+    rememberOnly(coordinator, b2);
+
+    final BlockHeader b2OnChain =
+        protocolContext.getBlockchain().getBlockByHash(b2.getHash()).orElseThrow().getHeader();
+    final ForkchoiceResult syncing = coordinator.updateForkChoice(b2OnChain, Hash.ZERO, Hash.ZERO);
+    assertThat(syncing.getStatus()).isEqualTo(ForkchoiceResult.Status.SYNCING);
+    verify(backwardSyncContext)
+        .syncBackwardsUntil(blockchain.getBlockByHash(b2.getHash()).orElseThrow());
+  }
+
+  private EthContext createEthContextAndWirePeers() {
+    final EthProtocolManager ethProtocolManager =
+        EthProtocolManagerTestBuilder.builder()
+            .setProtocolSchedule(protocolSchedule)
+            .setBlockchain(blockchain)
+            .setPeerTaskExecutor(peerTaskExecutor)
+            .setEthScheduler(ethScheduler)
+            .build();
+    EthProtocolManagerTestUtil.createPeer(ethProtocolManager);
+    final EthContext ethContext = ethProtocolManager.ethContext();
+
+    when(peerTaskExecutor.execute(any(GetHeadersFromPeerTask.class)))
+        .thenAnswer(
+            new GetHeadersFromPeerTaskExecutorAnswer(remoteBlockchain, ethContext.getEthPeers()));
+    when(peerTaskExecutor.execute(any(GetBodiesFromPeerTask.class)))
+        .thenAnswer(
+            new GetBodiesFromPeerTaskExecutorAnswer(remoteBlockchain, ethContext.getEthPeers()));
+    return ethContext;
+  }
+
+  private MergeCoordinator newMergeCoordinatorWithBackwardSync(final BackwardChain backwardChain) {
+    final EthContext ethContext = createEthContextAndWirePeers();
+    final BackwardSyncContext backwardSyncContext =
+        new BackwardSyncContext(
+            protocolContext,
+            protocolSchedule,
+            SynchronizerConfiguration.builder().build(),
+            new NoOpMetricsSystem(),
+            ethContext,
+            syncState,
+            backwardChain,
+            1,
+            25);
+    return newMergeCoordinator(ethContext, backwardSyncContext);
+  }
+
+  private MergeCoordinator newMergeCoordinator(
+      final EthContext ethContext, final BackwardSyncContext backwardSyncContext) {
+    final TransactionPoolConfiguration poolConf =
+        ImmutableTransactionPoolConfiguration.builder()
+            .txPoolMaxSize(10)
+            .txPoolLimitByAccountPercentage(Fraction.fromPercentage(100))
+            .build();
+    final var metrics = new StubMetricsSystem();
+    final var transactions =
+        new BaseFeePendingTransactionsSorter(
+            poolConf,
+            TestClock.system(ZoneId.systemDefault()),
+            metrics,
+            MergeCoordinatorForkchoiceBackwardSyncIntegrationTest::minimalHeader);
+    final TransactionPool transactionPool =
+        new TransactionPool(
+            () -> transactions,
+            protocolSchedule,
+            protocolContext,
+            mock(TransactionBroadcaster.class),
+            ethContext,
+            new TransactionPoolMetrics(metrics),
+            poolConf,
+            new BlobCache());
+    transactionPool.setEnabled();
+
+    return new MergeCoordinator(
+        protocolContext,
+        protocolSchedule,
+        ethScheduler,
+        transactionPool,
+        miningConfiguration,
+        backwardSyncContext);
+  }
+
+  private static BlockHeader minimalHeader() {
+    final var h = mock(BlockHeader.class);
+    when(h.getBaseFee()).thenReturn(Optional.of(org.hyperledger.besu.datatypes.Wei.ONE));
+    return h;
+  }
+
+  private void mirrorBlockToRemote(final Block block) {
+    final BlockProcessingResult result =
+        protocolSchedule
+            .getByBlockHeader(block.getHeader())
+            .getBlockValidator()
+            .validateAndProcessBlock(
+                remoteProtocolContext, block, HeaderValidationMode.FULL, HeaderValidationMode.NONE);
+    assertThat(result.isSuccessful()).withFailMessage(() -> result.toString()).isTrue();
+    result
+        .getYield()
+        .ifPresent(
+            y -> remoteBlockchain.appendBlock(block, y.getReceipts(), y.getBlockAccessList()));
+  }
+
+  /**
+   * With {@code posAtGenesis.json} the TTD is already satisfied at genesis; the first child must be
+   * a PoS header (difficulty zero), not a synthetic terminal PoW block.
+   */
+  private BlockHeader firstPostGenesisHeader() {
+    final BlockHeader genesisHeader = genesisState.getBlock().getHeader();
+    return headerGenerator
+        .difficulty(Difficulty.ZERO)
+        .parentHash(genesisHeader.getHash())
+        .number(genesisHeader.getNumber() + 1)
+        .baseFeePerGas(
+            feeMarket.computeBaseFee(
+                genesisHeader.getNumber() + 1,
+                genesisHeader.getBaseFee().orElseThrow(),
+                0,
+                15_000_000L))
+        .timestamp(genesisHeader.getTimestamp() + 12)
+        .gasLimit(genesisHeader.getGasLimit())
+        .stateRoot(genesisHeader.getStateRoot())
+        .buildHeader();
+  }
+
+  private Block nextEmptyBlock(final BlockHeader parent) {
+    final BlockHeader h =
+        headerGenerator
+            .difficulty(Difficulty.ZERO)
+            .parentHash(parent.getHash())
+            .number(parent.getNumber() + 1)
+            .gasLimit(parent.getGasLimit())
+            .stateRoot(parent.getStateRoot())
+            .timestamp(parent.getTimestamp() + 12)
+            .baseFeePerGas(
+                feeMarket.computeBaseFee(
+                    parent.getNumber() + 1, parent.getBaseFee().orElseThrow(), 0, 15_000_000L))
+            .buildHeader();
+    return new Block(h, BlockBody.empty());
+  }
+
+  private void importAndForkchoiceToHead(final MergeCoordinator coordinator, final Block block) {
+    rememberOnly(coordinator, block);
+    final Block stored =
+        protocolContext.getBlockchain().getBlockByHash(block.getHash()).orElseThrow();
+    final ForkchoiceResult res =
+        coordinator.updateForkChoice(stored.getHeader(), Hash.ZERO, Hash.ZERO);
+    assertThat(res.getStatus()).isEqualTo(ForkchoiceResult.Status.VALID);
+  }
+
+  private void rememberOnly(final MergeCoordinator coordinator, final Block block) {
+    final BlockProcessingResult result = coordinator.rememberBlock(block);
+    assertThat(result.isSuccessful()).withFailMessage(() -> result.toString()).isTrue();
+  }
+}

--- a/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinatorTest.java
+++ b/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinatorTest.java
@@ -1070,7 +1070,7 @@ public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
   }
 
   @Test
-  public void forkchoiceUpdateShouldIgnoreAncestorOfChainHead() {
+  public void forkchoiceUpdateShouldDeclineCanonicalRewindToAncestor() {
     BlockHeader terminalHeader = terminalPowBlock();
     sendNewPayloadAndForkchoiceUpdate(
         new Block(terminalHeader, BlockBody.empty()), Optional.empty(), Hash.ZERO);
@@ -1086,7 +1086,7 @@ public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
     ForkchoiceResult res =
         coordinator.updateForkChoice(parentHeader, Hash.ZERO, terminalHeader.getHash());
 
-    assertThat(res.getStatus()).isEqualTo(ForkchoiceResult.Status.IGNORE_UPDATE_TO_OLD_HEAD);
+    assertThat(res.getStatus()).isEqualTo(ForkchoiceResult.Status.DECLINED_CANONICAL_REWIND);
     assertThat(res.shouldNotProceedToPayloadBuildProcess()).isTrue();
     assertThat(res.getNewHead().isEmpty()).isTrue();
     assertThat(res.getLatestValid().isPresent()).isTrue();

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugSetHead.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugSetHead.java
@@ -28,35 +28,27 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorR
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
-import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.trie.pathbased.common.provider.PathBasedWorldStateProvider;
 
 import java.util.Optional;
 
-import graphql.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * {@code debug_setHead}: sets the canonical head to a block. Optional second parameter {@code true}
+ * also rolls the path-based (Bonsai) head world state to that block via {@code
+ * getWorldState(withBlockHeaderAndUpdateNodeHead(...))}, then rewinds the chain when the roll
+ * succeeds.
+ */
 public class DebugSetHead extends AbstractBlockParameterOrBlockHashMethod {
   private final ProtocolContext protocolContext;
   private static final Logger LOG = LoggerFactory.getLogger(DebugSetHead.class);
-  private static final int DEFAULT_MAX_TRIE_LOGS_TO_ROLL_AT_ONCE = 32;
-
-  private final long maxTrieLogsToRollAtOnce;
 
   public DebugSetHead(final BlockchainQueries blockchain, final ProtocolContext protocolContext) {
-    this(blockchain, protocolContext, DEFAULT_MAX_TRIE_LOGS_TO_ROLL_AT_ONCE);
-  }
-
-  @VisibleForTesting
-  DebugSetHead(
-      final BlockchainQueries blockchain,
-      final ProtocolContext protocolContext,
-      final long maxTrieLogsToRollAtOnce) {
     super(blockchain);
     this.protocolContext = protocolContext;
-    this.maxTrieLogsToRollAtOnce = Math.abs(maxTrieLogsToRollAtOnce);
   }
 
   @Override
@@ -92,71 +84,32 @@ public class DebugSetHead extends AbstractBlockParameterOrBlockHashMethod {
 
       // Only PathBasedWorldState's need to be moved:
       if (archive instanceof PathBasedWorldStateProvider pathBasedArchive) {
-        if (rollIncrementally(maybeBlockHeader.get(), blockchain, pathBasedArchive)) {
-          return JsonRpcSuccessResponse.SUCCESS_RESULT;
+        final BlockHeader target = maybeBlockHeader.get();
+        if (pathBasedArchive.isWorldStateAvailable(target.getStateRoot(), target.getBlockHash())) {
+          try {
+            // WARNING, this can be dangerous for a PathBasedWorldstate if a concurrent
+            //          process attempts to move or modify the head worldstate.
+            //          Ensure no block processing is occuring when using this feature.
+            //          No engine-api, block import, sync, mining or other rpc calls should be
+            // running.
+            if (pathBasedArchive
+                .getWorldState(withBlockHeaderAndUpdateNodeHead(target))
+                .isPresent()) {
+              blockchain.rewindToBlock(target.getBlockHash());
+              return JsonRpcSuccessResponse.SUCCESS_RESULT;
+            }
+          } catch (Exception ex) {
+            LOG.error("Failed to roll worldstate to " + target.toLogString(), ex);
+          }
         }
       }
     }
 
-    // If we are not rolling incrementally or if there was an error incrementally rolling,
+    // If we are not rolling the worldstate or if rolling failed,
     // move the blockchain to the requested hash:
     blockchain.rewindToBlock(maybeBlockHeader.get().getBlockHash());
 
     return JsonRpcSuccessResponse.SUCCESS_RESULT;
-  }
-
-  private boolean rollIncrementally(
-      final BlockHeader target,
-      final MutableBlockchain blockchain,
-      final PathBasedWorldStateProvider archive) {
-
-    try {
-      if (archive.isWorldStateAvailable(target.getStateRoot(), target.getBlockHash())) {
-        // WARNING, this can be dangerous for a PathBasedWorldstate if a concurrent
-        //          process attempts to move or modify the head worldstate.
-        //          Ensure no block processing is occuring when using this feature.
-        //          No engine-api, block import, sync, mining or other rpc calls should be running.
-
-        Optional<BlockHeader> currentHead =
-            archive
-                .getWorldStateKeyValueStorage()
-                .getWorldStateBlockHash()
-                .flatMap(blockchain::getBlockHeader);
-
-        while (currentHead.isPresent()
-            && !target.getStateRoot().equals(currentHead.get().getStateRoot())) {
-          long delta = currentHead.get().getNumber() - target.getNumber();
-
-          if (maxTrieLogsToRollAtOnce < Math.abs(delta)) {
-            // do we need to move forward or backward?
-            long distanceToMove = (delta > 0) ? -maxTrieLogsToRollAtOnce : maxTrieLogsToRollAtOnce;
-
-            // Add distanceToMove to the current block number to get the interim target header
-            var interimHead =
-                blockchain.getBlockHeader(currentHead.get().getNumber() + distanceToMove);
-
-            interimHead.ifPresent(
-                it -> {
-                  blockchain.rewindToBlock(it.getBlockHash());
-                  archive.getWorldState(withBlockHeaderAndUpdateNodeHead(it));
-                  LOG.info("incrementally rolled worldstate to {}", it.toLogString());
-                });
-            currentHead = interimHead;
-
-          } else {
-            blockchain.rewindToBlock(target.getBlockHash());
-            archive.getWorldState(withBlockHeaderAndUpdateNodeHead(target));
-            currentHead = Optional.of(target);
-            LOG.info("finished rolling worldstate to {}", target.toLogString());
-          }
-        }
-      }
-
-      return true;
-    } catch (Exception ex) {
-      LOG.error("Failed to incrementally roll blockchain to " + target.toLogString(), ex);
-      return false;
-    }
   }
 
   private Optional<Boolean> shouldMoveWorldstate(final JsonRpcRequestContext request) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdated.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdated.java
@@ -203,14 +203,14 @@ public abstract class AbstractEngineForkchoiceUpdated extends ExecutionEngineJso
     maybePayloadAttributes.ifPresentOrElse(
         this::logPayload, () -> LOG.debug("Payload attributes are null"));
 
-    /*if (forkchoiceResult.shouldNotProceedToPayloadBuildProcess()) {
+    if (forkchoiceResult.shouldNotProceedToPayloadBuildProcess()) {
       if (ForkchoiceResult.Status.DECLINED_CANONICAL_REWIND.equals(forkchoiceResult.getStatus())) {
         logAtInfoFCUCall(VALID, forkChoice);
       } else {
         logAtInfoFCUCall(INVALID, forkChoice);
       }
       return handleNonValidForkchoiceUpdate(requestId, forkchoiceResult);
-    }*/
+    }
 
     // begin preparing a block if we have a non-empty payload attributes param
     final Optional<List<Withdrawal>> finalWithdrawals = withdrawals;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdated.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdated.java
@@ -53,6 +53,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.spi.LoggingEventBuilder;
 
+@SuppressWarnings("unused")
 public abstract class AbstractEngineForkchoiceUpdated extends ExecutionEngineJsonRpcMethod {
   private static final Logger LOG = LoggerFactory.getLogger(AbstractEngineForkchoiceUpdated.class);
   private final MergeMiningCoordinator mergeCoordinator;
@@ -146,6 +147,11 @@ public abstract class AbstractEngineForkchoiceUpdated extends ExecutionEngineJso
               forkChoice.getSafeBlockHash());
     }
 
+    if (ForkchoiceResult.Status.SYNCING.equals(forkchoiceResult.getStatus())) {
+      logAtDebugFCUCall(SYNCING, forkChoice);
+      return syncingResponse(requestId, forkChoice);
+    }
+
     Optional<List<Withdrawal>> withdrawals = Optional.empty();
     if (maybePayloadAttributes.isPresent()) {
       final EnginePayloadAttributesParameter payloadAttributes = maybePayloadAttributes.get();
@@ -197,14 +203,14 @@ public abstract class AbstractEngineForkchoiceUpdated extends ExecutionEngineJso
     maybePayloadAttributes.ifPresentOrElse(
         this::logPayload, () -> LOG.debug("Payload attributes are null"));
 
-    if (forkchoiceResult.shouldNotProceedToPayloadBuildProcess()) {
-      if (ForkchoiceResult.Status.IGNORE_UPDATE_TO_OLD_HEAD.equals(forkchoiceResult.getStatus())) {
+    /*if (forkchoiceResult.shouldNotProceedToPayloadBuildProcess()) {
+      if (ForkchoiceResult.Status.DECLINED_CANONICAL_REWIND.equals(forkchoiceResult.getStatus())) {
         logAtInfoFCUCall(VALID, forkChoice);
       } else {
         logAtInfoFCUCall(INVALID, forkChoice);
       }
       return handleNonValidForkchoiceUpdate(requestId, forkchoiceResult);
-    }
+    }*/
 
     // begin preparing a block if we have a non-empty payload attributes param
     final Optional<List<Withdrawal>> finalWithdrawals = withdrawals;
@@ -270,7 +276,7 @@ public abstract class AbstractEngineForkchoiceUpdated extends ExecutionEngineJso
                 new EngineUpdateForkchoiceResult(
                     INVALID, latestValid.orElse(null), null, result.getErrorMessage()));
         break;
-      case IGNORE_UPDATE_TO_OLD_HEAD:
+      case DECLINED_CANONICAL_REWIND:
         response =
             new JsonRpcSuccessResponse(
                 requestId,

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugSetHeadTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugSetHeadTest.java
@@ -67,9 +67,7 @@ public class DebugSetHeadTest extends AbstractJsonRpcHttpServiceTest {
         new DebugSetHead(
             new BlockchainQueries(
                 protocolSchedule, blockchain, archive, MiningConfiguration.MINING_DISABLED),
-            protocolContext,
-            // a value of 2 here exercises all the state rolling code paths
-            2);
+            protocolContext);
     startService();
   }
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdatedTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdatedTest.java
@@ -421,14 +421,15 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
   }
 
   @Test
-  public void shouldIgnoreUpdateToOldHeadAndNotPreparePayload() {
+  public void shouldDeclineCanonicalRewindAndNotPreparePayload() {
     BlockHeader mockHeader = blockHeaderBuilder.buildHeader();
 
     when(mergeCoordinator.getOrSyncHeadByHash(mockHeader.getHash(), Hash.ZERO))
         .thenReturn(Optional.of(mockHeader));
 
-    var ignoreOldHeadUpdateRes = ForkchoiceResult.withIgnoreUpdateToOldHead(mockHeader);
-    when(mergeCoordinator.updateForkChoice(any(), any(), any())).thenReturn(ignoreOldHeadUpdateRes);
+    var declinedCanonicalRewindRes = ForkchoiceResult.withDeclinedCanonicalRewind(mockHeader);
+    when(mergeCoordinator.updateForkChoice(any(), any(), any()))
+        .thenReturn(declinedCanonicalRewindRes);
 
     var payloadParams =
         new EnginePayloadAttributesParameter(

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/provider/PathBasedWorldStateProvider.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/provider/PathBasedWorldStateProvider.java
@@ -177,16 +177,18 @@ public abstract class PathBasedWorldStateProvider implements WorldStateArchive {
    * retrieves the full world state from the cache.
    *
    * <p>The method follows these steps: 1. Check if the query parameters indicate that the world
-   * state should update the head. 2. If true, call {@link #getFullWorldStateFromHead(Hash)} with
-   * the block hash from the query parameters. 3. If false, call {@link
-   * #getFullWorldStateFromCache(BlockHeader)} with the block header from the query parameters.
+   * state should update the head. 2. If true, call {@code getFullWorldStateFromHead} with the block
+   * hash and whether fork choice should throw on an oversized trie-log plan. 3. If false, call
+   * {@link #getFullWorldStateFromCache(BlockHeader)} with the block header from the query
+   * parameters.
    *
    * @param queryParams the query parameters
    * @return the stateful world state, if available
    */
   protected Optional<MutableWorldState> getFullWorldState(final WorldStateQueryParams queryParams) {
     return queryParams.shouldWorldStateUpdateHead()
-        ? getFullWorldStateFromHead(queryParams.getBlockHash())
+        ? getFullWorldStateFromHead(
+            queryParams.getBlockHash(), queryParams.shouldEnforceTrieRollLayerBudget())
         : getFullWorldStateFromCache(queryParams.getBlockHeader());
   }
 
@@ -202,37 +204,28 @@ public abstract class PathBasedWorldStateProvider implements WorldStateArchive {
    * attempt to roll the full world state to the specified block hash.
    *
    * @param blockHash the block hash
+   * @param throwIfPlanExceedsBudget if true, {@link #rollFullWorldStateToBlockHash} throws {@link
+   *     TrieLogLayerBudgetExceededException} when the trie-log plan exceeds the layer limit; if
+   *     false, the plan is always applied ({@code debug_setHead}, etc.).
    * @return the full world state, if available
    */
-  private Optional<MutableWorldState> getFullWorldStateFromHead(final Hash blockHash) {
-    return rollFullWorldStateToBlockHash(headWorldState, blockHash);
+  private Optional<MutableWorldState> getFullWorldStateFromHead(
+      final Hash blockHash, final boolean throwIfPlanExceedsBudget) {
+    return rollFullWorldStateToBlockHash(headWorldState, blockHash, throwIfPlanExceedsBudget);
   }
 
   /**
    * Gets the full world state from the cache based on the provided block header.
    *
-   * <p>This method attempts to retrieve the world state from the cache using the block header. If
-   * the block header is too old (i.e., the number of blocks between the chain head and the provided
-   * block header exceeds the maximum layers to load), a warning is logged and an empty Optional is
-   * returned.
-   *
-   * <p>The method follows these steps: 1. Check if the world state for the given block header is
-   * available in the cache. 2. If not, attempt to get the nearest world state from the cache. 3. If
-   * still not found, attempt to get the head world state. 4. If a world state is found, roll it to
-   * the block hash of the provided block header. 5. Freeze the world state and return it.
+   * <p>Resolves a base layer from the cache and rolls to the header's block hash. Chain-depth and
+   * trie-log plan limits are enforced inside {@link #rollFullWorldStateToBlockHash}; {@link
+   * TrieLogLayerBudgetExceededException} is caught and an empty result is returned with guidance
+   * for {@code --bonsai-historical-block-limit}.
    *
    * @param blockHeader the block header
    * @return the full world state, if available
    */
   private Optional<MutableWorldState> getFullWorldStateFromCache(final BlockHeader blockHeader) {
-    final BlockHeader chainHeadBlockHeader = blockchain.getChainHeadHeader();
-    if (chainHeadBlockHeader.getNumber() - blockHeader.getNumber()
-        >= trieLogManager.getMaxLayersToLoad()) {
-      LOG.warn(
-          "Exceeded the limit of historical blocks that can be loaded ({}). If you need to make older historical queries, configure your `--bonsai-historical-block-limit`.",
-          trieLogManager.getMaxLayersToLoad());
-      return Optional.empty();
-    }
     return cachedWorldStorageManager
         .getWorldState(blockHeader.getBlockHash())
         .or(() -> cachedWorldStorageManager.getNearestWorldState(blockHeader))
@@ -242,33 +235,73 @@ public abstract class PathBasedWorldStateProvider implements WorldStateArchive {
                     blockHeaderHash ->
                         blockchain.getBlockHeader(blockHeaderHash).map(BlockHeader.class::cast)))
         .flatMap(
-            worldState -> rollFullWorldStateToBlockHash(worldState, blockHeader.getBlockHash()))
+            worldState -> {
+              try {
+                return rollFullWorldStateToBlockHash(worldState, blockHeader.getBlockHash(), true);
+              } catch (final TrieLogLayerBudgetExceededException e) {
+                logHistoricalWorldStateLimitExceeded(
+                    "trie-log roll plan size "
+                        + e.getPlannedOps()
+                        + " exceeds max layers "
+                        + e.getMaxLayersToLoad());
+                return Optional.empty();
+              }
+            })
         .map(MutableWorldState::freezeStorage);
+  }
+
+  private void logHistoricalWorldStateLimitExceeded(final String detail) {
+    LOG.warn(
+        "{}. Exceeded the limit of historical blocks that can be loaded ({}). If you need to make older historical queries, configure your `--bonsai-historical-block-limit`.",
+        detail,
+        trieLogManager.getMaxLayersToLoad());
   }
 
   /**
    * Rolls {@code mutableState} to {@code blockHash} by trie logs: builds a rollback/forward hash
    * plan, then applies it in batches (see {@link #applyTrieLogRollPlan}).
+   *
+   * @param throwIfPlanExceedsBudget when true: if the chain head is at least {@link
+   *     TrieLogManager#getMaxLayersToLoad()} blocks above the target block (cheap check, no trie
+   *     reads), or the planned trie-log steps exceed that limit, throws {@link
+   *     TrieLogLayerBudgetExceededException} before loading layers; when false, neither guard
+   *     throws and the full plan is always applied.
    */
   private Optional<MutableWorldState> rollFullWorldStateToBlockHash(
-      final PathBasedWorldState mutableState, final Hash blockHash) {
+      final PathBasedWorldState mutableState,
+      final Hash blockHash,
+      final boolean throwIfPlanExceedsBudget) {
     if (blockHash.equals(mutableState.blockHash())) {
       return Optional.of(mutableState);
     }
     try {
+      final Optional<BlockHeader> maybeDestinationHeader =
+          blockchain.getBlockHeader(blockHash).map(BlockHeader.class::cast);
+      final long maxLayers = trieLogManager.getMaxLayersToLoad();
+      if (throwIfPlanExceedsBudget && maybeDestinationHeader.isPresent()) {
+        final long depthBelowChainHead =
+            blockchain.getChainHeadHeader().getNumber() - maybeDestinationHeader.get().getNumber();
+        if (depthBelowChainHead >= maxLayers) {
+          throw new TrieLogLayerBudgetExceededException(depthBelowChainHead, maxLayers);
+        }
+      }
       final List<Hash> rollbackBlockHashes = new ArrayList<>();
       final List<Hash> forwardBlockHashes = new ArrayList<>();
-      planTrieLogRollHashes(mutableState, blockHash, rollbackBlockHashes, forwardBlockHashes);
+      planTrieLogRollHashes(
+          mutableState, maybeDestinationHeader, rollbackBlockHashes, forwardBlockHashes);
       if (rollbackBlockHashes.isEmpty() && forwardBlockHashes.isEmpty()) {
         return Optional.of(mutableState);
       }
+      final long totalOps = (long) rollbackBlockHashes.size() + (long) forwardBlockHashes.size();
+      if (throwIfPlanExceedsBudget && totalOps > maxLayers) {
+        throw new TrieLogLayerBudgetExceededException(totalOps, maxLayers);
+      }
       return applyTrieLogRollPlan(
-          mutableState,
-          blockHash,
-          rollbackBlockHashes,
-          forwardBlockHashes,
-          trieLogManager.getMaxLayersToLoad());
+          mutableState, blockHash, rollbackBlockHashes, forwardBlockHashes, maxLayers);
     } catch (final RuntimeException re) {
+      if (re instanceof TrieLogLayerBudgetExceededException) {
+        throw re;
+      }
       LOG.info("Archive rolling failed for block hash " + blockHash, re);
       if (re instanceof MerkleTrieException) {
         throw re;
@@ -287,10 +320,14 @@ public abstract class PathBasedWorldStateProvider implements WorldStateArchive {
    * <p>When the world state's block is indexed on the chain: align heights on the old branch, then
    * walk both forks in lockstep until a shared hash (common ancestor). When it is not indexed, only
    * a single rollback hash is planned if a trie log exists for that block.
+   *
+   * @param maybeDestinationHeader {@code blockchain.getBlockHeader(destination hash)} already cast;
+   *     when the persisted state header is present, this must be present too or this method throws
+   *     {@link java.util.NoSuchElementException}.
    */
   private void planTrieLogRollHashes(
       final PathBasedWorldState mutableState,
-      final Hash destinationBlockHash,
+      final Optional<BlockHeader> maybeDestinationHeader,
       final List<Hash> rollbackBlockHashes,
       final List<Hash> forwardBlockHashes) {
     final Optional<BlockHeader> maybePersistedHeader =
@@ -303,7 +340,7 @@ public abstract class PathBasedWorldStateProvider implements WorldStateArchive {
       return;
     }
 
-    BlockHeader targetHeader = blockchain.getBlockHeader(destinationBlockHash).get();
+    BlockHeader targetHeader = maybeDestinationHeader.orElseThrow();
     BlockHeader persistedHeader = maybePersistedHeader.get();
 
     Hash persistedBlockHash = persistedHeader.getBlockHash();

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/provider/PathBasedWorldStateProvider.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/provider/PathBasedWorldStateProvider.java
@@ -251,7 +251,7 @@ public abstract class PathBasedWorldStateProvider implements WorldStateArchive {
   }
 
   private void logHistoricalWorldStateLimitExceeded(final String detail) {
-    LOG.warn(
+    LOG.debug(
         "{}. Exceeded the limit of historical blocks that can be loaded ({}). If you need to make older historical queries, configure your `--bonsai-historical-block-limit`.",
         detail,
         trieLogManager.getMaxLayersToLoad());

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/provider/PathBasedWorldStateProvider.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/provider/PathBasedWorldStateProvider.java
@@ -246,101 +246,185 @@ public abstract class PathBasedWorldStateProvider implements WorldStateArchive {
         .map(MutableWorldState::freezeStorage);
   }
 
+  /**
+   * Rolls {@code mutableState} to {@code blockHash} by trie logs: builds a rollback/forward hash
+   * plan, then applies it in batches (see {@link #applyTrieLogRollPlan}).
+   */
   private Optional<MutableWorldState> rollFullWorldStateToBlockHash(
       final PathBasedWorldState mutableState, final Hash blockHash) {
     if (blockHash.equals(mutableState.blockHash())) {
       return Optional.of(mutableState);
-    } else {
-      try {
-
-        final Optional<BlockHeader> maybePersistedHeader =
-            blockchain.getBlockHeader(mutableState.blockHash()).map(BlockHeader.class::cast);
-
-        final List<TrieLog> rollBacks = new ArrayList<>();
-        final List<TrieLog> rollForwards = new ArrayList<>();
-        if (maybePersistedHeader.isEmpty()) {
-          trieLogManager.getTrieLogLayer(mutableState.blockHash()).ifPresent(rollBacks::add);
-        } else {
-          BlockHeader targetHeader = blockchain.getBlockHeader(blockHash).get();
-          BlockHeader persistedHeader = maybePersistedHeader.get();
-          // roll back from persisted to even with target
-          Hash persistedBlockHash = persistedHeader.getBlockHash();
-          while (persistedHeader.getNumber() > targetHeader.getNumber()) {
-            LOG.debug("Rollback {}", persistedBlockHash);
-            rollBacks.add(trieLogManager.getTrieLogLayer(persistedBlockHash).get());
-            persistedHeader = blockchain.getBlockHeader(persistedHeader.getParentHash()).get();
-            persistedBlockHash = persistedHeader.getBlockHash();
-          }
-          // roll forward to target
-          Hash targetBlockHash = targetHeader.getBlockHash();
-          while (persistedHeader.getNumber() < targetHeader.getNumber()) {
-            LOG.debug("Rollforward {}", targetBlockHash);
-            rollForwards.add(trieLogManager.getTrieLogLayer(targetBlockHash).get());
-            targetHeader = blockchain.getBlockHeader(targetHeader.getParentHash()).get();
-            targetBlockHash = targetHeader.getBlockHash();
-          }
-
-          // roll back in tandem until we hit a shared state
-          while (!persistedBlockHash.equals(targetBlockHash)) {
-            LOG.debug("Paired Rollback {}", persistedBlockHash);
-            LOG.debug("Paired Rollforward {}", targetBlockHash);
-            rollForwards.add(trieLogManager.getTrieLogLayer(targetBlockHash).get());
-            targetHeader = blockchain.getBlockHeader(targetHeader.getParentHash()).get();
-
-            rollBacks.add(trieLogManager.getTrieLogLayer(persistedBlockHash).get());
-            persistedHeader = blockchain.getBlockHeader(persistedHeader.getParentHash()).get();
-
-            targetBlockHash = targetHeader.getBlockHash();
-            persistedBlockHash = persistedHeader.getBlockHash();
-          }
-        }
-
-        // attempt the state rolling
-        final PathBasedWorldStateUpdateAccumulator<?> pathBasedUpdater =
-            (PathBasedWorldStateUpdateAccumulator<?>) mutableState.updater();
-        try {
-          for (final TrieLog rollBack : rollBacks) {
-            LOG.debug("Attempting Rollback of {}", rollBack.getBlockHash());
-            pathBasedUpdater.rollBack(rollBack);
-          }
-          for (int i = rollForwards.size() - 1; i >= 0; i--) {
-            final var forward = rollForwards.get(i);
-            LOG.debug("Attempting Rollforward of {}", rollForwards.get(i).getBlockHash());
-            pathBasedUpdater.rollForward(forward);
-          }
-          pathBasedUpdater.commit();
-
-          mutableState.persist(blockchain.getBlockHeader(blockHash).get());
-
-          LOG.debug(
-              "Archive rolling finished, {} now at {}",
-              mutableState.getWorldStateStorage().getClass().getSimpleName(),
-              blockHash);
-          return Optional.of(mutableState);
-        } catch (final MerkleTrieException re) {
-          // need to throw to trigger the heal
-          throw re;
-        } catch (final Exception e) {
-          // if we fail we must clean up the updater
-          pathBasedUpdater.reset();
-          LOG.atDebug()
-              .setMessage("State rolling failed on {} for block hash {}")
-              .addArgument(mutableState.getWorldStateStorage().getClass().getSimpleName())
-              .addArgument(blockHash)
-              .addArgument(e)
-              .log();
-
-          return Optional.empty();
-        }
-      } catch (final RuntimeException re) {
-        LOG.info("Archive rolling failed for block hash " + blockHash, re);
-        if (re instanceof MerkleTrieException) {
-          // need to throw to trigger the heal
-          throw re;
-        }
-        throw new MerkleTrieException(
-            "invalid", Optional.of(Address.ZERO), Bytes32.wrap(Hash.EMPTY.getBytes()), Bytes.EMPTY);
+    }
+    try {
+      final List<Hash> rollbackBlockHashes = new ArrayList<>();
+      final List<Hash> forwardBlockHashes = new ArrayList<>();
+      planTrieLogRollHashes(mutableState, blockHash, rollbackBlockHashes, forwardBlockHashes);
+      if (rollbackBlockHashes.isEmpty() && forwardBlockHashes.isEmpty()) {
+        return Optional.of(mutableState);
       }
+      return applyTrieLogRollPlan(
+          mutableState,
+          blockHash,
+          rollbackBlockHashes,
+          forwardBlockHashes,
+          trieLogManager.getMaxLayersToLoad());
+    } catch (final RuntimeException re) {
+      LOG.info("Archive rolling failed for block hash " + blockHash, re);
+      if (re instanceof MerkleTrieException) {
+        throw re;
+      }
+      throw new MerkleTrieException(
+          "invalid", Optional.of(Address.ZERO), Bytes32.wrap(Hash.EMPTY.getBytes()), Bytes.EMPTY);
+    }
+  }
+
+  /**
+   * Fills {@code rollbackBlockHashes} in head-to-ancestor order (each hash is the next trie-log
+   * layer to undo). Fills {@code forwardBlockHashes} from the destination tip toward the fork
+   * ancestor; {@link #applyTrieLogRollPlan} consumes that list from the end inward so rollforwards
+   * run ancestor-to-tip.
+   *
+   * <p>When the world state's block is indexed on the chain: align heights on the old branch, then
+   * walk both forks in lockstep until a shared hash (common ancestor). When it is not indexed, only
+   * a single rollback hash is planned if a trie log exists for that block.
+   */
+  private void planTrieLogRollHashes(
+      final PathBasedWorldState mutableState,
+      final Hash destinationBlockHash,
+      final List<Hash> rollbackBlockHashes,
+      final List<Hash> forwardBlockHashes) {
+    final Optional<BlockHeader> maybePersistedHeader =
+        blockchain.getBlockHeader(mutableState.blockHash()).map(BlockHeader.class::cast);
+
+    if (maybePersistedHeader.isEmpty()) {
+      trieLogManager
+          .getTrieLogLayer(mutableState.blockHash())
+          .ifPresent(__ -> rollbackBlockHashes.add(mutableState.blockHash()));
+      return;
+    }
+
+    BlockHeader targetHeader = blockchain.getBlockHeader(destinationBlockHash).get();
+    BlockHeader persistedHeader = maybePersistedHeader.get();
+
+    Hash persistedBlockHash = persistedHeader.getBlockHash();
+    // Old chain higher than target: undo blocks until the same height as the target header.
+    while (persistedHeader.getNumber() > targetHeader.getNumber()) {
+      LOG.debug("Rollback {}", persistedBlockHash);
+      rollbackBlockHashes.add(persistedBlockHash);
+      persistedHeader = blockchain.getBlockHeader(persistedHeader.getParentHash()).get();
+      persistedBlockHash = persistedHeader.getBlockHash();
+    }
+
+    Hash targetBlockHash = targetHeader.getBlockHash();
+    // Target branch longer: record trie-log keys from target tip down toward the common height.
+    while (persistedHeader.getNumber() < targetHeader.getNumber()) {
+      LOG.debug("Rollforward {}", targetBlockHash);
+      forwardBlockHashes.add(targetBlockHash);
+      targetHeader = blockchain.getBlockHeader(targetHeader.getParentHash()).get();
+      targetBlockHash = targetHeader.getBlockHash();
+    }
+
+    // Same height but different forks: paired undo on the old head and redo on the new branch.
+    while (!persistedBlockHash.equals(targetBlockHash)) {
+      LOG.debug("Paired Rollback {}", persistedBlockHash);
+      LOG.debug("Paired Rollforward {}", targetBlockHash);
+      forwardBlockHashes.add(targetBlockHash);
+      targetHeader = blockchain.getBlockHeader(targetHeader.getParentHash()).get();
+
+      rollbackBlockHashes.add(persistedBlockHash);
+      persistedHeader = blockchain.getBlockHeader(persistedHeader.getParentHash()).get();
+
+      targetBlockHash = targetHeader.getBlockHash();
+      persistedBlockHash = persistedHeader.getBlockHash();
+    }
+  }
+
+  /** Block hash of the world state after undoing {@code blockToUndo}'s trie log layer. */
+  private Hash rollBackOne(
+      final PathBasedWorldStateUpdateAccumulator<?> updater, final Hash blockToUndo) {
+    final TrieLog layer = trieLogManager.getTrieLogLayer(blockToUndo).get();
+    LOG.debug("Attempting Rollback of {}", layer.getBlockHash());
+    updater.rollBack(layer);
+    return blockchain.getBlockHeader(layer.getBlockHash()).get().getParentHash();
+  }
+
+  /** Block hash of the world state after applying {@code blockToApply}'s trie log layer. */
+  private Hash rollForwardOne(
+      final PathBasedWorldStateUpdateAccumulator<?> updater, final Hash blockToApply) {
+    final TrieLog layer = trieLogManager.getTrieLogLayer(blockToApply).get();
+    LOG.debug("Attempting Rollforward of {}", layer.getBlockHash());
+    updater.rollForward(layer);
+    return layer.getBlockHash();
+  }
+
+  /**
+   * Applies trie logs in at most {@code maxTrieLogsPerBatch} operations per {@code commit} + {@code
+   * persist}. Trie layers are loaded from storage per hash (lists hold hashes only).
+   *
+   * <p>Within each batch, rollbacks run first (required for correctness), then rollforwards until
+   * the batch budget is used. {@code min(batch, opsLeft)} lets the last batch combine tail
+   * rollbacks and forwards in a single persist when the total remainder fits in one batch.
+   */
+  private Optional<MutableWorldState> applyTrieLogRollPlan(
+      final PathBasedWorldState mutableState,
+      final Hash finalBlockHash,
+      final List<Hash> rollbackBlockHashes,
+      final List<Hash> forwardBlockHashes,
+      final long maxTrieLogsPerBatch) {
+    final PathBasedWorldStateUpdateAccumulator<?> updater =
+        (PathBasedWorldStateUpdateAccumulator<?>) mutableState.updater();
+    final int nRollbacks = rollbackBlockHashes.size();
+    final int nForwards = forwardBlockHashes.size();
+    int iRollback = 0;
+    int iForward = nForwards - 1;
+    Hash currentBlockHash = mutableState.blockHash();
+
+    try {
+      while (iRollback < nRollbacks || iForward >= 0) {
+        final long opsLeft = (long) (nRollbacks - iRollback) + (long) (iForward + 1);
+        final int budget = (int) Math.min(maxTrieLogsPerBatch, opsLeft);
+
+        int used = 0;
+        while (used < budget && iRollback < nRollbacks) {
+          currentBlockHash = rollBackOne(updater, rollbackBlockHashes.get(iRollback++));
+          used++;
+        }
+        while (used < budget && iForward >= 0) {
+          currentBlockHash = rollForwardOne(updater, forwardBlockHashes.get(iForward--));
+          used++;
+        }
+
+        updater.commit();
+        mutableState.persist(blockchain.getBlockHeader(currentBlockHash).get());
+      }
+
+      if (!currentBlockHash.equals(finalBlockHash)) {
+        updater.reset();
+        LOG.atDebug()
+            .setMessage("State rolling finished at unexpected block hash {} (expected {})")
+            .addArgument(currentBlockHash)
+            .addArgument(finalBlockHash)
+            .log();
+        return Optional.empty();
+      }
+
+      LOG.debug(
+          "Archive rolling finished, {} now at {}",
+          mutableState.getWorldStateStorage().getClass().getSimpleName(),
+          finalBlockHash);
+      return Optional.of(mutableState);
+    } catch (final MerkleTrieException re) {
+      throw re;
+    } catch (final Exception e) {
+      updater.reset();
+      LOG.atDebug()
+          .setMessage("State rolling failed on {} for block hash {}, {}")
+          .addArgument(mutableState.getWorldStateStorage().getClass().getSimpleName())
+          .addArgument(finalBlockHash)
+          .addArgument(e)
+          .log();
+
+      return Optional.empty();
     }
   }
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/provider/TrieLogLayerBudgetExceededException.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/provider/TrieLogLayerBudgetExceededException.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.trie.pathbased.common.provider;
+
+/**
+ * Thrown when a trie-log roll cannot stay within {@link TrieLogManager#getMaxLayersToLoad()}:
+ * either the chain head is that many blocks (or more) above the target block, or the planned
+ * trie-log op count exceeds the limit.
+ *
+ * <p>Propagates to engine fork choice when {@link
+ * WorldStateQueryParams#shouldEnforceTrieRollLayerBudget()} is true with {@link
+ * WorldStateQueryParams#shouldWorldStateUpdateHead()}. For cache / historical reads, {@link
+ * PathBasedWorldStateProvider#getFullWorldStateFromCache} catches this exception and returns an
+ * empty Optional.
+ */
+public final class TrieLogLayerBudgetExceededException extends RuntimeException {
+
+  private final long plannedOps;
+  private final long maxLayersToLoad;
+
+  public TrieLogLayerBudgetExceededException(final long plannedOps, final long maxLayersToLoad) {
+    super(
+        "Planned trie-log roll ("
+            + plannedOps
+            + " ops) exceeds max layers to load ("
+            + maxLayersToLoad
+            + ")");
+    this.plannedOps = plannedOps;
+    this.maxLayersToLoad = maxLayersToLoad;
+  }
+
+  public long getPlannedOps() {
+    return plannedOps;
+  }
+
+  public long getMaxLayersToLoad() {
+    return maxLayersToLoad;
+  }
+}

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/provider/WorldStateQueryParams.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/provider/WorldStateQueryParams.java
@@ -24,6 +24,12 @@ import java.util.Optional;
 public class WorldStateQueryParams {
   private final BlockHeader blockHeader;
   private final boolean shouldWorldStateUpdateHead;
+
+  /**
+   * When true with head update, path-based roll throws if the trie-log plan exceeds layer budget.
+   */
+  private final boolean enforceTrieRollLayerBudget;
+
   private final Hash blockHash;
   private final Optional<Hash> stateRoot;
 
@@ -35,6 +41,7 @@ public class WorldStateQueryParams {
   private WorldStateQueryParams(final Builder builder) {
     this.blockHeader = builder.blockHeader;
     this.shouldWorldStateUpdateHead = builder.shouldWorldStateUpdateHead;
+    this.enforceTrieRollLayerBudget = builder.enforceTrieRollLayerBudget;
     this.blockHash = builder.blockHash;
     this.stateRoot = builder.stateRoot;
   }
@@ -76,6 +83,14 @@ public class WorldStateQueryParams {
   }
 
   /**
+   * When {@link #shouldWorldStateUpdateHead()} is true, whether moving the head must fail fast if
+   * the trie-log roll plan exceeds the configured layer limit (engine fork choice).
+   */
+  public boolean shouldEnforceTrieRollLayerBudget() {
+    return enforceTrieRollLayerBudget;
+  }
+
+  /**
    * Creates a new builder for WorldStateQueryParams.
    *
    * @return a new builder
@@ -103,7 +118,11 @@ public class WorldStateQueryParams {
    */
   public static WorldStateQueryParams withBlockHeaderAndNoUpdateNodeHead(
       final BlockHeader blockHeader) {
-    return newBuilder().withBlockHeader(blockHeader).withShouldWorldStateUpdateHead(false).build();
+    return newBuilder()
+        .withBlockHeader(blockHeader)
+        .withShouldWorldStateUpdateHead(false)
+        .withEnforceTrieRollLayerBudget(false)
+        .build();
   }
 
   /**
@@ -120,32 +139,7 @@ public class WorldStateQueryParams {
         .withStateRoot(stateRoot)
         .withBlockHash(blockHash)
         .withShouldWorldStateUpdateHead(true)
-        .build();
-  }
-
-  /**
-   * Should return a worldstate instance with a state root and should update the node head.
-   *
-   * @param stateRoot the state root
-   * @return an instance of WorldStateQueryParams
-   */
-  public static WorldStateQueryParams withStateRootAndUpdateNodeHead(final Hash stateRoot) {
-    return newBuilder().withStateRoot(stateRoot).withShouldWorldStateUpdateHead(true).build();
-  }
-
-  /**
-   * Creates an instance with a state root, block hash, and does not update the node head.
-   *
-   * @param stateRoot the state root
-   * @param blockHash the block hash
-   * @return an instance of WorldStateQueryParams
-   */
-  public static WorldStateQueryParams withStateRootAndBlockHashAndNoUpdateNodeHead(
-      final Hash stateRoot, final Hash blockHash) {
-    return newBuilder()
-        .withStateRoot(stateRoot)
-        .withBlockHash(blockHash)
-        .withShouldWorldStateUpdateHead(false)
+        .withEnforceTrieRollLayerBudget(true)
         .build();
   }
 
@@ -154,6 +148,7 @@ public class WorldStateQueryParams {
     if (o == null || getClass() != o.getClass()) return false;
     WorldStateQueryParams that = (WorldStateQueryParams) o;
     return shouldWorldStateUpdateHead == that.shouldWorldStateUpdateHead
+        && enforceTrieRollLayerBudget == that.enforceTrieRollLayerBudget
         && Objects.equals(blockHeader, that.blockHeader)
         && Objects.equals(blockHash, that.blockHash)
         && Objects.equals(stateRoot, that.stateRoot);
@@ -161,12 +156,14 @@ public class WorldStateQueryParams {
 
   @Override
   public int hashCode() {
-    return Objects.hash(blockHeader, shouldWorldStateUpdateHead, blockHash, stateRoot);
+    return Objects.hash(
+        blockHeader, shouldWorldStateUpdateHead, enforceTrieRollLayerBudget, blockHash, stateRoot);
   }
 
   public static class Builder {
     private BlockHeader blockHeader;
     private boolean shouldWorldStateUpdateHead = false;
+    private boolean enforceTrieRollLayerBudget = false;
     private Hash blockHash;
     private Optional<Hash> stateRoot = Optional.empty();
 
@@ -194,6 +191,17 @@ public class WorldStateQueryParams {
      */
     public Builder withShouldWorldStateUpdateHead(final boolean shouldWorldStateUpdateHead) {
       this.shouldWorldStateUpdateHead = shouldWorldStateUpdateHead;
+      return this;
+    }
+
+    /**
+     * When true with {@link #withShouldWorldStateUpdateHead(boolean) true}, path-based head rolls
+     * throw {@link
+     * org.hyperledger.besu.ethereum.trie.pathbased.common.provider.TrieLogLayerBudgetExceededException}
+     * if the planned trie-log steps exceed the layer budget.
+     */
+    public Builder withEnforceTrieRollLayerBudget(final boolean enforceTrieRollLayerBudget) {
+      this.enforceTrieRollLayerBudget = enforceTrieRollLayerBudget;
       return this;
     }
 

--- a/ethereum/core/src/test-support/java/org/hyperledger/besu/ethereum/core/InMemoryKeyValueStorageProvider.java
+++ b/ethereum/core/src/test-support/java/org/hyperledger/besu/ethereum/core/InMemoryKeyValueStorageProvider.java
@@ -33,10 +33,13 @@ import org.hyperledger.besu.ethereum.trie.pathbased.bonsai.cache.BonsaiCachedMer
 import org.hyperledger.besu.ethereum.trie.pathbased.bonsai.cache.CodeCache;
 import org.hyperledger.besu.ethereum.trie.pathbased.bonsai.storage.BonsaiWorldStateKeyValueStorage;
 import org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration;
+import org.hyperledger.besu.ethereum.worldstate.ImmutableDataStorageConfiguration;
+import org.hyperledger.besu.ethereum.worldstate.PathBasedExtraStorageConfiguration;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateStorageCoordinator;
 import org.hyperledger.besu.evm.internal.EvmConfiguration;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.plugin.ServiceManager;
+import org.hyperledger.besu.plugin.services.storage.DataStorageFormat;
 import org.hyperledger.besu.services.kvstore.InMemoryKeyValueStorage;
 import org.hyperledger.besu.services.kvstore.SegmentedInMemoryKeyValueStorage;
 
@@ -111,6 +114,32 @@ public class InMemoryKeyValueStorageProvider extends KeyValueStorageProvider {
                 DataStorageConfiguration.DEFAULT_BONSAI_CONFIG),
         blockchain,
         DataStorageConfiguration.DEFAULT_BONSAI_CONFIG.getPathBasedExtraStorageConfiguration(),
+        bonsaiCachedMerkleTrieLoader,
+        serviceManager,
+        evmConfiguration,
+        throwingWorldStateHealerSupplier(),
+        new CodeCache());
+  }
+
+  public static BonsaiWorldStateProvider createBonsaiInMemoryWorldStateArchive(
+      final Blockchain blockchain,
+      final EvmConfiguration evmConfiguration,
+      final ServiceManager serviceManager,
+      final PathBasedExtraStorageConfiguration storageConfig) {
+    final DataStorageConfiguration dataConfig =
+        ImmutableDataStorageConfiguration.builder()
+            .dataStorageFormat(DataStorageFormat.BONSAI)
+            .pathBasedExtraStorageConfiguration(storageConfig)
+            .build();
+    final InMemoryKeyValueStorageProvider inMemoryKeyValueStorageProvider =
+        new InMemoryKeyValueStorageProvider();
+    final BonsaiCachedMerkleTrieLoader bonsaiCachedMerkleTrieLoader =
+        new BonsaiCachedMerkleTrieLoader(new NoOpMetricsSystem());
+    return new BonsaiWorldStateProvider(
+        (BonsaiWorldStateKeyValueStorage)
+            inMemoryKeyValueStorageProvider.createWorldStateStorage(dataConfig),
+        blockchain,
+        storageConfig,
         bonsaiCachedMerkleTrieLoader,
         serviceManager,
         evmConfiguration,


### PR DESCRIPTION
## PR description

This PR reduces memory pressure when rolling a path-based (Bonsai-style) archive world state across a long reorg by planning with block hashes only, then applying trie-log rollbacks and rollforwards in bounded batches (commit + persist per batch, budget from TrieLogManager#getMaxLayersToLoad). It also simplifies debug_setHead so incremental roll logic lives in PathBasedWorldStateProvider instead of the RPC layer. 

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


