### PR TITLE
feat(publish-release): add workflow_dispatch trigger, gated to maintainers

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,10 +1,16 @@
 name: Publish Release
 
-run-name: "Publish Release ${{ github.event.release.name }}"
+run-name: "Publish Release ${{ github.event.release.name || inputs.tag }}"
 
 on:
   release:
     types: [released]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to publish (e.g. 26.5.0). Use to re-fire publish jobs without toggling release draft state.'
+        required: true
+        type: string
 
 env:
   registry: docker.io
@@ -19,7 +25,7 @@ jobs:
       - name: Pre-process Release Name
         id: validate_release_version
         env:
-          RELEASE_VERSION: "${{ github.event.release.name }}"
+          RELEASE_VERSION: "${{ github.event.release.name || inputs.tag }}"
         run: |
           # strip all whitespace
           RELEASE_VERSION="${RELEASE_VERSION//[[:space:]]/}"
@@ -96,6 +102,12 @@ jobs:
   docker-promote:
     needs: [validate]
     runs-on: ubuntu-latest
+    # workflow_dispatch path is gated by the `production` environment in
+    # repo settings (branch policy: main, release-*). The release-event
+    # path is implicitly gated by who can publish a release, so it does
+    # not reference the environment (its github.ref is a tag, which
+    # would not match the branch policy).
+    environment: ${{ github.event_name == 'workflow_dispatch' && 'production' || '' }}
     env:
       RELEASE_VERSION: ${{ needs.validate.outputs.release_version }}
       RC_VERSION: ${{ needs.validate.outputs.rc_version }}
@@ -194,6 +206,8 @@ jobs:
   artifactory:
     runs-on: ubuntu-latest
     needs: [validate]
+    # See docker-promote for why environment is conditional on event.
+    environment: ${{ github.event_name == 'workflow_dispatch' && 'production' || '' }}
     env:
       RELEASE_VERSION: ${{ needs.validate.outputs.release_version }}
     steps:


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger to `publish-release.yml` with a `tag` input, so the validate + docker-promote + artifactory chain can be re-fired without toggling release draft state.
- Gates the privileged jobs (`docker-promote`, `artifactory`) on workflow_dispatch via the existing **`production` environment** (branch policy: `main`, `release-*`). Repo-settings enforcement — cannot be bypassed by editing yaml on a feature branch.
- Release-event path uses an empty environment expression (`${{ false && 'production' || '' }}`) so the branch policy does not apply to tag-ref runs. Implicitly gated by who can publish a release.

## Why
Release-triggered workflows resolve the workflow file from the release tag's target sha, not the default branch. If a bug in this workflow is discovered and fixed on main *after* a release is cut, the fix does NOT apply to refires via release draft toggle — those still run the pre-fix workflow from the release tag's commit. `workflow_dispatch` from main is the only path that picks up the fix.

Hit during the 26.5.0 publish recovery on 2026-05-12 — after [#10490](https://github.com/besu-eth/besu/pull/10490) merged, the released-event refire still ran the pre-fix workflow because the release tag predated the fix. Failed run: https://github.com/besu-eth/besu/actions/runs/25752880712

## Why environment, not a yaml-level actor check
A `gh api collaborators/<actor>/permission` check in the workflow is bypassable: anyone with write access can edit the workflow on their own branch to remove the step, then dispatch from that branch. The `production` environment's branch policy lives in repo settings and is enforced regardless of yaml contents.

## Test plan
- [ ] After merge: dispatch from main with `tag=26.5.0`; confirm validate passes and docker-promote / docker-verify / artifactory / verify_artifactory all run green.
- [ ] Confirm a workflow_dispatch from a non-main branch is blocked by the environment branch policy (docker-promote and artifactory should fail to start).
- [ ] Optional follow-up: add required reviewers to the `production` environment in repo settings for a manual approval step on dispatch.