### PR TITLE
perf(eth): stackless singleton for NoAvailablePeersException in peer retry paths

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/PendingPeerRequest.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/PendingPeerRequest.java
@@ -55,7 +55,7 @@ public class PendingPeerRequest {
     final Optional<EthPeer> maybePeer = getPeerToUse();
     if (maybePeer.isEmpty()) {
       // No peers have the required height.
-      result.completeExceptionally(NoAvailablePeersException.INSTANCE);
+      result.completeExceptionally(NoAvailablePeersException.WITHOUT_STACKTRACE);
       return true;
     } else {
       // At least one peer has the required height, but we are not able to use it if it's busy

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/PendingPeerRequest.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/PendingPeerRequest.java
@@ -55,7 +55,7 @@ public class PendingPeerRequest {
     final Optional<EthPeer> maybePeer = getPeerToUse();
     if (maybePeer.isEmpty()) {
       // No peers have the required height.
-      result.completeExceptionally(new NoAvailablePeersException());
+      result.completeExceptionally(NoAvailablePeersException.INSTANCE);
       return true;
     } else {
       // At least one peer has the required height, but we are not able to use it if it's busy

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/exceptions/NoAvailablePeersException.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/exceptions/NoAvailablePeersException.java
@@ -22,7 +22,7 @@ public class NoAvailablePeersException extends EthTaskException {
    * object and capturing a JVM stack trace on every retry attempt.
    */
   @SuppressWarnings("StaticAssignmentOfThrowable")
-  public static final NoAvailablePeersException INSTANCE =
+  public static final NoAvailablePeersException WITHOUT_STACKTRACE =
       new NoAvailablePeersException() {
         @Override
         public synchronized Throwable fillInStackTrace() {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/exceptions/NoAvailablePeersException.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/exceptions/NoAvailablePeersException.java
@@ -16,6 +16,20 @@ package org.hyperledger.besu.ethereum.eth.manager.exceptions;
 
 public class NoAvailablePeersException extends EthTaskException {
 
+  /**
+   * Stackless singleton. This exception is thrown as a flow-control signal in peer-selection retry
+   * loops; the stack trace is never inspected. Reusing a single instance avoids allocating a new
+   * object and capturing a JVM stack trace on every retry attempt.
+   */
+  @SuppressWarnings("StaticAssignmentOfThrowable")
+  public static final NoAvailablePeersException INSTANCE =
+      new NoAvailablePeersException() {
+        @Override
+        public synchronized Throwable fillInStackTrace() {
+          return this;
+        }
+      };
+
   public NoAvailablePeersException() {
     super(FailureReason.NO_AVAILABLE_PEERS);
   }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractRetryingSwitchingPeerTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractRetryingSwitchingPeerTask.java
@@ -73,7 +73,7 @@ public abstract class AbstractRetryingSwitchingPeerTask<T> extends AbstractRetry
           .addArgument(this::getRetryCount)
           .addArgument(triedPeers)
           .log();
-      return CompletableFuture.failedFuture(NoAvailablePeersException.INSTANCE);
+      return CompletableFuture.failedFuture(NoAvailablePeersException.WITHOUT_STACKTRACE);
     }
 
     final EthPeer peerToUse = maybePeer.get();

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractRetryingSwitchingPeerTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractRetryingSwitchingPeerTask.java
@@ -73,8 +73,7 @@ public abstract class AbstractRetryingSwitchingPeerTask<T> extends AbstractRetry
           .addArgument(this::getRetryCount)
           .addArgument(triedPeers)
           .log();
-      final var ex = new NoAvailablePeersException();
-      return CompletableFuture.failedFuture(ex);
+      return CompletableFuture.failedFuture(NoAvailablePeersException.INSTANCE);
     }
 
     final EthPeer peerToUse = maybePeer.get();

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/common/PivotSyncActions.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/common/PivotSyncActions.java
@@ -204,7 +204,7 @@ public class PivotSyncActions {
                 LOG.error(
                     "Failed to download pivot block header. Response Code was {}",
                     taskResult.responseCode());
-                return CompletableFuture.failedFuture(NoAvailablePeersException.INSTANCE);
+                return CompletableFuture.failedFuture(NoAvailablePeersException.WITHOUT_STACKTRACE);
               } else if (taskResult.responseCode() != PeerTaskExecutorResponseCode.SUCCESS
                   || taskResult.result().isEmpty()) {
                 LOG.error(

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/common/PivotSyncActions.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/common/PivotSyncActions.java
@@ -204,7 +204,7 @@ public class PivotSyncActions {
                 LOG.error(
                     "Failed to download pivot block header. Response Code was {}",
                     taskResult.responseCode());
-                return CompletableFuture.failedFuture(new NoAvailablePeersException());
+                return CompletableFuture.failedFuture(NoAvailablePeersException.INSTANCE);
               } else if (taskResult.responseCode() != PeerTaskExecutorResponseCode.SUCCESS
                   || taskResult.result().isEmpty()) {
                 LOG.error(

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/tasks/DownloadHeaderSequenceTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/tasks/DownloadHeaderSequenceTask.java
@@ -164,7 +164,8 @@ public class DownloadHeaderSequenceTask extends AbstractRetryingPeerTask<List<Bl
               if (taskResult.responseCode() != PeerTaskExecutorResponseCode.SUCCESS
                   || taskResult.result().isEmpty()) {
                 if (taskResult.responseCode() == PeerTaskExecutorResponseCode.NO_PEER_AVAILABLE) {
-                  return CompletableFuture.failedFuture(NoAvailablePeersException.WITHOUT_STACKTRACE);
+                  return CompletableFuture.failedFuture(
+                      NoAvailablePeersException.WITHOUT_STACKTRACE);
                 } else {
                   return CompletableFuture.failedFuture(
                       new RuntimeException(

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/tasks/DownloadHeaderSequenceTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/tasks/DownloadHeaderSequenceTask.java
@@ -164,7 +164,7 @@ public class DownloadHeaderSequenceTask extends AbstractRetryingPeerTask<List<Bl
               if (taskResult.responseCode() != PeerTaskExecutorResponseCode.SUCCESS
                   || taskResult.result().isEmpty()) {
                 if (taskResult.responseCode() == PeerTaskExecutorResponseCode.NO_PEER_AVAILABLE) {
-                  return CompletableFuture.failedFuture(NoAvailablePeersException.INSTANCE);
+                  return CompletableFuture.failedFuture(NoAvailablePeersException.WITHOUT_STACKTRACE);
                 } else {
                   return CompletableFuture.failedFuture(
                       new RuntimeException(

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/tasks/DownloadHeaderSequenceTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/tasks/DownloadHeaderSequenceTask.java
@@ -164,7 +164,7 @@ public class DownloadHeaderSequenceTask extends AbstractRetryingPeerTask<List<Bl
               if (taskResult.responseCode() != PeerTaskExecutorResponseCode.SUCCESS
                   || taskResult.result().isEmpty()) {
                 if (taskResult.responseCode() == PeerTaskExecutorResponseCode.NO_PEER_AVAILABLE) {
-                  return CompletableFuture.failedFuture(new NoAvailablePeersException());
+                  return CompletableFuture.failedFuture(NoAvailablePeersException.INSTANCE);
                 } else {
                   return CompletableFuture.failedFuture(
                       new RuntimeException(


### PR DESCRIPTION
## Summary

`NoAvailablePeersException` is thrown as a flow-control signal in four peer-selection retry paths:

- `PendingPeerRequest.attemptExecution()`
- `AbstractRetryingSwitchingPeerTask` retry loop
- `DownloadHeaderSequenceTask` (no peer available response)
- `PivotSyncActions` (pivot block download failure)

Each site previously allocated a fresh instance on every invocation, including a full JVM stack trace capture via the native `fillInStackTrace` call. The stack trace is never inspected — callers handle the exception by type or `FailureReason`.

## Change

Add a stackless `INSTANCE` singleton to `NoAvailablePeersException` itself, then update all four call sites. Because the exception carries only a constant `FailureReason` (`NO_AVAILABLE_PEERS`), sharing a single instance is safe.

```java
// Before (×4 call sites)
return CompletableFuture.failedFuture(new NoAvailablePeersException());

// After
return CompletableFuture.failedFuture(NoAvailablePeersException.INSTANCE);
```

Follows the same pattern as besu-eth/besu#10523 (RlpxAgent) and besu-eth/besu#10526 (AbstractEthTask). Part of the minor cleanup identified in besu-eth/besu#10498.

## Test plan

- [x] `./gradlew :ethereum:eth:test --tests "*PendingPeerRequest*" --tests "*AbstractRetryingSwitchingPeerTask*" --tests "*DownloadHeaderSequenceTask*" --tests "*PivotSyncActions*"`