### PR TITLE
CHANGELOG: add Unreleased section above 26.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Breaking Changes
+
+### Upcoming Breaking Changes
+
+### Bug fixes
+- `eth_getFilterLogs`: cache the chain head once when resolving default `latest..latest` bounds, so a block arriving between the two reads no longer expands the queried range into `[N, N+1]` and returns extra logs. [#10368](https://github.com/besu-eth/besu/pull/10368)
+
+### Additions and Improvements
+
 ## 26.5.0
 
 ### Breaking Changes
@@ -30,7 +41,6 @@
 - Cleanly stop backward sync if world state is unavailable [#10021](https://github.com/besu-eth/besu/pull/10021)
 - Enforce that `blob_versioned_hashes` match the supplied blobs [#10278](https://github.com/besu-eth/besu/pull/10278)
 - Restrict no-reorg behavior to the prefix of the known finalized chain (per execution-apis #786) [#10335](https://github.com/besu-eth/besu/pull/10335)
-- `eth_getFilterLogs`: cache the chain head once when resolving default `latest..latest` bounds, so a block arriving between the two reads no longer expands the queried range into `[N, N+1]` and returns extra logs.
 
 ### Additions and Improvements
 - The option to set a different block period for empty BFT blocks (`emptyblockperiodseconds`) is no longer experimental. The experimental flag `xemptyblockperiodseconds` will be removed in a future release. [#10264](https://github.com/besu-eth/besu/pull/10264)


### PR DESCRIPTION
## Summary
- Adds a new \`## Unreleased\` section above \`## 26.5.0\` so post-26.5.0 entries have a place to land
- Moves the #10368 \`eth_getFilterLogs\` TOCTOU fix entry from \`## 26.5.0\` to \`## Unreleased\`

The 26.5.0 tag is being cut at 91796a19d8 (the burn-in RC1 sha), which **does not** include #10368. The CHANGELOG entry for #10368 was added to the 26.5.0 section in f06fde4dc9 after the tag boundary, so it would be misleading to publish a 26.5.0 release note for a fix that isn't in the 26.5.0 binaries.

## Test plan
- [ ] CHANGELOG-only change; no code impact
- [ ] Verify \`## 26.5.0\` section reflects exactly what's in the 26.5.0 tag (\`91796a19d8\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)