### PR TITLE
Acceptance Tests: if error creating ports file, make it obvious

### DIFF
--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/BesuNode.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/BesuNode.java
@@ -348,7 +348,7 @@ public class BesuNode implements NodeConfiguration, RunnableNode, AutoCloseable 
   private String getRuntimeP2pPort() {
     final String port = portsProperties.getProperty("p2p");
     if (port == null) {
-      throw new IllegalStateException("Requested p2p port before ports properties was written");
+      throw new IllegalStateException(portsMissingMessage("p2p"));
     }
     return port;
   }
@@ -356,10 +356,25 @@ public class BesuNode implements NodeConfiguration, RunnableNode, AutoCloseable 
   private String getDiscoveryPort() {
     final String port = portsProperties.getProperty("discovery");
     if (port == null) {
-      throw new IllegalStateException(
-          "Requested discovery port before ports properties was written");
+      throw new IllegalStateException(portsMissingMessage("discovery"));
     }
     return port;
+  }
+
+  private String portsMissingMessage(final String portName) {
+    return exitCode
+        .map(
+            code ->
+                "Requested "
+                    + portName
+                    + " port but Besu process for node '"
+                    + name
+                    + "' exited with code "
+                    + code
+                    + " before writing ports properties."
+                    + " Re-run with --info or check the HTML test report for the startup error"
+                    + " (e.g. UnsupportedClassVersionError, port conflict, bad config).")
+        .orElse("Requested " + portName + " port before ports properties was written");
   }
 
   public Optional<String> jsonRpcBaseUrl() {

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ProcessBesuNodeRunner.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ProcessBesuNodeRunner.java
@@ -465,12 +465,13 @@ public class ProcessBesuNodeRunner implements BesuNodeRunner {
             () -> {
               final Process process = besuProcesses.get(node.getName());
               if (!process.isAlive()) {
-                LOG.warn(
-                    "Besu process for node {} exited with code {} before writing {}",
-                    node.getName(),
-                    process.exitValue(),
-                    fileName);
-                return true;
+                throw new IllegalStateException(
+                    String.format(
+                        "Besu process for node '%s' exited with code %d before writing %s."
+                            + " This usually means the node failed to start — check the"
+                            + " SubProcessLog output above for the startup error"
+                            + " (e.g. UnsupportedClassVersionError, port conflict, bad config).",
+                        node.getName(), process.exitValue(), fileName));
               }
 
               try (final Stream<String> s = Files.lines(file.toPath())) {

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ProcessBesuNodeRunner.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ProcessBesuNodeRunner.java
@@ -465,13 +465,12 @@ public class ProcessBesuNodeRunner implements BesuNodeRunner {
             () -> {
               final Process process = besuProcesses.get(node.getName());
               if (!process.isAlive()) {
-                throw new IllegalStateException(
-                    String.format(
-                        "Besu process for node '%s' exited with code %d before writing %s."
-                            + " This usually means the node failed to start — check the"
-                            + " SubProcessLog output above for the startup error"
-                            + " (e.g. UnsupportedClassVersionError, port conflict, bad config).",
-                        node.getName(), process.exitValue(), fileName));
+                LOG.warn(
+                    "Besu process for node {} exited with code {} before writing {}",
+                    node.getName(),
+                    process.exitValue(),
+                    fileName);
+                return true;
               }
 
               try (final Stream<String> s = Files.lines(file.toPath())) {


### PR DESCRIPTION
## PR description

Throw an exception rather than logging a warning so that it's obvious there's an issue with running besu itself for the Acceptance tests. 

An easy way to reproduce this is to attempt to run acceptance tests with Java 21 against latest besu (that has been compiled with Java 25).

eg with sdkman
```
sdk use java 21.0.2-open
./gradlew acceptanceTests
```
Many acceptance tests will fail, but the error message is not obvious. And because gradle magic uses Java 25 to compile/build besu. You might forget that your system java is older, but that is what ProcessBesuNodeRunner uses when running ATs.

## Fixed Issue(s)

before:
```
Requested discovery port before ports properties was written
java.lang.IllegalStateException: Requested discovery port before ports properties was written
	at org.hyperledger.besu.tests.acceptance.dsl.node.BesuNode.getDiscoveryPort(BesuNode.java:359)
	at org.hyperledger.besu.tests.acceptance.dsl.node.BesuNode.enodeUrl(BesuNode.java:339)
	at org.hyperledger.besu.tests.acceptance.dsl.node.cluster.Cluster.lambda$selectAndStartBootnode$3(Cluster.java:120)
	at java.base/java.util.Optional.ifPresent(Optional.java:178)
	at org.hyperledger.besu.tests.acceptance.dsl.node.cluster.Cluster.selectAndStartBootnode(Cluster.java:116)
	at org.hyperledger.besu.tests.acceptance.dsl.node.cluster.Cluster.start(Cluster.java:86)
	at org.hyperledger.besu.tests.acceptance.dsl.node.cluster.Cluster.start(Cluster.java:67)
	at org.hyperledger.besu.tests.acceptance.RpcApisTogglesAcceptanceTest.before(RpcApisTogglesAcceptanceTest.java:39)
```

after:
```
RpcApisTogglesAcceptanceTest > shouldFailConnectingToNodeWithJsonRpcDisabled() FAILED
    java.lang.IllegalStateException: Besu process for node 'rpc-enabled' exited with code 1 before writing besu.ports. This usually means the node failed to start - check the SubProcessLog output above for the startup error (e.g. UnsupportedClassVersionError, port conflict, bad config).
        at org.hyperledger.besu.tests.acceptance.dsl.node.ProcessBesuNodeRunner.lambda$waitForFileOrExit$0(ProcessBesuNodeRunner.java:469)
        at org.awaitility.core.CallableCondition$ConditionEvaluationWrapper.eval(CallableCondition.java:99)
        at org.awaitility.core.ConditionAwaiter$ConditionPoller.call(ConditionAwaiter.java:248)
        at org.awaitility.core.ConditionAwaiter$ConditionPoller.call(ConditionAwaiter.java:235)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:328)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
        at java.base/java.lang.Thread.run(Thread.java:1474)
and
Error: LinkageError occurred while loading main class org.hyperledger.besu.Besu
        java.lang.UnsupportedClassVersionError: org/hyperledger/besu/Besu has been compiled by a more recent version of the Java Runtime (class file version 69.0), this version of the Java Runtime only recognizes class file versions up to 65.0
```


- [x] spotless: `./gradlew spotlessApply`
- [x] acceptance tests: `./gradlew acceptanceTest`


