### PR TITLE
fix flaky PeerDiscoveryAgentV5Test.shouldEvictPeerWhenPermissionsRevoked

### DIFF
--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/discv5/PeerDiscoveryAgentV5Test.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/discv5/PeerDiscoveryAgentV5Test.java
@@ -104,6 +104,7 @@ class PeerDiscoveryAgentV5Test {
     lenient()
         .when(mockSystem.searchForNewPeers())
         .thenReturn(CompletableFuture.completedFuture(List.of()));
+    lenient().when(mockSystem.streamLiveNodes()).thenAnswer(invocation -> Stream.empty());
 
     agent =
         new PeerDiscoveryAgentV5(
@@ -299,7 +300,7 @@ class PeerDiscoveryAgentV5Test {
   }
 
   @Test
-  public void shouldEvictPeerWhenPermissionsRevoked() {
+  public void shouldEvictPeerWhenPermissionsRevoked() throws Exception {
     final NodeRecord peerNodeRecord =
         NodeRecordFactory.DEFAULT.fromEnr(
             "enr:-KO4QK1ecw-CGrDDZ4YwFrhgqctD0tWMHKJhUVxsS4um3aUFe3yBHRtVL9uYKk16DurN1IdSKTOB1zNCvjBybjZ_KAq"
@@ -321,12 +322,17 @@ class PeerDiscoveryAgentV5Test {
             false,
             (nodeRecord, listener) -> mockSystem);
 
-    try {
-      restrictedAgent.start(1234);
-      restrictedAgent.addPeer(discoveryPeer);
-      Mockito.verify(mockSystem).addNodeRecord(peerNodeRecord);
+    // Pre-stub before start() so the stub is in place before the scheduler thread begins
+    // invoking mockSystem from another thread.
+    Mockito.when(mockSystem.getNodeRecordBuckets()).thenReturn(List.of(List.of(peerNodeRecord)));
 
-      Mockito.when(mockSystem.getNodeRecordBuckets()).thenReturn(List.of(List.of(peerNodeRecord)));
+    try {
+      // Block on start() so the thenApply/whenComplete chain (which schedules the discovery
+      // tick) has fully run before the test thread does anything else.
+      restrictedAgent.start(1234).get();
+      restrictedAgent.addPeer(discoveryPeer);
+      Mockito.verify(mockSystem, Mockito.timeout(5000)).addNodeRecord(peerNodeRecord);
+
       denylist.add(discoveryPeer.getId());
       Mockito.verify(mockSystem, Mockito.timeout(10000)).deleteNodeRecord(discoveryPeer.getId());
     } finally {


### PR DESCRIPTION

## PR description

`PeerDiscoveryAgentV5Test.shouldEvictPeerWhenPermissionsRevoked` is still flaking in CI (`WantedButNotInvoked at PeerDiscoveryAgentV5Test.java:331`) even after PR #10384 wrapped the `deleteNodeRecord` verify in `Mockito.timeout(10000)`.

Root cause: `PeerDiscoveryAgentV5.start()` schedules `discoveryTick` with delay=0, so the `discv5-peer-discovery` scheduler thread starts invoking `mockSystem` (notably `streamLiveNodes`, which is unstubbed in this test) **concurrently** with the test thread's `Mockito.when(...).thenReturn(...)` setup and `verify(...)` calls. That cross-thread mock activity is the race the previous fix's timeout couldn't paper over.

Four test-only changes:

1. **`setUp`** — add a default lenient `streamLiveNodes()` stub returning `Stream.empty()`, alongside the existing `searchForNewPeers` default. The comment already noted these stubs exist "to avoid NPEs from unstubbed Mockito returns" — `streamLiveNodes` belongs in the list. Sibling tests (`candidatePeersFilteredByPeerPermissions`, `candidatePeersAllowedWithNoopPermissions`) already override `streamLiveNodes` explicitly, so they keep their existing behavior.
2. **`shouldEvictPeerWhenPermissionsRevoked`** — pre-stub `getNodeRecordBuckets` **before** `start(...)` so the stub is in place before any concurrent scheduler activity.
3. **`shouldEvictPeerWhenPermissionsRevoked`** — `restrictedAgent.start(1234).get()` to deterministically order the scheduler-setup before subsequent assertions.
4. **`shouldEvictPeerWhenPermissionsRevoked`** — wrap the `addNodeRecord` verify in `Mockito.timeout(5000)`, matching the pattern @Matilda-Clerke already applied to the `deleteNodeRecord` verify in #10384.

Verification:
- 15/15 stress-loop runs of the specific test passed (0 failures).
- Full `:ethereum:p2p:test` suite green.
- `./gradlew spotlessJavaApply` clean.

No production code changes.

## Fixed Issue(s)

fixes #10493

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)