### PR TITLE
perf(eth): stackless CancellationException in AbstractEthTask

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractEthTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractEthTask.java
@@ -35,6 +35,21 @@ import com.google.common.base.Stopwatch;
 
 public abstract class AbstractEthTask<T> implements EthTask<T> {
 
+  /**
+   * Stackless singleton used when a sub-task is rejected because this task has already been
+   * cancelled. Capturing a full stack trace on every cancellation adds unnecessary allocation and
+   * CPU overhead (native stack-walk) in the common case where the trace is never inspected. Safe to
+   * share: CancellationException carries no mutable state.
+   */
+  @SuppressWarnings("StaticAssignmentOfThrowable")
+  private static final CancellationException TASK_CANCELLED_EXCEPTION =
+      new CancellationException("Task already cancelled") {
+        @Override
+        public synchronized Throwable fillInStackTrace() {
+          return this;
+        }
+      };
+
   private double taskTimeInSec = -1.0D;
   private final OperationTimer taskTimer;
   protected final CompletableFuture<T> result = new CompletableFuture<>();
@@ -122,7 +137,7 @@ public abstract class AbstractEthTask<T> implements EthTask<T> {
         subTaskFuture.whenComplete((r, t) -> subTaskFutures.remove(subTaskFuture));
         return subTaskFuture;
       } else {
-        return CompletableFuture.failedFuture(new CancellationException());
+        return CompletableFuture.failedFuture(TASK_CANCELLED_EXCEPTION);
       }
     }
   }


### PR DESCRIPTION
## Summary

`AbstractEthTask.executeSubTask()` is the base-class dispatch point for every eth task in the sync stack. When the parent task is already cancelled, it previously allocated a fresh `CancellationException` — including a full JVM stack trace capture via the native `fillInStackTrace` call — on every invocation.

At high task-cancellation rates (during sync, peer churn, or shutdown) this generates unnecessary allocation pressure and CPU overhead. The stack trace is never meaningfully inspected in this code path; cancellation is treated as a normal flow-control signal.

This PR replaces the per-call allocation with a stackless singleton, following the same pattern as:
- besu-eth/besu#10523 (`RlpxAgent` peer-gate rejection, recently merged)
- Netty's `StacklessClosedChannelException`

## Change

```java
// Before
return CompletableFuture.failedFuture(new CancellationException());

// After — singleton, no stack trace captured
return CompletableFuture.failedFuture(TASK_CANCELLED_EXCEPTION);
```

The singleton is annotated `@SuppressWarnings("StaticAssignmentOfThrowable")` to acknowledge the ErrorProne warning, with a comment explaining the intent. `CancellationException` carries no mutable state so sharing is safe.

## Test plan

- [ ] Existing `AbstractEthTask` tests pass (`./gradlew :ethereum:eth:test --tests "*AbstractEthTask*"`)
- [ ] No stack trace is needed for cancelled-task diagnostics — callers check `isCancelled()` or catch `CancellationException` by type

Part of the minor cleanup identified in besu-eth/besu#10498.