### PR TITLE
build: exclude referencetests from spotless when running locally

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -238,46 +238,46 @@ configure(allprojects - project(':platform')) {
 
   if (System.getenv('CI') || project.path != ':ethereum:referencetests') {
     apply plugin: 'com.diffplug.spotless'
-  }
-  spotless {
-    java {
-      // This path needs to be relative to each project
-      target 'src/**/*.java'
-      targetExclude '**/src/reference-test/**', '**/src/main/generated/**', '**/src/test/generated/**', '**/src/jmh/generated/**', '**/build/generated/**'
-      removeUnusedImports()
-      googleJavaFormat('1.35.0')
-      importOrder 'org.hyperledger', 'java', ''
-      trimTrailingWhitespace()
-      endWithNewline()
-      // apply appropriate license header files.
-      licenseHeaderFile("${rootDir}/gradle/spotless/java.former.license").named("older").onlyIfContentMatches("^/\\*\\r?\\n.*Copyright ConsenSys AG\\.")
-      licenseHeaderFile("${rootDir}/gradle/spotless/java.former.date.license").named("older.year").onlyIfContentMatches("^/\\*\\r?\\n.* Copyright \\d{4} ConsenSys AG\\.")
-      licenseHeaderFile("${rootDir}/gradle/spotless/java.current.license").named("current").onlyIfContentMatches("^(?!/\\*\\r?\\n \\*.*(ConsenSys AG|Hyperledger Besu)\\.)")
-    }
-    // spotless check applied to build.gradle (groovy) files
-    groovyGradle {
-      target '*.gradle'
-      greclipse('4.31').configFile(rootProject.file('gradle/spotless/greclipse.properties'))
-      endWithNewline()
-    }
-    // Below this line are currently only license header tasks
-    format 'ShellScripts', {
-      target '**/*.sh'
-      targetExclude '**/src/reference-test/**', '**/src/main/generated/**', '**/src/test/generated/**', '**/src/jmh/generated/**', '**/bin/default/**'
-      trimTrailingWhitespace()
-      endWithNewline()
+    spotless {
+      java {
+        // This path needs to be relative to each project
+        target 'src/**/*.java'
+        targetExclude '**/src/reference-test/**', '**/src/main/generated/**', '**/src/test/generated/**', '**/src/jmh/generated/**', '**/build/generated/**'
+        removeUnusedImports()
+        googleJavaFormat('1.35.0')
+        importOrder 'org.hyperledger', 'java', ''
+        trimTrailingWhitespace()
+        endWithNewline()
+        // apply appropriate license header files.
+        licenseHeaderFile("${rootDir}/gradle/spotless/java.former.license").named("older").onlyIfContentMatches("^/\\*\\r?\\n.*Copyright ConsenSys AG\\.")
+        licenseHeaderFile("${rootDir}/gradle/spotless/java.former.date.license").named("older.year").onlyIfContentMatches("^/\\*\\r?\\n.* Copyright \\d{4} ConsenSys AG\\.")
+        licenseHeaderFile("${rootDir}/gradle/spotless/java.current.license").named("current").onlyIfContentMatches("^(?!/\\*\\r?\\n \\*.*(ConsenSys AG|Hyperledger Besu)\\.)")
+      }
+      // spotless check applied to build.gradle (groovy) files
+      groovyGradle {
+        target '*.gradle'
+        greclipse('4.31').configFile(rootProject.file('gradle/spotless/greclipse.properties'))
+        endWithNewline()
+      }
+      // Below this line are currently only license header tasks
+      format 'ShellScripts', {
+        target '**/*.sh'
+        targetExclude '**/src/reference-test/**', '**/src/main/generated/**', '**/src/test/generated/**', '**/src/jmh/generated/**', '**/bin/default/**'
+        trimTrailingWhitespace()
+        endWithNewline()
 
-      licenseHeaderFile("${rootDir}/gradle/spotless/sh.license","^(?!##).+").skipLinesMatching("^#!.+?\$")
-    }
-    format 'Solidity', {
-      target '**/*.sol'
-      targetExclude '**/src/reference-test/**', '**/src/main/generated/**', '**/src/test/generated/**', '**/src/jmh/generated/**', '**/bin/default/**'
-      trimTrailingWhitespace()
-      endWithNewline()
+        licenseHeaderFile("${rootDir}/gradle/spotless/sh.license","^(?!##).+").skipLinesMatching("^#!.+?\$")
+      }
+      format 'Solidity', {
+        target '**/*.sol'
+        targetExclude '**/src/reference-test/**', '**/src/main/generated/**', '**/src/test/generated/**', '**/src/jmh/generated/**', '**/bin/default/**'
+        trimTrailingWhitespace()
+        endWithNewline()
 
-      licenseHeaderFile("${rootDir}/gradle/spotless/java.former.license","^pragma solidity.+?").named("former").onlyIfContentMatches("^/\\*\\r?\\n.*Copyright ConsenSys AG\\.")
-      licenseHeaderFile("${rootDir}/gradle/spotless/java.former.date.license","^pragma solidity.+?").named("former.date").onlyIfContentMatches("^/\\*\\r?\\n.* Copyright \\d{4} ConsenSys AG\\.")
-      licenseHeaderFile("${rootDir}/gradle/spotless/java.current.license","^pragma solidity.+?").named("current").onlyIfContentMatches("^(?!/\\*\\r?\\n \\*.*(ConsenSys AG|Hyperledger Besu)\\.)")
+        licenseHeaderFile("${rootDir}/gradle/spotless/java.former.license","^pragma solidity.+?").named("former").onlyIfContentMatches("^/\\*\\r?\\n.*Copyright ConsenSys AG\\.")
+        licenseHeaderFile("${rootDir}/gradle/spotless/java.former.date.license","^pragma solidity.+?").named("former.date").onlyIfContentMatches("^/\\*\\r?\\n.* Copyright \\d{4} ConsenSys AG\\.")
+        licenseHeaderFile("${rootDir}/gradle/spotless/java.current.license","^pragma solidity.+?").named("current").onlyIfContentMatches("^(?!/\\*\\r?\\n \\*.*(ConsenSys AG|Hyperledger Besu)\\.)")
+      }
     }
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -236,7 +236,9 @@ configure(allprojects - project(':platform')) {
   }
 
 
-  apply plugin: 'com.diffplug.spotless'
+  if (System.getenv('CI') || project.path != ':ethereum:referencetests') {
+    apply plugin: 'com.diffplug.spotless'
+  }
   spotless {
     java {
       // This path needs to be relative to each project


### PR DESCRIPTION
## Summary

- The `ethereum:referencetests` module contains thousands of auto-generated Java test files, making `spotlessJavaApply` very slow locally (4+ minutes)
- When the `CI` environment variable is set (GitHub Actions, Jenkins, etc.), referencetests is included in spotless as before
- Locally (no `CI` env var), the spotless plugin is not applied to the referencetests module, skipping it entirely

## Test plan

- [x] `./gradlew :ethereum:api:spotlessJavaCheck` passes locally
- [x] `./gradlew :ethereum:referencetests:tasks --group spotless` shows "No tasks" locally
- CI will still run spotless on referencetests via the `CI` env var check

🤖 Generated with [Claude Code](https://claude.ai/code)