### PR TITLE
Fix LayeredKeyValueStorage.isClosed() duplicated execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - BFT option `xemptyblockperiodseconds` has been taken out of experimental and been renamed `emptyblockperiodseconds`. The old config option is deprecated and will be removed in a future release.
 
 ### Bug fixes
+- Fix `LayeredKeyValueStorage.isClosed()` O(N) recursion that caused CPU saturation (84% of samples in JFR) and blocked chain-head progress under sustained `engine_newPayloadV4` load with a stalled forkchoice head. The closed-state result is now cached per layer, converting the hot path from O(N) to O(1). [#10498](https://github.com/besu-eth/besu/issues/10498)
 - Fix `engine_forkchoiceUpdatedV1` now returns `-38003 INVALID_PAYLOAD_ATTRIBUTES` for invalid payload attribute timestamps (zero or not greater than head). [#10353](https://github.com/besu-eth/besu/pull/10353)
 - Fix `engine_newPayloadV4`/`V5` now returns `-32602 INVALID_PARAMS` instead of `INVALID` payload status when execution requests contain an unknown request type. [#10484](https://github.com/besu-eth/besu/pull/10484)
 - Fix `debug_trace*` `storage` field to emit only for SLOAD/SSTORE opcodes showing the single slot touched, matching the execution-apis spec and geth behaviour [#10176](https://github.com/besu-eth/besu/pull/10176)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - BFT option `xemptyblockperiodseconds` has been taken out of experimental and been renamed `emptyblockperiodseconds`. The old config option is deprecated and will be removed in a future release.
 
 ### Bug fixes
-- Fix `LayeredKeyValueStorage.isClosed()` repeatedly re-walking the full parent chain on every storage operation, causing CPU saturation under a stalled forkchoice head. The closed-state is now cached per layer after the first propagation. [#10498](https://github.com/besu-eth/besu/issues/10498)
+- Fix `LayeredKeyValueStorage.isClosed()` repeatedly re-walking the full parent chain on every storage operation, causing CPU saturation under a stalled forkchoice head. The closed-state is now cached per layer after the first propagation. [#10508](https://github.com/besu-eth/besu/issues/10508)
 - Fix `engine_forkchoiceUpdatedV1` now returns `-38003 INVALID_PAYLOAD_ATTRIBUTES` for invalid payload attribute timestamps (zero or not greater than head). [#10353](https://github.com/besu-eth/besu/pull/10353)
 - Fix `engine_newPayloadV4`/`V5` now returns `-32602 INVALID_PARAMS` instead of `INVALID` payload status when execution requests contain an unknown request type. [#10484](https://github.com/besu-eth/besu/pull/10484)
 - Fix `debug_trace*` `storage` field to emit only for SLOAD/SSTORE opcodes showing the single slot touched, matching the execution-apis spec and geth behaviour [#10176](https://github.com/besu-eth/besu/pull/10176)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - BFT option `xemptyblockperiodseconds` has been taken out of experimental and been renamed `emptyblockperiodseconds`. The old config option is deprecated and will be removed in a future release.
 
 ### Bug fixes
-- Fix `LayeredKeyValueStorage.isClosed()` O(N) recursion that caused CPU saturation (84% of samples in JFR) and blocked chain-head progress under sustained `engine_newPayloadV4` load with a stalled forkchoice head. The closed-state result is now cached per layer, converting the hot path from O(N) to O(1). [#10498](https://github.com/besu-eth/besu/issues/10498)
+- Fix `LayeredKeyValueStorage.isClosed()` repeatedly re-walking the full parent chain on every storage operation, causing CPU saturation under a stalled forkchoice head. The closed-state is now cached per layer after the first propagation. [#10498](https://github.com/besu-eth/besu/issues/10498)
 - Fix `engine_forkchoiceUpdatedV1` now returns `-38003 INVALID_PAYLOAD_ATTRIBUTES` for invalid payload attribute timestamps (zero or not greater than head). [#10353](https://github.com/besu-eth/besu/pull/10353)
 - Fix `engine_newPayloadV4`/`V5` now returns `-32602 INVALID_PARAMS` instead of `INVALID` payload status when execution requests contain an unknown request type. [#10484](https://github.com/besu-eth/besu/pull/10484)
 - Fix `debug_trace*` `storage` field to emit only for SLOAD/SSTORE opcodes showing the single slot touched, matching the execution-apis spec and geth behaviour [#10176](https://github.com/besu-eth/besu/pull/10176)

--- a/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/LayeredKeyValueStorageTest.java
+++ b/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/LayeredKeyValueStorageTest.java
@@ -16,8 +16,11 @@ package org.hyperledger.besu.plugin.services.storage.rocksdb.segmented;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.atMostOnce;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.plugin.services.storage.SegmentIdentifier;
@@ -299,6 +302,45 @@ public class LayeredKeyValueStorageTest {
     assertArrayEquals(value2, resultList.get(1).getValue());
     assertArrayEquals(key3, resultList.get(2).getKey());
     assertArrayEquals(value3, resultList.get(2).getValue());
+  }
+
+  @Test
+  void isClosedReturnsFalseWhenRootIsOpen() {
+    when(parentStorage.isClosed()).thenReturn(false);
+    assertFalse(layeredKeyValueStorage.isClosed());
+  }
+
+  @Test
+  void isClosedReturnsTrueWhenRootIsClosed() {
+    when(parentStorage.isClosed()).thenReturn(true);
+    assertTrue(layeredKeyValueStorage.isClosed());
+  }
+
+  /**
+   * Verifies that isClosed() on a deep chain only queries the root storage once after the closed
+   * state has been cached, regardless of chain depth. This is the O(1) correctness test for the
+   * volatile closedCache fix that eliminates the O(N) recursion hot path (besu-eth/besu#10498).
+   */
+  @Test
+  void isClosedCachesResultOnDeepChainAndQueriesRootAtMostOnce() {
+    // build a chain of depth 100: top -> layer99 -> ... -> layer1 -> parentStorage (the mock root)
+    int depth = 100;
+    LayeredKeyValueStorage top = layeredKeyValueStorage; // wraps parentStorage directly
+    for (int i = 0; i < depth - 1; i++) {
+      top = new LayeredKeyValueStorage(top);
+    }
+
+    when(parentStorage.isClosed()).thenReturn(true);
+
+    // First call at the top of the chain should propagate down to the root and cache at each layer
+    assertTrue(top.isClosed());
+
+    // Second call on the same instance must NOT reach the root again (cache hit)
+    assertTrue(top.isClosed());
+
+    // The root mock should have been queried at most once across both top-level calls because the
+    // intermediate layers cache the result and short-circuit before reaching the root
+    verify(parentStorage, atMostOnce()).isClosed();
   }
 
   /**

--- a/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/LayeredKeyValueStorage.java
+++ b/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/LayeredKeyValueStorage.java
@@ -53,6 +53,13 @@ public class LayeredKeyValueStorage extends SegmentedInMemoryKeyValueStorage
   private final SegmentedKeyValueStorage parent;
 
   /**
+   * Cached result of parent.isClosed(). The closed state transitions from false to true exactly
+   * once per process lifetime and never back, so caching the first true result is safe and converts
+   * the O(N) parent-chain walk into an O(1) check.
+   */
+  private volatile boolean closedCache = false;
+
+  /**
    * Instantiates a new Layered key value storage.
    *
    * @param parent the parent key value storage for this layered storage.
@@ -326,7 +333,14 @@ public class LayeredKeyValueStorage extends SegmentedInMemoryKeyValueStorage
 
   @Override
   public boolean isClosed() {
-    return parent.isClosed();
+    if (closedCache) {
+      return true;
+    }
+    if (parent.isClosed()) {
+      closedCache = true;
+      return true;
+    }
+    return false;
   }
 
   @Override
@@ -335,7 +349,7 @@ public class LayeredKeyValueStorage extends SegmentedInMemoryKeyValueStorage
   }
 
   private void throwIfClosed() {
-    if (parent.isClosed()) {
+    if (isClosed()) {
       LOG.error("Attempting to use a closed RocksDBKeyValueStorage");
       throw new StorageException("Storage has been closed");
     }


### PR DESCRIPTION
Under a sustained engine_newPayloadV4 load with a stalled forkchoice
head, LayeredKeyValueStorage layers accumulate. isClosed() delegated
to parent.isClosed() via unbounded tail recursion, so every get(),
stream(), streamKeys(), and startTransaction() call walked the entire
layer chain. JFR showed 84% of CPU samples in isClosed() with 512+
cached layers, blocking chain-head progress entirely.

Fix: add a volatile boolean closedCache field. The closed state
transitions from false to true exactly once per process lifetime
(at shutdown) and never back, so caching the first true result is
safe. This converts the O(N) hot path to O(1) after the first propagation.

Also change throwIfClosed() to call this.isClosed() so it benefits
from the same cache rather than calling parent.isClosed() directly.

Refs #10498

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Signed-off-by: Sally MacFarlane <macfarla.github@gmail.com>## PR description

### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)