### PR TITLE
remove used futures for parallel execution

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/parallelization/BalConcurrentTransactionProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/parallelization/BalConcurrentTransactionProcessor.java
@@ -187,7 +187,7 @@ public class BalConcurrentTransactionProcessor extends ParallelBlockTransactionP
       final Optional<Counter> confirmedParallelizedTransactionCounter,
       final Optional<Counter> conflictingButCachedTransactionCounter) {
 
-    final CompletableFuture<ParallelizedTransactionContext> future = futures[txIndex];
+    final CompletableFuture<ParallelizedTransactionContext> future = removeFuture(txIndex);
     if (future != null) {
       try {
         final ParallelizedTransactionContext ctx =
@@ -215,10 +215,17 @@ public class BalConcurrentTransactionProcessor extends ParallelBlockTransactionP
 
         return Optional.of(result);
       } catch (final TimeoutException e) {
+        future.cancel(true);
         LOG.error(
             "Timed out waiting {}ms for transaction {} processing result.",
             balProcessingTimeout.toMillis(),
             txIndex);
+        return Optional.empty();
+      } catch (final InterruptedException e) {
+        future.cancel(true);
+        Thread.currentThread().interrupt();
+        LOG.error(
+            "Interrupted while waiting for transaction {} processing result.", txIndex, e);
         return Optional.empty();
       } catch (final Exception e) {
         LOG.error(

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/parallelization/OptimisticConcurrentTransactionProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/parallelization/OptimisticConcurrentTransactionProcessor.java
@@ -47,7 +47,7 @@ import com.google.common.annotations.VisibleForTesting;
  * results to the world state.
  */
 @SuppressWarnings({"unchecked", "rawtypes"})
-public class ParallelizedConcurrentTransactionProcessor extends ParallelBlockTransactionProcessor {
+public class OptimisticConcurrentTransactionProcessor extends ParallelBlockTransactionProcessor {
 
   private final MainnetTransactionProcessor transactionProcessor;
 
@@ -59,14 +59,14 @@ public class ParallelizedConcurrentTransactionProcessor extends ParallelBlockTra
    *
    * @param transactionProcessor The transaction processor for processing individual transactions.
    */
-  public ParallelizedConcurrentTransactionProcessor(
+  public OptimisticConcurrentTransactionProcessor(
       final MainnetTransactionProcessor transactionProcessor) {
     this.transactionProcessor = transactionProcessor;
     this.transactionCollisionDetector = new TransactionCollisionDetector();
   }
 
   @VisibleForTesting
-  public ParallelizedConcurrentTransactionProcessor(
+  public OptimisticConcurrentTransactionProcessor(
       final MainnetTransactionProcessor transactionProcessor,
       final TransactionCollisionDetector transactionCollisionDetector) {
     this.transactionProcessor = transactionProcessor;
@@ -193,7 +193,8 @@ public class ParallelizedConcurrentTransactionProcessor extends ParallelBlockTra
       final Optional<Counter> confirmedParallelizedTransactionCounter,
       final Optional<Counter> conflictingButCachedTransactionCounter) {
 
-    final CompletableFuture<ParallelizedTransactionContext> future = futures[transactionLocation];
+    final CompletableFuture<ParallelizedTransactionContext> future =
+        removeFuture(transactionLocation);
 
     if (future != null && future.isDone()) {
       final ParallelizedTransactionContext parallelizedTransactionContext = future.resultNow();

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/parallelization/ParallelBlockTransactionProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/parallelization/ParallelBlockTransactionProcessor.java
@@ -36,6 +36,12 @@ public abstract class ParallelBlockTransactionProcessor {
 
   protected CompletableFuture<ParallelizedTransactionContext>[] futures;
 
+  protected CompletableFuture<ParallelizedTransactionContext> removeFuture(final int txIndex) {
+    final CompletableFuture<ParallelizedTransactionContext> future = futures[txIndex];
+    futures[txIndex] = null;
+    return future;
+  }
+
   @SuppressWarnings({"unchecked", "rawtypes"})
   public void runAsyncBlock(
       final ProtocolContext protocolContext,

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/parallelization/ParallelTransactionPreprocessing.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/parallelization/ParallelTransactionPreprocessing.java
@@ -68,7 +68,7 @@ public class ParallelTransactionPreprocessing implements PreprocessingFunction {
           new BalConcurrentTransactionProcessor(
               transactionProcessor, maybeBlockBal.get(), balConfiguration);
     } else {
-      parallelProcessor = new ParallelizedConcurrentTransactionProcessor(transactionProcessor);
+      parallelProcessor = new OptimisticConcurrentTransactionProcessor(transactionProcessor);
     }
 
     parallelProcessor.runAsyncBlock(

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/parallelization/BalTransactionProcessorUnitTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/parallelization/BalTransactionProcessorUnitTest.java
@@ -16,6 +16,7 @@ package org.hyperledger.besu.ethereum.mainnet.parallelization;
 
 import static org.hyperledger.besu.ethereum.trie.pathbased.common.worldview.WorldStateConfig.createStatefulConfigWithTrie;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -254,6 +255,7 @@ class BalTransactionProcessorUnitTest {
 
       assertTrue(result.isPresent(), "Expected processing result to be present");
       assertTrue(result.get().isSuccessful(), "Expected successful result");
+      assertNull(processor.futures[0], "Expected consumed future reference to be cleared");
     }
   }
 

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/parallelization/OptimisticTransactionProcessorUnitTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/parallelization/OptimisticTransactionProcessorUnitTest.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.ethereum.mainnet.parallelization;
 
 import static org.hyperledger.besu.ethereum.trie.pathbased.common.worldview.WorldStateConfig.createStatefulConfigWithTrie;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -84,13 +85,13 @@ class OptimisticTransactionProcessorUnitTest {
   @Mock private MainnetTransactionProcessor transactionProcessor;
   @Mock private TransactionCollisionDetector collisionDetector;
 
-  private ParallelizedConcurrentTransactionProcessor processor;
+  private OptimisticConcurrentTransactionProcessor processor;
   private TestEnvironment env;
 
   @BeforeEach
   void setUp() {
     processor =
-        new ParallelizedConcurrentTransactionProcessor(transactionProcessor, collisionDetector);
+        new OptimisticConcurrentTransactionProcessor(transactionProcessor, collisionDetector);
     env = createTestEnvironment();
   }
 
@@ -495,6 +496,7 @@ class OptimisticTransactionProcessorUnitTest {
 
       assertTrue(result.isPresent(), "Expected result when no collision");
       assertTrue(result.get().isSuccessful(), "Expected successful result");
+      assertNull(processor.futures[0], "Expected consumed future reference to be cleared");
     }
 
     @Test


### PR DESCRIPTION
This pull request change the parallel transaction processing logic by ensuring consumed transaction futures are cleared to prevent resource leaks

**Refactoring and Naming Improvements:**
- Renamed `ParallelizedConcurrentTransactionProcessor` to `OptimisticConcurrentTransactionProcessor` throughout the codebase 

**Resource Management Enhancements:**
- Added a `removeFuture` method in `ParallelBlockTransactionProcessor` to clear consumed `CompletableFuture` references, preventing potential memory leaks. Updated usages in both `BalConcurrentTransactionProcessor` and `OptimisticConcurrentTransactionProcessor`

**Error Handling Improvements:**
- Improved error handling in `getProcessingResult` by cancelling futures and properly handling `TimeoutException` and `InterruptedException`, ensuring threads are interrupted and resources are released on failure.


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


