### PR TITLE
fix: resolve process and file descriptor leaks in BesuCommand, PlatformDetector, and RlpBlockExporter

### DIFF
--- a/app/src/main/java/org/hyperledger/besu/chainexport/RlpBlockExporter.java
+++ b/app/src/main/java/org/hyperledger/besu/chainexport/RlpBlockExporter.java
@@ -67,33 +67,33 @@ public class RlpBlockExporter {
 
     // Append to file if a range is specified
     final boolean append = maybeStartBlock.isPresent();
-    FileOutputStream outputStream = new FileOutputStream(outputFile, append);
-
-    LOG.info(
-        "Exporting blocks [{},{}) to file {} (appending: {})",
-        startBlock,
-        endBlock,
-        outputFile.toString(),
-        Boolean.toString(append));
-
     long blockNumber = 0L;
-    for (long i = startBlock; i < endBlock; i++) {
-      Optional<Block> maybeBlock = blockchain.getBlockByNumber(i);
-      if (maybeBlock.isEmpty()) {
-        LOG.warn("Unable to export blocks [{} - {}).  Blocks not found.", i, endBlock);
-        break;
-      }
 
-      final Block block = maybeBlock.get();
-      blockNumber = block.getHeader().getNumber();
-      if (blockNumber % 100 == 0) {
-        LOG.info("Export at block {}", blockNumber);
-      }
+    try (FileOutputStream outputStream = new FileOutputStream(outputFile, append)) {
+      LOG.info(
+          "Exporting blocks [{},{}) to file {} (appending: {})",
+          startBlock,
+          endBlock,
+          outputFile.toString(),
+          Boolean.toString(append));
 
-      exportBlock(outputStream, block);
+      for (long i = startBlock; i < endBlock; i++) {
+        Optional<Block> maybeBlock = blockchain.getBlockByNumber(i);
+        if (maybeBlock.isEmpty()) {
+          LOG.warn("Unable to export blocks [{} - {}).  Blocks not found.", i, endBlock);
+          break;
+        }
+
+        final Block block = maybeBlock.get();
+        blockNumber = block.getHeader().getNumber();
+        if (blockNumber % 100 == 0) {
+          LOG.info("Export at block {}", blockNumber);
+        }
+
+        exportBlock(outputStream, block);
+      }
     }
 
-    outputStream.close();
     LOG.info("Export complete at block {}", blockNumber);
   }
 

--- a/app/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/app/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -1148,23 +1148,36 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
   private static boolean isGroupMember(final String userName, final GroupPrincipal group)
       throws IOException {
     // Get the groups of the user by executing 'id -Gn username'
-    Process process = Runtime.getRuntime().exec(new String[] {"id", "-Gn", userName});
-    BufferedReader reader =
-        new BufferedReader(new InputStreamReader(process.getInputStream(), UTF_8));
-
-    // Read the output of the command
-    String line = reader.readLine();
+    Process process = null;
     boolean isMember = false;
-    if (line != null) {
-      // Split the groups
-      Iterable<String> userGroups = Splitter.on(" ").split(line);
-      // Check if any of the user's groups match the file's group
+    try {
+      process = Runtime.getRuntime().exec(new String[] {"id", "-Gn", userName});
+      try (BufferedReader reader =
+          new BufferedReader(new InputStreamReader(process.getInputStream(), UTF_8))) {
 
-      for (String grp : userGroups) {
-        if (grp.equals(group.getName())) {
-          isMember = true;
-          break;
+        // Read the output of the command
+        String line = reader.readLine();
+        if (line != null) {
+          // Split the groups
+          Iterable<String> userGroups = Splitter.on(" ").split(line);
+          // Check if any of the user's groups match the file's group
+
+          for (String grp : userGroups) {
+            if (grp.equals(group.getName())) {
+              isMember = true;
+              break;
+            }
+          }
         }
+      }
+    } finally {
+      if (process != null) {
+        try {
+          process.waitFor(10, java.util.concurrent.TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+        process.destroy();
       }
     }
     return isMember;

--- a/util/src/main/java/org/hyperledger/besu/util/platform/PlatformDetector.java
+++ b/util/src/main/java/org/hyperledger/besu/util/platform/PlatformDetector.java
@@ -301,11 +301,21 @@ public class PlatformDetector {
     processBuilder.redirectErrorStream(true);
 
     final StringBuilder rawGlibcVersionBuilder;
+    Process process = null;
     try {
-      final Process process = processBuilder.start();
+      process = processBuilder.start();
       rawGlibcVersionBuilder = readGlibcVersionStream(process.getInputStream());
     } catch (IOException e) {
       return;
+    } finally {
+      if (process != null) {
+        try {
+          process.waitFor(10, java.util.concurrent.TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+        process.destroy();
+      }
     }
 
     _glibc = normalizeGLibcVersion(rawGlibcVersionBuilder.toString());


### PR DESCRIPTION
## PR description

This PR fixes multiple unreported resource leaks discovered during a codebase audit involving OS subprocess lifecycle mismanagement and unclosed file streams in three production classes.

**1. `BesuCommand.isGroupMember` — Process zombie + File Descriptor leak**
The method spawned `id -Gn <username>` via `Runtime.getRuntime().exec(...)` but never closed the resulting `BufferedReader`/`InputStream`, waited for the process to exit, or explicitly destroyed it. This left open file descriptors and zombie OS processes on every invocation of the `--print-paths-and-exit` CLI flag.

**Fix:** Wrapped the `BufferedReader` in a `try-with-resources` block and added a `try-finally` block to call `process.waitFor()` and `process.destroy()`.

**2. `PlatformDetector.detectGlibc` — Process zombie leak**
The `ldd --version` subprocess started via `ProcessBuilder` was never waited upon or destroyed after reading its output stream, leaving a zombie process on every call to `PlatformDetector.getGlibc()`.

**Fix:** Added a `try-finally` block to call `process.waitFor()` and `process.destroy()`.

**3. `RlpBlockExporter.exportBlocks` — File Descriptor leak**
A `FileOutputStream` was instantiated without a `try-with-resources` block. Any exception thrown during block fetching or exporting would permanently leak the file descriptor, since the manual `outputStream.close()` at the end of the method would be skipped.

**Fix:** Migrated the `FileOutputStream` to a `try-with-resources` block, removing the manual `close()` call.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
fixes #10446

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply` ✅
- [x] unit tests: `./gradlew :app:test :util:test` ✅
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)
