### PR TITLE
use stackless singleton for peer-gate rejection in RlpxAgent

### DIFF
--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgent.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgent.java
@@ -60,6 +60,25 @@ import org.slf4j.LoggerFactory;
 public class RlpxAgent {
   private static final Logger LOG = LoggerFactory.getLogger(RlpxAgent.class);
 
+  /**
+   * Singleton sentinel thrown when no ProtocolManager accepts an outbound connection. Capturing a
+   * full stack trace on every peer-gate rejection allocates ~1-3 KB and calls a JVM native each
+   * time; at high connection-attempt rates this adds measurable GC pressure. Using a stackless
+   * singleton avoids that cost, following the same pattern as Netty's
+   * StacklessClosedChannelException.
+   */
+  // Intentional static Throwable: this is a stackless sentinel used to avoid allocating a fresh
+  // RuntimeException (and capturing a stack trace) on every peer-gate rejection. The singleton
+  // is safe because it carries no mutable state and its stack trace is always empty.
+  @SuppressWarnings("StaticAssignmentOfThrowable")
+  private static final RuntimeException NO_PROTOCOL_MANAGER_EXCEPTION =
+      new RuntimeException("None of the ProtocolManagers wants to connect to this peer") {
+        @Override
+        public synchronized Throwable fillInStackTrace() {
+          return this;
+        }
+      };
+
   private final LocalNode localNode;
   private final PeerConnectionEvents connectionEvents;
   private final ConnectionInitializer connectionInitializer;
@@ -245,10 +264,8 @@ public class RlpxAgent {
         throw new RuntimeException(e);
       }
     } else {
-      final String errorMsg =
-          "None of the ProtocolManagers wants to connect to peer " + peer.getId();
-      LOG.trace(errorMsg);
-      return CompletableFuture.failedFuture((new RuntimeException(errorMsg)));
+      LOG.trace("None of the ProtocolManagers wants to connect to peer {}", peer.getId());
+      return CompletableFuture.failedFuture(NO_PROTOCOL_MANAGER_EXCEPTION);
     }
 
     return peerConnectionCompletableFuture;


### PR DESCRIPTION
Allocating a fresh RuntimeException with full stack trace on every outbound peer-gate rejection causes measurable GC pressure at high connection-attempt rates (observed ~1.5 throws/sec during chain-head stalls, per JFR in #10498).

Replace the per-call allocation with a stackless singleton sentinel, following the same pattern as Netty's StacklessClosedChannelException. The LOG.trace call is updated to use parameterised formatting to avoid string concatenation when trace logging is disabled.

## Fixed Issue(s)
Refs #10498 


### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew build`
- [x] acceptance tests: `./gradlew acceptanceTest`
- [x] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


