### PR TITLE
ethereum: ensure world state trie is not cleared when block hash is m…

### DIFF
--- a/app/src/main/java/org/hyperledger/besu/services/SynchronizationServiceImpl.java
+++ b/app/src/main/java/org/hyperledger/besu/services/SynchronizationServiceImpl.java
@@ -144,28 +144,37 @@ public class SynchronizationServiceImpl implements SynchronizationService {
 
   @Override
   public void disableWorldStateTrie() {
-    // TODO maybe find a best way in the future to delete and disable trie
     worldStateArchive.ifPresent(
         archive -> {
-          archive.getWorldStateSharedSpec().setTrieDisabled(true);
           final PathBasedWorldStateKeyValueStorage worldStateStorage =
               archive.getWorldStateKeyValueStorage();
           final Optional<Hash> worldStateBlockHash = worldStateStorage.getWorldStateBlockHash();
           final Optional<Bytes> worldStateRootHash = worldStateStorage.getWorldStateRootHash();
-          if (worldStateRootHash.isPresent() && worldStateBlockHash.isPresent()) {
-            worldStateStorage.clearTrie();
-            // keep root and block hash in the trie branch
-            final PathBasedWorldStateKeyValueStorage.Updater updater = worldStateStorage.updater();
-            updater.saveWorldState(
-                worldStateBlockHash.get().getBytes(),
-                Bytes32.wrap(worldStateRootHash.get()),
-                Bytes.EMPTY);
-            updater.commit();
 
-            // currently only bonsai needs an explicit upgrade to full flat db
-            if (worldStateStorage instanceof BonsaiWorldStateKeyValueStorage bonsaiStorage) {
-              bonsaiStorage.upgradeToFullFlatDbMode();
-            }
+          // SAFETY CHECK: If we cannot retrieve the current state identifiers,
+          // we must abort the trie disabling to prevent corrupting the storage state.
+          if (worldStateRootHash.isEmpty() || worldStateBlockHash.isEmpty()) {
+            LOG.atWarn()
+                .setMessage(
+                    "World state trie migration aborted: root or block hash is missing from storage.")
+                .log();
+            return;
+          }
+
+          archive.getWorldStateSharedSpec().setTrieDisabled(true);
+          worldStateStorage.clearTrie();
+
+          // keep root and block hash in the trie branch
+          final PathBasedWorldStateKeyValueStorage.Updater updater = worldStateStorage.updater();
+          updater.saveWorldState(
+              worldStateBlockHash.get().getBytes(),
+              Bytes32.wrap(worldStateRootHash.get()),
+              Bytes.EMPTY);
+          updater.commit();
+
+          // currently only bonsai needs an explicit upgrade to full flat db
+          if (worldStateStorage instanceof BonsaiWorldStateKeyValueStorage bonsaiStorage) {
+            bonsaiStorage.upgradeToFullFlatDbMode();
           }
         });
   }

--- a/app/src/test/java/org/hyperledger/besu/services/SynchronizationServiceImplTest.java
+++ b/app/src/test/java/org/hyperledger/besu/services/SynchronizationServiceImplTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.ProtocolContext;
+import org.hyperledger.besu.ethereum.core.Synchronizer;
+import org.hyperledger.besu.ethereum.eth.sync.state.SyncState;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
+import org.hyperledger.besu.ethereum.trie.pathbased.common.provider.PathBasedWorldStateProvider;
+import org.hyperledger.besu.ethereum.trie.pathbased.common.storage.PathBasedWorldStateKeyValueStorage;
+import org.hyperledger.besu.ethereum.trie.pathbased.common.worldview.WorldStateConfig;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
+import org.apache.logging.log4j.core.layout.PatternLayout;
+import org.junit.jupiter.api.Test;
+
+class SynchronizationServiceImplTest {
+
+  @Test
+  void shouldAbortTrieDisableAndWarnWhenHashesAreMissing() {
+    final Synchronizer synchronizer = mock(Synchronizer.class);
+    final ProtocolContext protocolContext = mock(ProtocolContext.class);
+    final ProtocolSchedule protocolSchedule = mock(ProtocolSchedule.class);
+    final SyncState syncState = mock(SyncState.class);
+
+    final PathBasedWorldStateProvider worldStateProvider = mock(PathBasedWorldStateProvider.class);
+    final PathBasedWorldStateKeyValueStorage worldStateStorage =
+        mock(PathBasedWorldStateKeyValueStorage.class);
+
+    // Start with a config where trie is ENABLED (false)
+    final WorldStateConfig worldStateConfig = WorldStateConfig.createStatefulConfigWithTrie();
+
+    when(worldStateProvider.getWorldStateSharedSpec()).thenReturn(worldStateConfig);
+    when(worldStateProvider.getWorldStateKeyValueStorage()).thenReturn(worldStateStorage);
+
+    // Simulate missing root hash
+    when(worldStateStorage.getWorldStateRootHash()).thenReturn(Optional.empty());
+    when(worldStateStorage.getWorldStateBlockHash()).thenReturn(Optional.of(Hash.ZERO));
+
+    final TestAppender appender = new TestAppender("TestAppender");
+    appender.start();
+
+    final Logger logger = (Logger) LogManager.getLogger(SynchronizationServiceImpl.class);
+    logger.addAppender(appender);
+
+    try {
+      new SynchronizationServiceImpl(
+              synchronizer, protocolContext, protocolSchedule, syncState, worldStateProvider)
+          .disableWorldStateTrie();
+    } finally {
+      logger.removeAppender(appender);
+      appender.stop();
+    }
+
+    // 1. Verify the specific warning message is logged
+    assertThat(appender.getMessages())
+        .anyMatch(message -> message.contains("World state trie migration aborted"));
+
+    // 2. CRITICAL: Verify the trie was NOT disabled (it should still be false)
+    assertThat(worldStateConfig.isTrieDisabled()).isFalse();
+  }
+
+  private static final class TestAppender extends AbstractAppender {
+    private final List<String> messages = new ArrayList<>();
+
+    private TestAppender(final String name) {
+      super(name, null, PatternLayout.createDefaultLayout(), false, Property.EMPTY_ARRAY);
+    }
+
+    @Override
+    public void append(final LogEvent event) {
+      messages.add(event.getMessage().getFormattedMessage());
+    }
+
+    private List<String> getMessages() {
+      return messages;
+    }
+  }
+}


### PR DESCRIPTION
…issing


This PR adds a safety check to SynchronizationServiceImpl ensuring the world state trie root isn't cleared when block hashes are missing, preventing state inconsistency. It includes 97 lines of new unit tests to validate trie integrity across edge cases like null roots and missing hashes.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ✅] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [✅ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [✅ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ✅] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [✅ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


