### PR TITLE
feat(acceptance-dsl): add discoveryV5Enabled toggle to BesuNodeConfigurationBuilder

### DIFF
--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/configuration/BesuNodeConfigurationBuilder.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/configuration/BesuNodeConfigurationBuilder.java
@@ -84,6 +84,7 @@ public class BesuNodeConfigurationBuilder {
   private Boolean p2pEnabled = true;
   private int p2pPort = 0;
   private boolean discoveryEnabled = true;
+  private boolean discoveryV5Enabled = true;
   private boolean bootnodeEligible = true;
   private boolean revertReasonEnabled = false;
   private NetworkDefinition network = null;
@@ -375,6 +376,11 @@ public class BesuNodeConfigurationBuilder {
     return this;
   }
 
+  public BesuNodeConfigurationBuilder discoveryV5Enabled(final boolean discoveryV5Enabled) {
+    this.discoveryV5Enabled = discoveryV5Enabled;
+    return this;
+  }
+
   public BesuNodeConfigurationBuilder plugins(final List<String> plugins) {
     this.plugins.clear();
     this.plugins.addAll(plugins);
@@ -478,7 +484,8 @@ public class BesuNodeConfigurationBuilder {
     final NetworkingConfiguration networkingConfiguration =
         ImmutableNetworkingConfiguration.builder()
             .initiateConnectionsFrequency(Duration.ofSeconds(5))
-            .discoveryConfiguration(DiscoveryConfiguration.create().setDiscoveryV5Enabled(true))
+            .discoveryConfiguration(
+                DiscoveryConfiguration.create().setDiscoveryV5Enabled(discoveryV5Enabled))
             .build();
 
     return new BesuNodeConfiguration(


### PR DESCRIPTION
## PR description
Re-introduces the ability for in-JVM consumers of the acceptance-test DSL
(retesteth, embedded test runners, downstream projects) to opt out of
DiscV5.

[#10337](https://github.com/hyperledger/besu/pull/10337) made
`BesuNodeConfigurationBuilder.build()` unconditionally apply
`DiscoveryConfiguration.create().setDiscoveryV5Enabled(true)`. There is
no public override on the builder, and the CLI flag
`--Xv5-discovery-enabled` does not take effect for `ThreadBesuNodeRunner`
(which injects `node.getNetworkingConfiguration()` directly into
`RunnerBuilder`).

This is a problem for in-JVM consumers that supply bootnodes as enode
URIs:

- `ThreadBesuNodeRunner` only calls `EthNetworkConfig.Builder.setEnodeBootNodes(...)`
  (line 150); it never sets ENR bootnodes.
- `RunnerBuilder` copies both lists into `DiscoveryConfiguration` (lines
  675–676), but the ENR list is empty.
- `DiscoveryConfiguration.getBootnodeIdentifiers()` returns
  `discoveryV5Enabled ? enrBootnodes : enodeBootnodes` (line 116),
  i.e. the empty ENR list when V5 is on.
- `PeerDiscoveryAgentFactoryV5.buildDefaultDiscoverySystemFactory()`
  feeds `discoveryConfig.getEnrBootnodes()` to
  `DiscoverySystemBuilder.bootnodes(...)` exclusively (lines 159–162).

Net effect: DiscV5 has no bootstrap records, the routing table never
populates, no RLPx peering occurs via discovery, and `net_peerCount`
stays at `0`. Embedded clusters that worked before #10337 silently fail.

This PR adds a `discoveryV5Enabled(boolean)` setter on
`BesuNodeConfigurationBuilder`. The default remains `true`, so #10337's
DiscV5 coverage in Besu's own acceptance tests is unchanged. Consumers
that need pre-#10337 enode-bootnode behavior can now call
`.discoveryV5Enabled(false)` to recover DiscV4 without forking the DSL.

No production CLI behavior changes: `BesuCommand` already validates
bootnode format strictly per discovery version (lines 2474–2528 of
`BesuCommand.java`).



## Fixed Issue(s)
https://github.com/Consensys/linea-monorepo/issues/2540
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


