### PR TITLE
fix(storage): resolve native memory leak by ensuring RocksDB Options are properly closed

### DIFF
--- a/app/src/main/java/org/hyperledger/besu/cli/subcommands/storage/RocksDbHelper.java
+++ b/app/src/main/java/org/hyperledger/besu/cli/subcommands/storage/RocksDbHelper.java
@@ -41,12 +41,9 @@ public class RocksDbHelper {
   static void forEachColumnFamily(
       final String dbPath, final BiConsumer<RocksDB, ColumnFamilyHandle> task) {
     RocksDB.loadLibrary();
-    Options options = new Options();
-    options.setCreateIfMissing(true);
-
     // Open the RocksDB database with multiple column families
     List<byte[]> cfNames;
-    try {
+    try (final Options options = new Options().setCreateIfMissing(true)) {
       cfNames = RocksDB.listColumnFamilies(options, dbPath);
     } catch (RocksDBException e) {
       throw new RuntimeException(e);
@@ -74,12 +71,9 @@ public class RocksDbHelper {
       final BiConsumer<RocksDB, ColumnFamilyHandle> task,
       final List<String> columnFamilyNameFilter) {
     RocksDB.loadLibrary();
-    Options options = new Options();
-    options.setCreateIfMissing(true);
-
     // Open the RocksDB database with multiple column families
     List<byte[]> cfNames;
-    try {
+    try (final Options options = new Options().setCreateIfMissing(true)) {
       cfNames = RocksDB.listColumnFamilies(options, dbPath);
     } catch (RocksDBException e) {
       throw new RuntimeException(e);

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
@@ -155,8 +155,11 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
 
     try {
       trimmedSegments = new ArrayList<>(defaultSegments);
-      final List<byte[]> existingColumnFamilies =
-          RocksDB.listColumnFamilies(new Options(), configuration.getDatabaseDir().toString());
+      final List<byte[]> existingColumnFamilies;
+      try (final Options options = new Options()) {
+        existingColumnFamilies =
+            RocksDB.listColumnFamilies(options, configuration.getDatabaseDir().toString());
+      }
       // Only ignore if not existed currently
       ignorableSegments.stream()
           .filter(


### PR DESCRIPTION
## PR description

This pull request fixes a silent native memory leak in the RocksDB integration layer. 

While auditing the codebase, I noticed that we were instantiating `org.rocksdb.Options` objects in a few places without ever closing them. Because these are native C++ objects exposed to Java via `RocksObject` (which implements `AutoCloseable`), the JVM garbage collector cannot properly manage their lifecycle or clean up the native pointers. Leaving them unclosed causes native memory to steadily bloat, which bypasses normal JVM heap limits and can eventually trigger an OS OOM-killer termination on long-running nodes or repeated CLI interactions. 

To solve this, I've simply wrapped these `Options` initializations in `try-with-resources` blocks within `RocksDbHelper.java` and `RocksDBColumnarKeyValueStorage.java`. This guarantees that their native memory is deterministically freed and closed as soon as the execution block completes.

## Fixed Issue(s)

* Fixes #10402 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about the changelog and included a changelog update if required.
