### PR TITLE
Skip BAL apply during snap sync if not enabled on the first pivot

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapDownloaderFactory.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapDownloaderFactory.java
@@ -106,6 +106,7 @@ public class SnapDownloaderFactory {
             ethContext,
             snapContext,
             protocolContext,
+            protocolSchedule,
             worldStateStorageCoordinator,
             snapTaskCollection,
             syncConfig.getSnapSyncConfiguration(),

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapWorldDownloadState.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapWorldDownloadState.java
@@ -31,6 +31,7 @@ import org.hyperledger.besu.ethereum.eth.sync.snapsync.request.StorageRangeDataR
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.request.heal.AccountFlatDatabaseHealingRangeRequest;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.request.heal.StorageFlatDatabaseHealingRangeRequest;
 import org.hyperledger.besu.ethereum.eth.sync.worldstate.WorldDownloadState;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.trie.RangeManager;
 import org.hyperledger.besu.ethereum.trie.pathbased.bonsai.storage.BonsaiWorldStateKeyValueStorage;
 import org.hyperledger.besu.ethereum.worldstate.FlatDbMode;
@@ -88,6 +89,8 @@ public class SnapWorldDownloadState extends WorldDownloadState<SnapDataRequest> 
 
   private final SnapSyncStatePersistenceManager snapContext;
   private final SnapSyncProcessState snapSyncState;
+  private final ProtocolSchedule protocolSchedule;
+
   // blockchain
   private final Blockchain blockchain;
   private final Long blockObserverId;
@@ -105,6 +108,7 @@ public class SnapWorldDownloadState extends WorldDownloadState<SnapDataRequest> 
       final SnapSyncStatePersistenceManager snapContext,
       final Blockchain blockchain,
       final SnapSyncProcessState snapSyncState,
+      final ProtocolSchedule protocolSchedule,
       final InMemoryTasksPriorityQueues<SnapDataRequest> pendingRequests,
       final int maxRequestsWithoutProgress,
       final long minMillisBeforeStalling,
@@ -122,6 +126,7 @@ public class SnapWorldDownloadState extends WorldDownloadState<SnapDataRequest> 
     this.snapContext = snapContext;
     this.blockchain = blockchain;
     this.snapSyncState = snapSyncState;
+    this.protocolSchedule = protocolSchedule;
     this.metricsManager = metricsManager;
     this.blockObserverId = blockchain.observeBlockAdded(createBlockchainObserver());
     this.ethContext = ethContext;
@@ -310,8 +315,6 @@ public class SnapWorldDownloadState extends WorldDownloadState<SnapDataRequest> 
     final Optional<BlockHeader> maybeFirstPivotHeader = snapSyncState.getFirstPivotBlockHeader();
     final Optional<BlockHeader> maybeLastPivotHeader = snapSyncState.getPivotBlockHeader();
 
-    LOG.debug("Starting BAL apply attempt");
-
     if (maybeFirstPivotHeader.isEmpty() || maybeLastPivotHeader.isEmpty()) {
       LOG.debug(
           "Skipping BAL apply - firstPivotHeader={}, lastPivotHeader={}",
@@ -320,7 +323,13 @@ public class SnapWorldDownloadState extends WorldDownloadState<SnapDataRequest> 
       return;
     }
 
-    final long fromBlock = maybeFirstPivotHeader.get().getNumber();
+    final BlockHeader firstPivotHeader = maybeFirstPivotHeader.get();
+    if (!protocolSchedule.getByBlockHeader(firstPivotHeader).isBlockAccessListEnabled()) {
+      LOG.debug("Skipping BAL apply - BALs not enabled on first pivot {}", firstPivotHeader);
+      return;
+    }
+
+    final long fromBlock = firstPivotHeader.getNumber();
     final long toBlock = maybeLastPivotHeader.get().getNumber();
 
     LOG.info("Applying block access lists from block {} to {}", fromBlock, toBlock);

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapWorldStateDownloader.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapWorldStateDownloader.java
@@ -27,6 +27,7 @@ import org.hyperledger.besu.ethereum.eth.sync.snapsync.context.SnapSyncStatePers
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.request.AccountRangeDataRequest;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.request.SnapDataRequest;
 import org.hyperledger.besu.ethereum.eth.sync.worldstate.WorldStateDownloader;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.trie.RangeManager;
 import org.hyperledger.besu.ethereum.trie.pathbased.bonsai.storage.BonsaiWorldStateKeyValueStorage;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateStorageCoordinator;
@@ -66,6 +67,7 @@ public class SnapWorldStateDownloader implements WorldStateDownloader {
   private final int maxNodeRequestsWithoutProgress;
   private final ProtocolContext protocolContext;
   private final WorldStateStorageCoordinator worldStateStorageCoordinator;
+  private final ProtocolSchedule protocolSchedule;
 
   private final AtomicReference<SnapWorldDownloadState> downloadState = new AtomicReference<>();
   private final SyncDurationMetrics syncDurationMetrics;
@@ -76,6 +78,7 @@ public class SnapWorldStateDownloader implements WorldStateDownloader {
       final EthContext ethContext,
       final SnapSyncStatePersistenceManager snapContext,
       final ProtocolContext protocolContext,
+      final ProtocolSchedule protocolSchedule,
       final WorldStateStorageCoordinator worldStateStorageCoordinator,
       final InMemoryTasksPriorityQueues<SnapDataRequest> snapTaskCollection,
       final SnapSyncConfiguration snapSyncConfiguration,
@@ -87,6 +90,7 @@ public class SnapWorldStateDownloader implements WorldStateDownloader {
       final SyncDurationMetrics syncDurationMetrics) {
     this.ethContext = ethContext;
     this.protocolContext = protocolContext;
+    this.protocolSchedule = protocolSchedule;
     this.worldStateStorageCoordinator = worldStateStorageCoordinator;
     this.snapContext = snapContext;
     this.snapTaskCollection = snapTaskCollection;
@@ -160,6 +164,7 @@ public class SnapWorldStateDownloader implements WorldStateDownloader {
               snapContext,
               protocolContext.getBlockchain(),
               snapSyncState,
+              protocolSchedule,
               snapTaskCollection,
               maxNodeRequestsWithoutProgress,
               minMillisBeforeStalling,

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapWorldDownloadStateTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapWorldDownloadStateTest.java
@@ -40,6 +40,8 @@ import org.hyperledger.besu.ethereum.eth.sync.snapsync.context.SnapSyncStatePers
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.request.BytecodeRequest;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.request.SnapDataRequest;
 import org.hyperledger.besu.ethereum.eth.sync.worldstate.WorldStateDownloadProcess;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
 import org.hyperledger.besu.ethereum.trie.RangeManager;
 import org.hyperledger.besu.ethereum.trie.forest.storage.ForestWorldStateKeyValueStorage;
 import org.hyperledger.besu.ethereum.trie.pathbased.bonsai.storage.BonsaiWorldStateKeyValueStorage;
@@ -94,6 +96,8 @@ public class SnapWorldDownloadStateTest {
   private final DynamicPivotBlockSelector dynamicPivotBlockManager =
       mock(DynamicPivotBlockSelector.class);
   private final EthContext ethContext = mock(EthContext.class);
+  private final ProtocolSchedule protocolSchedule = mock(ProtocolSchedule.class);
+  private final ProtocolSpec protocolSpec = mock(ProtocolSpec.class);
 
   private final TestClock clock = new TestClock();
   private SnapWorldDownloadState downloadState;
@@ -113,6 +117,9 @@ public class SnapWorldDownloadStateTest {
   public void setUp(final DataStorageFormat storageFormat) {
 
     when(metricsManager.getMetricsSystem()).thenReturn(new NoOpMetricsSystem());
+    when(protocolSchedule.getByBlockHeader(any(BlockHeader.class))).thenReturn(protocolSpec);
+    when(protocolSpec.getBlockAccessListFactory()).thenReturn(Optional.empty());
+
     if (storageFormat == DataStorageFormat.BONSAI) {
       worldStateKeyValueStorage =
           new BonsaiWorldStateKeyValueStorage(
@@ -131,6 +138,7 @@ public class SnapWorldDownloadStateTest {
             snapContext,
             blockchain,
             snapSyncState,
+            protocolSchedule,
             pendingRequests,
             MAX_REQUESTS_WITHOUT_PROGRESS,
             MIN_MILLIS_BEFORE_STALLING,


### PR DESCRIPTION
Fix for regression introduced [here](https://github.com/besu-eth/besu/pull/10245#discussion_r3093881641) causing excessive logs during the snap sync healing phase:
```
{"@timestamp":"2026-04-30T08:25:40,131","level":"WARN","thread":"EthScheduler-Services-42 (requestCompleteTask)","class":"BlockAccessListFlatDatabaseUpdater","message":"Missing stored BAL while applying BALs to flat database at block 2720088 (0x1d4584c4b971158e894ec3cf5515e89d62bcc805170bf02a9d9f528a83569e45); continuing","throwable":""}
{"@timestamp":"2026-04-30T08:25:40,131","level":"WARN","thread":"EthScheduler-Services-42 (requestCompleteTask)","class":"BlockAccessListFlatDatabaseUpdater","message":"Missing stored BAL while applying BALs to flat database at block 2720089 (0x236381a921c68b0b62d3d24bb38cb08171e8560d68d166c8f730049d9c6df392); continuing","throwable":""}
{"@timestamp":"2026-04-30T08:25:40,131","level":"WARN","thread":"EthScheduler-Services-42 (requestCompleteTask)","class":"BlockAccessListFlatDatabaseUpdater","message":"Missing stored BAL while applying BALs to flat database at block 2720090 (0x1408a4d3cc92580db602c89c50e4d399ead371e0e20100c5932b63f8b8a74f56); continuing","throwable":""}
{"@timestamp":"2026-04-30T08:25:40,131","level":"WARN","thread":"EthScheduler-Services-42 (requestCompleteTask)","class":"BlockAccessListFlatDatabaseUpdater","message":"Missing stored BAL while applying BALs to flat database at block 2720091 (0x461938f5b1e25f71d2ce0338aee4684a28b7d937124147b22deaf1baa914c4e5); continuing","throwable":""}
{"@timestamp":"2026-04-30T08:25:40,131","level":"WARN","thread":"EthScheduler-Services-42 (requestCompleteTask)","class":"BlockAccessListFlatDatabaseUpdater","message":"Missing stored BAL while applying BALs to flat database at block 2720092 (0x8e6a3ff9f4c7f757afe8a94a157ff09782d76057ac8fd0e2d130d002dce59216); continuing","throwable":""}
{"@timestamp":"2026-04-30T08:25:40,131","level":"WARN","thread":"EthScheduler-Services-42 (requestCompleteTask)","class":"BlockAccessListFlatDatabaseUpdater","message":"Missing stored BAL while applying BALs to flat database at block 2720093 (0x7305aa60186c872432b34193069ad0ce07883703a63d9a57b4a9cd096d7fdda0); continuing","throwable":""}
```

Now BALs will be applied only if the first pivot was BAL-enabled.