### PR TITLE
Prepare snap sync downloader selection for snap/2

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/DefaultSynchronizer.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/DefaultSynchronizer.java
@@ -30,7 +30,7 @@ import org.hyperledger.besu.ethereum.eth.sync.common.PivotSyncState;
 import org.hyperledger.besu.ethereum.eth.sync.fullsync.FullSyncDownloader;
 import org.hyperledger.besu.ethereum.eth.sync.fullsync.SyncTerminationCondition;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.SnapDownloaderFactory;
-import org.hyperledger.besu.ethereum.eth.sync.snapsync.SnapSyncDownloader;
+import org.hyperledger.besu.ethereum.eth.sync.snapsync.SnapSyncController;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.context.SnapSyncStatePersistenceManager;
 import org.hyperledger.besu.ethereum.eth.sync.state.PendingBlocksManager;
 import org.hyperledger.besu.ethereum.eth.sync.state.SyncState;
@@ -68,9 +68,9 @@ public class DefaultSynchronizer implements Synchronizer, UnverifiedForkchoiceLi
   private final SyncState syncState;
   private final AtomicBoolean running = new AtomicBoolean(false);
   private final Optional<BlockPropagationManager> blockPropagationManager;
-  private final Supplier<Optional<SnapSyncDownloader>> fastSyncFactory;
+  private final Supplier<Optional<SnapSyncController>> fastSyncFactory;
   private final SyncDurationMetrics syncDurationMetrics;
-  private Optional<SnapSyncDownloader> fastSyncDownloader;
+  private Optional<SnapSyncController> fastSyncDownloader;
   private final Optional<FullSyncDownloader> fullSyncDownloader;
   private final ProtocolContext protocolContext;
   private final PivotBlockSelector pivotBlockSelector;
@@ -174,7 +174,7 @@ public class DefaultSynchronizer implements Synchronizer, UnverifiedForkchoiceLi
 
   public TrailingPeerRequirements calculateTrailingPeerRequirements() {
     return fastSyncDownloader
-        .flatMap(SnapSyncDownloader::calculateTrailingPeerRequirements)
+        .flatMap(SnapSyncController::calculateTrailingPeerRequirements)
         .orElse(
             fullSyncDownloader
                 .map(FullSyncDownloader::calculateTrailingPeerRequirements)
@@ -212,7 +212,7 @@ public class DefaultSynchronizer implements Synchronizer, UnverifiedForkchoiceLi
   public void stop() {
     if (running.compareAndSet(true, false)) {
       LOG.info("Stopping synchronizer");
-      fastSyncDownloader.ifPresent(SnapSyncDownloader::stop);
+      fastSyncDownloader.ifPresent(SnapSyncController::stop);
       fullSyncDownloader.ifPresent(FullSyncDownloader::stop);
       blockPropagationManager.ifPresent(
           manager -> {
@@ -236,7 +236,7 @@ public class DefaultSynchronizer implements Synchronizer, UnverifiedForkchoiceLi
       LOG.info("Sync ended (no sync required)");
       syncState.markInitialSyncPhaseAsDone();
     } else {
-      fastSyncDownloader.ifPresent(SnapSyncDownloader::deletePivotSyncState);
+      fastSyncDownloader.ifPresent(SnapSyncController::deletePivotSyncState);
       final Optional<BlockHeader> maybePivotHeader = result.getPivotBlockHeader();
       maybePivotHeader.ifPresent(
           blockHeader -> protocolContext.getWorldStateArchive().resetArchiveStateTo(blockHeader));

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapDownloaderFactory.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapDownloaderFactory.java
@@ -47,7 +47,39 @@ public class SnapDownloaderFactory {
   private static final Logger LOG = LoggerFactory.getLogger(SnapDownloaderFactory.class);
   protected static final String SYNC_FOLDER = "syncFolder";
 
-  public static Optional<SnapSyncDownloader> createSnapDownloader(
+  public static Optional<SnapSyncController> createSnapDownloader(
+      final SnapSyncStatePersistenceManager snapContext,
+      final PivotBlockSelector pivotBlockSelector,
+      final SynchronizerConfiguration syncConfig,
+      final Path dataDirectory,
+      final ProtocolSchedule protocolSchedule,
+      final ProtocolContext protocolContext,
+      final MetricsSystem metricsSystem,
+      final EthContext ethContext,
+      final WorldStateStorageCoordinator worldStateStorageCoordinator,
+      final SyncState syncState,
+      final Clock clock,
+      final SyncDurationMetrics syncDurationMetrics) {
+    if (Boolean.TRUE.equals(syncConfig.getSnapSyncConfiguration().isSnap2Enabled())) {
+      // The snap/2 controller will be created here; until then v2 uses v1 behavior.
+    }
+
+    return createSnapDownloaderV1(
+        snapContext,
+        pivotBlockSelector,
+        syncConfig,
+        dataDirectory,
+        protocolSchedule,
+        protocolContext,
+        metricsSystem,
+        ethContext,
+        worldStateStorageCoordinator,
+        syncState,
+        clock,
+        syncDurationMetrics);
+  }
+
+  public static Optional<SnapSyncController> createSnapDownloaderV1(
       final SnapSyncStatePersistenceManager snapContext,
       final PivotBlockSelector pivotBlockSelector,
       final SynchronizerConfiguration syncConfig,

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapSyncController.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapSyncController.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.eth.sync.snapsync;
+
+import org.hyperledger.besu.ethereum.eth.sync.TrailingPeerRequirements;
+import org.hyperledger.besu.ethereum.eth.sync.common.PivotSyncState;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+public interface SnapSyncController {
+
+  CompletableFuture<PivotSyncState> start();
+
+  void stop();
+
+  void deletePivotSyncState();
+
+  Optional<TrailingPeerRequirements> calculateTrailingPeerRequirements();
+}

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapSyncDownloader.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapSyncDownloader.java
@@ -45,7 +45,7 @@ import com.google.common.io.RecursiveDeleteOption;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class SnapSyncDownloader {
+public class SnapSyncDownloader implements SnapSyncController {
 
   private static final Duration FAST_SYNC_RETRY_DELAY = Duration.ofSeconds(5);
   private static final Logger LOG = LoggerFactory.getLogger(SnapSyncDownloader.class);
@@ -71,6 +71,7 @@ public class SnapSyncDownloader {
     this.syncDurationMetrics = syncDurationMetrics;
   }
 
+  @Override
   public CompletableFuture<PivotSyncState> start() {
     if (!running.compareAndSet(false, true)) {
       throw new IllegalStateException("SyncDownloader already running");
@@ -131,6 +132,7 @@ public class SnapSyncDownloader {
     }
   }
 
+  @Override
   public void stop() {
     synchronized (this) {
       if (running.compareAndSet(true, false)) {
@@ -141,6 +143,7 @@ public class SnapSyncDownloader {
     }
   }
 
+  @Override
   public void deletePivotSyncState() {
     // Make sure downloader is stopped before we start cleaning up its dependencies
     worldStateDownloader.cancel();
@@ -227,6 +230,7 @@ public class SnapSyncDownloader {
     }
   }
 
+  @Override
   public Optional<TrailingPeerRequirements> calculateTrailingPeerRequirements() {
     return trailingPeerRequirements;
   }


### PR DESCRIPTION
Adds `SnapSyncController` as the interface used by `DefaultSynchronizer` and implemented by `SnapSyncDownloader`.

Future snap/2 work can add a dedicated controller behind the same interface without changing synchronizer lifecycle logic.

Concrete `SnapSyncController` implementation is selected based on configuration (`--Xsnap2-enabled`) in `SnapDownloaderFactory`.