### PR TITLE
Reject negative minPeers and maxBlocksBehind in readiness check

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/health/HealthCheckResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/health/HealthCheckResult.java
@@ -14,8 +14,26 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.health;
 
+import io.netty.handler.codec.http.HttpResponseStatus;
+
 public enum HealthCheckResult {
-  HEALTHY,
-  UNHEALTHY,
-  BAD_REQUEST
+  HEALTHY(HttpResponseStatus.OK.code(), "UP"),
+  UNHEALTHY(HttpResponseStatus.SERVICE_UNAVAILABLE.code(), "DOWN"),
+  BAD_REQUEST(HttpResponseStatus.BAD_REQUEST.code(), "BAD_REQUEST");
+
+  private final int statusCode;
+  private final String statusText;
+
+  HealthCheckResult(final int statusCode, final String statusText) {
+    this.statusCode = statusCode;
+    this.statusText = statusText;
+  }
+
+  public int getStatusCode() {
+    return statusCode;
+  }
+
+  public String getStatusText() {
+    return statusText;
+  }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/health/HealthCheckResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/health/HealthCheckResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright ConsenSys AG.
+ * Copyright contributors to Besu.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -14,15 +14,8 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.health;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-public class LivenessCheck implements HealthService.HealthCheck {
-  private static final Logger LOG = LoggerFactory.getLogger(LivenessCheck.class);
-
-  @Override
-  public HealthCheckResult check(final HealthService.ParamSource params) {
-    LOG.debug("Invoking liveness check.");
-    return HealthCheckResult.HEALTHY;
-  }
+public enum HealthCheckResult {
+  HEALTHY,
+  UNHEALTHY,
+  BAD_REQUEST
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/health/HealthService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/health/HealthService.java
@@ -16,7 +16,6 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.health;
 
 import static java.util.Collections.singletonMap;
 
-import io.netty.handler.codec.http.HttpResponseStatus;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
@@ -29,13 +28,6 @@ public final class HealthService {
   public static final String LIVENESS_PATH = "/liveness";
   public static final String READINESS_PATH = "/readiness";
 
-  private static final int HEALTHY_STATUS_CODE = HttpResponseStatus.OK.code();
-  private static final int UNHEALTHY_STATUS_CODE = HttpResponseStatus.SERVICE_UNAVAILABLE.code();
-  private static final int BAD_REQUEST_STATUS_CODE = HttpResponseStatus.BAD_REQUEST.code();
-  private static final String HEALTHY_STATUS_TEXT = "UP";
-  private static final String UNHEALTHY_STATUS_TEXT = "DOWN";
-  private static final String BAD_REQUEST_STATUS_TEXT = "BAD_REQUEST";
-
   private final HealthCheck healthCheck;
 
   public HealthService(final HealthCheck healthCheck) {
@@ -43,29 +35,13 @@ public final class HealthService {
   }
 
   public void handleRequest(final RoutingContext routingContext) {
-    final int statusCode;
-    final String statusText;
     final HealthCheckResult result =
         healthCheck.check(name -> routingContext.queryParams().get(name));
-    switch (result) {
-      case HEALTHY:
-        statusCode = HEALTHY_STATUS_CODE;
-        statusText = HEALTHY_STATUS_TEXT;
-        break;
-      case BAD_REQUEST:
-        statusCode = BAD_REQUEST_STATUS_CODE;
-        statusText = BAD_REQUEST_STATUS_TEXT;
-        break;
-      default:
-        statusCode = UNHEALTHY_STATUS_CODE;
-        statusText = UNHEALTHY_STATUS_TEXT;
-        break;
-    }
     final HttpServerResponse response = routingContext.response();
     if (!response.closed()) {
       response
-          .setStatusCode(statusCode)
-          .end(new JsonObject(singletonMap("status", statusText)).encodePrettily());
+          .setStatusCode(result.getStatusCode())
+          .end(new JsonObject(singletonMap("status", result.getStatusText())).encodePrettily());
     }
   }
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/health/HealthService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/health/HealthService.java
@@ -23,15 +23,18 @@ import io.vertx.ext.web.RoutingContext;
 
 public final class HealthService {
 
-  public static final HealthService ALWAYS_HEALTHY = new HealthService(params -> true);
+  public static final HealthService ALWAYS_HEALTHY =
+      new HealthService(params -> HealthCheckResult.HEALTHY);
 
   public static final String LIVENESS_PATH = "/liveness";
   public static final String READINESS_PATH = "/readiness";
 
   private static final int HEALTHY_STATUS_CODE = HttpResponseStatus.OK.code();
   private static final int UNHEALTHY_STATUS_CODE = HttpResponseStatus.SERVICE_UNAVAILABLE.code();
+  private static final int BAD_REQUEST_STATUS_CODE = HttpResponseStatus.BAD_REQUEST.code();
   private static final String HEALTHY_STATUS_TEXT = "UP";
   private static final String UNHEALTHY_STATUS_TEXT = "DOWN";
+  private static final String BAD_REQUEST_STATUS_TEXT = "BAD_REQUEST";
 
   private final HealthCheck healthCheck;
 
@@ -42,12 +45,21 @@ public final class HealthService {
   public void handleRequest(final RoutingContext routingContext) {
     final int statusCode;
     final String statusText;
-    if (healthCheck.isHealthy(name -> routingContext.queryParams().get(name))) {
-      statusCode = HEALTHY_STATUS_CODE;
-      statusText = HEALTHY_STATUS_TEXT;
-    } else {
-      statusCode = UNHEALTHY_STATUS_CODE;
-      statusText = UNHEALTHY_STATUS_TEXT;
+    final HealthCheckResult result =
+        healthCheck.check(name -> routingContext.queryParams().get(name));
+    switch (result) {
+      case HEALTHY:
+        statusCode = HEALTHY_STATUS_CODE;
+        statusText = HEALTHY_STATUS_TEXT;
+        break;
+      case BAD_REQUEST:
+        statusCode = BAD_REQUEST_STATUS_CODE;
+        statusText = BAD_REQUEST_STATUS_TEXT;
+        break;
+      default:
+        statusCode = UNHEALTHY_STATUS_CODE;
+        statusText = UNHEALTHY_STATUS_TEXT;
+        break;
     }
     final HttpServerResponse response = routingContext.response();
     if (!response.closed()) {
@@ -59,7 +71,7 @@ public final class HealthService {
 
   @FunctionalInterface
   public interface HealthCheck {
-    boolean isHealthy(ParamSource paramSource);
+    HealthCheckResult check(ParamSource paramSource);
   }
 
   @FunctionalInterface

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/health/ReadinessCheck.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/health/ReadinessCheck.java
@@ -60,6 +60,10 @@ public class ReadinessCheck implements HealthService.HealthCheck {
         LOG.debug("Invalid maxBlocksBehind: {}. Reporting as not ready.", maxBlocksBehindParam);
         return false;
       }
+      if (maxBlocksBehind < 0) {
+        LOG.debug("Negative maxBlocksBehind: {}. Reporting as not ready.", maxBlocksBehindParam);
+        return false;
+      }
     }
     return syncStatus.getHighestBlock() - syncStatus.getCurrentBlock() <= maxBlocksBehind;
   }
@@ -74,6 +78,10 @@ public class ReadinessCheck implements HealthService.HealthCheck {
         minimumPeers = Integer.parseInt(peersParam);
       } catch (final NumberFormatException e) {
         LOG.debug("Invalid minPeers: {}. Reporting as not ready.", peersParam);
+        return false;
+      }
+      if (minimumPeers < 0) {
+        LOG.debug("Negative minPeers: {}. Reporting as not ready.", peersParam);
         return false;
       }
     }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/health/ReadinessCheck.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/health/ReadinessCheck.java
@@ -34,21 +34,23 @@ public class ReadinessCheck implements HealthService.HealthCheck {
   }
 
   @Override
-  public boolean isHealthy(final HealthService.ParamSource params) {
+  public HealthCheckResult check(final HealthService.ParamSource params) {
     LOG.debug("Invoking readiness check.");
     if (p2pNetwork.isP2pEnabled()) {
       final int peerCount = p2pNetwork.getPeerCount();
-      if (!hasMinimumPeers(params, peerCount)) {
-        return false;
+      final HealthCheckResult peersResult = checkMinimumPeers(params, peerCount);
+      if (peersResult != HealthCheckResult.HEALTHY) {
+        return peersResult;
       }
     }
     return synchronizer
         .getSyncStatus()
-        .map(syncStatus -> isInSync(syncStatus, params))
-        .orElse(true);
+        .map(syncStatus -> checkInSync(syncStatus, params))
+        .orElse(HealthCheckResult.HEALTHY);
   }
 
-  private boolean isInSync(final SyncStatus syncStatus, final HealthService.ParamSource params) {
+  private HealthCheckResult checkInSync(
+      final SyncStatus syncStatus, final HealthService.ParamSource params) {
     final String maxBlocksBehindParam = params.getParam("maxBlocksBehind");
     final long maxBlocksBehind;
     if (maxBlocksBehindParam == null) {
@@ -57,18 +59,21 @@ public class ReadinessCheck implements HealthService.HealthCheck {
       try {
         maxBlocksBehind = Long.parseLong(maxBlocksBehindParam);
       } catch (final NumberFormatException e) {
-        LOG.debug("Invalid maxBlocksBehind: {}. Reporting as not ready.", maxBlocksBehindParam);
-        return false;
+        LOG.debug("Invalid maxBlocksBehind: {}. Bad request.", maxBlocksBehindParam);
+        return HealthCheckResult.BAD_REQUEST;
       }
       if (maxBlocksBehind < 0) {
-        LOG.debug("Negative maxBlocksBehind: {}. Reporting as not ready.", maxBlocksBehindParam);
-        return false;
+        LOG.debug("Negative maxBlocksBehind: {}. Bad request.", maxBlocksBehindParam);
+        return HealthCheckResult.BAD_REQUEST;
       }
     }
-    return syncStatus.getHighestBlock() - syncStatus.getCurrentBlock() <= maxBlocksBehind;
+    return syncStatus.getHighestBlock() - syncStatus.getCurrentBlock() <= maxBlocksBehind
+        ? HealthCheckResult.HEALTHY
+        : HealthCheckResult.UNHEALTHY;
   }
 
-  private boolean hasMinimumPeers(final HealthService.ParamSource params, final int peerCount) {
+  private HealthCheckResult checkMinimumPeers(
+      final HealthService.ParamSource params, final int peerCount) {
     final int minimumPeers;
     final String peersParam = params.getParam("minPeers");
     if (peersParam == null) {
@@ -77,14 +82,17 @@ public class ReadinessCheck implements HealthService.HealthCheck {
       try {
         minimumPeers = Integer.parseInt(peersParam);
       } catch (final NumberFormatException e) {
-        LOG.debug("Invalid minPeers: {}. Reporting as not ready.", peersParam);
-        return false;
+        LOG.debug("Invalid minPeers: {}. Bad request.", peersParam);
+        return HealthCheckResult.BAD_REQUEST;
       }
       if (minimumPeers < 0) {
-        LOG.debug("Negative minPeers: {}. Reporting as not ready.", peersParam);
-        return false;
+        LOG.debug("Negative minPeers: {}. Bad request.", peersParam);
+        return HealthCheckResult.BAD_REQUEST;
       }
     }
-    return peerCount >= minimumPeers;
+    return peerCount >= minimumPeers
+        ? HealthCheckResult.HEALTHY
+        : HealthCheckResult.UNHEALTHY;
   }
 }
+

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/health/ReadinessCheckTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/health/ReadinessCheckTest.java
@@ -142,6 +142,28 @@ public class ReadinessCheckTest {
     assertThat(readinessCheck.isHealthy(paramSource)).isFalse();
   }
 
+  @Test
+  public void shouldNotBeReadyWhenMinPeersIsNegative() {
+    when(p2pNetwork.isP2pEnabled()).thenReturn(true);
+    when(p2pNetwork.getPeerCount()).thenReturn(5);
+    when(synchronizer.getSyncStatus()).thenReturn(Optional.empty());
+
+    params.put(MIN_PEERS_PARAM, "-1");
+
+    assertThat(readinessCheck.isHealthy(paramSource)).isFalse();
+  }
+
+  @Test
+  public void shouldNotBeReadyWhenMaxBlocksBehindIsNegative() {
+    when(p2pNetwork.isP2pEnabled()).thenReturn(true);
+    when(p2pNetwork.getPeerCount()).thenReturn(5);
+    when(synchronizer.getSyncStatus()).thenReturn(createSyncStatus(1000, 1000));
+
+    params.put("maxBlocksBehind", "-1");
+
+    assertThat(readinessCheck.isHealthy(paramSource)).isFalse();
+  }
+
   private Optional<SyncStatus> createSyncStatus(final int currentBlock, final int highestBlock) {
     return Optional.of(
         new DefaultSyncStatus(0, currentBlock, highestBlock, Optional.empty(), Optional.empty()));

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/health/ReadinessCheckTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/health/ReadinessCheckTest.java
@@ -46,7 +46,7 @@ public class ReadinessCheckTest {
     when(p2pNetwork.getPeerCount()).thenReturn(1);
     when(synchronizer.getSyncStatus()).thenReturn(Optional.empty());
 
-    assertThat(readinessCheck.isHealthy(paramSource)).isTrue();
+    assertThat(readinessCheck.check(paramSource)).isEqualTo(HealthCheckResult.HEALTHY);
   }
 
   @Test
@@ -55,7 +55,7 @@ public class ReadinessCheckTest {
     when(p2pNetwork.getPeerCount()).thenReturn(0);
     when(synchronizer.getSyncStatus()).thenReturn(Optional.empty());
 
-    assertThat(readinessCheck.isHealthy(paramSource)).isTrue();
+    assertThat(readinessCheck.check(paramSource)).isEqualTo(HealthCheckResult.HEALTHY);
   }
 
   @Test
@@ -66,7 +66,7 @@ public class ReadinessCheckTest {
 
     params.put(MIN_PEERS_PARAM, "0");
 
-    assertThat(readinessCheck.isHealthy(paramSource)).isTrue();
+    assertThat(readinessCheck.check(paramSource)).isEqualTo(HealthCheckResult.HEALTHY);
   }
 
   @Test
@@ -77,18 +77,18 @@ public class ReadinessCheckTest {
 
     params.put(MIN_PEERS_PARAM, "10");
 
-    assertThat(readinessCheck.isHealthy(paramSource)).isFalse();
+    assertThat(readinessCheck.check(paramSource)).isEqualTo(HealthCheckResult.UNHEALTHY);
   }
 
   @Test
-  public void shouldNotBeReadyWhenMinimumPeersParamIsInvalid() {
+  public void shouldReturnBadRequestWhenMinimumPeersParamIsInvalid() {
     when(p2pNetwork.isP2pEnabled()).thenReturn(true);
     when(p2pNetwork.getPeerCount()).thenReturn(500);
     when(synchronizer.getSyncStatus()).thenReturn(Optional.empty());
 
     params.put(MIN_PEERS_PARAM, "abc");
 
-    assertThat(readinessCheck.isHealthy(paramSource)).isFalse();
+    assertThat(readinessCheck.check(paramSource)).isEqualTo(HealthCheckResult.BAD_REQUEST);
   }
 
   @Test
@@ -97,16 +97,16 @@ public class ReadinessCheckTest {
     when(p2pNetwork.getPeerCount()).thenReturn(5);
     when(synchronizer.getSyncStatus()).thenReturn(createSyncStatus(1000, 1002));
 
-    assertThat(readinessCheck.isHealthy(paramSource)).isTrue();
+    assertThat(readinessCheck.check(paramSource)).isEqualTo(HealthCheckResult.HEALTHY);
   }
 
   @Test
-  public void shouldNotBeReadyWhenLessThanDefaultMaxBlocksBehind() {
+  public void shouldNotBeReadyWhenMoreThanDefaultMaxBlocksBehind() {
     when(p2pNetwork.isP2pEnabled()).thenReturn(true);
     when(p2pNetwork.getPeerCount()).thenReturn(5);
     when(synchronizer.getSyncStatus()).thenReturn(createSyncStatus(1000, 1003));
 
-    assertThat(readinessCheck.isHealthy(paramSource)).isFalse();
+    assertThat(readinessCheck.check(paramSource)).isEqualTo(HealthCheckResult.UNHEALTHY);
   }
 
   @Test
@@ -117,7 +117,7 @@ public class ReadinessCheckTest {
 
     params.put("maxBlocksBehind", "100");
 
-    assertThat(readinessCheck.isHealthy(paramSource)).isTrue();
+    assertThat(readinessCheck.check(paramSource)).isEqualTo(HealthCheckResult.HEALTHY);
   }
 
   @Test
@@ -128,40 +128,40 @@ public class ReadinessCheckTest {
 
     params.put("maxBlocksBehind", "100");
 
-    assertThat(readinessCheck.isHealthy(paramSource)).isFalse();
+    assertThat(readinessCheck.check(paramSource)).isEqualTo(HealthCheckResult.UNHEALTHY);
   }
 
   @Test
-  public void shouldNotBeReadyWhenCustomMaxBlocksBehindIsInvalid() {
+  public void shouldReturnBadRequestWhenCustomMaxBlocksBehindIsInvalid() {
     when(p2pNetwork.isP2pEnabled()).thenReturn(true);
     when(p2pNetwork.getPeerCount()).thenReturn(5);
     when(synchronizer.getSyncStatus()).thenReturn(createSyncStatus(500, 500));
 
     params.put("maxBlocksBehind", "abc");
 
-    assertThat(readinessCheck.isHealthy(paramSource)).isFalse();
+    assertThat(readinessCheck.check(paramSource)).isEqualTo(HealthCheckResult.BAD_REQUEST);
   }
 
   @Test
-  public void shouldNotBeReadyWhenMinPeersIsNegative() {
+  public void shouldReturnBadRequestWhenMinPeersIsNegative() {
     when(p2pNetwork.isP2pEnabled()).thenReturn(true);
     when(p2pNetwork.getPeerCount()).thenReturn(5);
     when(synchronizer.getSyncStatus()).thenReturn(Optional.empty());
 
     params.put(MIN_PEERS_PARAM, "-1");
 
-    assertThat(readinessCheck.isHealthy(paramSource)).isFalse();
+    assertThat(readinessCheck.check(paramSource)).isEqualTo(HealthCheckResult.BAD_REQUEST);
   }
 
   @Test
-  public void shouldNotBeReadyWhenMaxBlocksBehindIsNegative() {
+  public void shouldReturnBadRequestWhenMaxBlocksBehindIsNegative() {
     when(p2pNetwork.isP2pEnabled()).thenReturn(true);
     when(p2pNetwork.getPeerCount()).thenReturn(5);
     when(synchronizer.getSyncStatus()).thenReturn(createSyncStatus(1000, 1000));
 
     params.put("maxBlocksBehind", "-1");
 
-    assertThat(readinessCheck.isHealthy(paramSource)).isFalse();
+    assertThat(readinessCheck.check(paramSource)).isEqualTo(HealthCheckResult.BAD_REQUEST);
   }
 
   private Optional<SyncStatus> createSyncStatus(final int currentBlock, final int highestBlock) {
@@ -169,3 +169,4 @@ public class ReadinessCheckTest {
         new DefaultSyncStatus(0, currentBlock, highestBlock, Optional.empty(), Optional.empty()));
   }
 }
+

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/JsonRpcJWTTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/JsonRpcJWTTest.java
@@ -22,6 +22,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.EngineJsonRpcService;
 import org.hyperledger.besu.ethereum.api.jsonrpc.JsonRpcConfiguration;
 import org.hyperledger.besu.ethereum.api.jsonrpc.authentication.AuthenticationService;
 import org.hyperledger.besu.ethereum.api.jsonrpc.authentication.EngineAuthService;
+import org.hyperledger.besu.ethereum.api.jsonrpc.health.HealthCheckResult;
 import org.hyperledger.besu.ethereum.api.jsonrpc.health.HealthService;
 import org.hyperledger.besu.ethereum.api.jsonrpc.health.HealthService.HealthCheck;
 import org.hyperledger.besu.ethereum.api.jsonrpc.health.HealthService.ParamSource;
@@ -115,8 +116,8 @@ public class JsonRpcJWTTest {
         new HealthService(
             new HealthCheck() {
               @Override
-              public boolean isHealthy(final ParamSource paramSource) {
-                return true;
+              public HealthCheckResult check(final ParamSource paramSource) {
+                return HealthCheckResult.HEALTHY;
               }
             });
 


### PR DESCRIPTION
## Summary
Fixes #10451 

The `/readiness` health check endpoint silently accepts negative integer values for the `minPeers` and `maxBlocksBehind` query parameters, producing semantically incorrect health responses:

*   `minPeers=-N` always reports healthy (even with 0 peers), because `peerCount >= -N` is always true.
*   `maxBlocksBehind=-N` always reports unhealthy (even when fully synced), because `blocksBehind <= -N` is always false.

This PR adds validation after parsing to reject negative values. When a negative value is detected, the check logs a debug message and returns `false` (not ready), which is consistent with the existing `NumberFormatException` handling for non-numeric inputs.

## Changes
*   Added negative value checks in `hasMinimumPeers()` and `isInSync()` within `ReadinessCheck.java`.
*   Added `shouldNotBeReadyWhenMinPeersIsNegative` and `shouldNotBeReadyWhenMaxBlocksBehindIsNegative` unit tests to `ReadinessCheckTest.java`.

## Testing
*   Locally verified that `/readiness?minPeers=-1` and `/readiness?maxBlocksBehind=-1` now correctly return `DOWN`.
*   Ran `gradlew :ethereum:api:test --tests "*ReadinessCheckTest"` and all tests pass.
