### PR TITLE
Improve Partial Block Access List sorting

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/block/access/list/PartialBlockAccessView.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/block/access/list/PartialBlockAccessView.java
@@ -19,7 +19,7 @@ import org.hyperledger.besu.datatypes.StorageSlotKey;
 import org.hyperledger.besu.datatypes.Wei;
 
 import java.util.ArrayList;
-import java.util.Comparator;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -179,12 +179,15 @@ public final class PartialBlockAccessView {
     }
 
     public PartialBlockAccessView build() {
-      List<AccountChanges> accountChanges =
-          accountBuilders.values().stream()
-              .map(AccountChangesBuilder::build)
-              .sorted(
-                  Comparator.comparing(ac -> ac.getAddress().getBytes().toUnprefixedHexString()))
-              .toList();
+      final List<AccountChanges> accountChanges = new ArrayList<>(accountBuilders.size());
+      for (AccountChangesBuilder accountBuilder : accountBuilders.values()) {
+        accountChanges.add(accountBuilder.build());
+      }
+      accountChanges.sort(
+          (left, right) ->
+              Arrays.compareUnsigned(
+                  left.getAddress().getBytes().toArrayUnsafe(),
+                  right.getAddress().getBytes().toArrayUnsafe()));
       return new PartialBlockAccessView(accountChanges, txIndex);
     }
   }


### PR DESCRIPTION
## PR description
Similar to https://github.com/besu-eth/besu/pull/10351, but for Partial Block Access List sorting.
**Before** (556 samples)

<img width="1709" height="677" alt="image" src="https://github.com/user-attachments/assets/0fad5adf-b65d-42fa-ac4b-9c65308e6dcc" />

**After** (76 samples)
<img width="1709" height="766" alt="image" src="https://github.com/user-attachments/assets/31763208-fa00-4aa5-ae7e-be9776ccef95" />


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


