### PR TITLE
fix: return -38003 for FCUv1 timestamp errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Upcoming Breaking Changes
 
 ### Bug fixes
+- Fix `engine_forkchoiceUpdatedV1` now returns `-38003 INVALID_PAYLOAD_ATTRIBUTES` for invalid payload attribute timestamps (zero or not greater than head). [#10353](https://github.com/besu-eth/besu/pull/10353)
 
 ### Additions and Improvements
 

--- a/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/paris/test-cases/06_update_forkchoice_invalid_payload_attributes.json
+++ b/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/paris/test-cases/06_update_forkchoice_invalid_payload_attributes.json
@@ -20,8 +20,8 @@
     "jsonrpc": "2.0",
     "id": 67,
     "error": {
-      "code": -32602,
-      "message": "Invalid withdrawals"
+      "code": -38003,
+      "message": "Invalid payload attributes"
     }
   },
   "statusCode": 200

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdated.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdated.java
@@ -187,7 +187,7 @@ public abstract class AbstractEngineForkchoiceUpdated extends ExecutionEngineJso
       if (!getWithdrawalsValidator(
               protocolSchedule.get(), newHead, maybePayloadAttributes.get().getTimestamp())
           .validateWithdrawals(withdrawals)) {
-        return new JsonRpcErrorResponse(requestId, getInvalidPayloadAttributesError());
+        return new JsonRpcErrorResponse(requestId, getInvalidWithdrawalsError());
       }
     }
 
@@ -382,6 +382,10 @@ public abstract class AbstractEngineForkchoiceUpdated extends ExecutionEngineJso
   }
 
   protected RpcErrorType getInvalidPayloadAttributesError() {
+    return RpcErrorType.INVALID_PAYLOAD_ATTRIBUTES;
+  }
+
+  protected RpcErrorType getInvalidWithdrawalsError() {
     return RpcErrorType.INVALID_PAYLOAD_ATTRIBUTES;
   }
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV1.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV1.java
@@ -59,7 +59,7 @@ public class EngineForkchoiceUpdatedV1 extends AbstractEngineForkchoiceUpdated {
   }
 
   @Override
-  protected RpcErrorType getInvalidPayloadAttributesError() {
+  protected RpcErrorType getInvalidWithdrawalsError() {
     return RpcErrorType.INVALID_WITHDRAWALS_PARAMS;
   }
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdatedTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdatedTest.java
@@ -510,7 +510,7 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
                 mockHeader.getHash(), Hash.ZERO, mockParent.getHash()),
             Optional.of(payloadParams));
 
-    assertInvalidForkchoiceState(resp, expectedInvalidPayloadError());
+    assertInvalidForkchoiceState(resp, expectedInvalidWithdrawalsError());
     verify(engineCallListener, times(1)).executionEngineCalled();
   }
 
@@ -583,7 +583,7 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
                 mockHeader.getHash(), Hash.ZERO, mockParent.getHash()),
             Optional.of(payloadParams));
 
-    assertInvalidForkchoiceState(resp, expectedInvalidPayloadError());
+    assertInvalidForkchoiceState(resp, expectedInvalidWithdrawalsError());
     verify(engineCallListener, times(1)).executionEngineCalled();
   }
 
@@ -755,7 +755,11 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
   }
 
   protected RpcErrorType expectedInvalidPayloadError() {
-    return RpcErrorType.INVALID_WITHDRAWALS_PARAMS;
+    return RpcErrorType.INVALID_PAYLOAD_ATTRIBUTES;
+  }
+
+  protected RpcErrorType expectedInvalidWithdrawalsError() {
+    return RpcErrorType.INVALID_PAYLOAD_ATTRIBUTES;
   }
 
   protected JsonRpcResponse resp(

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV1Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV1Test.java
@@ -21,14 +21,20 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.consensus.merge.blockcreation.MergeMiningCoordinator.ForkchoiceResult;
+import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.EngineForkchoiceUpdatedParameter;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.EnginePayloadAttributesParameter;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 
 import java.util.Optional;
 
+import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -55,8 +61,68 @@ public class EngineForkchoiceUpdatedV1Test extends AbstractEngineForkchoiceUpdat
   }
 
   @Override
-  protected RpcErrorType expectedInvalidPayloadError() {
+  protected RpcErrorType expectedInvalidWithdrawalsError() {
     return RpcErrorType.INVALID_WITHDRAWALS_PARAMS;
+  }
+
+  @Test
+  public void shouldReturnInvalidPayloadAttributesWhenTimestampIsZero() {
+    BlockHeader mockParent = blockHeaderBuilder.timestamp(99).number(9L).buildHeader();
+    BlockHeader mockHeader =
+        blockHeaderBuilder.number(10L).parentHash(mockParent.getHash()).buildHeader();
+    setupValidForkchoiceUpdate(mockHeader);
+
+    final EnginePayloadAttributesParameter payloadParams =
+        new EnginePayloadAttributesParameter(
+            "0x0",
+            Bytes32.fromHexStringLenient("0xDEADBEEF").toHexString(),
+            Address.ECREC.toString(),
+            null,
+            null,
+            null);
+
+    final JsonRpcResponse resp =
+        resp(
+            new EngineForkchoiceUpdatedParameter(
+                mockHeader.getHash(), Hash.ZERO, mockParent.getHash()),
+            Optional.of(payloadParams));
+
+    final JsonRpcError jsonRpcError =
+        Optional.of(resp)
+            .map(JsonRpcErrorResponse.class::cast)
+            .map(JsonRpcErrorResponse::getError)
+            .get();
+    assertThat(jsonRpcError.getCode()).isEqualTo(RpcErrorType.INVALID_PAYLOAD_ATTRIBUTES.getCode());
+  }
+
+  @Test
+  public void shouldReturnInvalidPayloadAttributesWhenTimestampEqualsParent() {
+    BlockHeader mockParent = blockHeaderBuilder.timestamp(99).number(9L).buildHeader();
+    BlockHeader mockHeader =
+        blockHeaderBuilder.number(10L).parentHash(mockParent.getHash()).buildHeader();
+    setupValidForkchoiceUpdate(mockHeader);
+
+    final EnginePayloadAttributesParameter payloadParams =
+        new EnginePayloadAttributesParameter(
+            String.valueOf(mockHeader.getTimestamp()),
+            Bytes32.fromHexStringLenient("0xDEADBEEF").toHexString(),
+            Address.ECREC.toString(),
+            null,
+            null,
+            null);
+
+    final JsonRpcResponse resp =
+        resp(
+            new EngineForkchoiceUpdatedParameter(
+                mockHeader.getHash(), Hash.ZERO, mockParent.getHash()),
+            Optional.of(payloadParams));
+
+    final JsonRpcError jsonRpcError =
+        Optional.of(resp)
+            .map(JsonRpcErrorResponse.class::cast)
+            .map(JsonRpcErrorResponse::getError)
+            .get();
+    assertThat(jsonRpcError.getCode()).isEqualTo(RpcErrorType.INVALID_PAYLOAD_ATTRIBUTES.getCode());
   }
 
   @Test


### PR DESCRIPTION
### PR description

`engine_forkchoiceUpdatedV1` was returning `-32602 INVALID_WITHDRAWALS_PARAMS` instead of the spec-mandated `-38003 INVALID_PAYLOAD_ATTRIBUTES` when the supplied `payloadAttributes.timestamp` was invalid (zero or ≤ head's timestamp).

The single getter `getInvalidPayloadAttributesError()` in `AbstractEngineForkchoiceUpdated` was used by two distinct code paths, the withdrawals validator and the timestamp validator. A V1 override of that getter was preserving V1's legacy `INVALID_WITHDRAWALS_PARAMS` return for withdrawals issues, but inadvertently changed V1's timestamp errors too.

This PR splits the getter into two, `getInvalidPayloadAttributesError()` for the timestamp path and a new `getInvalidWithdrawalsError()` for the withdrawals path, so the V1 carve-out can be scoped to withdrawals only. V1 now correctly returns `-38003` for timestamp errors per the Engine API spec, while continuing to return `-32602` for withdrawals as before.

V2/V3/V4 behavior is unchanged.

### Hive impact

Fixes the following Hive `engine-api` failures for `besu`:
- `Invalid PayloadAttributes, Zero timestamp, Syncing=False (Paris)`
- `Invalid PayloadAttributes, Parent timestamp, Syncing=False (Paris)`

Verified locally there hive test pass now

## Fixed Issue(s)

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew :ethereum:api:test` (25/25 V1Test, 24/24 V2Test pass)
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [x] hive tests: verified locally 
