### PR TITLE
fix: cap EIP-8037 same-tx-selfdestruct refund at execution state gas

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessor.java
@@ -459,8 +459,9 @@ public class MainnetTransactionProcessor {
         worldUpdater.commit();
         // EIP-8037: end-of-tx refund for accounts created and
         // self-destructed within this transaction. Must run before tx_gas_used_before_refund is
-        // computed below so the sender is not charged for state that was destroyed.
-        stateGasCalc.refundSameTransactionSelfDestructStateGas(initialFrame);
+        // computed below so the sender is not charged for state that was destroyed. Pass the
+        // intrinsic state gas so the refund is capped at execution-time state gas only.
+        stateGasCalc.refundSameTransactionSelfDestructStateGas(initialFrame, intrinsicStateGas);
       } else {
         if (initialFrame.getExceptionalHaltReason().isPresent()) {
           validationResult =

--- a/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/Eip8037StateGasCostCalculator.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/Eip8037StateGasCostCalculator.java
@@ -243,16 +243,14 @@ public class Eip8037StateGasCostCalculator implements StateGasCostCalculator {
       }
     }
     if (totalRefund > 0L) {
-      // Cap refund at execution-time state gas only — never eat into the intrinsic charge the
-      // user paid upfront. Matches geth/nethermind/erigon/ethrex semantics: the same-tx-
-      // selfdestruct refund returns state gas spent during EVM execution (inner CREATEs, code
-      // deposits, storage growth), not the intrinsic charge for the top-level CREATE itself.
+      // Cap at execution-time state gas; intrinsic was paid up-front and is not refundable.
+      // Matches geth/nethermind/erigon/ethrex.
       final long executionStateGas =
           Math.max(0L, initialFrame.getStateGasUsed() - intrinsicStateGas);
-      final long capped = Math.min(totalRefund, executionStateGas);
-      if (capped > 0L) {
-        initialFrame.incrementStateGasReservoir(capped);
-        initialFrame.decrementStateGasUsed(capped);
+      final long cappedRefund = Math.min(totalRefund, executionStateGas);
+      if (cappedRefund > 0L) {
+        initialFrame.incrementStateGasReservoir(cappedRefund);
+        initialFrame.decrementStateGasUsed(cappedRefund);
       }
     }
   }

--- a/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/Eip8037StateGasCostCalculator.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/Eip8037StateGasCostCalculator.java
@@ -214,7 +214,8 @@ public class Eip8037StateGasCostCalculator implements StateGasCostCalculator {
   }
 
   @Override
-  public void refundSameTransactionSelfDestructStateGas(final MessageFrame initialFrame) {
+  public void refundSameTransactionSelfDestructStateGas(
+      final MessageFrame initialFrame, final long intrinsicStateGas) {
     final Set<Address> destroyed = initialFrame.getSelfDestructs();
     if (destroyed.isEmpty()) {
       return;
@@ -242,8 +243,17 @@ public class Eip8037StateGasCostCalculator implements StateGasCostCalculator {
       }
     }
     if (totalRefund > 0L) {
-      initialFrame.incrementStateGasReservoir(totalRefund);
-      initialFrame.decrementStateGasUsed(totalRefund);
+      // Cap refund at execution-time state gas only — never eat into the intrinsic charge the
+      // user paid upfront. Matches geth/nethermind/erigon/ethrex semantics: the same-tx-
+      // selfdestruct refund returns state gas spent during EVM execution (inner CREATEs, code
+      // deposits, storage growth), not the intrinsic charge for the top-level CREATE itself.
+      final long executionStateGas =
+          Math.max(0L, initialFrame.getStateGasUsed() - intrinsicStateGas);
+      final long capped = Math.min(totalRefund, executionStateGas);
+      if (capped > 0L) {
+        initialFrame.incrementStateGasReservoir(capped);
+        initialFrame.decrementStateGasUsed(capped);
+      }
     }
   }
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/StateGasCostCalculator.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/StateGasCostCalculator.java
@@ -253,8 +253,11 @@ public interface StateGasCostCalculator {
    * already returned their state gas.
    *
    * @param initialFrame the initial (depth-0) frame after transaction execution
+   * @param intrinsicStateGas the intrinsic state gas charged at tx start; the refund is capped so
+   *     it does not eat into this amount — only execution-time state gas is eligible
    */
-  default void refundSameTransactionSelfDestructStateGas(final MessageFrame initialFrame) {}
+  default void refundSameTransactionSelfDestructStateGas(
+      final MessageFrame initialFrame, final long intrinsicStateGas) {}
 
   /**
    * Computes the intrinsic state gas for a transaction. This is the worst-case state gas charged

--- a/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/StateGasCostCalculator.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/StateGasCostCalculator.java
@@ -247,14 +247,20 @@ public interface StateGasCostCalculator {
    *   <li>non-zero storage slots: {@code 32 × cost_per_state_byte} per slot
    * </ul>
    *
-   * This must be applied before {@code tx_gas_used_before_refund} is computed so the sender is not
-   * charged for state that was destroyed. Storage slots restored to zero during execution (0→X→0)
-   * are not counted here because they have a final value of zero — the SSTORE restoration refund
-   * already returned their state gas.
+   * <p>The total refund is capped at execution-time state gas ({@code stateGasUsed -
+   * intrinsicStateGas}); the intrinsic charge paid at transaction start is never refunded. This
+   * matters when a top-level CREATE's own contract address is in {@code createSet ∩
+   * selfDestructSet} — without the cap, the refund would erase the intrinsic create-state-gas.
+   * Matches geth/nethermind/erigon/ethrex.
+   *
+   * <p>This must be applied before {@code tx_gas_used_before_refund} is computed so the sender is
+   * not charged for state that was destroyed. Storage slots restored to zero during execution
+   * (0→X→0) are not counted here because they have a final value of zero — the SSTORE restoration
+   * refund already returned their state gas.
    *
    * @param initialFrame the initial (depth-0) frame after transaction execution
-   * @param intrinsicStateGas the intrinsic state gas charged at tx start; the refund is capped so
-   *     it does not eat into this amount — only execution-time state gas is eligible
+   * @param intrinsicStateGas the intrinsic state gas charged at tx start; refund cannot consume
+   *     this portion of {@code stateGasUsed}
    */
   default void refundSameTransactionSelfDestructStateGas(
       final MessageFrame initialFrame, final long intrinsicStateGas) {}

--- a/evm/src/test/java/org/hyperledger/besu/evm/gascalculator/Eip8037StateGasCostCalculatorTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/gascalculator/Eip8037StateGasCostCalculatorTest.java
@@ -131,14 +131,63 @@ class Eip8037StateGasCostCalculatorTest {
     frame.addCreate(addr);
     frame.addSelfDestruct(addr);
 
-    calculator.refundSameTransactionSelfDestructStateGas(frame, 0L);
-
     final long expected =
         calculator.createStateGas()
             + calculator.codeDepositStateGas(code.size())
             + 2L * calculator.storageSetStateGas();
+    // Simulate execution-time state gas charges that the refund will return.
+    frame.incrementStateGasUsed(expected);
+
+    calculator.refundSameTransactionSelfDestructStateGas(frame, 0L);
+
     assertThat(frame.getStateGasReservoir()).isEqualTo(expected);
-    assertThat(frame.getStateGasUsed()).isEqualTo(-expected);
+    assertThat(frame.getStateGasUsed()).isZero();
+  }
+
+  @Test
+  void refundSameTxSelfDestructCappedAtExecutionStateGas() {
+    // Top-level CREATE whose own contract self-destructs in initcode: the address sits in both
+    // createSet and selfDestructSet, but the only state gas charged was the intrinsic
+    // createStateGas. Without the cap, the refund would erase intrinsic and zero out stateGasUsed.
+    final Address addr = Address.fromHexString("0x00000000000000000000000000000000000000cc");
+    final ToyWorld world = new ToyWorld();
+    world.createAccount(addr, 1, Wei.ZERO);
+
+    final MessageFrame frame = buildFrame(world);
+    frame.addCreate(addr);
+    frame.addSelfDestruct(addr);
+
+    final long intrinsicStateGas = calculator.createStateGas();
+    frame.incrementStateGasUsed(intrinsicStateGas);
+
+    calculator.refundSameTransactionSelfDestructStateGas(frame, intrinsicStateGas);
+
+    assertThat(frame.getStateGasReservoir()).isZero();
+    assertThat(frame.getStateGasUsed()).isEqualTo(intrinsicStateGas);
+  }
+
+  @Test
+  void refundSameTxSelfDestructPartiallyCappedWhenExecutionGasBelowFullRefund() {
+    // Top-level CREATE that did one SSTORE then SELFDESTRUCTed. Total stateGasUsed =
+    // intrinsic + storageSetStateGas. The full refund (createStateGas + storageSetStateGas)
+    // exceeds execution-time gas (storageSetStateGas), so the cap clamps it.
+    final Address addr = Address.fromHexString("0x00000000000000000000000000000000000000dd");
+    final ToyWorld world = new ToyWorld();
+    final MutableAccount account = world.createAccount(addr, 1, Wei.ZERO);
+    account.setStorageValue(UInt256.ONE, UInt256.valueOf(42L));
+
+    final MessageFrame frame = buildFrame(world);
+    frame.addCreate(addr);
+    frame.addSelfDestruct(addr);
+
+    final long intrinsicStateGas = calculator.createStateGas();
+    final long executionStateGas = calculator.storageSetStateGas();
+    frame.incrementStateGasUsed(intrinsicStateGas + executionStateGas);
+
+    calculator.refundSameTransactionSelfDestructStateGas(frame, intrinsicStateGas);
+
+    assertThat(frame.getStateGasReservoir()).isEqualTo(executionStateGas);
+    assertThat(frame.getStateGasUsed()).isEqualTo(intrinsicStateGas);
   }
 
   @Test

--- a/evm/src/test/java/org/hyperledger/besu/evm/gascalculator/Eip8037StateGasCostCalculatorTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/gascalculator/Eip8037StateGasCostCalculatorTest.java
@@ -131,7 +131,7 @@ class Eip8037StateGasCostCalculatorTest {
     frame.addCreate(addr);
     frame.addSelfDestruct(addr);
 
-    calculator.refundSameTransactionSelfDestructStateGas(frame);
+    calculator.refundSameTransactionSelfDestructStateGas(frame, 0L);
 
     final long expected =
         calculator.createStateGas()
@@ -150,7 +150,7 @@ class Eip8037StateGasCostCalculatorTest {
     final MessageFrame frame = buildFrame(world);
     frame.addSelfDestruct(addr); // destroyed but not created in this tx — EIP-6780 no-op
 
-    calculator.refundSameTransactionSelfDestructStateGas(frame);
+    calculator.refundSameTransactionSelfDestructStateGas(frame, 0L);
 
     assertThat(frame.getStateGasReservoir()).isZero();
     assertThat(frame.getStateGasUsed()).isZero();
@@ -161,7 +161,7 @@ class Eip8037StateGasCostCalculatorTest {
     final ToyWorld world = new ToyWorld();
     final MessageFrame frame = buildFrame(world);
 
-    calculator.refundSameTransactionSelfDestructStateGas(frame);
+    calculator.refundSameTransactionSelfDestructStateGas(frame, 0L);
 
     assertThat(frame.getStateGasReservoir()).isZero();
     assertThat(frame.getStateGasUsed()).isZero();


### PR DESCRIPTION
## PR description

EIP-8037's same-tx-selfdestruct refund (`refundSameTransactionSelfDestructStateGas`) currently refunds the full create-state-gas of any address present in `createSet ∩ selfDestructSet`, with no cap. When the refund target is the **top-level CREATE's own contract address**, the refund eats into the **intrinsic** create-state-gas charged at tx start — collapsing `stateGasUsed` and producing a receipt `gasUsed` that's roughly `131488` (`= 112 * cpsb`) lower than canonical.

Geth, nethermind, erigon and ethrex all cap this refund at the execution-time state gas (`execGasUsed.StateGas`). This PR mirrors that semantics in besu.

### Reference: geth's clamp (`go-ethereum/core/state_transition.go`)

\`\`\`go
} else if sdRefund > uint64(execGasUsed.StateGas) {
    sdRefund = uint64(execGasUsed.StateGas)
}
\`\`\`

## Reproduction (tracked as B-001)

Trigger pattern: a top-level CREATE whose initcode SELFDESTRUCTs to an existing beneficiary (no inner CREATE / SSTORE / new-beneficiary state-gas charges). The contract address ends up in both \`createSet\` and \`selfDestructSet\`, but execution state gas is 0 — so the refund overdraws into the intrinsic 131488. Visible in production with spamoor's \`evm-fuzz\` (\`payload_seed=0x0400\`) on bal-devnet-6 — chain split at the first qualifying tx after the Gloas activation block.

Receipt-level signature for the failing tx:

| Client | gasUsed |
|---|---|
| geth / nethermind / erigon / ethrex | \`max(regularGas + stateGas, floor)\` ≈ \`174,439\` |
| besu (pre-fix) | \`max(regularGas, floor) + 0\` ≈ \`51,848\` (state gas refunded to 0) |

Internal observability via instrumentation showed:

\`\`\`
incrementStateGasReservoir frame=… stack=0 amount=131488 stateGasUsedBefore=131488 reservoirBefore=0
  at Eip8037StateGasCostCalculator.refundSameTransactionSelfDestructStateGas(…:255)
  at MainnetTransactionProcessor.processTransaction(…:463)
\`\`\`

## What this PR changes

- \`Eip8037StateGasCostCalculator.refundSameTransactionSelfDestructStateGas\`: cap \`totalRefund\` at \`max(0, stateGasUsed - intrinsicStateGas)\`.
- \`StateGasCostCalculator\` interface: signature now takes \`intrinsicStateGas\`.
- \`MainnetTransactionProcessor\`: pass \`intrinsicStateGas\` (already computed locally at line 319) into the refund call.
- Tests in \`Eip8037StateGasCostCalculatorTest\` updated to pass \`0L\` (their existing fixtures don't exercise an intrinsic charge, so behavior is unchanged for them).

## Verification

- Heterogeneous \`1× geth + 1× besu-(patched)\` Kurtosis enclave on bal-devnet-6: post-fix the chain advances cleanly past the Gloas fork; 15 sampled blocks (0x10–0x1e) match between geth and besu.
- Empty-code-CREATE pattern still triggers in spamoor evm-fuzz — confirmed via post-fix block inspection that the txs that previously caused divergence are now executed identically by both clients.
- Note: there is no upstream EELS test that today catches this exact bug. The closest, \`test_selfdestruct_in_create_tx_initcode\`, masks it because its \`SELFDESTRUCT(0xDEAD, value=1)\` itself charges \`NEW_ACCOUNT\` state gas, which sits inside the executable cap. A follow-up EELS test using \`SELFDESTRUCT(<existing-EOA>)\` (no new-beneficiary charge) would expose the bug; happy to send that to \`execution-spec-tests\` separately.

## Risk

Only changes the cap behavior on the success-tx-end refund path. All non-CREATE / non-SET_CODE transactions have \`intrinsicStateGas = 0\`, so the cap is a no-op and behavior is unchanged. For CREATE / SET_CODE transactions the cap aligns with all four other client implementations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)