### PR TITLE
Add gradle task to run custom tests

### DIFF
--- a/ethereum/referencetests/build.gradle
+++ b/ethereum/referencetests/build.gradle
@@ -353,6 +353,16 @@ tasks.register('referenceTestsDevnet', Test) {
   classpath = sourceSets.referenceTestDevnet.runtimeClasspath
 }
 
+tasks.register('referenceTestsCustom', Test) {
+  useJUnitPlatform()
+  filter {
+    includeTestsMatching 'org.hyperledger.besu.ethereum.vm.custom.*'
+  }
+  description = 'Runs custom blockchain reference tests.'
+  testClassesDirs = sourceSets.referenceTest.output.classesDirs
+  classpath = sourceSets.referenceTest.runtimeClasspath
+}
+
 tasks.register('validateReferenceTestSubmodule') {
   description = "Checks that the reference tests submodule is not accidentally changed"
   doLast {


### PR DESCRIPTION
Adds gradle task `referenceTestsCustom` analogous to `referenceTests` and `referenceTestsDevnet` which allows running custom reference tests from `besu/ethereum/referencetests/src/reference-test/resources/custom`.