### PR TITLE
fix: avoid TOCTOU on head block reads in eth_getFilterLogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Cleanly stop backward sync if world state is unavailable [#10021](https://github.com/besu-eth/besu/pull/10021)
 - Enforce that `blob_versioned_hashes` match the supplied blobs [#10278](https://github.com/besu-eth/besu/pull/10278)
 - Restrict no-reorg behavior to the prefix of the known finalized chain (per execution-apis #786) [#10335](https://github.com/besu-eth/besu/pull/10335)
+- `eth_getFilterLogs`: cache the chain head once when resolving default `latest..latest` bounds, so a block arriving between the two reads no longer expands the queried range into `[N, N+1]` and returns extra logs.
 
 ### Additions and Improvements
 - The option to set a different block period for empty BFT blocks (`emptyblockperiodseconds`) is no longer experimental. The experimental flag `xemptyblockperiodseconds` will be removed in a future release. [#10264](https://github.com/besu-eth/besu/pull/10264)

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/filter/FilterManager.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/filter/FilterManager.java
@@ -240,10 +240,9 @@ public class FilterManager extends AbstractVerticle {
       filter.resetExpireTime();
     }
 
-    final long fromBlockNumber =
-        filter.getFromBlock().getNumber().orElse(blockchainQueries.headBlockNumber());
-    final long toBlockNumber =
-        filter.getToBlock().getNumber().orElse(blockchainQueries.headBlockNumber());
+    final long headBlockNumber = blockchainQueries.headBlockNumber();
+    final long fromBlockNumber = filter.getFromBlock().getNumber().orElse(headBlockNumber);
+    final long toBlockNumber = filter.getToBlock().getNumber().orElse(headBlockNumber);
 
     return findLogsWithinRange(filter, fromBlockNumber, toBlockNumber);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/filter/FilterManagerTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/filter/FilterManagerTest.java
@@ -16,14 +16,18 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.BlockParameter;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
+import org.hyperledger.besu.ethereum.api.query.LogsQuery;
 import org.hyperledger.besu.ethereum.chain.BlockAddedEvent;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.Block;
@@ -227,6 +231,27 @@ public class FilterManagerTest {
     filterManager.pendingTransactionChanges("foo");
 
     verify(filter).resetExpireTime();
+  }
+
+  @Test
+  public void logsForLatestLatestFilterResolvesHeadOnce() {
+    // A filter installed with no fromBlock/toBlock defaults to latest..latest.
+    // headBlockNumber() must be read once and reused for both bounds; otherwise
+    // a block landing between the two reads makes the range straddle into
+    // [N, N+1] and returns logs the caller did not ask for.
+    final LogsQuery logsQuery = new LogsQuery.Builder().build();
+    final String filterId = "latest-latest";
+    filterRepository.save(
+        new LogFilter(filterId, BlockParameter.LATEST, BlockParameter.LATEST, logsQuery));
+
+    when(blockchainQueries.headBlockNumber()).thenReturn(100L, 101L);
+    when(blockchainQueries.matchingLogs(anyLong(), anyLong(), any(LogsQuery.class), any()))
+        .thenReturn(Collections.emptyList());
+
+    filterManager.logs(filterId);
+
+    verify(blockchainQueries, times(1)).headBlockNumber();
+    verify(blockchainQueries).matchingLogs(eq(100L), eq(100L), eq(logsQuery), any());
   }
 
   private Hash appendBlockToBlockchain() {


### PR DESCRIPTION
## What's the problem?

While reading through the filter code I noticed `FilterManager.logs()` resolves the from/to bounds of a filter installed with default `latest..latest` bounds by calling `blockchainQueries.headBlockNumber()` twice — once for the from side, once for the to side:

```java
final long fromBlockNumber =
    filter.getFromBlock().getNumber().orElse(blockchainQueries.headBlockNumber());
final long toBlockNumber =
    filter.getToBlock().getNumber().orElse(blockchainQueries.headBlockNumber());
```

`headBlockNumber()` is not memoised — each call freshly reads the current chain head. If a new block lands between the two reads (which happens routinely on a busy chain), the first call returns N and the second returns N + 1. The query then runs over `[N, N + 1]` and the response includes logs from a block the caller did not ask for.

This is the same shape as #10051: two reads of a moving piece of chain state with an implicit assumption they'll agree. `eth_getFilterLogs` is heavily used by indexers and event-driven dapps that install a filter via `eth_newFilter({ topics: [...] })` and then poll — both block params default to `latest`, which is exactly the path that hits this race.

## How I fixed it

Read the head once and reuse it:

```java
final long headBlockNumber = blockchainQueries.headBlockNumber();
final long fromBlockNumber = filter.getFromBlock().getNumber().orElse(headBlockNumber);
final long toBlockNumber = filter.getToBlock().getNumber().orElse(headBlockNumber);
```

## Testing

Added `logsForLatestLatestFilterResolvesHeadOnce` to `FilterManagerTest`. The mock returns `100L` on the first `headBlockNumber()` call and `101L` on the second; the test then asserts the resolver made a single read and queried `[100, 100]`. Without the fix the test would see two reads and a `[100, 101]` query.

All existing `FilterManager` and `eth_getFilter*` tests still pass. Ran `:ethereum:api:spotlessApply` and the wider build before pushing.

Signed-off-by: Shridhar Panigrahi <sridharpanigrahi2006@gmail.com>