### PR TITLE
Simplify wiring bidirectional references between state and chain downloader

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/common/PivotSyncDownloader.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/common/PivotSyncDownloader.java
@@ -20,8 +20,6 @@ import org.hyperledger.besu.ethereum.eth.manager.exceptions.MaxRetriesReachedExc
 import org.hyperledger.besu.ethereum.eth.manager.exceptions.NoAvailablePeersException;
 import org.hyperledger.besu.ethereum.eth.sync.ChainDownloader;
 import org.hyperledger.besu.ethereum.eth.sync.TrailingPeerRequirements;
-import org.hyperledger.besu.ethereum.eth.sync.snapsync.SnapSyncChainDownloader;
-import org.hyperledger.besu.ethereum.eth.sync.snapsync.SnapWorldStateDownloader;
 import org.hyperledger.besu.ethereum.eth.sync.worldstate.StalledDownloadException;
 import org.hyperledger.besu.ethereum.eth.sync.worldstate.WorldStateDownloader;
 import org.hyperledger.besu.ethereum.trie.pathbased.bonsai.storage.BonsaiWorldStateKeyValueStorage;
@@ -192,13 +190,7 @@ public class PivotSyncDownloader {
       LOG.debug("Registered chain downloader as pivot update listener");
     }
 
-    // Wire bidirectional references for SnapSync
-    if (worldStateDownloader instanceof SnapWorldStateDownloader
-        && chainDownloader instanceof SnapSyncChainDownloader) {
-      ((SnapWorldStateDownloader) worldStateDownloader)
-          .setChainDownloader((SnapSyncChainDownloader) chainDownloader);
-      LOG.debug("Wired bidirectional references between chain and world state downloaders");
-    }
+    worldStateDownloader.setChainDownloader(chainDownloader);
   }
 
   protected PivotSyncState storeState(final PivotSyncState state) {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapWorldStateDownloader.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapWorldStateDownloader.java
@@ -21,6 +21,7 @@ import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.eth.manager.EthContext;
+import org.hyperledger.besu.ethereum.eth.sync.ChainDownloader;
 import org.hyperledger.besu.ethereum.eth.sync.common.PivotSyncActions;
 import org.hyperledger.besu.ethereum.eth.sync.common.PivotSyncState;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.context.SnapSyncStatePersistenceManager;
@@ -129,8 +130,11 @@ public class SnapWorldStateDownloader implements WorldStateDownloader {
    *
    * @param chainDownloader the chain downloader to wire up
    */
-  public void setChainDownloader(final SnapSyncChainDownloader chainDownloader) {
-    this.chainDownloader = chainDownloader;
+  @Override
+  public void setChainDownloader(final ChainDownloader chainDownloader) {
+    if (chainDownloader instanceof SnapSyncChainDownloader snapSyncChainDownloader) {
+      this.chainDownloader = snapSyncChainDownloader;
+    }
   }
 
   @Override

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/worldstate/WorldStateDownloader.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/worldstate/WorldStateDownloader.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.ethereum.eth.sync.worldstate;
 
+import org.hyperledger.besu.ethereum.eth.sync.ChainDownloader;
 import org.hyperledger.besu.ethereum.eth.sync.common.PivotSyncActions;
 import org.hyperledger.besu.ethereum.eth.sync.common.PivotSyncState;
 
@@ -23,6 +24,8 @@ public interface WorldStateDownloader extends WorldStateDownloadStatus {
 
   CompletableFuture<Void> run(
       final PivotSyncActions fastSyncActions, final PivotSyncState fastSyncState);
+
+  default void setChainDownloader(final ChainDownloader chainDownloader) {}
 
   void cancel();
 }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/common/PivotSyncDownloaderTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/common/PivotSyncDownloaderTest.java
@@ -128,6 +128,7 @@ public class PivotSyncDownloaderTest {
         .createChainDownloader(
             downloadPivotBlockHeaderState, SyncDurationMetrics.NO_OP_SYNC_DURATION_METRICS);
     verify(chainDownloader).start();
+    verify(worldStateDownloader).setChainDownloader(chainDownloader);
     verify(worldStateDownloader)
         .run(any(PivotSyncActions.class), eq(new PivotSyncState(pivotBlockHeader, false)));
     verifyNoMoreInteractions(fastSyncActions, worldStateDownloader);
@@ -167,6 +168,7 @@ public class PivotSyncDownloaderTest {
     verify(fastSyncActions)
         .createChainDownloader(fastSyncState, SyncDurationMetrics.NO_OP_SYNC_DURATION_METRICS);
     verify(chainDownloader).start();
+    verify(worldStateDownloader).setChainDownloader(chainDownloader);
     verify(worldStateDownloader)
         .run(any(PivotSyncActions.class), eq(new PivotSyncState(pivotBlockHeader, false)));
     verifyNoMoreInteractions(fastSyncActions, worldStateDownloader);
@@ -218,6 +220,7 @@ public class PivotSyncDownloaderTest {
     verify(fastSyncActions)
         .createChainDownloader(
             downloadPivotBlockHeaderState, SyncDurationMetrics.NO_OP_SYNC_DURATION_METRICS);
+    verify(worldStateDownloader).setChainDownloader(chainDownloader);
     verify(worldStateDownloader)
         .run(any(PivotSyncActions.class), eq(new PivotSyncState(pivotBlockHeader, false)));
     verifyNoMoreInteractions(fastSyncActions, worldStateDownloader);
@@ -261,6 +264,7 @@ public class PivotSyncDownloaderTest {
     verify(fastSyncActions)
         .createChainDownloader(
             downloadPivotBlockHeaderState, SyncDurationMetrics.NO_OP_SYNC_DURATION_METRICS);
+    verify(worldStateDownloader).setChainDownloader(chainDownloader);
     verify(worldStateDownloader)
         .run(any(PivotSyncActions.class), eq(new PivotSyncState(pivotBlockHeader, false)));
     verifyNoMoreInteractions(fastSyncActions);
@@ -340,6 +344,7 @@ public class PivotSyncDownloaderTest {
     verify(fastSyncActions)
         .createChainDownloader(
             downloadPivotBlockHeaderState, SyncDurationMetrics.NO_OP_SYNC_DURATION_METRICS);
+    verify(worldStateDownloader).setChainDownloader(chainDownloader);
     verify(worldStateDownloader)
         .run(any(PivotSyncActions.class), eq(new PivotSyncState(pivotBlockHeader, false)));
     verifyNoMoreInteractions(fastSyncActions);
@@ -382,6 +387,7 @@ public class PivotSyncDownloaderTest {
     verify(fastSyncActions)
         .createChainDownloader(
             downloadPivotBlockHeaderState, SyncDurationMetrics.NO_OP_SYNC_DURATION_METRICS);
+    verify(worldStateDownloader).setChainDownloader(chainDownloader);
     verify(worldStateDownloader)
         .run(any(PivotSyncActions.class), eq(new PivotSyncState(pivotBlockHeader, false)));
     verifyNoMoreInteractions(fastSyncActions);
@@ -446,6 +452,7 @@ public class PivotSyncDownloaderTest {
     verify(fastSyncActions)
         .createChainDownloader(
             downloadPivotBlockHeaderState, SyncDurationMetrics.NO_OP_SYNC_DURATION_METRICS);
+    verify(worldStateDownloader).setChainDownloader(chainDownloader);
     verify(worldStateDownloader)
         .run(any(PivotSyncActions.class), eq(new PivotSyncState(pivotBlockHeader, false)));
     verifyNoMoreInteractions(fastSyncActions, worldStateDownloader);
@@ -463,6 +470,7 @@ public class PivotSyncDownloaderTest {
     verify(fastSyncActions)
         .createChainDownloader(
             secondDownloadPivotBlockHeaderState, SyncDurationMetrics.NO_OP_SYNC_DURATION_METRICS);
+    verify(worldStateDownloader).setChainDownloader(secondChainDownloader);
     verify(worldStateDownloader)
         .run(any(PivotSyncActions.class), eq(new PivotSyncState(secondPivotBlockHeader, false)));
     verifyNoMoreInteractions(fastSyncActions, worldStateDownloader);
@@ -527,6 +535,7 @@ public class PivotSyncDownloaderTest {
     verify(fastSyncActions)
         .createChainDownloader(
             downloadPivotBlockHeaderState, SyncDurationMetrics.NO_OP_SYNC_DURATION_METRICS);
+    verify(worldStateDownloader).setChainDownloader(chainDownloader);
     verify(worldStateDownloader)
         .run(any(PivotSyncActions.class), eq(new PivotSyncState(pivotBlockHeader, false)));
     verifyNoMoreInteractions(fastSyncActions, worldStateDownloader);
@@ -546,6 +555,7 @@ public class PivotSyncDownloaderTest {
     verify(fastSyncActions)
         .createChainDownloader(
             secondDownloadPivotBlockHeaderState, SyncDurationMetrics.NO_OP_SYNC_DURATION_METRICS);
+    verify(worldStateDownloader).setChainDownloader(secondChainDownloader);
     verify(worldStateDownloader)
         .run(any(PivotSyncActions.class), eq(new PivotSyncState(secondPivotBlockHeader, false)));
     verifyNoMoreInteractions(fastSyncActions, worldStateDownloader);


### PR DESCRIPTION
Makes `setChainDownloader` a method of `WorldStateDownloader`, which allows removing runtime instance type checks and thus simplifies the callsite. This becomes especially useful as `WorldStateDownloader` will have multiple implementations in snap sync v2.