### PR TITLE
fix: close `RlpBlockImporter` after RLP block import to release executor threads

### DIFF
--- a/app/src/main/java/org/hyperledger/besu/cli/subcommands/blocks/BlocksSubCommand.java
+++ b/app/src/main/java/org/hyperledger/besu/cli/subcommands/blocks/BlocksSubCommand.java
@@ -304,10 +304,9 @@ public class BlocksSubCommand implements Runnable {
 
     private void importRlpBlocks(final BesuController controller, final Path path)
         throws IOException {
-      parentCommand
-          .rlpBlockImporter
-          .get()
-          .importBlockchain(path, controller, skipPow, startBlock, endBlock);
+      try (final RlpBlockImporter importer = parentCommand.rlpBlockImporter.get()) {
+        importer.importBlockchain(path, controller, skipPow, startBlock, endBlock);
+      }
     }
 
     private void importEra1Blocks(final BesuController controller, final Path path)


### PR DESCRIPTION
`RlpBlockImporter` implements `Closeable` and eagerly creates a cached thread pool plus a single-thread executor in its constructor. `ImportSubCommand.importRlpBlocks` was obtaining an instance via the `Supplier` and never invoking `close()`, leaking those executor threads after each CLI run. Wrap the importer in try-with-resources so the executors shut down once the import completes.
