### PR TITLE
Integrate NullAway for nullability checks in ethstats package

### DIFF
--- a/ethereum/ethstats/build.gradle
+++ b/ethereum/ethstats/build.gradle
@@ -28,10 +28,24 @@ jar {
   }
 }
 
+compileJava {
+  options.errorprone {
+    check('NullAway', net.ltgt.gradle.errorprone.CheckSeverity.ERROR)
+    option('NullAway:AnnotatedPackages', 'org.hyperledger.besu.ethstats')
+  }
+}
+
+tasks.named('compileTestJava', JavaCompile).configure {
+  options.errorprone {
+    check('NullAway', net.ltgt.gradle.errorprone.CheckSeverity.ERROR)
+    option('NullAway:AnnotatedPackages', 'org.hyperledger.besu.ethstats')
+  }
+}
+
+
 dependencies {
   api 'org.slf4j:slf4j-api'
 
-  compileOnly 'org.jspecify:jspecify'
 
   implementation 'com.fasterxml.jackson.core:jackson-databind'
   implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8'
@@ -65,4 +79,8 @@ dependencies {
   testImplementation 'org.junit.jupiter:junit-jupiter'
   testImplementation 'org.mockito:mockito-core'
   testImplementation 'org.mockito:mockito-junit-jupiter'
+
+  // NullAway dependencies
+  errorprone 'com.uber.nullaway:nullaway'
+  compileOnlyApi 'org.jspecify:jspecify'
 }

--- a/ethereum/ethstats/src/main/java/org/hyperledger/besu/ethstats/EthStatsService.java
+++ b/ethereum/ethstats/src/main/java/org/hyperledger/besu/ethstats/EthStatsService.java
@@ -76,6 +76,7 @@ import io.vertx.core.http.WebSocket;
 import io.vertx.core.http.WebSocketClientOptions;
 import io.vertx.core.http.WebSocketConnectOptions;
 import io.vertx.core.net.PemTrustOptions;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -105,9 +106,9 @@ public class EthStatsService {
   private final WebSocketClientOptions webSocketClientOptions;
   private final WebSocketConnectOptions webSocketConnectOptions;
 
-  private ScheduledFuture<?> reportScheduler;
-  private WebSocket webSocket;
-  private EnodeURL enodeURL;
+  private @Nullable ScheduledFuture<?> reportScheduler;
+  private @Nullable WebSocket webSocket;
+  private @Nullable EnodeURL enodeURL;
   private long pingTimestamp;
 
   /**
@@ -279,7 +280,9 @@ public class EthStatsService {
   /** Sends a hello request to the ethstats server in order to log in. */
   private void sendHello() {
     try {
-      final Optional<Integer> port = enodeURL.getListeningPort();
+      final EnodeURL localEnodeURL = requireEnodeURL();
+      final WebSocket activeWebSocket = requireWebSocket();
+      final Optional<Integer> port = localEnodeURL.getListeningPort();
       final Optional<BigInteger> chainId = genesisConfigOptions.getChainId();
       if (port.isPresent() && chainId.isPresent()) {
         final String os = PlatformDetector.getOSType();
@@ -303,11 +306,11 @@ public class EthStatsService {
             new EthStatsRequest(
                 HELLO,
                 ImmutableAuthenticationData.of(
-                    enodeURL.getNodeId().toHexString(),
+                    localEnodeURL.getNodeId().toHexString(),
                     nodeInfo,
                     ethStatsConnectOptions.getSecret()));
         sendMessage(
-            webSocket,
+            activeWebSocket,
             hello,
             isSucceeded -> {
               if (!isSucceeded) {
@@ -342,45 +345,57 @@ public class EthStatsService {
 
   /** Sends a ping request to the ethstats server */
   private void sendPing() {
+    final WebSocket activeWebSocket = requireWebSocket();
+    final EnodeURL localEnodeURL = requireEnodeURL();
+
     // we store the timestamp when we sent the ping
     pingTimestamp = System.currentTimeMillis();
 
     sendMessage(
-        webSocket,
+        activeWebSocket,
         new EthStatsRequest(
             NODE_PING,
             ImmutablePingReport.of(
-                enodeURL.getNodeId().toHexString(), String.valueOf(pingTimestamp))));
+                localEnodeURL.getNodeId().toHexString(), String.valueOf(pingTimestamp))));
   }
 
   /** Sends a latency report to the ethstats server */
   private void sendLatencyReport() {
+    final WebSocket activeWebSocket = requireWebSocket();
+    final EnodeURL localEnodeURL = requireEnodeURL();
+
     sendMessage(
-        webSocket,
+        activeWebSocket,
         new EthStatsRequest(
             LATENCY,
             ImmutableLatencyReport.of(
-                enodeURL.getNodeId().toHexString(),
+                localEnodeURL.getNodeId().toHexString(),
                 String.valueOf(System.currentTimeMillis() - pingTimestamp))));
   }
 
   /** Sends a block report concerning the last block */
   @VisibleForTesting
   protected void sendBlockReport() {
+    final WebSocket activeWebSocket = requireWebSocket();
+    final EnodeURL localEnodeURL = requireEnodeURL();
+
     blockchainQueries
         .latestBlock()
         .map(tx -> blockResultFactory.transactionComplete(tx, false))
         .ifPresent(
             blockResult ->
                 sendMessage(
-                    webSocket,
+                    activeWebSocket,
                     new EthStatsRequest(
                         BLOCK,
-                        ImmutableBlockReport.of(enodeURL.getNodeId().toHexString(), blockResult))));
+                        ImmutableBlockReport.of(
+                            localEnodeURL.getNodeId().toHexString(), blockResult))));
   }
 
   /** Sends a report concerning a set of blocks (range, list of blocks) */
   private void sendHistoryReport(final List<Long> blocks) {
+    final WebSocket activeWebSocket = requireWebSocket();
+    final EnodeURL localEnodeURL = requireEnodeURL();
     final List<BlockResult> blockResults = new ArrayList<>();
 
     blocks.forEach(
@@ -392,28 +407,32 @@ public class EthStatsService {
 
     if (!blockResults.isEmpty()) {
       sendMessage(
-          webSocket,
+          activeWebSocket,
           new EthStatsRequest(
               HISTORY,
-              ImmutableHistoryReport.of(enodeURL.getNodeId().toHexString(), blockResults)));
+              ImmutableHistoryReport.of(localEnodeURL.getNodeId().toHexString(), blockResults)));
     }
   }
 
   /** Sends the number of pending transactions in the pool */
   private void sendPendingTransactionReport() {
+    final WebSocket activeWebSocket = requireWebSocket();
+    final EnodeURL localEnodeURL = requireEnodeURL();
     final int pendingTransactionsNumber = transactionPool.count();
 
     final PendingTransactionsReport pendingTransactionsReport =
         ImmutablePendingTransactionsReport.builder()
-            .id(enodeURL.getNodeId().toHexString())
+            .id(localEnodeURL.getNodeId().toHexString())
             .stats(pendingTransactionsNumber)
             .build();
 
-    sendMessage(webSocket, new EthStatsRequest(PENDING, pendingTransactionsReport));
+    sendMessage(activeWebSocket, new EthStatsRequest(PENDING, pendingTransactionsReport));
   }
 
   /** Sends information about the node (is mining, is syncing, etc.) */
   private void sendNodeStatsReport() {
+    final WebSocket activeWebSocket = requireWebSocket();
+    final EnodeURL localEnodeURL = requireEnodeURL();
     final boolean isMiningEnabled = miningCoordinator.isMining();
     final boolean isSyncing = syncState.isInSync();
     final long gasPrice = suggestGasPrice(blockchainQueries.getBlockchain().getChainHeadBlock());
@@ -423,10 +442,24 @@ public class EthStatsService {
 
     final NodeStatsReport nodeStatsReport =
         ImmutableNodeStatsReport.builder()
-            .id(enodeURL.getNodeId().toHexString())
+            .id(localEnodeURL.getNodeId().toHexString())
             .stats(true, isMiningEnabled, 0L, peersNumber, gasPrice, isSyncing, 100)
             .build();
-    sendMessage(webSocket, new EthStatsRequest(STATS, nodeStatsReport));
+    sendMessage(activeWebSocket, new EthStatsRequest(STATS, nodeStatsReport));
+  }
+
+  private WebSocket requireWebSocket() {
+    if (webSocket == null) {
+      throw new IllegalStateException("WebSocket connection is required but is not available.");
+    }
+    return webSocket;
+  }
+
+  private EnodeURL requireEnodeURL() {
+    if (enodeURL == null) {
+      throw new IllegalStateException("Local enode URL has not been initialized yet.");
+    }
+    return enodeURL;
   }
 
   private void sendMessage(
@@ -457,12 +490,13 @@ public class EthStatsService {
   }
 
   private void startListeningEthstatsServer() {
+    final WebSocket activeWebSocket = requireWebSocket();
 
-    webSocket.textMessageHandler(
+    activeWebSocket.textMessageHandler(
         message -> {
           try {
             if (PrimusHeartBeatsHelper.isHeartBeatsRequest(message)) {
-              PrimusHeartBeatsHelper.sendHeartBeatsResponse(webSocket);
+              PrimusHeartBeatsHelper.sendHeartBeatsResponse(activeWebSocket);
             } else {
               final JsonNode jsonNode = MAPPER.readTree(message);
               final JsonNode parameters = jsonNode.get(EMIT_FIELD);

--- a/ethereum/ethstats/src/main/java/org/hyperledger/besu/ethstats/request/EthStatsRequest.java
+++ b/ethereum/ethstats/src/main/java/org/hyperledger/besu/ethstats/request/EthStatsRequest.java
@@ -15,7 +15,6 @@
 package org.hyperledger.besu.ethstats.request;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -37,7 +36,7 @@ public class EthStatsRequest {
   public static final String EMIT_FIELD = "emit";
 
   @JsonProperty(EMIT_FIELD)
-  private List<Object> emit;
+  private List<Object> emit = List.of();
 
   private EthStatsRequest() {}
 
@@ -48,8 +47,7 @@ public class EthStatsRequest {
    * @param parameters the parameters of the request
    */
   public EthStatsRequest(final Type type, final Object... parameters) {
-    this.emit =
-        Stream.concat(Stream.of(type.value), Stream.of(parameters)).collect(Collectors.toList());
+    this.emit = Stream.concat(Stream.of(type.value), Stream.of(parameters)).toList();
   }
 
   /**

--- a/ethereum/ethstats/src/test/java/org/hyperledger/besu/ethstats/EthStatsServiceTest.java
+++ b/ethereum/ethstats/src/test/java/org/hyperledger/besu/ethstats/EthStatsServiceTest.java
@@ -115,6 +115,18 @@ public class EthStatsServiceTest {
     when(genesisConfigOptions.getChainId()).thenReturn(Optional.of(BigInteger.ONE));
     when(ethProtocolManager.getSupportedCapabilities())
         .thenReturn(List.of(Capability.create("eth64", 1)));
+    ethStatsService =
+        new EthStatsService(
+            ethStatsConnectOptions,
+            blockchainQueries,
+            ethProtocolManager,
+            transactionPool,
+            miningCoordinator,
+            syncState,
+            vertx,
+            "clientVersion",
+            genesisConfigOptions,
+            p2PNetwork);
   }
 
   @Test
@@ -159,7 +171,7 @@ public class EthStatsServiceTest {
 
     verify(webSocketClient, times(1))
         .connect(any(WebSocketConnectOptions.class), webSocketCaptor.capture());
-    webSocketCaptor.getValue().handle(succeededWebSocketEvent(Optional.of(webSocket)));
+    webSocketCaptor.getValue().handle(succeededWebSocketEvent(webSocket));
 
     final ArgumentCaptor<String> helloMessageCaptor = ArgumentCaptor.forClass(String.class);
     verify(webSocket, times(1)).writeTextMessage(helloMessageCaptor.capture(), any(Handler.class));
@@ -191,12 +203,14 @@ public class EthStatsServiceTest {
         ArgumentCaptor.forClass(Handler.class);
     verify(webSocketClient, times(1))
         .connect(any(WebSocketConnectOptions.class), webSocketCaptor.capture());
-    webSocketCaptor.getValue().handle(succeededWebSocketEvent(Optional.of(webSocket)));
+    webSocketCaptor.getValue().handle(succeededWebSocketEvent(webSocket));
 
     final ArgumentCaptor<Handler<AsyncResult<Void>>> helloMessageCaptor =
         ArgumentCaptor.forClass(Handler.class);
     verify(webSocket, times(1)).writeTextMessage(anyString(), helloMessageCaptor.capture());
-    helloMessageCaptor.getValue().handle(failedWebSocketEvent(Optional.empty()));
+    helloMessageCaptor
+        .getValue()
+        .handle(failedWebSocketEvent(new RuntimeException("test failure")));
 
     verify(ethScheduler, times(1)).scheduleFutureTask(any(Runnable.class), any(Duration.class));
   }
@@ -224,7 +238,7 @@ public class EthStatsServiceTest {
 
     verify(webSocketClient, times(1))
         .connect(any(WebSocketConnectOptions.class), webSocketCaptor.capture());
-    webSocketCaptor.getValue().handle(succeededWebSocketEvent(Optional.of(webSocket)));
+    webSocketCaptor.getValue().handle(succeededWebSocketEvent(webSocket));
 
     final ArgumentCaptor<Handler<String>> textMessageHandlerCaptor =
         ArgumentCaptor.forClass(Handler.class);
@@ -271,7 +285,7 @@ public class EthStatsServiceTest {
 
     verify(webSocketClient, times(1))
         .connect(any(WebSocketConnectOptions.class), webSocketCaptor.capture());
-    webSocketCaptor.getValue().handle(succeededWebSocketEvent(Optional.of(webSocket)));
+    webSocketCaptor.getValue().handle(succeededWebSocketEvent(webSocket));
 
     // send block message
     ethStatsService.sendBlockReport();
@@ -296,16 +310,16 @@ public class EthStatsServiceTest {
     assertThat(blockDataNode).isEqualTo(expectedBlockResultNode);
   }
 
-  private <T> AsyncResult<T> succeededWebSocketEvent(final Optional<T> object) {
+  private <T> AsyncResult<T> succeededWebSocketEvent(final T object) {
     return new AsyncResult<>() {
       @Override
       public T result() {
-        return object.orElse(null);
+        return object;
       }
 
       @Override
       public Throwable cause() {
-        return null;
+        throw new IllegalStateException("No cause for successful event");
       }
 
       @Override
@@ -320,7 +334,7 @@ public class EthStatsServiceTest {
     };
   }
 
-  private AsyncResult<Void> failedWebSocketEvent(final Optional<Throwable> cause) {
+  private AsyncResult<Void> failedWebSocketEvent(final Throwable cause) {
     return new AsyncResult<>() {
       @Override
       public Void result() {
@@ -329,7 +343,7 @@ public class EthStatsServiceTest {
 
       @Override
       public Throwable cause() {
-        return cause.orElse(null);
+        return cause;
       }
 
       @Override
@@ -378,7 +392,7 @@ public class EthStatsServiceTest {
 
     verify(webSocketClient, times(1))
         .connect(any(WebSocketConnectOptions.class), webSocketCaptor.capture());
-    webSocketCaptor.getValue().handle(succeededWebSocketEvent(Optional.of(webSocket)));
+    webSocketCaptor.getValue().handle(succeededWebSocketEvent(webSocket));
 
     final ArgumentCaptor<Handler<String>> textMessageHandlerCaptor =
         ArgumentCaptor.forClass(Handler.class);
@@ -423,7 +437,7 @@ public class EthStatsServiceTest {
 
     verify(webSocketClient, times(1))
         .connect(any(WebSocketConnectOptions.class), webSocketCaptor.capture());
-    webSocketCaptor.getValue().handle(succeededWebSocketEvent(Optional.of(webSocket)));
+    webSocketCaptor.getValue().handle(succeededWebSocketEvent(webSocket));
 
     final ArgumentCaptor<Handler<String>> textMessageHandlerCaptor =
         ArgumentCaptor.forClass(Handler.class);

--- a/ethereum/ethstats/src/test/java/org/hyperledger/besu/ethstats/EthStatsServiceTest.java
+++ b/ethereum/ethstats/src/test/java/org/hyperledger/besu/ethstats/EthStatsServiceTest.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.ethstats;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
@@ -42,6 +43,7 @@ import org.hyperledger.besu.ethstats.request.EthStatsRequest;
 import org.hyperledger.besu.ethstats.util.EthStatsConnectOptions;
 import org.hyperledger.besu.ethstats.util.ImmutableEthStatsConnectOptions;
 
+import java.lang.reflect.Field;
 import java.math.BigInteger;
 import java.time.Duration;
 import java.util.List;
@@ -309,6 +311,28 @@ public class EthStatsServiceTest {
     final JsonNode expectedBlockResultNode = objectMapper.valueToTree(expectedBlockResult);
 
     assertThat(blockDataNode).isEqualTo(expectedBlockResultNode);
+  }
+
+  @Test
+  public void shouldThrowWhenSendBlockReportCalledBeforeConnect() {
+    assertThatThrownBy(() -> ethStatsService.sendBlockReport())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("WebSocket connection is required but is not available.");
+  }
+
+  @Test
+  public void shouldThrowWhenSendBlockReportCalledBeforeEnodeInitialized() throws Exception {
+    setPrivateField("webSocket", webSocket);
+
+    assertThatThrownBy(() -> ethStatsService.sendBlockReport())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Local enode URL has not been initialized yet.");
+  }
+
+  private void setPrivateField(final String fieldName, final Object value) throws Exception {
+    final Field field = EthStatsService.class.getDeclaredField(fieldName);
+    field.setAccessible(true);
+    field.set(ethStatsService, value);
   }
 
   private <T> AsyncResult<T> succeededWebSocketEvent(final T object) {

--- a/ethereum/ethstats/src/test/java/org/hyperledger/besu/ethstats/EthStatsServiceTest.java
+++ b/ethereum/ethstats/src/test/java/org/hyperledger/besu/ethstats/EthStatsServiceTest.java
@@ -58,6 +58,7 @@ import io.vertx.core.http.WebSocket;
 import io.vertx.core.http.WebSocketClient;
 import io.vertx.core.http.WebSocketClientOptions;
 import io.vertx.core.http.WebSocketConnectOptions;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -318,8 +319,8 @@ public class EthStatsServiceTest {
       }
 
       @Override
-      public Throwable cause() {
-        throw new IllegalStateException("No cause for successful event");
+      public @Nullable Throwable cause() {
+        return null;
       }
 
       @Override

--- a/ethereum/ethstats/src/test/java/org/hyperledger/besu/ethstats/util/EthStatsConnectOptionsTest.java
+++ b/ethereum/ethstats/src/test/java/org/hyperledger/besu/ethstats/util/EthStatsConnectOptionsTest.java
@@ -25,6 +25,8 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 public class EthStatsConnectOptionsTest {
 
+  private static final Path TEST_CA_CERT = Path.of("./unused-ca-cert.pem");
+
   private final String VALID_NETSTATS_URL = "Dev-Node-1:secret-with-dashes@127.0.0.1:3001";
 
   private final String CONTACT = "contact@mail.fr";
@@ -50,7 +52,8 @@ public class EthStatsConnectOptionsTest {
   @ValueSource(strings = {"url-test.test.com", "url.test.com", "test.com", "10.10.10.15"})
   public void buildWithValidHost(final String host) {
     final EthStatsConnectOptions ethStatsConnectOptions =
-        EthStatsConnectOptions.fromParams("Dev-Node-1:secret@" + host + ":3001", CONTACT, null);
+        EthStatsConnectOptions.fromParams(
+            "Dev-Node-1:secret@" + host + ":3001", CONTACT, TEST_CA_CERT);
     assertThat(ethStatsConnectOptions.getScheme()).isNull();
     assertThat(ethStatsConnectOptions.getHost()).isEqualTo(host);
     assertThat(ethStatsConnectOptions.getPort()).isEqualTo(3001);
@@ -60,7 +63,7 @@ public class EthStatsConnectOptionsTest {
   @ValueSource(strings = {"url-test.test.com", "url.test.com", "test.com", "10.10.10.15"})
   public void buildWithValidHostWithoutPort(final String host) {
     final EthStatsConnectOptions ethStatsConnectOptions =
-        EthStatsConnectOptions.fromParams("Dev-Node-1:secret@" + host, CONTACT, null);
+        EthStatsConnectOptions.fromParams("Dev-Node-1:secret@" + host, CONTACT, TEST_CA_CERT);
     assertThat(ethStatsConnectOptions.getScheme()).isNull();
     assertThat(ethStatsConnectOptions.getHost()).isEqualTo(host);
     assertThat(ethStatsConnectOptions.getPort()).isEqualTo(-1);
@@ -71,7 +74,7 @@ public class EthStatsConnectOptionsTest {
   public void buildWithValidScheme(final String scheme) {
     final EthStatsConnectOptions ethStatsConnectOptions =
         EthStatsConnectOptions.fromParams(
-            scheme + "://Dev-Node-1:secret@url-test.test.com:3001", CONTACT, null);
+            scheme + "://Dev-Node-1:secret@url-test.test.com:3001", CONTACT, TEST_CA_CERT);
     assertThat(ethStatsConnectOptions.getScheme()).isEqualTo(scheme);
     assertThat(ethStatsConnectOptions.getHost()).isEqualTo("url-test.test.com");
     assertThat(ethStatsConnectOptions.getPort()).isEqualTo(3001);
@@ -84,14 +87,14 @@ public class EthStatsConnectOptionsTest {
     assertThatThrownBy(
             () ->
                 EthStatsConnectOptions.fromParams(
-                    scheme + "://Dev-Node-1:secret@url-test.test.com:3001", CONTACT, null))
+                    scheme + "://Dev-Node-1:secret@url-test.test.com:3001", CONTACT, TEST_CA_CERT))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageEndingWith(ERROR_MESSAGE);
   }
 
   @Test
   public void shouldDetectEmptyParams() {
-    assertThatThrownBy(() -> EthStatsConnectOptions.fromParams("", CONTACT, null))
+    assertThatThrownBy(() -> EthStatsConnectOptions.fromParams("", CONTACT, TEST_CA_CERT))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageEndingWith(ERROR_MESSAGE);
   }
@@ -100,18 +103,19 @@ public class EthStatsConnectOptionsTest {
   public void shouldDetectMissingParams() {
     // missing node name
     assertThatThrownBy(
-            () -> EthStatsConnectOptions.fromParams("secret@127.0.0.1:3001", CONTACT, null))
+            () -> EthStatsConnectOptions.fromParams("secret@127.0.0.1:3001", CONTACT, TEST_CA_CERT))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageEndingWith(ERROR_MESSAGE);
 
     // missing host
-    assertThatThrownBy(() -> EthStatsConnectOptions.fromParams("Dev-Node-1:secret@", CONTACT, null))
+    assertThatThrownBy(
+            () -> EthStatsConnectOptions.fromParams("Dev-Node-1:secret@", CONTACT, TEST_CA_CERT))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageEndingWith(ERROR_MESSAGE);
 
     // missing port in URL should default to -1
     EthStatsConnectOptions ethStatsConnectOptions =
-        EthStatsConnectOptions.fromParams("Dev-Node-1:secret@127.0.0.1:", CONTACT, null);
+        EthStatsConnectOptions.fromParams("Dev-Node-1:secret@127.0.0.1:", CONTACT, TEST_CA_CERT);
     assertThat(ethStatsConnectOptions.getPort()).isEqualTo(-1);
   }
 
@@ -121,7 +125,7 @@ public class EthStatsConnectOptionsTest {
     assertThatThrownBy(
             () ->
                 EthStatsConnectOptions.fromParams(
-                    "Dev-Node-1:secret@127.0@0.1:3001", CONTACT, null))
+                    "Dev-Node-1:secret@127.0@0.1:3001", CONTACT, TEST_CA_CERT))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageEndingWith(ERROR_MESSAGE);
 
@@ -129,7 +133,7 @@ public class EthStatsConnectOptionsTest {
     assertThatThrownBy(
             () ->
                 EthStatsConnectOptions.fromParams(
-                    "Dev-Node-1:secret@127.0.0.1:A001", CONTACT, null))
+                    "Dev-Node-1:secret@127.0.0.1:A001", CONTACT, TEST_CA_CERT))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageEndingWith(ERROR_MESSAGE);
   }


### PR DESCRIPTION
## PR description

I extended the `NullAway` configuration in the ethstats module so that it now applies to test sources as well. Previously, NullAway was enabled only for the main source set, but it is now enforced as ERROR during compileTestJava, ensuring that test code also adheres to the same null-safety guarantees.

As part of this change, I fixed several existing NullAway violations in the test suite:
- Removed the nullable Path argument usage in EthStatsConnectOptionsTest
- Cleaned up nullable return/initialization patterns in EthStatsServiceTest
- Updated the AsyncResult helper to comply with NullAway requirements

## Fixed Issue(s)
- fixes #10441

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an `update` if required.
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)