### PR TITLE
fix: two QBFT regressions on chains that run PoS through the merge

### DIFF
--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/BftExecutors.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/BftExecutors.java
@@ -108,13 +108,26 @@ public class BftExecutors {
   /**
    * Await stop.
    *
+   * <p>Tolerates the IDLE state, i.e. {@link #start()} was never called. This happens on a chain
+   * that is configured with QBFT/IBFT in the genesis but is post-merge from block 0
+   * (terminalTotalDifficulty=0): the BftMiningCoordinator is wrapped in a TransitionCoordinator
+   * that never delegates to the BFT side, so the executors are never created. Without this guard,
+   * shutting such a node down NPEs on {@code timerExecutor} / {@code bftProcessorExecutor}, which
+   * in turn poisons the BesuPluginContext lifecycle for any subsequent in-JVM restart (acceptance
+   * tests reusing ports/temp dirs).
+   *
    * @throws InterruptedException the interrupted exception
    */
   public void awaitStop() throws InterruptedException {
-    if (!timerExecutor.awaitTermination(shutdownTimeout.toSeconds(), TimeUnit.SECONDS)) {
+    final ScheduledExecutorService localTimerExecutor = timerExecutor;
+    final ExecutorService localBftProcessorExecutor = bftProcessorExecutor;
+    if (localTimerExecutor != null
+        && !localTimerExecutor.awaitTermination(shutdownTimeout.toSeconds(), TimeUnit.SECONDS)) {
       LOG.error("{} timer executor did not shutdown cleanly.", getClass().getSimpleName());
     }
-    if (!bftProcessorExecutor.awaitTermination(shutdownTimeout.toSeconds(), TimeUnit.SECONDS)) {
+    if (localBftProcessorExecutor != null
+        && !localBftProcessorExecutor.awaitTermination(
+            shutdownTimeout.toSeconds(), TimeUnit.SECONDS)) {
       LOG.error("{} bftProcessor executor did not shutdown cleanly.", getClass().getSimpleName());
     }
   }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/DefaultProtocolSchedule.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/DefaultProtocolSchedule.java
@@ -55,6 +55,13 @@ public class DefaultProtocolSchedule implements ProtocolSchedule {
   protected DefaultProtocolSchedule(final DefaultProtocolSchedule protocolSchedule) {
     this.chainId = protocolSchedule.chainId;
     this.protocolSpecs = protocolSchedule.protocolSpecs;
+    // Copy the milestones map populated by ProtocolScheduleBuilder.setMilestones(...). Without
+    // this, subclasses that wrap an existing schedule via this copy constructor (e.g.
+    // BftProtocolSchedule) keep an empty milestones map even though protocolSpecs are inherited,
+    // and milestoneFor(HardforkId) returns Optional.empty() for every fork. Engine API handlers
+    // (e.g. EngineForkchoiceUpdatedV3) cache those Optionals at construction time and then reject
+    // every payload at the Cancun/Amsterdam boundary with UNSUPPORTED_FORK.
+    this.milestones.putAll(protocolSchedule.milestones);
   }
 
   @Override

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/DefaultProtocolScheduleTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/DefaultProtocolScheduleTest.java
@@ -21,6 +21,7 @@ import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.FRONTI
 import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.GRAY_GLACIER;
 import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.HOMESTEAD;
 import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.LONDON;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.PRAGUE;
 import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.SHANGHAI;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -35,6 +36,7 @@ import org.hyperledger.besu.evm.internal.EvmConfiguration;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 
 import java.math.BigInteger;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -258,5 +260,35 @@ public class DefaultProtocolScheduleTest {
 
   private BlockHeader header(final long number, final long timestamp) {
     return new BlockHeaderTestFixture().number(number).timestamp(timestamp).buildHeader();
+  }
+
+  @Test
+  public void copyConstructor_propagatesMilestonesMap() {
+    final ProtocolSpec frontierSpec = mock(ProtocolSpec.class);
+    when(frontierSpec.getHardforkId()).thenReturn(FRONTIER);
+
+    final DefaultProtocolSchedule source = new DefaultProtocolSchedule(CHAIN_ID);
+    source.putBlockNumberMilestone(0, frontierSpec);
+    source.setMilestones(Map.of(SHANGHAI, 100L, CANCUN, 200L, PRAGUE, 300L));
+
+    final DefaultProtocolSchedule copy = new TestProtocolScheduleCopy(source);
+
+    assertThat(copy.milestoneFor(SHANGHAI)).contains(100L);
+    assertThat(copy.milestoneFor(CANCUN)).contains(200L);
+    assertThat(copy.milestoneFor(PRAGUE)).contains(300L);
+    assertThat(copy.getChainId()).isEqualTo(CHAIN_ID);
+    assertThat(copy.getByBlockHeader(header(0L, 0L))).isSameAs(frontierSpec);
+
+    source.setMilestones(Map.of());
+
+    assertThat(copy.milestoneFor(SHANGHAI)).contains(100L);
+    assertThat(copy.milestoneFor(CANCUN)).contains(200L);
+    assertThat(copy.milestoneFor(PRAGUE)).contains(300L);
+  }
+
+  private static final class TestProtocolScheduleCopy extends DefaultProtocolSchedule {
+    TestProtocolScheduleCopy(final DefaultProtocolSchedule source) {
+      super(source);
+    }
   }
 }


### PR DESCRIPTION
## PR description
fix: two QBFT regressions on chains that run PoS through the merge

Both bugs surface only when the chain declares QBFT/IBFT in genesis but either runs PoS from block 0 (terminalTotalDifficulty=0) or transitions through the merge into Cancun and beyond. Standalone mainnet / pure QBFT / pure Clique deployments are unaffected, which is why neither showed up in CI.

## Fixed Issue(s)
https://github.com/Consensys/linea-monorepo/issues/2540
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


