### PR TITLE
Fix unavailable BAL handling in snap

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/SyncBlockAccessList.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/SyncBlockAccessList.java
@@ -32,8 +32,8 @@ public class SyncBlockAccessList {
     return rlp;
   }
 
-  public boolean isEmpty() {
-    return rlp.equals(RLP.EMPTY_LIST);
+  public boolean isUnavailable() {
+    return rlp.equals(RLP.NULL);
   }
 
   @Override

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/snap/GetBlockAccessListsFromPeerTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/snap/GetBlockAccessListsFromPeerTask.java
@@ -128,7 +128,7 @@ public class GetBlockAccessListsFromPeerTask
                 .formatted(blockHeaders.size(), index + 1));
       }
       final SyncBlockAccessList syncBlockAccessList = new SyncBlockAccessList(balRlp);
-      if (!syncBlockAccessList.isEmpty()) {
+      if (!syncBlockAccessList.isUnavailable()) {
         final int currentIndex = index;
         final BlockHeader blockHeader = blockHeaders.get(currentIndex);
         final Hash expected =

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/DownloadAndPersistBlockAccessListsStep.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/DownloadAndPersistBlockAccessListsStep.java
@@ -120,6 +120,9 @@ public class DownloadAndPersistBlockAccessListsStep
     for (int i = 0; i < persistedCount; i++) {
       final BlockHeader header = balEnabledHeaders.get(i);
       final SyncBlockAccessList syncBlockAccessList = syncBlockAccessLists.get(i);
+      if (syncBlockAccessList.isUnavailable()) {
+        continue;
+      }
       try {
         updater.putSyncBlockAccessList(header.getHash(), syncBlockAccessList);
       } catch (final Exception exception) {

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/snap/GetBlockAccessListsFromPeerTaskTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/snap/GetBlockAccessListsFromPeerTaskTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.eth.manager.snap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.core.BlockDataGenerator;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.core.SyncBlockAccessList;
+import org.hyperledger.besu.ethereum.eth.SnapProtocol;
+import org.hyperledger.besu.ethereum.eth.manager.EthContext;
+import org.hyperledger.besu.ethereum.eth.manager.EthPeer;
+import org.hyperledger.besu.ethereum.eth.manager.EthPeerImmutableAttributes;
+import org.hyperledger.besu.ethereum.eth.manager.exceptions.ProtocolViolationException;
+import org.hyperledger.besu.ethereum.eth.messages.snap.BlockAccessListsMessage;
+import org.hyperledger.besu.ethereum.mainnet.BodyValidation;
+import org.hyperledger.besu.ethereum.mainnet.block.access.list.BlockAccessList;
+import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Capability;
+import org.hyperledger.besu.ethereum.p2p.rlpx.wire.MessageData;
+import org.hyperledger.besu.ethereum.rlp.RLP;
+import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
+
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.apache.tuweni.units.bigints.UInt256;
+import org.junit.jupiter.api.Test;
+
+class GetBlockAccessListsFromPeerTaskTest {
+
+  private static final BigInteger REQUEST_ID = BigInteger.ONE;
+
+  private final BlockDataGenerator dataGenerator = new BlockDataGenerator(1);
+
+  @Test
+  void shouldProcessValidBlockAccessLists() {
+    final BlockAccessList firstBal = dataGenerator.blockAccessList();
+    final BlockAccessList secondBal = dataGenerator.blockAccessList();
+
+    final GetBlockAccessListsFromPeerTask task =
+        taskFor(List.of(headerForBal(1, firstBal), headerForBal(2, secondBal)));
+
+    final Optional<List<SyncBlockAccessList>> result =
+        task.processResponse(
+            false,
+            responseWith(Optional.of(firstBal), Optional.of(secondBal)),
+            mock(EthPeer.class));
+
+    assertThat(result).contains(List.of(syncBal(firstBal), syncBal(secondBal)));
+  }
+
+  @Test
+  void shouldProcessUnavailableBlockAccessListPlaceholder() {
+    final BlockAccessList expectedBal = dataGenerator.blockAccessList();
+    final GetBlockAccessListsFromPeerTask task = taskFor(List.of(headerForBal(1, expectedBal)));
+
+    final Optional<List<SyncBlockAccessList>> result =
+        task.processResponse(false, responseWith(Optional.empty()), mock(EthPeer.class));
+
+    assertThat(result).contains(List.of(unavailableBal()));
+    assertThat(result.orElseThrow().getFirst().isUnavailable()).isTrue();
+  }
+
+  @Test
+  void shouldRejectBlockAccessListWithInvalidHash() {
+    final BlockAccessList expectedBal = new BlockAccessList(List.of());
+    final BlockAccessList mismatchingBal = dataGenerator.blockAccessList();
+    final GetBlockAccessListsFromPeerTask task = taskFor(List.of(headerForBal(1, expectedBal)));
+
+    assertThatThrownBy(
+            () ->
+                task.processResponse(
+                    false, responseWith(Optional.of(mismatchingBal)), mock(EthPeer.class)))
+        .isInstanceOf(ProtocolViolationException.class)
+        .hasMessageContaining("invalid hash");
+  }
+
+  @Test
+  void shouldAcceptTruncatedBlockAccessListResponse() {
+    final BlockAccessList firstBal = dataGenerator.blockAccessList();
+    final BlockAccessList secondBal = dataGenerator.blockAccessList();
+
+    final GetBlockAccessListsFromPeerTask task =
+        taskFor(List.of(headerForBal(1, firstBal), headerForBal(2, secondBal)));
+
+    final Optional<List<SyncBlockAccessList>> result =
+        task.processResponse(false, responseWith(Optional.of(firstBal)), mock(EthPeer.class));
+
+    assertThat(result).contains(List.of(syncBal(firstBal)));
+  }
+
+  @Test
+  void shouldSelectOnlySnap2ServingPeers() {
+    final RetryingGetBlockAccessListsFromPeerTask task = retryingTask();
+
+    assertThat(task.isSuitablePeer(peerAttributes(true, Set.of(SnapProtocol.SNAP2)))).isTrue();
+    assertThat(task.isSuitablePeer(peerAttributes(false, Set.of(SnapProtocol.SNAP2)))).isFalse();
+    assertThat(task.isSuitablePeer(peerAttributes(true, Set.of(SnapProtocol.SNAP1)))).isFalse();
+  }
+
+  private GetBlockAccessListsFromPeerTask taskFor(final List<BlockHeader> blockHeaders) {
+    return GetBlockAccessListsFromPeerTask.forBlockAccessLists(
+        mock(EthContext.class), blockHeaders, new NoOpMetricsSystem());
+  }
+
+  private RetryingGetBlockAccessListsFromPeerTask retryingTask() {
+    return (RetryingGetBlockAccessListsFromPeerTask)
+        RetryingGetBlockAccessListsFromPeerTask.forBlockAccessLists(
+            mock(EthContext.class),
+            List.of(headerForBal(1, dataGenerator.blockAccessList())),
+            new NoOpMetricsSystem());
+  }
+
+  private BlockHeader headerForBal(final long number, final BlockAccessList blockAccessList) {
+    final Hash hash = dataGenerator.hash();
+    final BlockHeader blockHeader = mock(BlockHeader.class);
+    when(blockHeader.getNumber()).thenReturn(number);
+    when(blockHeader.getHash()).thenReturn(hash);
+    when(blockHeader.getBlockHash()).thenReturn(hash);
+    when(blockHeader.getBalHash()).thenReturn(Optional.of(BodyValidation.balHash(blockAccessList)));
+    return blockHeader;
+  }
+
+  @SafeVarargs
+  private final MessageData responseWith(final Optional<BlockAccessList>... blockAccessLists) {
+    return BlockAccessListsMessage.create(List.of(blockAccessLists)).wrapMessageData(REQUEST_ID);
+  }
+
+  private SyncBlockAccessList syncBal(final BlockAccessList blockAccessList) {
+    return new SyncBlockAccessList(RLP.encode(blockAccessList::writeTo));
+  }
+
+  private SyncBlockAccessList unavailableBal() {
+    return new SyncBlockAccessList(RLP.NULL);
+  }
+
+  private EthPeerImmutableAttributes peerAttributes(
+      final boolean isServingSnap, final Set<Capability> agreedCapabilities) {
+    final EthPeer ethPeer = mock(EthPeer.class);
+    when(ethPeer.getAgreedCapabilities()).thenReturn(agreedCapabilities);
+    return new EthPeerImmutableAttributes(
+        UInt256.ZERO, true, 1L, 0, 0, 0L, false, true, isServingSnap, true, false, ethPeer);
+  }
+}

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/DownloadAndPersistBlockAccessListsStepTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/DownloadAndPersistBlockAccessListsStepTest.java
@@ -110,6 +110,46 @@ class DownloadAndPersistBlockAccessListsStepTest {
   }
 
   @Test
+  void shouldSkipUnavailableBlockAccessListPlaceholders() {
+    final BlockAccessList availableBal = blockDataGenerator.blockAccessList();
+    final BlockAccessList unavailableBal = blockDataGenerator.blockAccessList();
+
+    final BlockHeader availableBalHeader = balEnabledHeader(250, availableBal);
+    final BlockHeader unavailableBalHeader = balEnabledHeader(251, unavailableBal);
+
+    final List<SyncBlockWithReceipts> syncBlocks =
+        List.of(syncBlockWithHeader(availableBalHeader), syncBlockWithHeader(unavailableBalHeader));
+
+    final DownloadAndPersistBlockAccessListsStep step =
+        new DownloadAndPersistBlockAccessListsStep(
+            blockchain,
+            Duration.ofSeconds(2),
+            headers ->
+                CompletableFuture.completedFuture(
+                    List.of(syncBal(availableBal), unavailableBal())));
+
+    step.apply(syncBlocks).join();
+
+    assertThat(blockchain.getBlockAccessList(availableBalHeader.getHash())).contains(availableBal);
+    assertThat(blockchain.getBlockAccessList(unavailableBalHeader.getHash())).isEmpty();
+  }
+
+  @Test
+  void shouldPersistEmptyBlockAccessList() {
+    final BlockAccessList emptyBal = new BlockAccessList(List.of());
+    final BlockHeader emptyBalHeader = balEnabledHeader(252, emptyBal);
+    final List<SyncBlockWithReceipts> syncBlocks = List.of(syncBlockWithHeader(emptyBalHeader));
+
+    final DownloadAndPersistBlockAccessListsStep step =
+        new DownloadAndPersistBlockAccessListsStep(
+            blockchain, Duration.ofSeconds(2), headers -> completedFutureWithSyncBals(emptyBal));
+
+    step.apply(syncBlocks).join();
+
+    assertThat(blockchain.getBlockAccessList(emptyBalHeader.getHash())).contains(emptyBal);
+  }
+
+  @Test
   void shouldSkipPersistingWhenDownloaderFails() {
     final BlockAccessList expectedBal = blockDataGenerator.blockAccessList();
     final BlockHeader balHeader = balEnabledHeader(300, expectedBal);
@@ -192,5 +232,9 @@ class DownloadAndPersistBlockAccessListsStepTest {
 
   private SyncBlockAccessList syncBal(final BlockAccessList blockAccessList) {
     return new SyncBlockAccessList(RLP.encode(blockAccessList::writeTo));
+  }
+
+  private SyncBlockAccessList unavailableBal() {
+    return new SyncBlockAccessList(RLP.NULL);
   }
 }


### PR DESCRIPTION
In snap protocol, it was incorrectly assumed that an empty list is the placeholder for unavailable entries, while it is actually empty string.

Hive tests didn't catch this because this is a bug on the side of response handling, whereas they test only request handling.

Added missing test coverage for `snap.GetBlockAccessListsFromPeerTask`: happy case, unavailable placeholder, invalid BAL hash, fewer-than-requested responses, ...