### PR TITLE
Consider maxFeePerBlobGas when sorting tx in the layered txpool

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/Transaction.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/Transaction.java
@@ -1149,8 +1149,15 @@ public class Transaction
         sb.append("], ");
       }
     }
-    if (transactionType.supportsBlob() && this.blobsWithCommitments.isPresent()) {
-      sb.append("numberOfBlobs=").append(blobsWithCommitments.get().getBlobs().size()).append(", ");
+    if (transactionType.supportsBlob()) {
+      sb.append("numberOfBlobs=")
+          .append(blobsWithCommitments.map(bwc -> bwc.getBlobs().size()).orElse(-1))
+          .append(", ");
+    }
+    if (transactionType.supportsDelegateCode()) {
+      sb.append("numberOfCodeDelegations=")
+          .append(maybeCodeDelegationList.map(List::size).orElse(-1))
+          .append(", ");
     }
     sb.append("payload=").append(getPayload());
     return sb.append("}").toString();
@@ -1178,6 +1185,14 @@ public class Transaction
           .append(", ");
       getMaxFeePerBlobGas()
           .ifPresent(wei -> sb.append("df: ").append(wei.toHumanReadableString()).append(", "));
+    }
+    if (transactionType.supportsBlob()) {
+      sb.append("b: ")
+          .append(blobsWithCommitments.map(bwc -> bwc.getBlobs().size()).orElse(-1))
+          .append(", ");
+    }
+    if (transactionType.supportsDelegateCode()) {
+      sb.append("cd: ").append(maybeCodeDelegationList.map(List::size).orElse(-1)).append(", ");
     }
     sb.append("gl: ").append(getGasLimit()).append(", ");
     sb.append("v: ").append(getValue().toHumanReadableString()).append(", ");

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/layered/BaseFeePrioritizedTransactions.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/layered/BaseFeePrioritizedTransactions.java
@@ -76,6 +76,9 @@ public class BaseFeePrioritizedTransactions extends AbstractPrioritizedTransacti
                 pendingTransaction.getTransaction().getEffectivePriorityFeePerGas(nextBlockBaseFee))
         .thenComparing(
             (PendingTransaction pendingTransaction) ->
+                pendingTransaction.getTransaction().getMaxFeePerBlobGas().orElse(Wei.ZERO))
+        .thenComparing(
+            (PendingTransaction pendingTransaction) ->
                 pendingTransaction.getTransaction().getMaxGasPrice())
         .thenComparing(Comparator.comparing(PendingTransaction::getNonce).reversed())
         .thenComparing(PendingTransaction::getSequence)


### PR DESCRIPTION
## PR description

Change the prioritized layer given all other things being equal, sort tx by arrival time first.
Bonus added some missing fields when printing tx for logs.

This small change has the effect of making the last failing Hive test (Blob Transaction Ordering, Multiple Accounts (Cancun)) in the `engine-cancun` suite pass. 
Actually the Hive test should not make assumption on the tx ordering, since that is implementation dependent, but the change seems reasonable and fair, so that is a win-win

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


