### PR TITLE
Fix: make stopPlugins() resilient to all non-stopped lifecycle states

### DIFF
--- a/app/src/main/java/org/hyperledger/besu/services/BesuPluginContextImpl.java
+++ b/app/src/main/java/org/hyperledger/besu/services/BesuPluginContextImpl.java
@@ -88,6 +88,12 @@ public class BesuPluginContextImpl implements ServiceManager, PluginVersionsProv
   private PluginConfiguration config;
   private URLClassLoader pluginClassLoader;
 
+  /**
+   * Per-plugin high-watermark tracking to track which lifecycle phase it reached, specifically for
+   * stopPlugins() calls
+   */
+  private final Map<BesuPlugin, Lifecycle> pluginHighWatermark = new LinkedHashMap<>();
+
   /** Instantiates a new Besu plugin context. */
   public BesuPluginContextImpl() {}
 
@@ -201,6 +207,7 @@ public class BesuPluginContextImpl implements ServiceManager, PluginVersionsProv
     try {
       plugin.register(this);
       pluginVersions.put(plugin.getName(), plugin.getVersion());
+      pluginHighWatermark.put(plugin, Lifecycle.REGISTERED);
       LOG.info("Registered plugin of type {}.", plugin.getClass().getName());
     } catch (final Exception e) {
       if (config.isContinueOnPluginError()) {
@@ -232,6 +239,7 @@ public class BesuPluginContextImpl implements ServiceManager, PluginVersionsProv
 
       try {
         plugin.beforeExternalServices();
+        pluginHighWatermark.put(plugin, Lifecycle.BEFORE_EXTERNAL_SERVICES_FINISHED);
         LOG.debug(
             "beforeExternalServices called on plugin of type {}.", plugin.getClass().getName());
       } catch (final Exception e) {
@@ -268,6 +276,7 @@ public class BesuPluginContextImpl implements ServiceManager, PluginVersionsProv
 
       try {
         plugin.start();
+        pluginHighWatermark.put(plugin, Lifecycle.BEFORE_MAIN_LOOP_STARTED);
         LOG.debug("Started plugin of type {}.", plugin.getClass().getName());
       } catch (final Exception e) {
         if (config.isContinueOnPluginError()) {
@@ -318,21 +327,36 @@ public class BesuPluginContextImpl implements ServiceManager, PluginVersionsProv
     }
   }
 
+  private boolean pluginReachedState(final BesuPlugin plugin, final Lifecycle target) {
+    Lifecycle reached = pluginHighWatermark.getOrDefault(plugin, Lifecycle.UNINITIALIZED);
+    return reached.ordinal() >= target.ordinal();
+  }
+
+  private void safeStop(final BesuPlugin plugin) {
+    try {
+      plugin.stop();
+      LOG.debug("Stopped plugin of type {}.", plugin.getClass().getName());
+    } catch (final Exception e) {
+      LOG.error("Error stopping plugin of type " + plugin.getClass().getName(), e);
+    }
+  }
+
   /** Stop plugins. */
   public void stopPlugins() {
-    checkState(
-        state == Lifecycle.BEFORE_MAIN_LOOP_FINISHED,
-        "BesuContext should be in state %s but it was in %s",
-        Lifecycle.BEFORE_MAIN_LOOP_FINISHED,
-        state);
+    if (state == Lifecycle.STOPPED || state == Lifecycle.STOPPING) {
+      LOG.debug("stopPlugins() called but already in state {}. Ignoring.", state);
+      return;
+    }
     state = Lifecycle.STOPPING;
 
     for (final BesuPlugin plugin : registeredPlugins) {
-      try {
-        plugin.stop();
-        LOG.debug("Stopped plugin of type {}.", plugin.getClass().getName());
-      } catch (final Exception e) {
-        LOG.error("Error stopping plugin of type " + plugin.getClass().getName(), e);
+      if (pluginReachedState(plugin, Lifecycle.BEFORE_MAIN_LOOP_STARTED)) {
+        safeStop(plugin);
+      } else {
+        LOG.debug(
+            "Skipping stop for plugin {} — it did not reach start(). Watermark: {}",
+            plugin.getClass().getName(),
+            pluginHighWatermark.getOrDefault(plugin, Lifecycle.UNINITIALIZED));
       }
     }
 
@@ -406,6 +430,23 @@ public class BesuPluginContextImpl implements ServiceManager, PluginVersionsProv
   @VisibleForTesting
   List<BesuPlugin> getRegisteredPlugins() {
     return Collections.unmodifiableList(registeredPlugins);
+  }
+
+  /**
+   * Directly registers a plugin instance into the context, bypassing ServiceLoader discovery. This
+   * is intended for unit tests that need to inject a controlled plugin without touching the
+   * filesystem.
+   *
+   * <p>Drives the plugin through the real {@code registerPlugin()} path so that the high-watermark
+   * is stamped correctly (REGISTERED), exactly as production does.
+   *
+   * @param plugin the plugin to inject
+   */
+  @VisibleForTesting
+  void addPluginForTesting(final BesuPlugin plugin) {
+    if (registerPlugin(plugin)) {
+      registeredPlugins.add(plugin);
+    }
   }
 
   /**

--- a/app/src/test/java/org/hyperledger/besu/services/BesuPluginContextImplTest.java
+++ b/app/src/test/java/org/hyperledger/besu/services/BesuPluginContextImplTest.java
@@ -15,7 +15,12 @@
 package org.hyperledger.besu.services;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
+import org.hyperledger.besu.ethereum.core.plugins.ImmutablePluginConfiguration;
+import org.hyperledger.besu.ethereum.core.plugins.PluginConfiguration;
+import org.hyperledger.besu.plugin.BesuPlugin;
+import org.hyperledger.besu.plugin.ServiceManager;
 import org.hyperledger.besu.plugin.services.BesuService;
 
 import java.util.ArrayList;
@@ -27,6 +32,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
 
@@ -109,6 +115,365 @@ public class BesuPluginContextImplTest {
     // Verify services are still accessible after concurrent operations
     assertThat(context.getService(TestServiceA.class)).isPresent().contains(serviceA);
     assertThat(context.getService(TestServiceB.class)).isPresent();
+  }
+
+  // -------------------------------------------------------------------------
+  // Helpers shared by stopPlugins() lifecycle tests
+  // -------------------------------------------------------------------------
+
+  /**
+   * Builds a PluginConfiguration that has external plugins disabled so that initialize() +
+   * registerPlugins() succeed without touching the filesystem, and continueOnPluginError controls
+   * whether a throwing plugin aborts startup.
+   */
+  private static PluginConfiguration configWith(final boolean continueOnPluginError) {
+    return ImmutablePluginConfiguration.builder()
+        .externalPluginsEnabled(false)
+        .continueOnPluginError(continueOnPluginError)
+        .build();
+  }
+
+  // -------------------------------------------------------------------------
+  // stopPlugins() resilience tests  (P20 fix)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Core happy-path: after a full startup, stopPlugins() calls stop() on every plugin and does not
+   * throw.
+   */
+  @Test
+  void stopPlugins_callsStop_afterFullStartup() {
+    final AtomicInteger stopCount = new AtomicInteger(0);
+    final BesuPlugin plugin =
+        new NoOpPlugin() {
+          @Override
+          public void stop() {
+            stopCount.incrementAndGet();
+          }
+        };
+
+    final BesuPluginContextImpl context = new BesuPluginContextImpl();
+    context.initialize(configWith(false));
+    context.registerPlugins();
+    context.addPluginForTesting(plugin);
+
+    context.beforeExternalServices();
+    context.startPlugins();
+
+    assertThatCode(context::stopPlugins).doesNotThrowAnyException();
+    assertThat(stopCount.get()).isEqualTo(1);
+  }
+
+  /**
+   * Scenario A (the exact production crash path): shutdown hook fires while the context is in
+   * BEFORE_MAIN_LOOP_STARTED because startPlugins() threw with continueOnPluginError=false.
+   * stopPlugins() must not throw and must still call stop() on the plugin that successfully
+   * completed start().
+   */
+  @Test
+  void stopPlugins_doesNotThrow_whenStartPluginsFailedWithContinueOnErrorFalse() {
+    final AtomicInteger stopCount = new AtomicInteger(0);
+
+    // pluginA completes start() successfully
+    final BesuPlugin pluginA =
+        new NoOpPlugin() {
+          @Override
+          public void stop() {
+            stopCount.incrementAndGet();
+          }
+        };
+    // pluginB throws during start(), aborting the startup loop
+    final BesuPlugin pluginB =
+        new NoOpPlugin() {
+          @Override
+          public void start() {
+            throw new RuntimeException("pluginB start failure");
+          }
+
+          @Override
+          public void stop() {
+            stopCount.incrementAndGet();
+          }
+        };
+
+    final BesuPluginContextImpl context = new BesuPluginContextImpl();
+    context.initialize(configWith(false)); // continueOnPluginError = false
+    context.registerPlugins();
+    context.addPluginForTesting(pluginA);
+    context.addPluginForTesting(pluginB);
+
+    context.beforeExternalServices();
+
+    // startPlugins() throws because pluginB fails and continueOnPluginError=false
+    assertThatCode(context::startPlugins).isInstanceOf(RuntimeException.class);
+
+    // The state is now BEFORE_MAIN_LOOP_STARTED — the old code crashed here
+    assertThatCode(context::stopPlugins).doesNotThrowAnyException();
+
+    // pluginA reached start() → must be stopped; pluginB never completed start() → skipped
+    assertThat(stopCount.get()).isEqualTo(1);
+  }
+
+  /**
+   * Scenario C: the JVM shuts down after startExternalServices() threw but after buildRunner()
+   * already registered the shutdown hook. Context state = BEFORE_EXTERNAL_SERVICES_FINISHED. No
+   * plugin ever reached start() so none should have stop() called.
+   */
+  @Test
+  void stopPlugins_doesNotThrow_whenNoPluginReachedStart() {
+    final AtomicInteger stopCount = new AtomicInteger(0);
+    final BesuPlugin plugin =
+        new NoOpPlugin() {
+          @Override
+          public void stop() {
+            stopCount.incrementAndGet();
+          }
+        };
+
+    final BesuPluginContextImpl context = new BesuPluginContextImpl();
+    context.initialize(configWith(false));
+    context.registerPlugins();
+    context.addPluginForTesting(plugin);
+
+    // Only drive up to beforeExternalServices — startPlugins() never called
+    context.beforeExternalServices();
+
+    assertThatCode(context::stopPlugins).doesNotThrowAnyException();
+    // Plugin never started → stop() must NOT be called
+    assertThat(stopCount.get()).isEqualTo(0);
+  }
+
+  /**
+   * stopPlugins() called before any lifecycle method has run (e.g. ThreadBesuNodeRunner calling
+   * stopNode on a context that never completed registration). Must be a no-op — no throw, no stop()
+   * calls.
+   */
+  @Test
+  void stopPlugins_doesNotThrow_whenCalledBeforeAnyLifecycleStep() {
+    final AtomicInteger stopCount = new AtomicInteger(0);
+    final BesuPlugin plugin =
+        new NoOpPlugin() {
+          @Override
+          public void stop() {
+            stopCount.incrementAndGet();
+          }
+        };
+
+    final BesuPluginContextImpl context = new BesuPluginContextImpl();
+    context.initialize(configWith(false));
+    context.registerPlugins();
+    context.addPluginForTesting(plugin);
+
+    // Intentionally skip beforeExternalServices() and startPlugins()
+    assertThatCode(context::stopPlugins).doesNotThrowAnyException();
+    assertThat(stopCount.get()).isEqualTo(0);
+  }
+
+  /**
+   * Idempotency: calling stopPlugins() a second time after a successful stop must be a silent no-op
+   * — not throw, not call stop() again.
+   */
+  @Test
+  void stopPlugins_isIdempotent_secondCallIsNoOp() {
+    final AtomicInteger stopCount = new AtomicInteger(0);
+    final BesuPlugin plugin =
+        new NoOpPlugin() {
+          @Override
+          public void stop() {
+            stopCount.incrementAndGet();
+          }
+        };
+
+    final BesuPluginContextImpl context = new BesuPluginContextImpl();
+    context.initialize(configWith(false));
+    context.registerPlugins();
+    context.addPluginForTesting(plugin);
+    context.beforeExternalServices();
+    context.startPlugins();
+
+    context.stopPlugins(); // first call — normal stop
+    assertThatCode(context::stopPlugins).doesNotThrowAnyException(); // second call — must be no-op
+    assertThat(stopCount.get()).isEqualTo(1); // stop() called exactly once
+  }
+
+  /**
+   * stopPlugins() is re-entrant-safe: if the context is currently mid-stop (state == STOPPING), a
+   * concurrent call must return immediately without calling stop() a second time.
+   */
+  @Test
+  void stopPlugins_doesNotThrow_whenAlreadyStopping() throws Exception {
+    final AtomicInteger stopCount = new AtomicInteger(0);
+    final CountDownLatch stopEntered = new CountDownLatch(1);
+    final CountDownLatch stopRelease = new CountDownLatch(1);
+
+    final BesuPlugin slowPlugin =
+        new NoOpPlugin() {
+          @Override
+          public void stop() {
+            stopCount.incrementAndGet();
+            stopEntered.countDown(); // signal that we are inside stop()
+            try {
+              stopRelease.await();
+            } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
+            }
+          }
+        };
+
+    final BesuPluginContextImpl context = new BesuPluginContextImpl();
+    context.initialize(configWith(false));
+    context.registerPlugins();
+    context.addPluginForTesting(slowPlugin);
+    context.beforeExternalServices();
+    context.startPlugins();
+
+    // First call in background — will block inside stop()
+    final Thread firstStop = new Thread(context::stopPlugins, "first-stop");
+    firstStop.start();
+    assertThat(stopEntered.await(5, TimeUnit.SECONDS)).isTrue();
+
+    // Second call while first is still running — must return immediately without throwing
+    assertThatCode(context::stopPlugins).doesNotThrowAnyException();
+    assertThat(stopCount.get()).isEqualTo(1); // stop() called only once so far
+
+    stopRelease.countDown(); // unblock the first stop
+    firstStop.join(5_000);
+  }
+
+  /**
+   * With continueOnPluginError=true, a plugin that throws during start() is removed from
+   * registeredPlugins before stopPlugins() is called. The remaining plugins that started
+   * successfully must each receive stop().
+   */
+  @Test
+  void stopPlugins_stopsOnlySuccessfullyStartedPlugins_withContinueOnErrorTrue() {
+    final AtomicInteger stopCount = new AtomicInteger(0);
+
+    final BesuPlugin pluginA =
+        new NoOpPlugin() {
+          @Override
+          public void stop() {
+            stopCount.incrementAndGet();
+          }
+        };
+    final BesuPlugin pluginB =
+        new NoOpPlugin() {
+          @Override
+          public void start() {
+            throw new RuntimeException("pluginB start failure");
+          }
+
+          @Override
+          public void stop() {
+            stopCount.incrementAndGet();
+          }
+        };
+    final BesuPlugin pluginC =
+        new NoOpPlugin() {
+          @Override
+          public void stop() {
+            stopCount.incrementAndGet();
+          }
+        };
+
+    final BesuPluginContextImpl context = new BesuPluginContextImpl();
+    context.initialize(configWith(true)); // continueOnPluginError = true
+    context.registerPlugins();
+    context.addPluginForTesting(pluginA);
+    context.addPluginForTesting(pluginB);
+    context.addPluginForTesting(pluginC);
+
+    context.beforeExternalServices();
+    // startPlugins() removes pluginB from registeredPlugins when it throws
+    assertThatCode(context::startPlugins).doesNotThrowAnyException();
+    assertThatCode(context::stopPlugins).doesNotThrowAnyException();
+
+    // pluginA and pluginC started and must be stopped; pluginB was removed so not stopped
+    assertThat(stopCount.get()).isEqualTo(2);
+  }
+
+  /**
+   * A plugin whose stop() throws must not prevent subsequent plugins from having their own stop()
+   * called (stop errors are swallowed, not propagated).
+   */
+  @Test
+  void stopPlugins_continuesStoppingRemainingPlugins_whenOneStopThrows() {
+    final AtomicInteger stopCount = new AtomicInteger(0);
+
+    final BesuPlugin pluginA =
+        new NoOpPlugin() {
+          @Override
+          public void stop() {
+            throw new RuntimeException("stop failure in A");
+          }
+        };
+    final BesuPlugin pluginB =
+        new NoOpPlugin() {
+          @Override
+          public void stop() {
+            stopCount.incrementAndGet();
+          }
+        };
+
+    final BesuPluginContextImpl context = new BesuPluginContextImpl();
+    context.initialize(configWith(false));
+    context.registerPlugins();
+    context.addPluginForTesting(pluginA);
+    context.addPluginForTesting(pluginB);
+    context.beforeExternalServices();
+    context.startPlugins();
+
+    assertThatCode(context::stopPlugins).doesNotThrowAnyException();
+    // pluginB must still have been stopped despite pluginA throwing
+    assertThat(stopCount.get()).isEqualTo(1);
+  }
+
+  /**
+   * beforeExternalServices() throws (continueOnPluginError=false): plugin never reaches start() so
+   * its watermark stays at REGISTERED. stopPlugins() must skip stop() for it.
+   */
+  @Test
+  void stopPlugins_skipsStop_whenPluginFailedDuringBeforeExternalServices() {
+    final AtomicInteger stopCount = new AtomicInteger(0);
+
+    final BesuPlugin plugin =
+        new NoOpPlugin() {
+          @Override
+          public void beforeExternalServices() {
+            throw new RuntimeException("beforeExternalServices failure");
+          }
+
+          @Override
+          public void stop() {
+            stopCount.incrementAndGet();
+          }
+        };
+
+    final BesuPluginContextImpl context = new BesuPluginContextImpl();
+    context.initialize(configWith(false));
+    context.registerPlugins();
+    context.addPluginForTesting(plugin);
+
+    assertThatCode(context::beforeExternalServices).isInstanceOf(RuntimeException.class);
+    assertThatCode(context::stopPlugins).doesNotThrowAnyException();
+    assertThat(stopCount.get()).isEqualTo(0);
+  }
+
+  // -------------------------------------------------------------------------
+  // Minimal no-op plugin base used by all stopPlugins() tests
+  // -------------------------------------------------------------------------
+
+  /** A do-nothing BesuPlugin whose lifecycle methods can be individually overridden. */
+  private abstract static class NoOpPlugin implements BesuPlugin {
+
+    @Override
+    public void register(final ServiceManager context) {}
+
+    @Override
+    public void start() {}
+
+    @Override
+    public void stop() {}
   }
 
   @Test


### PR DESCRIPTION
Issue Description  - #10422 

## PR description


### Fix

**`BesuPluginContextImpl.java` — 4 targeted changes:**

**1. New field — per-plugin high-watermark map**

Tracks the furthest lifecycle phase each individual plugin successfully reached, independently of the global context state:

```besu/app/src/main/java/org/hyperledger/besu/services/BesuPluginContextImpl.java#L90-93
  private final Map<BesuPlugin, Lifecycle> pluginHighWatermark = new LinkedHashMap<>();
```

**2. Watermark stamps — in each phase method**

After each successful per-plugin lifecycle call, the plugin's watermark is updated:
- `registerPlugin()` → stamps `REGISTERED`
- `beforeExternalServices()` → stamps `BEFORE_EXTERNAL_SERVICES_FINISHED`
- `startPlugins()` → stamps `BEFORE_MAIN_LOOP_STARTED`

**3. Two new private helpers**

`pluginReachedState()` checks whether a plugin's individual watermark is at or beyond a target phase. `safeStop()` calls `plugin.stop()` with error isolation so one failing `stop()` never blocks the others.

**4. Rewritten `stopPlugins()`**

The hard `checkState` precondition is replaced with a guard that returns early only for `STOPPED` and `STOPPING` (idempotency). All other states proceed to shutdown — iterating `registeredPlugins`, calling `safeStop()` only for plugins whose watermark confirms they reached `start()`, then closing the classloader unconditionally.

BesuPluginContextImpl.java` — 1 test-support addition:**

`addPluginForTesting()` is a `@VisibleForTesting` package-private method that drives a plugin through the real `registerPlugin()` path (stamping the watermark correctly) without going through the ServiceLoader filesystem discovery.

Tests Added — `BesuPluginContextImplTest.java`

9 new tests covering every scenario. All 4 existing tests are untouched and continue to pass.

| Test | Scenario |
|---|---|
| `stopPlugins_callsStop_afterFullStartup` | Happy path — `stop()` is called after a full successful lifecycle |
| `stopPlugins_doesNotThrow_whenStartPluginsFailedWithContinueOnErrorFalse` | **The exact production crash** — `startPlugins()` throws, hook fires in `BEFORE_MAIN_LOOP_STARTED`. Only pluginA (which succeeded) is stopped; pluginB (which threw) is skipped |
| `stopPlugins_doesNotThrow_whenNoPluginReachedStart` | Hook fires in `BEFORE_EXTERNAL_SERVICES_FINISHED` — no plugin reached `start()`, none are stopped |
| `stopPlugins_doesNotThrow_whenCalledBeforeAnyLifecycleStep` | Called with no lifecycle steps run — complete no-op, no throw |
| `stopPlugins_isIdempotent_secondCallIsNoOp` | Second call after a successful stop — silent no-op, `stop()` called exactly once |
| `stopPlugins_doesNotThrow_whenAlreadyStopping` | Concurrent second call while mid-stop — returns immediately, `stop()` not duplicated |
| `stopPlugins_stopsOnlySuccessfullyStartedPlugins_withContinueOnErrorTrue` | `continueOnPluginError=true` — failed plugin is removed from list by iterator; remaining 2 of 3 are stopped |
| `stopPlugins_continuesStoppingRemainingPlugins_whenOneStopThrows` | A throwing `stop()` in pluginA is swallowed — pluginB still receives `stop()` |
| `stopPlugins_skipsStop_whenPluginFailedDuringBeforeExternalServices` | Plugin throws in `beforeExternalServices()` — watermark stays at `REGISTERED`, `stop()` is correctly skipped |

---

### Behaviour Comparison

| Situation | Before | After |
|---|---|---|
| `startPlugins()` throws (`continueOnPluginError=false`) | 💥 `IllegalStateException` in shutdown hook | ✅ pluginA stopped, pluginB skipped, classloader closed |
| `startExternalServices()` throws | 💥 `IllegalStateException` | ✅ no plugins stopped (none started), classloader closed |
| `stopPlugins()` called twice | 💥 second call throws | ✅ second call is silent no-op |
| Plugin A stops, Plugin B's `stop()` throws | 💥 B's exception propagates | ✅ B's exception is logged, remaining plugins continue |
| Classloader release on early shutdown | ❌ never happens (crash before close) | ✅ always happens regardless of state

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fixes #10422 


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


