### PR TITLE
perf: skip account/storage preloader on importFrom

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/worldview/accumulator/PathBasedWorldStateUpdateAccumulator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/worldview/accumulator/PathBasedWorldStateUpdateAccumulator.java
@@ -159,10 +159,12 @@ public abstract class PathBasedWorldStateUpdateAccumulator<ACCOUNT extends PathB
                   priorOnly
                       ? new PathBasedValue<>(copyPrior, copyUpdated)
                       : new PathBasedValue<>(copyPrior, copyUpdated, srcValue.isLastStepCleared());
+              // Bypass the account preloader: importing already-executed state, so spawning a
+              // virtual thread to async-prefetch the trie node would only contend with the merge.
               if (priorOnly) {
-                accountsToUpdate.putIfAbsent(address, newValue);
+                accountsToUpdate.putIfAbsentWithoutPreload(address, newValue);
               } else {
-                accountsToUpdate.put(address, newValue);
+                accountsToUpdate.putWithoutPreload(address, newValue);
               }
             });
 
@@ -202,10 +204,11 @@ public abstract class PathBasedWorldStateUpdateAccumulator<ACCOUNT extends PathB
                             ? new PathBasedValue<>(slotPrior, slotUpdated)
                             : new PathBasedValue<>(
                                 slotPrior, slotUpdated, srcSlot.isLastStepCleared());
+                    // Bypass the storage preloader: same reasoning as accountsToUpdate above.
                     if (priorOnly) {
-                      targetSlots.putIfAbsent(slotKey, newSlotValue);
+                      targetSlots.putIfAbsentWithoutPreload(slotKey, newSlotValue);
                     } else {
-                      targetSlots.put(slotKey, newSlotValue);
+                      targetSlots.putWithoutPreload(slotKey, newSlotValue);
                     }
                   });
             });

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/worldview/accumulator/preload/AccountConsumingMap.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/worldview/accumulator/preload/AccountConsumingMap.java
@@ -35,7 +35,21 @@ public class AccountConsumingMap<T> extends ForwardingMap<Address, T> {
   @Override
   public T put(@NotNull final Address address, @NotNull final T value) {
     consumer.process(address, value);
+    return putWithoutPreload(address, value);
+  }
+
+  /**
+   * Insert without triggering the preload consumer. Use when the account is already known to the
+   * caller (e.g. merging an executed transaction's changes into the block accumulator) so spawning
+   * an async trie-node fetch would only burn cycles.
+   */
+  public T putWithoutPreload(@NotNull final Address address, @NotNull final T value) {
     return accounts.put(address, value);
+  }
+
+  /** Same as {@link #putWithoutPreload} but only inserts when the key is absent. */
+  public T putIfAbsentWithoutPreload(@NotNull final Address address, @NotNull final T value) {
+    return accounts.putIfAbsent(address, value);
   }
 
   public Consumer<T> getConsumer() {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/worldview/accumulator/preload/StorageConsumingMap.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/worldview/accumulator/preload/StorageConsumingMap.java
@@ -39,7 +39,21 @@ public class StorageConsumingMap<K, T> extends ForwardingMap<K, T> {
   @Override
   public T put(@NotNull final K slotKey, @NotNull final T value) {
     consumer.process(address, slotKey);
+    return putWithoutPreload(slotKey, value);
+  }
+
+  /**
+   * Insert without triggering the preload consumer. Use when the slot is already known to the
+   * caller (e.g. merging an executed transaction's changes into the block accumulator) so spawning
+   * an async trie-node fetch would only burn cycles.
+   */
+  public T putWithoutPreload(@NotNull final K slotKey, @NotNull final T value) {
     return storages.put(slotKey, value);
+  }
+
+  /** Same as {@link #putWithoutPreload} but only inserts when the key is absent. */
+  public T putIfAbsentWithoutPreload(@NotNull final K slotKey, @NotNull final T value) {
+    return storages.putIfAbsent(slotKey, value);
   }
 
   public Consumer<K> getConsumer() {


### PR DESCRIPTION
## Summary

`PathBasedWorldStateUpdateAccumulator.importFrom` is called from the
parallel-tx merge path (`BalConcurrentTransactionProcessor`,
`ParallelizedConcurrentTransactionProcessor`,
`BalStateRootCommitterFactory`) to fold each per-tx accumulator into the
block accumulator after the txs have finished executing.

`importFrom` does this fold via `Map.put(...)` on the
`AccountConsumingMap` / `StorageConsumingMap`. Both override `put` to
fire a preloader before delegating:

```java
// StorageConsumingMap
public T put(K slotKey, T value) {
    consumer.process(address, slotKey);   // <-- preloader
    return storages.put(slotKey, value);
}
```

The preloader is `BonsaiCachedMerkleTrieLoader.preLoadStorageSlot` (and
`preLoadAccount`), which schedules a `CompletableFuture.runAsync` on a
virtual-thread executor to walk the trie and warm a node cache. That is
useful **before** a tx runs — it overlaps disk I/O with execution. But
in `importFrom` the txs are already done; the merge spawns one virtual
thread per slot/account that never benefits anyone, while contending
with the merge worker for the same `ConcurrentHashMap` puts and CPU.

## How it was found

While running EEST hive against a 2,661-tx EIP-8037 fixture
(`tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_reservoir.py::test_block_2d_gas_valid_when_cumulative_exceeds_limit`),
`engine_newPayloadV5` exceeded the 30s JSON-RPC timeout. With the timeout
bumped, the block import itself logged **150s @ 0.67 Mgas/s**.

Sampling stack traces of the busy vert.x worker via Vert.x's
`BlockedThreadChecker` over ~125s of import showed the worker pinned
inside this exact stack:

```
PathBasedWorldStateUpdateAccumulator.importFrom (line 188 / 208)
  → StorageConsumingMap.put
      → consumer.process  →  BonsaiCachedMerkleTrieLoader.preLoadStorageSlot
            → CompletableFuture.runAsync(..., VIRTUAL_POOL)   ← virtual thread per slot
      → ConcurrentHashMap.put  →  StorageSlotKey.equals → AbstractBytes.equals
```

Top frames across worker samples:

| share | frame |
|---|---|
| 30% | `ArrayWrappingBytes.toArray` (tuweni byte copies feeding ConcurrentHashMap puts) |
| 22% | `ConcurrentHashMap.put / computeIfAbsent / KeySetView.add` |
| 14% | `BytesHolder.equals` / `AbstractBytes.equals` (StorageSlotKey eq) |
| 8% | `ThreadPerTaskExecutor.newThread` (virtual thread starts for the preloader) |

## Fix

Add `putWithoutPreload` / `putIfAbsentWithoutPreload` to both
`AccountConsumingMap` and `StorageConsumingMap` that write straight to
the underlying `ConcurrentMap` and skip the preload consumer. Switch
`importFrom`'s account merge and storage-slot merge to use them. The
existing `put(...)` is refactored to call `putWithoutPreload(...)`
internally so the storage write path stays defined in one place.

The default `put` semantics are unchanged, so the execution-time path
(where the preloader actually helps) is untouched. The other call site
that walks these maps in bulk, `cloneFromUpdater`, already uses `putAll`
which `ForwardingMap` forwards to the delegate, so it was never firing
the preloader to begin with — only `importFrom`'s per-entry puts were.

## Measured impact

Same fixture, same besu, only this patch:

| | before | after |
|---|---|---|
| `engine_newPayloadV5` block import | 125–150s | **11.1–12.7s** |
| throughput | 0.67 Mgas/s | **~8 Mgas/s** |
| passes default 30s JSON-RPC timeout | ❌ | ✅ |

## Test plan

- [ ] CI green
- [ ] Re-run EEST `consume engine` against the EIP-8037 fixture set
- [ ] Spot-check a broader EIP suite to confirm no regression on smaller blocks