### PR TITLE
Refactor: move PluginVersionsProvider out of plugin-api into cli/util

### DIFF
--- a/app/src/main/java/org/hyperledger/besu/cli/util/BesuCommandCustomFactory.java
+++ b/app/src/main/java/org/hyperledger/besu/cli/util/BesuCommandCustomFactory.java
@@ -14,8 +14,6 @@
  */
 package org.hyperledger.besu.cli.util;
 
-import org.hyperledger.besu.plugin.services.PluginVersionsProvider;
-
 import picocli.CommandLine;
 
 /**

--- a/app/src/main/java/org/hyperledger/besu/cli/util/PluginVersionsProvider.java
+++ b/app/src/main/java/org/hyperledger/besu/cli/util/PluginVersionsProvider.java
@@ -12,7 +12,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.hyperledger.besu.plugin.services;
+package org.hyperledger.besu.cli.util;
 
 import java.util.Map;
 

--- a/app/src/main/java/org/hyperledger/besu/cli/util/VersionProvider.java
+++ b/app/src/main/java/org/hyperledger/besu/cli/util/VersionProvider.java
@@ -14,7 +14,6 @@
  */
 package org.hyperledger.besu.cli.util;
 
-import org.hyperledger.besu.plugin.services.PluginVersionsProvider;
 import org.hyperledger.besu.util.BesuVersionUtils;
 
 import java.util.stream.Stream;

--- a/app/src/main/java/org/hyperledger/besu/services/BesuPluginContextImpl.java
+++ b/app/src/main/java/org/hyperledger/besu/services/BesuPluginContextImpl.java
@@ -17,11 +17,11 @@ package org.hyperledger.besu.services;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 
+import org.hyperledger.besu.cli.util.PluginVersionsProvider;
 import org.hyperledger.besu.ethereum.core.plugins.PluginConfiguration;
 import org.hyperledger.besu.plugin.BesuPlugin;
 import org.hyperledger.besu.plugin.ServiceManager;
 import org.hyperledger.besu.plugin.services.BesuService;
-import org.hyperledger.besu.plugin.services.PluginVersionsProvider;
 
 import java.io.IOException;
 import java.net.MalformedURLException;

--- a/app/src/test/java/org/hyperledger/besu/cli/util/BesuCommandCustomFactoryTest.java
+++ b/app/src/test/java/org/hyperledger/besu/cli/util/BesuCommandCustomFactoryTest.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.cli.util;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
-import org.hyperledger.besu.plugin.services.PluginVersionsProvider;
 import org.hyperledger.besu.util.BesuVersionUtils;
 
 import com.google.common.collect.ImmutableMap;

--- a/app/src/test/java/org/hyperledger/besu/cli/util/VersionProviderTest.java
+++ b/app/src/test/java/org/hyperledger/besu/cli/util/VersionProviderTest.java
@@ -18,7 +18,6 @@ import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
-import org.hyperledger.besu.plugin.services.PluginVersionsProvider;
 import org.hyperledger.besu.util.BesuVersionUtils;
 
 import java.util.Collections;

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -71,7 +71,7 @@ Calculated : ${currentHash}
 tasks.register('checkAPIChanges', FileStateChecker) {
   description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
   files = sourceSets.main.allJava.files
-  knownHash = 'dPuJtMlxYH8grWQNiM5dVOtM08X51fu7K+/6rtO5J5I='
+  knownHash = 'n2+gmRRv4KXlHs9BP92fDcIUGf3UnmVKxeYnkwJgev8='
 }
 check.dependsOn('checkAPIChanges')
 


### PR DESCRIPTION

## PR description

PluginVersionsProvider was living in `plugin-api/.../plugin/services/` — the same package as all `BesuService` implementations — but it does not extend `BesuService` and was never registered in the service registry. Any plugin calling `context.getService(PluginVersionsProvider.class)` would always get `Optional.empty()` with no diagnostic, making it a silent trap for plugin authors.

The interface has only two consumers (`BesuCommandCustomFactory`, `VersionProvider`), both in `app/.../cli/util`, and its sole purpose is populating the `--version` CLI output. It is an internal CLI concern, not a plugin API.

This PR moves it to where it actually belongs.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fixes #10431 


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


