### PR TITLE
Make snap/2 BAL fetching strict

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/snap/GetBlockAccessListsFromPeerTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/snap/GetBlockAccessListsFromPeerTask.java
@@ -14,7 +14,6 @@
  */
 package org.hyperledger.besu.ethereum.eth.manager.snap;
 
-import static java.util.Collections.emptyList;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import org.hyperledger.besu.datatypes.Hash;
@@ -50,19 +49,12 @@ public class GetBlockAccessListsFromPeerTask
 
   private final List<BlockHeader> blockHeaders;
 
-  private GetBlockAccessListsFromPeerTask(
+  public GetBlockAccessListsFromPeerTask(
       final EthContext ethContext,
       final List<BlockHeader> blockHeaders,
       final MetricsSystem metricsSystem) {
     super(ethContext, SnapProtocol.NAME, SnapV2.BLOCK_ACCESS_LISTS, metricsSystem);
     this.blockHeaders = blockHeaders;
-  }
-
-  public static GetBlockAccessListsFromPeerTask forBlockAccessLists(
-      final EthContext ethContext,
-      final List<BlockHeader> blockHeaders,
-      final MetricsSystem metricsSystem) {
-    return new GetBlockAccessListsFromPeerTask(ethContext, blockHeaders, metricsSystem);
   }
 
   @Override
@@ -116,7 +108,7 @@ public class GetBlockAccessListsFromPeerTask
   protected Optional<List<SyncBlockAccessList>> processResponse(
       final boolean streamClosed, final MessageData message, final EthPeer peer) {
     if (streamClosed) {
-      return Optional.of(emptyList());
+      return Optional.empty();
     }
 
     final List<SyncBlockAccessList> result = new ArrayList<>();
@@ -128,6 +120,7 @@ public class GetBlockAccessListsFromPeerTask
                 .formatted(blockHeaders.size(), index + 1));
       }
       final SyncBlockAccessList syncBlockAccessList = new SyncBlockAccessList(balRlp);
+      // TODO: Penalize peers maliciously denying BALs
       if (!syncBlockAccessList.isUnavailable()) {
         final int currentIndex = index;
         final BlockHeader blockHeader = blockHeaders.get(currentIndex);

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/snap/RetryingGetBlockAccessListsFromPeerTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/snap/RetryingGetBlockAccessListsFromPeerTask.java
@@ -20,6 +20,7 @@ import org.hyperledger.besu.ethereum.eth.SnapProtocol;
 import org.hyperledger.besu.ethereum.eth.manager.EthContext;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeer;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeerImmutableAttributes;
+import org.hyperledger.besu.ethereum.eth.manager.exceptions.IncompleteResultsException;
 import org.hyperledger.besu.ethereum.eth.manager.task.AbstractRetryingSwitchingPeerTask;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 
@@ -76,7 +77,7 @@ public class RetryingGetBlockAccessListsFromPeerTask
               if (pendingIndexes.isEmpty()) {
                 return completedBlockAccessLists();
               }
-              throw new IncompleteBlockAccessListsException(pendingIndexes.size());
+              throw new IncompleteResultsException();
             });
   }
 
@@ -107,19 +108,8 @@ public class RetryingGetBlockAccessListsFromPeerTask
   }
 
   @Override
-  protected boolean isRetryableError(final Throwable error) {
-    return super.isRetryableError(error) || error instanceof IncompleteBlockAccessListsException;
-  }
-
-  @Override
   protected boolean isSuitablePeer(final EthPeerImmutableAttributes peer) {
     return peer.isServingSnap()
         && peer.ethPeer().getAgreedCapabilities().contains(SnapProtocol.SNAP2);
-  }
-
-  private static class IncompleteBlockAccessListsException extends RuntimeException {
-    private IncompleteBlockAccessListsException(final int pendingBlockAccessLists) {
-      super("Still waiting for " + pendingBlockAccessLists + " block access lists");
-    }
   }
 }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/snap/RetryingGetBlockAccessListsFromPeerTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/snap/RetryingGetBlockAccessListsFromPeerTask.java
@@ -21,22 +21,29 @@ import org.hyperledger.besu.ethereum.eth.manager.EthContext;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeer;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeerImmutableAttributes;
 import org.hyperledger.besu.ethereum.eth.manager.task.AbstractRetryingSwitchingPeerTask;
-import org.hyperledger.besu.ethereum.eth.manager.task.EthTask;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+
+import com.google.common.annotations.VisibleForTesting;
 
 public class RetryingGetBlockAccessListsFromPeerTask
     extends AbstractRetryingSwitchingPeerTask<List<SyncBlockAccessList>> {
 
-  public static final int MAX_RETRIES = 4;
+  public static final int MAX_RETRIES = 16;
 
   private final EthContext ethContext;
   private final List<BlockHeader> blockHeaders;
   private final MetricsSystem metricsSystem;
+  private final List<SyncBlockAccessList> blockAccessLists;
+  private final Set<Integer> pendingIndexes = new LinkedHashSet<>();
 
-  private RetryingGetBlockAccessListsFromPeerTask(
+  public RetryingGetBlockAccessListsFromPeerTask(
       final EthContext ethContext,
       final List<BlockHeader> blockHeaders,
       final MetricsSystem metricsSystem) {
@@ -44,32 +51,75 @@ public class RetryingGetBlockAccessListsFromPeerTask
     this.ethContext = ethContext;
     this.blockHeaders = blockHeaders;
     this.metricsSystem = metricsSystem;
-  }
-
-  public static EthTask<List<SyncBlockAccessList>> forBlockAccessLists(
-      final EthContext ethContext,
-      final List<BlockHeader> blockHeaders,
-      final MetricsSystem metricsSystem) {
-    return new RetryingGetBlockAccessListsFromPeerTask(ethContext, blockHeaders, metricsSystem);
+    this.blockAccessLists = new ArrayList<>(Collections.nCopies(blockHeaders.size(), null));
+    for (int i = 0; i < blockHeaders.size(); i++) {
+      pendingIndexes.add(i);
+    }
   }
 
   @Override
   protected CompletableFuture<List<SyncBlockAccessList>> executeTaskOnCurrentPeer(
       final EthPeer peer) {
+    if (pendingIndexes.isEmpty()) {
+      return CompletableFuture.completedFuture(completedBlockAccessLists());
+    }
+
+    final List<Integer> requestedIndexes = List.copyOf(pendingIndexes);
     final GetBlockAccessListsFromPeerTask task =
-        GetBlockAccessListsFromPeerTask.forBlockAccessLists(
-            ethContext, blockHeaders, metricsSystem);
+        new GetBlockAccessListsFromPeerTask(
+            ethContext, requestedIndexes.stream().map(blockHeaders::get).toList(), metricsSystem);
+    task.assignPeer(peer);
     return executeSubTask(task::run)
         .thenApply(
             peerResult -> {
-              result.complete(peerResult.getResult());
-              return peerResult.getResult();
+              processBlockAccessLists(requestedIndexes, peerResult.getResult());
+              if (pendingIndexes.isEmpty()) {
+                return completedBlockAccessLists();
+              }
+              throw new IncompleteBlockAccessListsException(pendingIndexes.size());
             });
+  }
+
+  @VisibleForTesting
+  void processBlockAccessLists(
+      final List<Integer> requestedIndexes,
+      final List<SyncBlockAccessList> receivedBlockAccessLists) {
+    for (int i = 0; i < receivedBlockAccessLists.size(); i++) {
+      final SyncBlockAccessList blockAccessList = receivedBlockAccessLists.get(i);
+      if (blockAccessList.isUnavailable()) {
+        continue;
+      }
+
+      final int originalIndex = requestedIndexes.get(i);
+      if (pendingIndexes.remove(originalIndex)) {
+        blockAccessLists.set(originalIndex, blockAccessList);
+      }
+    }
+  }
+
+  private List<SyncBlockAccessList> completedBlockAccessLists() {
+    return List.copyOf(blockAccessLists);
+  }
+
+  @VisibleForTesting
+  int pendingBlockAccessLists() {
+    return pendingIndexes.size();
+  }
+
+  @Override
+  protected boolean isRetryableError(final Throwable error) {
+    return super.isRetryableError(error) || error instanceof IncompleteBlockAccessListsException;
   }
 
   @Override
   protected boolean isSuitablePeer(final EthPeerImmutableAttributes peer) {
     return peer.isServingSnap()
         && peer.ethPeer().getAgreedCapabilities().contains(SnapProtocol.SNAP2);
+  }
+
+  private static class IncompleteBlockAccessListsException extends RuntimeException {
+    private IncompleteBlockAccessListsException(final int pendingBlockAccessLists) {
+      super("Still waiting for " + pendingBlockAccessLists + " block access lists");
+    }
   }
 }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/snap/GetBlockAccessListsFromPeerTaskTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/snap/GetBlockAccessListsFromPeerTaskTest.java
@@ -16,7 +16,10 @@ package org.hyperledger.besu.ethereum.eth.manager.snap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.datatypes.Hash;
@@ -27,6 +30,9 @@ import org.hyperledger.besu.ethereum.eth.SnapProtocol;
 import org.hyperledger.besu.ethereum.eth.manager.EthContext;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeer;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeerImmutableAttributes;
+import org.hyperledger.besu.ethereum.eth.manager.EthPeers;
+import org.hyperledger.besu.ethereum.eth.manager.PeerRequest;
+import org.hyperledger.besu.ethereum.eth.manager.PendingPeerRequest;
 import org.hyperledger.besu.ethereum.eth.manager.exceptions.ProtocolViolationException;
 import org.hyperledger.besu.ethereum.eth.messages.snap.BlockAccessListsMessage;
 import org.hyperledger.besu.ethereum.mainnet.BodyValidation;
@@ -94,6 +100,22 @@ class GetBlockAccessListsFromPeerTaskTest {
   }
 
   @Test
+  void shouldRejectMoreBlockAccessListsThanRequested() {
+    final BlockAccessList firstBal = dataGenerator.blockAccessList();
+    final BlockAccessList unexpectedBal = dataGenerator.blockAccessList();
+    final GetBlockAccessListsFromPeerTask task = taskFor(List.of(headerForBal(1, firstBal)));
+
+    assertThatThrownBy(
+            () ->
+                task.processResponse(
+                    false,
+                    responseWith(Optional.of(firstBal), Optional.of(unexpectedBal)),
+                    mock(EthPeer.class)))
+        .isInstanceOf(ProtocolViolationException.class)
+        .hasMessageContaining("more block access lists than requested");
+  }
+
+  @Test
   void shouldAcceptTruncatedBlockAccessListResponse() {
     final BlockAccessList firstBal = dataGenerator.blockAccessList();
     final BlockAccessList secondBal = dataGenerator.blockAccessList();
@@ -108,6 +130,79 @@ class GetBlockAccessListsFromPeerTaskTest {
   }
 
   @Test
+  void shouldWaitForResponseWhenStreamClosesBeforeBlockAccessListsArrive() {
+    final GetBlockAccessListsFromPeerTask task =
+        taskFor(List.of(headerForBal(1, dataGenerator.blockAccessList())));
+
+    final Optional<List<SyncBlockAccessList>> result =
+        task.processResponse(true, null, mock(EthPeer.class));
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void shouldRetryUnavailableAndTruncatedBlockAccessListEntries() {
+    final BlockAccessList firstBal = dataGenerator.blockAccessList();
+    final BlockAccessList secondBal = dataGenerator.blockAccessList();
+    final BlockAccessList thirdBal = dataGenerator.blockAccessList();
+    final RetryingGetBlockAccessListsFromPeerTask task =
+        retryingTaskFor(
+            List.of(
+                headerForBal(1, firstBal), headerForBal(2, secondBal), headerForBal(3, thirdBal)));
+
+    task.processBlockAccessLists(List.of(0, 1, 2), List.of(syncBal(firstBal), unavailableBal()));
+
+    assertThat(task.pendingBlockAccessLists()).isEqualTo(2);
+
+    task.processBlockAccessLists(List.of(1, 2), List.of(syncBal(secondBal), syncBal(thirdBal)));
+
+    assertThat(task.pendingBlockAccessLists()).isEqualTo(0);
+    assertThat(task.executeTaskOnCurrentPeer(mock(EthPeer.class)).join())
+        .containsExactly(syncBal(firstBal), syncBal(secondBal), syncBal(thirdBal));
+  }
+
+  @Test
+  void shouldMapRetriedResponsesToOriginalRequestIndexes() {
+    final BlockAccessList firstBal = dataGenerator.blockAccessList();
+    final BlockAccessList secondBal = dataGenerator.blockAccessList();
+    final BlockAccessList thirdBal = dataGenerator.blockAccessList();
+    final RetryingGetBlockAccessListsFromPeerTask task =
+        retryingTaskFor(
+            List.of(
+                headerForBal(1, firstBal), headerForBal(2, secondBal), headerForBal(3, thirdBal)));
+
+    task.processBlockAccessLists(List.of(0, 1, 2), List.of(unavailableBal(), syncBal(secondBal)));
+
+    assertThat(task.pendingBlockAccessLists()).isEqualTo(2);
+
+    task.processBlockAccessLists(List.of(0, 2), List.of(syncBal(firstBal), syncBal(thirdBal)));
+
+    assertThat(task.executeTaskOnCurrentPeer(mock(EthPeer.class)).join())
+        .containsExactly(syncBal(firstBal), syncBal(secondBal), syncBal(thirdBal));
+  }
+
+  @Test
+  void shouldRequestBlockAccessListsFromSelectedSwitchingPeer() {
+    final BlockAccessList blockAccessList = dataGenerator.blockAccessList();
+    final EthContext ethContext = mock(EthContext.class);
+    final EthPeers ethPeers = mock(EthPeers.class);
+    final PendingPeerRequest pendingPeerRequest = mock(PendingPeerRequest.class);
+    final EthPeer selectedPeer = mock(EthPeer.class);
+    final RetryingGetBlockAccessListsFromPeerTask task =
+        new RetryingGetBlockAccessListsFromPeerTask(
+            ethContext, List.of(headerForBal(1, blockAccessList)), new NoOpMetricsSystem());
+
+    when(ethContext.getEthPeers()).thenReturn(ethPeers);
+    when(ethPeers.executePeerRequest(any(PeerRequest.class), eq(1L), eq(Optional.of(selectedPeer))))
+        .thenReturn(pendingPeerRequest);
+
+    task.executeTaskOnCurrentPeer(selectedPeer);
+
+    verify(ethPeers)
+        .executePeerRequest(any(PeerRequest.class), eq(1L), eq(Optional.of(selectedPeer)));
+  }
+
+  @Test
   void shouldSelectOnlySnap2ServingPeers() {
     final RetryingGetBlockAccessListsFromPeerTask task = retryingTask();
 
@@ -117,16 +212,18 @@ class GetBlockAccessListsFromPeerTaskTest {
   }
 
   private GetBlockAccessListsFromPeerTask taskFor(final List<BlockHeader> blockHeaders) {
-    return GetBlockAccessListsFromPeerTask.forBlockAccessLists(
+    return new GetBlockAccessListsFromPeerTask(
         mock(EthContext.class), blockHeaders, new NoOpMetricsSystem());
   }
 
   private RetryingGetBlockAccessListsFromPeerTask retryingTask() {
-    return (RetryingGetBlockAccessListsFromPeerTask)
-        RetryingGetBlockAccessListsFromPeerTask.forBlockAccessLists(
-            mock(EthContext.class),
-            List.of(headerForBal(1, dataGenerator.blockAccessList())),
-            new NoOpMetricsSystem());
+    return retryingTaskFor(List.of(headerForBal(1, dataGenerator.blockAccessList())));
+  }
+
+  private RetryingGetBlockAccessListsFromPeerTask retryingTaskFor(
+      final List<BlockHeader> blockHeaders) {
+    return new RetryingGetBlockAccessListsFromPeerTask(
+        mock(EthContext.class), blockHeaders, new NoOpMetricsSystem());
   }
 
   private BlockHeader headerForBal(final long number, final BlockAccessList blockAccessList) {


### PR DESCRIPTION
Changes BAL fetching to match snap/2 requirements: sync must not advance without valid block access lists.

Behavior changes:
- Retry missing, unavailable, or truncated BALs with other snap/2 peers.
- Keep waiting for suitable peers instead of completing with partial BAL data.
- Pin retry sub-requests to the selected peer.

Based on: https://github.com/besu-eth/besu/pull/10538