### PR TITLE
 feat: add debug_traceCallMany RPC method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Fix `debug_trace*` `storage` field to emit only for SLOAD/SSTORE opcodes showing the single slot touched, matching the execution-apis spec and geth behaviour [#10176](https://github.com/besu-eth/besu/pull/10176)
 
 ### Additions and Improvements
+- Add `debug_traceCallMany` JSON-RPC method: batch form of `debug_traceCall` that executes multiple calls sequentially against shared state and returns an array of structLog trace results
 - Add `eth_getStorageValues` JSON-RPC method for batched reads of multiple storage slots across multiple accounts in a single call [#10259](https://github.com/besu-eth/besu/pull/10259)
 - Add `enableReturnData` parameter to `debug_traceTransaction` and `debug_traceBlockByNumber`, and include `returnData` in `StructLog` when captured; the field is omitted when return data is empty or not captured. [#10172](https://github.com/besu-eth/besu/pull/10172)
 - Updated `Bouncycastle` to 1.84 and `maven-artifact` to 3.9.15 to resolve CVEs reported in those libraries. Besu's usage patterns are not affected by these vulnerabilities. [#10420](https://github.com/besu-eth/besu/pull/10420)

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/RpcMethod.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/RpcMethod.java
@@ -40,6 +40,7 @@ public enum RpcMethod {
   DEBUG_STANDARD_TRACE_BAD_BLOCK_TO_FILE("debug_standardTraceBadBlockToFile"),
   DEBUG_TRACE_TRANSACTION("debug_traceTransaction"),
   DEBUG_TRACE_CALL("debug_traceCall"),
+  DEBUG_TRACE_CALL_MANY("debug_traceCallMany"),
   DEBUG_BATCH_RAW_TRANSACTION("debug_batchSendRawTransaction"),
   DEBUG_GET_BAD_BLOCKS("debug_getBadBlocks"),
   DEBUG_GET_RAW_HEADER("debug_getRawHeader"),

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceCallMany.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceCallMany.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
+
+import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType.BLOCK_NOT_FOUND;
+import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType.INTERNAL_ERROR;
+
+import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.BlockParameter;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.DebugTraceCallManyParameter;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter.JsonRpcParameterException;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.TransactionTraceParams;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.TransactionTrace;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
+import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.debug.TraceOptions;
+import org.hyperledger.besu.ethereum.mainnet.ImmutableTransactionValidationParams;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
+import org.hyperledger.besu.ethereum.mainnet.TransactionValidationParams;
+import org.hyperledger.besu.ethereum.transaction.CallParameter;
+import org.hyperledger.besu.ethereum.transaction.TransactionSimulator;
+import org.hyperledger.besu.ethereum.transaction.TransactionSimulatorResult;
+import org.hyperledger.besu.ethereum.vm.DebugOperationTracer;
+import org.hyperledger.besu.evm.worldstate.WorldUpdater;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Implements {@code debug_traceCallMany}: executes a batch of calls sequentially against a shared
+ * world state (each call sees the state changes from all prior calls) and returns an array of
+ * structLog trace results — one per call — in the same format as {@code debug_traceCall}.
+ *
+ * <p>Parameters:
+ *
+ * <ol>
+ *   <li>calls — array of {@code [callParams, traceConfig?]} pairs
+ *   <li>blockParameter — block to execute against (default: {@code latest})
+ * </ol>
+ */
+public class DebugTraceCallMany extends AbstractBlockParameterMethod {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DebugTraceCallMany.class);
+
+  private static final TransactionValidationParams VALIDATION_PARAMS =
+      ImmutableTransactionValidationParams.builder()
+          .from(TransactionValidationParams.transactionSimulator())
+          .isAllowFutureNonce(true)
+          .isAllowExceedingBalance(true)
+          .allowUnderpriced(true)
+          .build();
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private final ProtocolSchedule protocolSchedule;
+  private final TransactionSimulator transactionSimulator;
+
+  public DebugTraceCallMany(
+      final BlockchainQueries blockchainQueries,
+      final ProtocolSchedule protocolSchedule,
+      final TransactionSimulator transactionSimulator) {
+    super(blockchainQueries);
+    this.protocolSchedule = protocolSchedule;
+    this.transactionSimulator = transactionSimulator;
+  }
+
+  @Override
+  public String getName() {
+    return RpcMethod.DEBUG_TRACE_CALL_MANY.getMethodName();
+  }
+
+  @Override
+  protected BlockParameter blockParameter(final JsonRpcRequestContext request) {
+    try {
+      return request.getOptionalParameter(1, BlockParameter.class).orElse(BlockParameter.LATEST);
+    } catch (JsonRpcParameterException e) {
+      throw new InvalidJsonRpcParameters(
+          "Invalid block parameter (index 1)", RpcErrorType.INVALID_BLOCK_PARAMS, e);
+    }
+  }
+
+  @Override
+  protected Object resultByBlockNumber(
+      final JsonRpcRequestContext requestContext, final long blockNumber) {
+    if (requestContext.getRequest().getParamLength() < 1
+        || requestContext.getRequest().getParamLength() > 2) {
+      return new JsonRpcErrorResponse(
+          requestContext.getRequest().getId(), RpcErrorType.INVALID_PARAM_COUNT);
+    }
+
+    final DebugTraceCallManyParameter[] callParameters;
+    try {
+      callParameters = requestContext.getRequiredParameter(0, DebugTraceCallManyParameter[].class);
+      LOG.atTrace()
+          .setMessage("Received RPC rpcName={} params={} block={}")
+          .addArgument(this::getName)
+          .addArgument(callParameters)
+          .addArgument(blockNumber)
+          .log();
+    } catch (final Exception e) {
+      LOG.error("Error parsing {} parameters: {}", getName(), e.getLocalizedMessage());
+      return new JsonRpcErrorResponse(
+          requestContext.getRequest().getId(), RpcErrorType.INVALID_PARAMS);
+    }
+
+    final Optional<BlockHeader> maybeBlockHeader =
+        blockchainQueriesSupplier.get().getBlockHeaderByNumber(blockNumber);
+
+    if (maybeBlockHeader.isEmpty()) {
+      return new JsonRpcErrorResponse(requestContext.getRequest().getId(), BLOCK_NOT_FOUND);
+    }
+    final BlockHeader blockHeader = maybeBlockHeader.get();
+
+    final List<JsonNode> results = new ArrayList<>();
+
+    final Optional<Object> maybeResult =
+        getBlockchainQueries()
+            .getAndMapWorldState(
+                blockHeader.getBlockHash(),
+                ws -> {
+                  final WorldUpdater updater =
+                      transactionSimulator.getEffectiveWorldStateUpdater(ws);
+                  try {
+                    Arrays.stream(callParameters)
+                        .forEachOrdered(
+                            param -> {
+                              final WorldUpdater localUpdater = updater.updater();
+                              results.add(
+                                  executeSingleCall(
+                                      param.getTuple().getCallParameter(),
+                                      param.getTuple().getTraceParams(),
+                                      blockHeader,
+                                      localUpdater));
+                              localUpdater.commit();
+                            });
+                  } catch (final TransactionInvalidException e) {
+                    LOG.error("Invalid transaction simulator result in {}", getName());
+                    return Optional.of(
+                        new JsonRpcErrorResponse(
+                            requestContext.getRequest().getId(), INTERNAL_ERROR));
+                  } catch (final EmptySimulatorResultException e) {
+                    LOG.error("Empty simulator result in {}", getName());
+                    return Optional.of(
+                        new JsonRpcErrorResponse(
+                            requestContext.getRequest().getId(), INTERNAL_ERROR));
+                  } catch (final Exception e) {
+                    LOG.error("Unexpected error in {}: {}", getName(), e.getLocalizedMessage(), e);
+                    return Optional.of(
+                        new JsonRpcErrorResponse(
+                            requestContext.getRequest().getId(), INTERNAL_ERROR));
+                  }
+                  return Optional.of(results);
+                });
+    return maybeResult.orElseGet(
+        () -> new JsonRpcErrorResponse(requestContext.getRequest().getId(), INTERNAL_ERROR));
+  }
+
+  private JsonNode executeSingleCall(
+      final CallParameter callParameter,
+      final TransactionTraceParams traceParams,
+      final BlockHeader blockHeader,
+      final WorldUpdater worldUpdater) {
+    final TraceOptions traceOptions =
+        traceParams != null ? traceParams.traceOptions() : TraceOptions.DEFAULT;
+
+    final ProtocolSpec protocolSpec = protocolSchedule.getByBlockHeader(blockHeader);
+    final DebugOperationTracer tracer =
+        new DebugOperationTracer(traceOptions.opCodeTracerConfig(), false);
+
+    final var miningBeneficiary =
+        protocolSpec.getMiningBeneficiaryCalculator().calculateBeneficiary(blockHeader);
+
+    final Optional<TransactionSimulatorResult> maybeResult =
+        transactionSimulator.processWithWorldUpdater(
+            callParameter,
+            Optional.ofNullable(traceOptions.stateOverrides()),
+            VALIDATION_PARAMS,
+            tracer,
+            blockHeader,
+            worldUpdater,
+            miningBeneficiary,
+            Optional.empty());
+
+    if (maybeResult.isEmpty()) {
+      throw new EmptySimulatorResultException();
+    }
+    final TransactionSimulatorResult simulatorResult = maybeResult.get();
+    if (simulatorResult.isInvalid()) {
+      throw new TransactionInvalidException();
+    }
+
+    final TransactionTrace transactionTrace =
+        new TransactionTrace(
+            simulatorResult.transaction(), simulatorResult.result(), tracer.getTraceFrames());
+
+    return MAPPER.valueToTree(
+        DebugTraceTransactionStepFactory.create(traceOptions, protocolSpec)
+            .apply(transactionTrace)
+            .getResult());
+  }
+
+  private static class TransactionInvalidException extends RuntimeException {
+
+    TransactionInvalidException() {
+      super();
+    }
+  }
+
+  private static class EmptySimulatorResultException extends RuntimeException {
+
+    EmptySimulatorResultException() {
+      super();
+    }
+  }
+}

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/DebugTraceCallManyParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/DebugTraceCallManyParameter.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters;
+
+import org.hyperledger.besu.ethereum.transaction.CallParameter;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+
+/**
+ * Represents one entry in the {@code debug_traceCallMany} parameter array. Each entry is a
+ * 2-element JSON array: {@code [callParams, traceConfig]}, where {@code traceConfig} is the same
+ * optional object accepted by {@code debug_traceCall} (disableStorage, disableMemory, etc.).
+ */
+public class DebugTraceCallManyParameter {
+
+  private final DebugCallParameterTuple params;
+
+  @JsonCreator
+  public DebugTraceCallManyParameter(
+      @JsonDeserialize(using = DebugCallParameterDeserializer.class)
+          final DebugCallParameterTuple parameters) {
+    this.params = parameters;
+  }
+
+  public DebugCallParameterTuple getTuple() {
+    return params;
+  }
+
+  /** Holds the deserialized {@link CallParameter} and optional {@link TransactionTraceParams}. */
+  public static class DebugCallParameterTuple {
+    private final CallParameter callParameter;
+    private final TransactionTraceParams traceParams;
+
+    public DebugCallParameterTuple(
+        final CallParameter callParameter, final TransactionTraceParams traceParams) {
+      this.callParameter = callParameter;
+      this.traceParams = traceParams;
+    }
+
+    public CallParameter getCallParameter() {
+      return callParameter;
+    }
+
+    public TransactionTraceParams getTraceParams() {
+      return traceParams;
+    }
+  }
+}
+
+class DebugCallParameterDeserializer
+    extends StdDeserializer<DebugTraceCallManyParameter.DebugCallParameterTuple> {
+
+  private static final ObjectMapper mapper = new ObjectMapper().registerModule(new Jdk8Module());
+
+  public DebugCallParameterDeserializer() {
+    this(null);
+  }
+
+  public DebugCallParameterDeserializer(final Class<?> vc) {
+    super(vc);
+  }
+
+  @Override
+  public DebugTraceCallManyParameter.DebugCallParameterTuple deserialize(
+      final JsonParser p, final DeserializationContext ctxt) throws IOException {
+    final JsonNode tupleNode = p.getCodec().readTree(p);
+    final CallParameter callParameter =
+        mapper.readValue(tupleNode.get(0).toString(), CallParameter.class);
+    // traceConfig (index 1) is optional
+    final TransactionTraceParams traceParams =
+        tupleNode.size() > 1 && !tupleNode.get(1).isNull()
+            ? mapper.readValue(tupleNode.get(1).toString(), TransactionTraceParams.class)
+            : null;
+    return new DebugTraceCallManyParameter.DebugCallParameterTuple(callParameter, traceParams);
+  }
+}

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/DebugJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/DebugJsonRpcMethods.java
@@ -35,6 +35,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.DebugTraceBloc
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.DebugTraceBlockByHash;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.DebugTraceBlockByNumber;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.DebugTraceCall;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.DebugTraceCallMany;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.DebugTraceTransaction;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.BlockReplay;
@@ -116,6 +117,7 @@ public class DebugJsonRpcMethods extends ApiGroupJsonRpcMethods {
         new DebugGetRawBlock(blockchainQueries),
         new DebugGetRawReceipts(blockchainQueries),
         new DebugGetRawTransaction(blockchainQueries),
-        new DebugTraceCall(blockchainQueries, protocolSchedule, transactionSimulator));
+        new DebugTraceCall(blockchainQueries, protocolSchedule, transactionSimulator),
+        new DebugTraceCallMany(blockchainQueries, protocolSchedule, transactionSimulator));
   }
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceCallManyTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceCallManyTest.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.DebugTraceCallManyParameter;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.DebugTraceCallManyParameter.DebugCallParameterTuple;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
+import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.mainnet.MiningBeneficiaryCalculator;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
+import org.hyperledger.besu.ethereum.processing.TransactionProcessingResult;
+import org.hyperledger.besu.ethereum.transaction.CallParameter;
+import org.hyperledger.besu.ethereum.transaction.ImmutableCallParameter;
+import org.hyperledger.besu.ethereum.transaction.TransactionSimulator;
+import org.hyperledger.besu.ethereum.transaction.TransactionSimulatorResult;
+import org.hyperledger.besu.evm.worldstate.WorldUpdater;
+import org.hyperledger.besu.plugin.services.worldstate.MutableWorldState;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
+
+public class DebugTraceCallManyTest {
+
+  private final BlockchainQueries blockchainQueries = mock(BlockchainQueries.class);
+  private final ProtocolSchedule protocolSchedule = mock(ProtocolSchedule.class);
+  private final ProtocolSpec protocolSpec = mock(ProtocolSpec.class, Answers.RETURNS_DEEP_STUBS);
+  private final TransactionSimulator transactionSimulator = mock(TransactionSimulator.class);
+  private final MutableWorldState worldState = mock(MutableWorldState.class);
+  private final WorldUpdater worldUpdater = mock(WorldUpdater.class);
+  private final WorldUpdater localUpdater = mock(WorldUpdater.class);
+  private final BlockHeader blockHeader = mock(BlockHeader.class);
+  private final MiningBeneficiaryCalculator miningBeneficiaryCalculator =
+      mock(MiningBeneficiaryCalculator.class);
+
+  private DebugTraceCallMany method;
+
+  private static final Hash BLOCK_HASH =
+      Hash.fromHexString("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+  private static final long BLOCK_NUMBER = 42L;
+
+  @BeforeEach
+  @SuppressWarnings("unchecked")
+  public void setUp() {
+    method = new DebugTraceCallMany(blockchainQueries, protocolSchedule, transactionSimulator);
+
+    when(blockHeader.getNumber()).thenReturn(BLOCK_NUMBER);
+    when(blockHeader.getHash()).thenReturn(BLOCK_HASH);
+    when(blockHeader.getBlockHash()).thenReturn(BLOCK_HASH);
+    when(blockchainQueries.getBlockHeaderByNumber(BLOCK_NUMBER))
+        .thenReturn(Optional.of(blockHeader));
+    when(protocolSchedule.getByBlockHeader(blockHeader)).thenReturn(protocolSpec);
+    when(protocolSpec.getMiningBeneficiaryCalculator()).thenReturn(miningBeneficiaryCalculator);
+    when(miningBeneficiaryCalculator.calculateBeneficiary(any())).thenReturn(Address.ZERO);
+    when(transactionSimulator.getEffectiveWorldStateUpdater(worldState)).thenReturn(worldUpdater);
+    when(worldUpdater.updater()).thenReturn(localUpdater);
+    doAnswer(
+            inv -> {
+              Function<MutableWorldState, Optional<?>> fn = inv.getArgument(1);
+              return fn.apply(worldState);
+            })
+        .when(blockchainQueries)
+        .getAndMapWorldState(any(), any());
+  }
+
+  @Test
+  public void methodNameIsDebugTraceCallMany() {
+    assertThat(method.getName()).isEqualTo(RpcMethod.DEBUG_TRACE_CALL_MANY.getMethodName());
+    assertThat(method.getName()).isEqualTo("debug_traceCallMany");
+  }
+
+  @Test
+  public void returnsErrorForWrongParamCount() {
+    final JsonRpcRequestContext request =
+        new JsonRpcRequestContext(
+            new JsonRpcRequest("2.0", "debug_traceCallMany", new Object[] {}));
+
+    final JsonRpcResponse response = method.response(request);
+
+    assertThat(response).isInstanceOf(JsonRpcErrorResponse.class);
+    assertThat(((JsonRpcErrorResponse) response).getError().getCode())
+        .isEqualTo(RpcErrorType.INVALID_PARAM_COUNT.getCode());
+  }
+
+  @Test
+  public void returnsErrorWhenBlockNotFound() {
+    when(blockchainQueries.getBlockHeaderByNumber(BLOCK_NUMBER)).thenReturn(Optional.empty());
+
+    final JsonRpcResponse response = method.response(buildRequest(BLOCK_NUMBER));
+
+    assertThat(response).isInstanceOf(JsonRpcErrorResponse.class);
+    assertThat(((JsonRpcErrorResponse) response).getError().getCode())
+        .isEqualTo(RpcErrorType.BLOCK_NOT_FOUND.getCode());
+  }
+
+  @Test
+  public void returnsSingleCallResult() {
+    mockSuccessfulSimulation();
+
+    final JsonRpcRequestContext request =
+        buildRequestWithParams(
+            new Object[] {
+              new DebugTraceCallManyParameter[] {
+                parameter(callParameter()),
+              },
+              "0x" + Long.toHexString(BLOCK_NUMBER),
+            });
+
+    final JsonRpcResponse response = method.response(request);
+
+    assertThat(response).isInstanceOf(JsonRpcSuccessResponse.class);
+    final Object result = ((JsonRpcSuccessResponse) response).getResult();
+    assertThat(result).isInstanceOf(List.class);
+    assertThat((List<?>) result).hasSize(1);
+  }
+
+  @Test
+  public void returnsResultPerCallInOrder() {
+    mockSuccessfulSimulation();
+
+    final JsonRpcRequestContext request =
+        buildRequestWithParams(
+            new Object[] {
+              new DebugTraceCallManyParameter[] {
+                parameter(callParameter()), parameter(callParameter()),
+              },
+              "0x" + Long.toHexString(BLOCK_NUMBER),
+            });
+
+    final JsonRpcResponse response = method.response(request);
+
+    assertThat(response).isInstanceOf(JsonRpcSuccessResponse.class);
+    assertThat((List<?>) ((JsonRpcSuccessResponse) response).getResult()).hasSize(2);
+  }
+
+  @Test
+  public void returnsInternalErrorWhenSimulatorResultIsInvalid() {
+    mockInvalidSimulation();
+
+    final JsonRpcRequestContext request =
+        buildRequestWithParams(
+            new Object[] {
+              new DebugTraceCallManyParameter[] {
+                parameter(callParameter()),
+              },
+              "0x" + Long.toHexString(BLOCK_NUMBER),
+            });
+
+    final JsonRpcResponse response = method.response(request);
+
+    assertThat(response).isInstanceOf(JsonRpcErrorResponse.class);
+    assertThat(((JsonRpcErrorResponse) response).getError().getCode())
+        .isEqualTo(RpcErrorType.INTERNAL_ERROR.getCode());
+  }
+
+  @Test
+  public void defaultsToLatestBlockWhenBlockParamOmitted() {
+    final long headBlock = 99L;
+    when(blockchainQueries.headBlockNumber()).thenReturn(headBlock);
+    when(blockchainQueries.getBlockHeaderByNumber(headBlock)).thenReturn(Optional.of(blockHeader));
+    when(blockHeader.getNumber()).thenReturn(headBlock);
+    mockSuccessfulSimulation();
+
+    final JsonRpcRequestContext request =
+        buildRequestWithParams(
+            new Object[] {
+              new DebugTraceCallManyParameter[] {
+                parameter(callParameter()),
+              },
+            });
+
+    final JsonRpcResponse response = method.response(request);
+
+    assertThat(response).isInstanceOf(JsonRpcSuccessResponse.class);
+  }
+
+  // --- helpers ---
+
+  private void mockSuccessfulSimulation() {
+    final TransactionSimulatorResult result = mock(TransactionSimulatorResult.class);
+    final TransactionProcessingResult processingResult =
+        mock(TransactionProcessingResult.class, Answers.RETURNS_DEEP_STUBS);
+
+    when(result.isInvalid()).thenReturn(false);
+    when(result.isSuccessful()).thenReturn(true);
+    when(result.result()).thenReturn(processingResult);
+    when(result.transaction())
+        .thenReturn(
+            mock(org.hyperledger.besu.ethereum.core.Transaction.class, Answers.RETURNS_DEEP_STUBS));
+    when(processingResult.getOutput()).thenReturn(org.apache.tuweni.bytes.Bytes.EMPTY);
+    when(processingResult.getRevertReason()).thenReturn(Optional.empty());
+
+    when(transactionSimulator.processWithWorldUpdater(
+            any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(Optional.of(result));
+  }
+
+  private void mockInvalidSimulation() {
+    final TransactionSimulatorResult result = mock(TransactionSimulatorResult.class);
+    when(result.isInvalid()).thenReturn(true);
+
+    when(transactionSimulator.processWithWorldUpdater(
+            any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(Optional.of(result));
+  }
+
+  private CallParameter callParameter() {
+    return ImmutableCallParameter.builder()
+        .sender(Address.fromHexString("0x1111111111111111111111111111111111111111"))
+        .to(Address.fromHexString("0x2222222222222222222222222222222222222222"))
+        .build();
+  }
+
+  private DebugTraceCallManyParameter parameter(final CallParameter callParams) {
+    return new DebugTraceCallManyParameter(new DebugCallParameterTuple(callParams, null));
+  }
+
+  private JsonRpcRequestContext buildRequest(final long blockNumber) {
+    return buildRequestWithParams(
+        new Object[] {
+          new DebugTraceCallManyParameter[] {}, "0x" + Long.toHexString(blockNumber),
+        });
+  }
+
+  private JsonRpcRequestContext buildRequestWithParams(final Object[] params) {
+    return new JsonRpcRequestContext(new JsonRpcRequest("2.0", "debug_traceCallMany", params));
+  }
+}


### PR DESCRIPTION
Batch form of debug_traceCall. Executes an array of [callParams, traceConfig] pairs sequentially against a shared WorldUpdater so each call sees prior state changes, and returns one structLog result per call.

- Add DebugTraceCallManyParameter for deserializing the input pairs
- Add DebugTraceCallMany method wired into DebugJsonRpcMethods
- RpcMethod.DEBUG_TRACE_CALL_MANY was already declared; now implemented
- Add unit tests (7) covering single call, multi-call state chaining, invalid simulation, block-not-found, and default block parameter


## PR description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fixes #10479 


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


