### PR TITLE
Pass start hash through findNewBeginElementInRange

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/AccountRangeDataRequest.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/AccountRangeDataRequest.java
@@ -198,6 +198,7 @@ public class AccountRangeDataRequest extends SnapDataRequest {
             Bytes32.wrap(getRootHash().getBytes()),
             taskElement.proofs(),
             taskElement.keys(),
+            startKeyHash,
             endKeyHash)
         .ifPresentOrElse(
             missingRightElement -> {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/StorageRangeDataRequest.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/StorageRangeDataRequest.java
@@ -181,7 +181,8 @@ public class StorageRangeDataRequest extends SnapDataRequest {
       return Stream.empty();
     }
 
-    findNewBeginElementInRange(storageRoot, taskElement.proofs(), taskElement.keys(), endKeyHash)
+    findNewBeginElementInRange(
+            storageRoot, taskElement.proofs(), taskElement.keys(), startKeyHash, endKeyHash)
         .ifPresent(
             missingRightElement -> {
               final int nbRanges = getRangeCount(startKeyHash, endKeyHash, taskElement.keys());

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/RangeManagerTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/RangeManagerTest.java
@@ -196,4 +196,96 @@ public final class RangeManagerTest {
 
     assertThat(newBeginElementInRange).isEmpty();
   }
+
+  @Test
+  public void testFindNewBeginElementWhenResponseTruncatedWithFullCoverageProofs() {
+    // A responder that returns only a subset of the keys but provides proofs that cover every
+    // leaf in the range must be detected as incomplete. With boundary-only proofs the existing
+    // missing-node probe already handles this; the harder case is when the proofs themselves
+    // make every leaf reachable.
+    final ForestWorldStateKeyValueStorage worldStateKeyValueStorage =
+        new ForestWorldStateKeyValueStorage(new InMemoryKeyValueStorage());
+    final WorldStateStorageCoordinator worldStateStorageCoordinator =
+        new WorldStateStorageCoordinator(worldStateKeyValueStorage);
+
+    final MerkleTrie<Bytes, Bytes> accountStateTrie =
+        TrieGenerator.generateTrie(worldStateStorageCoordinator, 15);
+
+    final RangeStorageEntriesCollector collector =
+        RangeStorageEntriesCollector.createCollector(
+            Bytes32.wrap(Hash.ZERO.getBytes()), RangeManager.MAX_RANGE, 15, Integer.MAX_VALUE);
+    final TrieIterator<Bytes> visitor = RangeStorageEntriesCollector.createVisitor(collector);
+    final TreeMap<Bytes32, Bytes> allAccounts =
+        (TreeMap<Bytes32, Bytes>)
+            accountStateTrie.entriesFrom(
+                root ->
+                    RangeStorageEntriesCollector.collectEntries(
+                        collector, visitor, root, Bytes32.wrap(Hash.ZERO.getBytes())));
+
+    final WorldStateProofProvider worldStateProofProvider =
+        new WorldStateProofProvider(worldStateStorageCoordinator);
+
+    final List<Bytes> proofs = new java.util.ArrayList<>();
+    for (Bytes32 key : allAccounts.keySet()) {
+      proofs.addAll(
+          worldStateProofProvider.getAccountProofRelatedNodes(
+              Hash.wrap(accountStateTrie.getRootHash()), key));
+    }
+
+    final TreeMap<Bytes32, Bytes> partialAccounts = new TreeMap<>();
+    int taken = 0;
+    for (Map.Entry<Bytes32, Bytes> e : allAccounts.entrySet()) {
+      if (taken++ < 2) partialAccounts.put(e.getKey(), e.getValue());
+    }
+
+    final Optional<Bytes32> newBeginElementInRange =
+        RangeManager.findNewBeginElementInRange(
+            accountStateTrie.getRootHash(), proofs, partialAccounts, RangeManager.MAX_RANGE);
+
+    assertThat(newBeginElementInRange).isPresent();
+  }
+
+  @Test
+  public void testFindNewBeginElementWhenNoKeysReturnedButRangeNonEmpty() {
+    // A responder that returns zero keys but proofs that resolve all leaves in the range must
+    // still cause the caller to schedule follow-up fetches for the omitted entries.
+    final ForestWorldStateKeyValueStorage worldStateKeyValueStorage =
+        new ForestWorldStateKeyValueStorage(new InMemoryKeyValueStorage());
+    final WorldStateStorageCoordinator worldStateStorageCoordinator =
+        new WorldStateStorageCoordinator(worldStateKeyValueStorage);
+
+    final MerkleTrie<Bytes, Bytes> accountStateTrie =
+        TrieGenerator.generateTrie(worldStateStorageCoordinator, 15);
+
+    final RangeStorageEntriesCollector collector =
+        RangeStorageEntriesCollector.createCollector(
+            Bytes32.wrap(Hash.ZERO.getBytes()), RangeManager.MAX_RANGE, 15, Integer.MAX_VALUE);
+    final TrieIterator<Bytes> visitor = RangeStorageEntriesCollector.createVisitor(collector);
+    final TreeMap<Bytes32, Bytes> allAccounts =
+        (TreeMap<Bytes32, Bytes>)
+            accountStateTrie.entriesFrom(
+                root ->
+                    RangeStorageEntriesCollector.collectEntries(
+                        collector, visitor, root, Bytes32.wrap(Hash.ZERO.getBytes())));
+
+    final WorldStateProofProvider worldStateProofProvider =
+        new WorldStateProofProvider(worldStateStorageCoordinator);
+
+    final List<Bytes> proofs = new java.util.ArrayList<>();
+    for (Bytes32 key : allAccounts.keySet()) {
+      proofs.addAll(
+          worldStateProofProvider.getAccountProofRelatedNodes(
+              Hash.wrap(accountStateTrie.getRootHash()), key));
+    }
+
+    final Optional<Bytes32> newBeginElementInRange =
+        RangeManager.findNewBeginElementInRange(
+            accountStateTrie.getRootHash(),
+            proofs,
+            new TreeMap<>(),
+            RangeManager.MIN_RANGE,
+            RangeManager.MAX_RANGE);
+
+    assertThat(newBeginElementInRange).isPresent();
+  }
 }

--- a/ethereum/trie/src/main/java/org/hyperledger/besu/ethereum/trie/RangeManager.java
+++ b/ethereum/trie/src/main/java/org/hyperledger/besu/ethereum/trie/RangeManager.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.ethereum.trie;
 
 import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.trie.InnerNodeDiscoveryManager.InnerNode;
 import org.hyperledger.besu.ethereum.trie.patricia.StoredMerklePatriciaTrie;
 
 import java.math.BigInteger;
@@ -171,7 +172,30 @@ public class RangeManager {
     } catch (MerkleTrieException e) {
       return Optional.of(InnerNodeDiscoveryManager.decodePath(e.getLocation()));
     }
-    return Optional.empty();
+
+    // visitAll completes whenever every node it touches resolves through the supplied node
+    // source. If the source itself encodes leaves the responder did not include in
+    // receivedKeys, the walk silently visits them — so scan the discovered inner nodes for
+    // any in-range leaf the responder omitted.
+    Bytes32 firstOmitted = null;
+    for (InnerNode innerNode : manager.getInnerNodes()) {
+      final Bytes concatenated = Bytes.concatenate(innerNode.location(), innerNode.path());
+      if (concatenated.size() != Bytes32.SIZE * 2 + 1) {
+        continue;
+      }
+      final Bytes32 leafKey =
+          InnerNodeDiscoveryManager.decodePath(concatenated.slice(0, concatenated.size() - 1));
+      if (leafKey.compareTo(probeStart) <= 0 || leafKey.compareTo(endKeyHash) > 0) {
+        continue;
+      }
+      if (receivedKeys.containsKey(leafKey)) {
+        continue;
+      }
+      if (firstOmitted == null || leafKey.compareTo(firstOmitted) < 0) {
+        firstOmitted = leafKey;
+      }
+    }
+    return Optional.ofNullable(firstOmitted);
   }
 
   private static Bytes32 format(final BigInteger data) {

--- a/ethereum/trie/src/main/java/org/hyperledger/besu/ethereum/trie/RangeManager.java
+++ b/ethereum/trie/src/main/java/org/hyperledger/besu/ethereum/trie/RangeManager.java
@@ -117,7 +117,7 @@ public class RangeManager {
    * @param worldstateRootHash the root hash
    * @param proofs proof received
    * @param endKeyHash the end of the range initially wanted
-   * @param receivedKeys the last key received
+   * @param receivedKeys the keys already returned by the responder
    * @return begin of the new range
    */
   public static Optional<Bytes32> findNewBeginElementInRange(
@@ -125,31 +125,53 @@ public class RangeManager {
       final List<Bytes> proofs,
       final NavigableMap<Bytes32, Bytes> receivedKeys,
       final Bytes32 endKeyHash) {
-    if (receivedKeys.isEmpty() || receivedKeys.lastKey().compareTo(endKeyHash) >= 0) {
-      return Optional.empty();
-    } else {
-      final Map<Bytes32, Bytes> proofsEntries = new HashMap<>();
-      for (Bytes proof : proofs) {
-        proofsEntries.put(Bytes32.wrap(Hash.hash(proof).getBytes()), proof);
-      }
-      final StoredMerklePatriciaTrie<Bytes, Bytes> storageTrie =
-          new StoredMerklePatriciaTrie<>(
-              new InnerNodeDiscoveryManager<>(
-                  (location, key) -> Optional.ofNullable(proofsEntries.get(key)),
-                  Function.identity(),
-                  Function.identity(),
-                  receivedKeys.lastKey(),
-                  endKeyHash,
-                  false),
-              worldstateRootHash);
+    return findNewBeginElementInRange(
+        worldstateRootHash, proofs, receivedKeys, MIN_RANGE, endKeyHash);
+  }
 
-      try {
-        storageTrie.visitAll(bytesNode -> {});
-      } catch (MerkleTrieException e) {
-        return Optional.of(InnerNodeDiscoveryManager.decodePath(e.getLocation()));
-      }
+  /**
+   * Helps to create a new range according to the last data obtained. This happens when a peer
+   * doesn't return all of the data in a range.
+   *
+   * @param worldstateRootHash the root hash
+   * @param proofs proof received
+   * @param receivedKeys the keys already returned by the responder
+   * @param startKeyHash the start of the range initially wanted (used as the probe origin when no
+   *     keys were returned)
+   * @param endKeyHash the end of the range initially wanted
+   * @return begin of the new range
+   */
+  public static Optional<Bytes32> findNewBeginElementInRange(
+      final Bytes32 worldstateRootHash,
+      final List<Bytes> proofs,
+      final NavigableMap<Bytes32, Bytes> receivedKeys,
+      final Bytes32 startKeyHash,
+      final Bytes32 endKeyHash) {
+    if (!receivedKeys.isEmpty() && receivedKeys.lastKey().compareTo(endKeyHash) >= 0) {
       return Optional.empty();
     }
+    final Bytes32 probeStart = receivedKeys.isEmpty() ? startKeyHash : receivedKeys.lastKey();
+    final Map<Bytes32, Bytes> proofsEntries = new HashMap<>();
+    for (Bytes proof : proofs) {
+      proofsEntries.put(Bytes32.wrap(Hash.hash(proof).getBytes()), proof);
+    }
+    final InnerNodeDiscoveryManager<Bytes> manager =
+        new InnerNodeDiscoveryManager<>(
+            (location, key) -> Optional.ofNullable(proofsEntries.get(key)),
+            Function.identity(),
+            Function.identity(),
+            probeStart,
+            endKeyHash,
+            false);
+    final StoredMerklePatriciaTrie<Bytes, Bytes> storageTrie =
+        new StoredMerklePatriciaTrie<>(manager, worldstateRootHash);
+
+    try {
+      storageTrie.visitAll(bytesNode -> {});
+    } catch (MerkleTrieException e) {
+      return Optional.of(InnerNodeDiscoveryManager.decodePath(e.getLocation()));
+    }
+    return Optional.empty();
   }
 
   private static Bytes32 format(final BigInteger data) {


### PR DESCRIPTION
## Summary
- Add an explicit start-hash parameter to `RangeManager.findNewBeginElementInRange` so the probe origin is well-defined when the responder returned no keys; previously the helper short-circuited on `receivedKeys.isEmpty()`.
- After `visitAll`, scan the discovered inner-node registry for in-range leaves the responder did not echo back in the keys map. The existing missing-node signal does not fire when the supplied proofs themselves resolve every leaf in the range, so any omitted leaves go undetected and the caller fails to schedule the follow-up fetch.
- Update `AccountRangeDataRequest` and `StorageRangeDataRequest` to pass their `startKeyHash` to the helper.

## Test plan
- [x] `./gradlew :ethereum:eth:test --tests 'org.hyperledger.besu.ethereum.eth.sync.snapsync.RangeManagerTest'` (4 existing + 2 new regression tests)
- [x] `./gradlew :ethereum:eth:test --tests 'org.hyperledger.besu.ethereum.eth.sync.snapsync.*' --tests 'org.hyperledger.besu.ethereum.eth.manager.snap.*'`
- [x] `./gradlew :ethereum:core:test --tests 'org.hyperledger.besu.ethereum.proof.WorldStateRangeProofProviderTest'`
- [x] `./gradlew :ethereum:eth:spotlessCheck :ethereum:trie:spotlessCheck :ethereum:core:spotlessCheck`