### PR TITLE
fix(rpc): add eth_getTransactionBySenderAndNonce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `eth_getFilterLogs`: cache the chain head once when resolving default `latest..latest` bounds, so a block arriving between the two reads no longer expands the queried range into `[N, N+1]` and returns extra logs. [#10368](https://github.com/besu-eth/besu/pull/10368)
 
 ### Additions and Improvements
+- Added `eth_getTransactionBySenderAndNonce` JSON-RPC method to fetch a transaction by sender and nonce from the txpool or chain history [#10346](https://github.com/besu-eth/besu/pull/10346)
 
 ## 26.5.0
 
@@ -63,6 +64,7 @@
 - Publish `besu-evm` as an API dependency from `plugin-api` [#10262](https://github.com/besu-eth/besu/pull/10262)
 - Update Gradle plugin for Besu plugin development to 0.2.0 [#10263](https://github.com/besu-eth/besu/pull/10263)
 - Rename `InvalidSystemCallAddressException` to `SystemCallNoCodeAtAddressException` to better reflect when it is thrown [#10305](https://github.com/besu-eth/besu/pull/10305)
+
 
 ## 26.4.0
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/RpcMethod.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/RpcMethod.java
@@ -100,6 +100,7 @@ public enum RpcMethod {
   ETH_GET_TRANSACTION_BY_BLOCK_HASH_AND_INDEX("eth_getTransactionByBlockHashAndIndex"),
   ETH_GET_TRANSACTION_BY_BLOCK_NUMBER_AND_INDEX("eth_getTransactionByBlockNumberAndIndex"),
   ETH_GET_TRANSACTION_BY_HASH("eth_getTransactionByHash"),
+  ETH_GET_TRANSACTION_BY_SENDER_AND_NONCE("eth_getTransactionBySenderAndNonce"),
   ETH_GET_TRANSACTION_COUNT("eth_getTransactionCount"),
   ETH_GET_TRANSACTION_RECEIPT("eth_getTransactionReceipt"),
   ETH_GET_UNCLE_BY_BLOCK_HASH_AND_INDEX("eth_getUncleByBlockHashAndIndex"),

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetTransactionBySenderAndNonce.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetTransactionBySenderAndNonce.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
+
+import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.datatypes.parameters.UnsignedLongParameter;
+import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter.JsonRpcParameterException;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.TransactionBaseResult;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.TransactionWithMetadataResult;
+import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
+import org.hyperledger.besu.ethereum.api.query.TransactionWithMetadata;
+import org.hyperledger.besu.ethereum.eth.transactions.PendingTransaction;
+import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
+
+import java.util.Optional;
+
+public class EthGetTransactionBySenderAndNonce implements JsonRpcMethod {
+
+  private final BlockchainQueries blockchainQueries;
+  private final TransactionPool transactionPool;
+
+  public EthGetTransactionBySenderAndNonce(
+      final BlockchainQueries blockchainQueries, final TransactionPool transactionPool) {
+    this.blockchainQueries = blockchainQueries;
+    this.transactionPool = transactionPool;
+  }
+
+  @Override
+  public String getName() {
+    return RpcMethod.ETH_GET_TRANSACTION_BY_SENDER_AND_NONCE.getMethodName();
+  }
+
+  @Override
+  public JsonRpcResponse response(final JsonRpcRequestContext requestContext) {
+    if (requestContext.getRequest().getParamLength() != 2) {
+      return new JsonRpcErrorResponse(
+          requestContext.getRequest().getId(), RpcErrorType.INVALID_PARAM_COUNT);
+    }
+
+    final Address sender;
+    try {
+      sender = requestContext.getRequiredParameter(0, Address.class);
+    } catch (JsonRpcParameterException e) {
+      throw new InvalidJsonRpcParameters(
+          "Invalid address parameter (index 0)", RpcErrorType.INVALID_ADDRESS_PARAMS, e);
+    }
+
+    final long nonce;
+    try {
+      nonce = requestContext.getRequiredParameter(1, UnsignedLongParameter.class).getValue();
+    } catch (JsonRpcParameterException e) {
+      throw new InvalidJsonRpcParameters(
+          "Invalid nonce parameter (index 1)", RpcErrorType.INVALID_NONCE_PARAMS, e);
+    }
+
+    return new JsonRpcSuccessResponse(
+        requestContext.getRequest().getId(), getResult(sender, nonce));
+  }
+
+  private Object getResult(final Address sender, final long nonce) {
+    final Optional<TransactionBaseResult> pendingTransactionResult =
+        transactionPool.getPendingTransactionsFor(sender).pendingTransactions().stream()
+            .map(PendingTransaction::getTransaction)
+            .filter(tx -> Long.compareUnsigned(tx.getNonce(), nonce) == 0)
+            .findFirst()
+            .map(TransactionBaseResult::new);
+    if (pendingTransactionResult.isPresent()) {
+      return pendingTransactionResult.get();
+    }
+
+    return transactionBySenderAndNonceInBlockchain(sender, nonce)
+        .map(TransactionWithMetadataResult::new)
+        .orElse(null);
+  }
+
+  private Optional<TransactionWithMetadata> transactionBySenderAndNonceInBlockchain(
+      final Address sender, final long nonce) {
+    final long chainHeadBlockNumber = blockchainQueries.getBlockchain().getChainHeadBlockNumber();
+    final long senderTxCountAtHead =
+        blockchainQueries.getTransactionCount(sender, chainHeadBlockNumber);
+    if (Long.compareUnsigned(senderTxCountAtHead, nonce) <= 0) {
+      return Optional.empty();
+    }
+
+    long low = blockchainQueries.getBlockchain().getEarliestBlockNumber().orElse(0L);
+    long high = chainHeadBlockNumber;
+
+    while (low < high) {
+      final long mid = low + ((high - low) >>> 1);
+      final long txCountAtMid = blockchainQueries.getTransactionCount(sender, mid);
+      if (Long.compareUnsigned(txCountAtMid, nonce) <= 0) {
+        low = mid + 1;
+      } else {
+        high = mid;
+      }
+    }
+
+    return findTransactionInBlockBySenderAndNonce(low, sender, nonce);
+  }
+
+  private Optional<TransactionWithMetadata> findTransactionInBlockBySenderAndNonce(
+      final long blockNumber, final Address sender, final long nonce) {
+    final int txCountInBlock = blockchainQueries.getTransactionCount(blockNumber).orElse(0);
+    for (int i = 0; i < txCountInBlock; i++) {
+      final Optional<TransactionWithMetadata> candidate =
+          blockchainQueries.transactionByBlockNumberAndIndex(blockNumber, i);
+      if (candidate.isEmpty()) {
+        continue;
+      }
+      final var transaction = candidate.get().getTransaction();
+      if (transaction.getSender().equals(sender)
+          && Long.compareUnsigned(transaction.getNonce(), nonce) == 0) {
+        return candidate;
+      }
+    }
+
+    return Optional.empty();
+  }
+}

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EthJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EthJsonRpcMethods.java
@@ -44,6 +44,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.EthGetStorageA
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.EthGetTransactionByBlockHashAndIndex;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.EthGetTransactionByBlockNumberAndIndex;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.EthGetTransactionByHash;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.EthGetTransactionBySenderAndNonce;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.EthGetTransactionCount;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.EthGetTransactionReceipt;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.EthGetUncleByBlockHashAndIndex;
@@ -156,6 +157,7 @@ public class EthJsonRpcMethods extends ApiGroupJsonRpcMethods {
             new EthNewPendingTransactionFilter(filterManager),
             new EthNewFilter(filterManager),
             new EthGetTransactionByHash(blockchainQueries, transactionPool),
+            new EthGetTransactionBySenderAndNonce(blockchainQueries, transactionPool),
             new EthGetTransactionByBlockHashAndIndex(blockchainQueries),
             new EthGetTransactionByBlockNumberAndIndex(blockchainQueries),
             new EthGetTransactionCount(blockchainQueries, transactionPool),

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetTransactionBySenderAndNonceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetTransactionBySenderAndNonceTest.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.Quantity;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.TransactionBaseResult;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.TransactionWithMetadataResult;
+import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
+import org.hyperledger.besu.ethereum.api.query.TransactionWithMetadata;
+import org.hyperledger.besu.ethereum.chain.Blockchain;
+import org.hyperledger.besu.ethereum.core.BlockDataGenerator;
+import org.hyperledger.besu.ethereum.eth.transactions.PendingTransaction;
+import org.hyperledger.besu.ethereum.eth.transactions.SenderPendingTransactionsData;
+import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class EthGetTransactionBySenderAndNonceTest {
+
+  private static final String JSON_RPC_VERSION = "2.0";
+  private static final String ETH_METHOD = "eth_getTransactionBySenderAndNonce";
+
+  @Mock private BlockchainQueries blockchainQueries;
+  @Mock private TransactionPool transactionPool;
+  @Mock private Blockchain blockchain;
+
+  private EthGetTransactionBySenderAndNonce method;
+
+  @BeforeEach
+  void setUp() {
+    method = new EthGetTransactionBySenderAndNonce(blockchainQueries, transactionPool);
+  }
+
+  @Test
+  void returnsCorrectMethodName() {
+    assertThat(method.getName()).isEqualTo(ETH_METHOD);
+  }
+
+  @Test
+  void shouldReturnErrorResponseIfMissingRequiredParameters() {
+    final JsonRpcRequest request =
+        new JsonRpcRequest(JSON_RPC_VERSION, method.getName(), new Object[] {"0x1"});
+    final JsonRpcRequestContext context = new JsonRpcRequestContext(request);
+
+    final JsonRpcErrorResponse expectedResponse =
+        new JsonRpcErrorResponse(request.getId(), RpcErrorType.INVALID_PARAM_COUNT);
+
+    final JsonRpcResponse actualResponse = method.response(context);
+
+    assertThat(actualResponse).usingRecursiveComparison().isEqualTo(expectedResponse);
+  }
+
+  @Test
+  void shouldReturnPendingTransactionWhenPresentInTransactionPool() {
+    final var transaction = new BlockDataGenerator().transaction();
+    final Address sender = transaction.getSender();
+    final long nonce = transaction.getNonce();
+
+    when(transactionPool.getPendingTransactionsFor(sender))
+        .thenReturn(
+            new SenderPendingTransactionsData(
+                sender, nonce, List.of(new PendingTransaction.Local(transaction))));
+
+    final JsonRpcRequest request =
+        new JsonRpcRequest(
+            JSON_RPC_VERSION,
+            method.getName(),
+            new Object[] {sender.toHexString(), Quantity.create(nonce)});
+    final JsonRpcRequestContext context = new JsonRpcRequestContext(request);
+
+    final JsonRpcSuccessResponse expectedResponse =
+        new JsonRpcSuccessResponse(request.getId(), new TransactionBaseResult(transaction));
+
+    final JsonRpcResponse actualResponse = method.response(context);
+
+    assertThat(actualResponse).usingRecursiveComparison().isEqualTo(expectedResponse);
+  }
+
+  @Test
+  void shouldReturnCompleteTransactionWhenPresentInBlockchain() {
+    final var transaction = new BlockDataGenerator().transaction();
+    final Address sender = transaction.getSender();
+    final long nonce = transaction.getNonce();
+
+    final long foundAtBlock = 10L;
+    final long headBlock = 20L;
+
+    final TransactionWithMetadata transactionWithMetadata =
+        new TransactionWithMetadata(transaction, foundAtBlock, Optional.empty(), Hash.ZERO, 0, 0L);
+
+    when(transactionPool.getPendingTransactionsFor(sender))
+        .thenReturn(SenderPendingTransactionsData.empty(sender));
+
+    when(blockchainQueries.getBlockchain()).thenReturn(blockchain);
+    when(blockchain.getChainHeadBlockNumber()).thenReturn(headBlock);
+    when(blockchain.getEarliestBlockNumber()).thenReturn(Optional.of(0L));
+
+    when(blockchainQueries.getTransactionCount(eq(sender), anyLong()))
+        .thenAnswer(
+            invocation -> {
+              final long block = invocation.getArgument(1);
+              return block >= foundAtBlock ? nonce + 1 : nonce;
+            });
+
+    when(blockchainQueries.getTransactionCount(foundAtBlock)).thenReturn(Optional.of(1));
+    when(blockchainQueries.transactionByBlockNumberAndIndex(foundAtBlock, 0))
+        .thenReturn(Optional.of(transactionWithMetadata));
+
+    final JsonRpcRequest request =
+        new JsonRpcRequest(
+            JSON_RPC_VERSION,
+            method.getName(),
+            new Object[] {sender.toHexString(), Quantity.create(nonce)});
+    final JsonRpcRequestContext context = new JsonRpcRequestContext(request);
+
+    final JsonRpcSuccessResponse expectedResponse =
+        new JsonRpcSuccessResponse(
+            request.getId(), new TransactionWithMetadataResult(transactionWithMetadata));
+
+    final JsonRpcResponse actualResponse = method.response(context);
+
+    assertThat(actualResponse).usingRecursiveComparison().isEqualTo(expectedResponse);
+  }
+
+  @Test
+  void shouldThrowInvalidJsonRpcParametersForInvalidAddress() {
+    final JsonRpcRequest request =
+        new JsonRpcRequest(
+            JSON_RPC_VERSION, method.getName(), new Object[] {"not-an-address", "0x1"});
+    final JsonRpcRequestContext context = new JsonRpcRequestContext(request);
+
+    assertThatThrownBy(() -> method.response(context))
+        .isInstanceOf(InvalidJsonRpcParameters.class)
+        .hasMessageContaining("Invalid address parameter");
+  }
+
+  @Test
+  void shouldThrowInvalidJsonRpcParametersForInvalidNonce() {
+    final var transaction = new BlockDataGenerator().transaction();
+    final Address sender = transaction.getSender();
+    final JsonRpcRequest request =
+        new JsonRpcRequest(
+            JSON_RPC_VERSION,
+            method.getName(),
+            new Object[] {sender.toHexString(), "invalid-nonce"});
+    final JsonRpcRequestContext context = new JsonRpcRequestContext(request);
+
+    assertThatThrownBy(() -> method.response(context))
+        .isInstanceOf(InvalidJsonRpcParameters.class)
+        .hasMessageContaining("Invalid nonce parameter");
+  }
+
+  @Test
+  void shouldReturnTransactionFoundAtGenesisBlock() {
+    final var transaction = new BlockDataGenerator().transaction();
+    final Address sender = transaction.getSender();
+    final long nonce = transaction.getNonce();
+
+    final TransactionWithMetadata transactionWithMetadata =
+        new TransactionWithMetadata(transaction, 0L, Optional.empty(), Hash.ZERO, 0, 0L);
+
+    when(transactionPool.getPendingTransactionsFor(sender))
+        .thenReturn(SenderPendingTransactionsData.empty(sender));
+
+    when(blockchainQueries.getBlockchain()).thenReturn(blockchain);
+    when(blockchain.getChainHeadBlockNumber()).thenReturn(10L);
+    when(blockchain.getEarliestBlockNumber()).thenReturn(Optional.of(0L));
+
+    when(blockchainQueries.getTransactionCount(eq(sender), anyLong()))
+        .thenAnswer(
+            invocation -> {
+              final long block = invocation.getArgument(1);
+              return block >= 0 ? nonce + 1 : nonce;
+            });
+
+    when(blockchainQueries.getTransactionCount(0L)).thenReturn(Optional.of(1));
+    when(blockchainQueries.transactionByBlockNumberAndIndex(0L, 0))
+        .thenReturn(Optional.of(transactionWithMetadata));
+
+    final JsonRpcRequest request =
+        new JsonRpcRequest(
+            JSON_RPC_VERSION,
+            method.getName(),
+            new Object[] {sender.toHexString(), Quantity.create(nonce)});
+    final JsonRpcRequestContext context = new JsonRpcRequestContext(request);
+
+    final JsonRpcSuccessResponse expectedResponse =
+        new JsonRpcSuccessResponse(
+            request.getId(), new TransactionWithMetadataResult(transactionWithMetadata));
+
+    final JsonRpcResponse actualResponse = method.response(context);
+
+    assertThat(actualResponse).usingRecursiveComparison().isEqualTo(expectedResponse);
+  }
+
+  @Test
+  void shouldReturnNullWhenTransactionDoesNotExist() {
+    final Address sender = Address.fromHexString("0x0000000000000000000000000000000000000001");
+    final long nonce = 7L;
+
+    when(transactionPool.getPendingTransactionsFor(sender))
+        .thenReturn(SenderPendingTransactionsData.empty(sender));
+
+    when(blockchainQueries.getBlockchain()).thenReturn(blockchain);
+    when(blockchain.getChainHeadBlockNumber()).thenReturn(20L);
+    when(blockchainQueries.getTransactionCount(sender, 20L)).thenReturn(nonce);
+
+    final JsonRpcRequest request =
+        new JsonRpcRequest(
+            JSON_RPC_VERSION,
+            method.getName(),
+            new Object[] {sender.toHexString(), Quantity.create(nonce)});
+    final JsonRpcRequestContext context = new JsonRpcRequestContext(request);
+
+    final JsonRpcSuccessResponse expectedResponse =
+        new JsonRpcSuccessResponse(request.getId(), null);
+
+    final JsonRpcResponse actualResponse = method.response(context);
+
+    assertThat(actualResponse).usingRecursiveComparison().isEqualTo(expectedResponse);
+  }
+}


### PR DESCRIPTION
What the bug is:
Besu does not implement `eth_getTransactionBySenderAndNonce`, so the JSON-RPC call returns method not found even though the execution-apis spec includes it and other EL clients support it.

Where it is in the code:
ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetTransactionBySenderAndNonce.java, class `EthGetTransactionBySenderAndNonce`, method `response(...)`, plus registration in ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EthJsonRpcMethods.java and enum addition in ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/RpcMethod.java.

Why the fix is correct:
The handler first checks the txpool for a sender+nonce match and returns that pending transaction if present, then uses a binary search over historical block heights with `getTransactionCount(sender, block)` to find the first block where the sender nonce advances past the target and scans that block for the exact sender+nonce. This matches the reth-style approach, avoids new indexes, and returns a full transaction object consistent with `eth_getTransactionByHash`.

Steps to reproduce:
Call `eth_getTransactionBySenderAndNonce` with a sender address and nonce (per execution-apis #494). Current Besu builds return method not found.

Fixes #10284
Added changelog entry to Unreleased section