### PR TITLE
Avoid blocking txpool save restore callers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ### Bug fixes
 - `debug_accountAt`: fix off-by-one in transaction index validation that caused an `IndexOutOfBoundsException` when `txIndex` equalled the transaction list size; the boundary is now correctly rejected with `INVALID_TRANSACTION_PARAMS` [#10464](https://github.com/besu-eth/besu/pull/10464)
+- Fix transaction pool save/restore so disk access lock contention is reported through the returned futures instead of blocking callers or leaving the pool partially disabled. [#10561](https://github.com/besu-eth/besu/pull/10561)
 - Fix `Address.addressHash()` stalling under high concurrent load: replaced Guava `LoadingCache` (non-fair segment lock caused indefinite starvation when transaction pool validation and parallel block processing threads simultaneously saturated the same cache segments) with Caffeine, which computes hashes without holding a segment lock. [#10235](https://github.com/besu-eth/besu/pull/10235)
 - Fix `testing_buildBlockV1` to return correct `blockValue` (actual priority fees) and omit null `blockAccessList`/`slotNumber` fields from the response payload; same omission applies to `engine_getPayloadV6` (these fields are always populated for a V6 payload). [#10492](https://github.com/besu-eth/besu/pull/10492)
 - Fix `testing_buildBlockV1` to return error `-32000` when an explicitly provided transaction is not applicable (e.g. wrong nonce), instead of silently dropping it and returning a success response. [#10486](https://github.com/besu-eth/besu/pull/10486)

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
@@ -72,6 +72,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
@@ -80,6 +81,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
@@ -687,10 +689,11 @@ public class TransactionPool implements BlockAddedObserver {
       final CompletableFuture<Void> saveOperation =
           saveRestoreManager
               .saveToDisk(pendingTransactions)
-              .exceptionally(
-                  t -> {
-                    LOG.error("Error while saving transaction pool to disk", t);
-                    return null;
+              .whenComplete(
+                  (_, t) -> {
+                    if (t != null) {
+                      LOG.error("Error while saving transaction pool to disk", t);
+                    }
                   });
       pendingTransactions = new DisabledPendingTransactions();
       logStop();
@@ -788,28 +791,35 @@ public class TransactionPool implements BlockAddedObserver {
 
     synchronized CompletableFuture<Void> saveToDisk(
         final PendingTransactions pendingTransactionsToSave) {
-      cancelInProgressReadOperation();
-      return serializeAndDedupOperation(
-          () -> executeSaveToDisk(pendingTransactionsToSave), writeInProgress);
+      return cancelInProgressReadOperation()
+          .thenCompose(
+              _ ->
+                  serializeAndDedupOperation(
+                      () -> executeSaveToDisk(pendingTransactionsToSave), writeInProgress));
     }
 
     synchronized CompletableFuture<Void> loadFromDisk() {
       return serializeAndDedupOperation(this::executeLoadFromDisk, readInProgress);
     }
 
-    private void cancelInProgressReadOperation() {
-      final CompletableFuture<Void> maybeReadInProgress = readInProgress.get();
-      if (maybeReadInProgress != null && !maybeReadInProgress.isDone()) {
-        LOG.debug("Cancelling in progress read operation");
-        isCancelled.set(true);
-        try {
+    private CompletableFuture<Void> cancelInProgressReadOperation() {
+      try {
+        final CompletableFuture<Void> maybeReadInProgress = readInProgress.get();
+        if (maybeReadInProgress != null && !maybeReadInProgress.isDone()) {
+          LOG.debug("Cancelling in progress read operation");
+          isCancelled.set(true);
           // wait until read operation is canceled
           maybeReadInProgress.get();
           LOG.debug("In progress read operation cancelled");
-        } catch (InterruptedException | ExecutionException e) {
-          LOG.warn("Error while cancelling in progress read operation", e);
-          throw new RuntimeException(e);
         }
+        return CompletableFuture.completedFuture(null);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return CompletableFuture.failedFuture(
+            new RuntimeException("Error during the cancellation of current read operation", e));
+      } catch (ExecutionException e) {
+        return CompletableFuture.failedFuture(
+            new RuntimeException("Error during the cancellation of current read operation", e));
       }
     }
 
@@ -822,34 +832,48 @@ public class TransactionPool implements BlockAddedObserver {
         // at a time.
         CompletableFuture<Void> newOperation = new CompletableFuture<>();
         if (operationInProgress.compareAndSet(null, newOperation)) {
-          newOperation
-              .completeAsync(
-                  () -> {
-                    try {
-                      if (diskAccessLock.tryAcquire(
+          // acquire the lock asynchronously to not block the caller
+          CompletableFuture.runAsync(
+              () -> {
+                boolean lockAcquired = false;
+                Throwable failure = null;
+                try {
+                  lockAcquired =
+                      diskAccessLock.tryAcquire(
                           configuration.getUnstable().getSaveRestoreTimeout().toMillis(),
-                          TimeUnit.MILLISECONDS)) {
-                        try {
-                          isCancelled.set(false);
-                          operation.run();
-                        } finally {
-                          diskAccessLock.release();
-                        }
-                      } else {
-                        throw new RuntimeException("Timeout waiting for disk access lock");
-                      }
-                    } catch (InterruptedException e) {
-                      throw new RuntimeException(e);
-                    }
-                    return null;
-                  })
-              .whenComplete(
-                  (_, _) ->
-                      // remove in progress operation, so that the next one can start
-                      operationInProgress.set(null));
+                          TimeUnit.MILLISECONDS);
+                  if (lockAcquired) {
+                    isCancelled.set(false);
+                    operation.run();
+                  } else {
+                    failure = new TimeoutException("Timeout waiting for disk access lock");
+                  }
+                } catch (InterruptedException e) {
+                  Thread.currentThread().interrupt();
+                  failure = e;
+                } catch (Throwable t) {
+                  failure = t;
+                } finally {
+                  if (lockAcquired) {
+                    diskAccessLock.release();
+                  }
+                  if (failure == null) {
+                    newOperation.complete(null);
+                  } else {
+                    newOperation.completeExceptionally(failure);
+                  }
+                  // remove in progress operation, so that the next one can start
+                  operationInProgress.set(null);
+                }
+              });
           return newOperation;
         }
-        return operationInProgress.get();
+        return Objects.requireNonNullElseGet(
+            operationInProgress.get(),
+            () ->
+                CompletableFuture.failedFuture(
+                    new IllegalStateException(
+                        "Save/restore operation completed before it could be reused")));
       }
       return CompletableFuture.completedFuture(null);
     }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
@@ -80,7 +80,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
@@ -611,11 +610,6 @@ public class TransactionPool implements BlockAddedObserver {
     return pendingTransactions.getClass();
   }
 
-  @VisibleForTesting
-  SaveRestoreManager getSaveRestoreManager() {
-    return saveRestoreManager;
-  }
-
   public interface TransactionBatchAddedListener {
 
     void onTransactionsAdded(Collection<Transaction> transactions);
@@ -659,10 +653,11 @@ public class TransactionPool implements BlockAddedObserver {
           OptionalLong.of(ethContext.getEthPeers().subscribeConnect(this::handleConnect));
       return saveRestoreManager
           .loadFromDisk()
-          .exceptionally(
-              t -> {
-                LOG.error("Error while restoring transaction pool from disk", t);
-                return null;
+          .whenComplete(
+              (_, t) -> {
+                if (t != null) {
+                  LOG.error("Error while restoring transaction pool from disk", t);
+                }
               });
     }
     return CompletableFuture.completedFuture(null);
@@ -786,32 +781,30 @@ public class TransactionPool implements BlockAddedObserver {
   class SaveRestoreManager {
     private final Semaphore diskAccessLock = new Semaphore(1, true);
     private final AtomicReference<CompletableFuture<Void>> writeInProgress =
-        new AtomicReference<>(CompletableFuture.completedFuture(null));
+        new AtomicReference<>(null);
     private final AtomicReference<CompletableFuture<Void>> readInProgress =
-        new AtomicReference<>(CompletableFuture.completedFuture(null));
+        new AtomicReference<>(null);
     private final AtomicBoolean isCancelled = new AtomicBoolean(false);
 
-    @VisibleForTesting
-    Semaphore getDiskAccessLock() {
-      return diskAccessLock;
-    }
-
-    CompletableFuture<Void> saveToDisk(final PendingTransactions pendingTransactionsToSave) {
+    synchronized CompletableFuture<Void> saveToDisk(
+        final PendingTransactions pendingTransactionsToSave) {
       cancelInProgressReadOperation();
       return serializeAndDedupOperation(
           () -> executeSaveToDisk(pendingTransactionsToSave), writeInProgress);
     }
 
-    CompletableFuture<Void> loadFromDisk() {
+    synchronized CompletableFuture<Void> loadFromDisk() {
       return serializeAndDedupOperation(this::executeLoadFromDisk, readInProgress);
     }
 
     private void cancelInProgressReadOperation() {
-      if (!readInProgress.get().isDone()) {
+      final CompletableFuture<Void> maybeReadInProgress = readInProgress.get();
+      if (maybeReadInProgress != null && !maybeReadInProgress.isDone()) {
         LOG.debug("Cancelling in progress read operation");
         isCancelled.set(true);
         try {
-          waitUntilReadOperationIsCancelled();
+          // wait until read operation is canceled
+          maybeReadInProgress.get();
           LOG.debug("In progress read operation cancelled");
         } catch (InterruptedException | ExecutionException e) {
           LOG.warn("Error while cancelling in progress read operation", e);
@@ -820,32 +813,41 @@ public class TransactionPool implements BlockAddedObserver {
       }
     }
 
-    private void waitUntilReadOperationIsCancelled()
-        throws InterruptedException, ExecutionException {
-      readInProgress.get().get();
-    }
-
     private CompletableFuture<Void> serializeAndDedupOperation(
         final Runnable operation,
         final AtomicReference<CompletableFuture<Void>> operationInProgress) {
       if (configuration.getEnableSaveRestore()) {
-        try {
-          if (diskAccessLock.tryAcquire(
-              configuration.getUnstable().getSaveRestoreTimeout().toMillis(),
-              TimeUnit.MILLISECONDS)) {
-
-            isCancelled.set(false);
-            operationInProgress.set(
-                CompletableFuture.runAsync(operation)
-                    .whenComplete((res, err) -> diskAccessLock.release()));
-            return operationInProgress.get();
-          } else {
-            return CompletableFuture.failedFuture(
-                new TimeoutException("Timeout waiting for disk access lock"));
-          }
-        } catch (InterruptedException ie) {
-          return CompletableFuture.failedFuture(ie);
+        // only if there is not already an in-progress operation of its kind,
+        // create and run the new one. This ensures that there is only one read or write operation
+        // at a time.
+        CompletableFuture<Void> newOperation = new CompletableFuture<>();
+        if (operationInProgress.compareAndSet(null, newOperation)) {
+          newOperation
+              .completeAsync(
+                  () -> {
+                    try {
+                      if (diskAccessLock.tryAcquire(
+                          configuration.getUnstable().getSaveRestoreTimeout().toMillis(),
+                          TimeUnit.MILLISECONDS)) {
+                        try {
+                          isCancelled.set(false);
+                          operation.run();
+                        } finally {
+                          // reset everything so that the next operation can be started
+                          diskAccessLock.release();
+                        }
+                      } else {
+                        throw new RuntimeException("Timeout waiting for disk access lock");
+                      }
+                    } catch (InterruptedException e) {
+                      throw new RuntimeException(e);
+                    }
+                    return null;
+                  })
+              .whenComplete((_, _) -> operationInProgress.set(null));
+          return newOperation;
         }
+        return operationInProgress.get();
       }
       return CompletableFuture.completedFuture(null);
     }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
@@ -833,7 +833,6 @@ public class TransactionPool implements BlockAddedObserver {
                           isCancelled.set(false);
                           operation.run();
                         } finally {
-                          // reset everything so that the next operation can be started
                           diskAccessLock.release();
                         }
                       } else {
@@ -844,7 +843,10 @@ public class TransactionPool implements BlockAddedObserver {
                     }
                     return null;
                   })
-              .whenComplete((_, _) -> operationInProgress.set(null));
+              .whenComplete(
+                  (_, _) ->
+                      // remove in progress operation, so that the next one can start
+                      operationInProgress.set(null));
           return newOperation;
         }
         return operationInProgress.get();

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolSaveRestoreTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolSaveRestoreTest.java
@@ -39,6 +39,7 @@ import org.hyperledger.besu.ethereum.eth.transactions.layered.ReadyTransactions;
 import org.hyperledger.besu.ethereum.eth.transactions.layered.SparseTransactions;
 import org.hyperledger.besu.ethereum.eth.transactions.layered.TransactionsLayer;
 import org.hyperledger.besu.ethereum.mainnet.feemarket.FeeMarket;
+import org.hyperledger.besu.ethereum.mainnet.transactionpool.TransactionPoolPreProcessor;
 import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
 
 import java.io.IOException;
@@ -52,6 +53,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 
 import org.junit.jupiter.api.AfterEach;
@@ -299,7 +301,7 @@ public class TransactionPoolSaveRestoreTest extends AbstractTransactionPoolTestB
 
       assertThatThrownBy(result::get)
           .isInstanceOf(ExecutionException.class)
-          .hasCauseInstanceOf(RuntimeException.class)
+          .hasCauseInstanceOf(TimeoutException.class)
           .hasMessageContaining("Timeout waiting for disk access lock");
     } finally {
       releaseSave.countDown();
@@ -324,7 +326,7 @@ public class TransactionPoolSaveRestoreTest extends AbstractTransactionPoolTestB
 
       assertThatThrownBy(timedOutRestore::get)
           .isInstanceOf(ExecutionException.class)
-          .hasCauseInstanceOf(RuntimeException.class)
+          .hasCauseInstanceOf(TimeoutException.class)
           .hasMessageContaining("Timeout waiting for disk access lock");
 
       // Once the save releases the disk lock, a later restore must be allowed to create and run a
@@ -336,6 +338,79 @@ public class TransactionPoolSaveRestoreTest extends AbstractTransactionPoolTestB
       transactionPool.setEnabled().get(10, TimeUnit.SECONDS);
     } finally {
       releaseSave.countDown();
+    }
+  }
+
+  @Test
+  public void failedReadCancellationDoesNotLeavePoolPartiallyDisabled()
+      throws IOException, InterruptedException, ExecutionException, TimeoutException {
+    final Transaction transaction = createTransaction(1);
+    Files.writeString(
+        saveFilePath,
+        "127r" + transaction2Base64(transaction) + System.lineSeparator(),
+        StandardCharsets.US_ASCII);
+    givenAllTransactionsAreValid();
+
+    final CountDownLatch restorePreProcessorStarted = new CountDownLatch(1);
+    final CountDownLatch failRestore = new CountDownLatch(1);
+    final TransactionPoolPreProcessor failingRestorePreProcessor =
+        (transactionToProcess, isLocal) -> {
+          restorePreProcessorStarted.countDown();
+          try {
+            assertThat(failRestore.await(10, TimeUnit.SECONDS))
+                .as("restore pre-processor should be released by the test")
+                .isTrue();
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+          }
+          throw new IllegalStateException("restore failed while being cancelled");
+        };
+    doReturn(Optional.of(failingRestorePreProcessor))
+        .when(protocolSpec)
+        .getTransactionPoolPreProcessor();
+
+    this.transactionPool =
+        createTransactionPool(b -> b.enableSaveRestore(true).saveFile(saveFilePath.toFile()));
+
+    assertThat(restorePreProcessorStarted.await(10, TimeUnit.SECONDS)).isTrue();
+
+    final AtomicReference<CompletableFuture<Void>> saveOperation = new AtomicReference<>();
+    final AtomicReference<Throwable> disableFailure = new AtomicReference<>();
+    final Thread disableThread =
+        new Thread(
+            () -> {
+              try {
+                saveOperation.set(transactionPool.setDisabled());
+              } catch (Throwable t) {
+                disableFailure.set(t);
+              }
+            });
+
+    try {
+      disableThread.start();
+      // The restore failure is released only once setDisabled is waiting for the in-progress read.
+      // Before the fix, that failure escaped synchronously and skipped the final disabled state.
+      await()
+          .untilAsserted(
+              () ->
+                  assertThat(disableThread.getStackTrace())
+                      .extracting(StackTraceElement::getMethodName)
+                      .contains("cancelInProgressReadOperation"));
+
+      failRestore.countDown();
+      disableThread.join(TimeUnit.SECONDS.toMillis(10));
+
+      assertThat(disableThread.isAlive()).isFalse();
+      assertThat(disableFailure.get()).isNull();
+      assertThatThrownBy(() -> saveOperation.get().get())
+          .isInstanceOf(ExecutionException.class)
+          .hasCauseInstanceOf(RuntimeException.class)
+          .hasMessageContaining("Error during the cancellation of current read operation");
+      assertThat(transactionPool.isEnabled()).isFalse();
+      assertThat(transactionPool.getPendingTransactions()).isEmpty();
+    } finally {
+      failRestore.countDown();
     }
   }
 
@@ -354,6 +429,7 @@ public class TransactionPoolSaveRestoreTest extends AbstractTransactionPoolTestB
                             .build()));
     givenAllTransactionsAreValid();
 
+    final CompletableFuture<Void> blockedWriteReleased = new CompletableFuture<>();
     final Transaction slowWriteTx = spy(createTransaction(1));
     // The layered pool stores a detached copy for new transactions. Return the spy from
     // detachedCopy so the save path still hits the writeTo stub below.
@@ -363,7 +439,19 @@ public class TransactionPoolSaveRestoreTest extends AbstractTransactionPoolTestB
               // Signal only after save serialization has started; at this point the save operation
               // has already acquired the disk lock.
               saveStarted.countDown();
-              releaseSave.await(10, TimeUnit.SECONDS);
+              try {
+                assertThat(releaseSave.await(10, TimeUnit.SECONDS))
+                    .as("blocked save should be released by the test")
+                    .isTrue();
+                blockedWriteReleased.complete(null);
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                blockedWriteReleased.completeExceptionally(e);
+                throw e;
+              } catch (AssertionError e) {
+                blockedWriteReleased.completeExceptionally(e);
+                throw e;
+              }
               invocation.callRealMethod();
               return null;
             })
@@ -371,6 +459,6 @@ public class TransactionPoolSaveRestoreTest extends AbstractTransactionPoolTestB
         .writeTo(any(), any());
     addAndAssertTransactionViaApiValid(slowWriteTx, false);
 
-    return transactionPool.setDisabled();
+    return CompletableFuture.allOf(transactionPool.setDisabled(), blockedWriteReleased);
   }
 }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolSaveRestoreTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolSaveRestoreTest.java
@@ -17,6 +17,8 @@ package org.hyperledger.besu.ethereum.eth.transactions;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
 
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.core.Block;
@@ -37,6 +39,7 @@ import org.hyperledger.besu.ethereum.eth.transactions.layered.TransactionsLayer;
 import org.hyperledger.besu.ethereum.mainnet.feemarket.FeeMarket;
 import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -44,6 +47,7 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -275,39 +279,56 @@ public class TransactionPoolSaveRestoreTest extends AbstractTransactionPoolTestB
   }
 
   @Test
-  public void diskLockTimeoutIsPropagatedNotSwallowed() throws InterruptedException {
+  public void diskLockTimeoutIsPropagatedNotSwallowed()
+      throws InterruptedException, ExecutionException, TimeoutException {
+    final Duration saveRestoreTimeoutSeconds = Duration.ofMillis(100);
     // Create a txpool with save and restore enabled and a short lock timeout
     // so the test does not block for 60 seconds
+    final File spySaveFile = spy(saveFilePath.toFile());
+
+    // making the writing to disk take longer than the lock timeout, pretending the exists method is
+    // very slow
+    final CountDownLatch saveStarted = new CountDownLatch(1);
+    final CountDownLatch releaseSave = new CountDownLatch(1);
+
+    doAnswer(
+            invocation -> {
+              saveStarted.countDown();
+              releaseSave.await(2, TimeUnit.SECONDS);
+              invocation.callRealMethod();
+              return null;
+            })
+        .when(spySaveFile)
+        .exists();
+
     this.transactionPool =
         createTransactionPool(
             b ->
                 b.enableSaveRestore(true)
-                    .saveFile(saveFilePath.toFile())
+                    .saveFile(spySaveFile)
                     .unstable(
                         ImmutableTransactionPoolConfiguration.Unstable.builder()
-                            .saveRestoreTimeout(Duration.ofMillis(100))
+                            .saveRestoreTimeout(saveRestoreTimeoutSeconds)
                             .build()));
 
-    // Acquire the lock to simulate another operation holding it. Using acquire()
-    // instead of drainPermits() ensures we wait for any in-progress async operation
-    // (e.g. loadFromDisk triggered by pool creation) to release the permit first.
-    final var lock = transactionPool.getSaveRestoreManager().getDiskAccessLock();
-    lock.acquire();
+    givenAllTransactionsAreValid();
+
+    addAndAssertTransactionViaApiValid(createTransaction(1), false);
+
+    final CompletableFuture<Void> saveOperation = transactionPool.setDisabled();
 
     try {
-      // Call loadFromDisk() directly on the SaveRestoreManager to test
-      // serializeAndDedupOperation() in isolation, since setDisabled() wraps the
-      // future with .exceptionally() which swallows the error for logging.
-      // Before the fix, the failedFuture was not returned and the caller silently got
-      // completedFuture(null). After the fix, the failed future must be propagated.
-      final CompletableFuture<Void> result = transactionPool.getSaveRestoreManager().loadFromDisk();
+      assertThat(saveStarted.await(2, TimeUnit.SECONDS)).isTrue();
+
+      final CompletableFuture<Void> result = transactionPool.setEnabled();
 
       assertThatThrownBy(result::get)
           .isInstanceOf(ExecutionException.class)
-          .hasCauseInstanceOf(TimeoutException.class);
+          .hasCauseInstanceOf(RuntimeException.class)
+          .hasMessageContaining("Timeout waiting for disk access lock");
     } finally {
-      // Always restore the permit so cleanup does not hang
-      lock.release();
+      releaseSave.countDown();
+      saveOperation.get(2, TimeUnit.SECONDS);
     }
   }
 }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolSaveRestoreTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolSaveRestoreTest.java
@@ -17,7 +17,9 @@ package org.hyperledger.besu.ethereum.eth.transactions;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 
 import org.hyperledger.besu.datatypes.Wei;
@@ -39,7 +41,6 @@ import org.hyperledger.besu.ethereum.eth.transactions.layered.TransactionsLayer;
 import org.hyperledger.besu.ethereum.mainnet.feemarket.FeeMarket;
 import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -281,45 +282,19 @@ public class TransactionPoolSaveRestoreTest extends AbstractTransactionPoolTestB
   @Test
   public void diskLockTimeoutIsPropagatedNotSwallowed()
       throws InterruptedException, ExecutionException, TimeoutException {
-    final Duration saveRestoreTimeoutSeconds = Duration.ofMillis(100);
-    // Create a txpool with save and restore enabled and a short lock timeout
-    // so the test does not block for 60 seconds
-    final File spySaveFile = spy(saveFilePath.toFile());
-
-    // making the writing to disk take longer than the lock timeout, pretending the exists method is
-    // very slow
+    final Duration saveRestoreTimeout = Duration.ofMillis(100);
     final CountDownLatch saveStarted = new CountDownLatch(1);
     final CountDownLatch releaseSave = new CountDownLatch(1);
-
-    doAnswer(
-            invocation -> {
-              saveStarted.countDown();
-              releaseSave.await(2, TimeUnit.SECONDS);
-              invocation.callRealMethod();
-              return null;
-            })
-        .when(spySaveFile)
-        .exists();
-
-    this.transactionPool =
-        createTransactionPool(
-            b ->
-                b.enableSaveRestore(true)
-                    .saveFile(spySaveFile)
-                    .unstable(
-                        ImmutableTransactionPoolConfiguration.Unstable.builder()
-                            .saveRestoreTimeout(saveRestoreTimeoutSeconds)
-                            .build()));
-
-    givenAllTransactionsAreValid();
-
-    addAndAssertTransactionViaApiValid(createTransaction(1), false);
-
-    final CompletableFuture<Void> saveOperation = transactionPool.setDisabled();
+    // Start a save that blocks while serializing a transaction, after it has acquired the disk
+    // lock. The restore below must fail fast instead of waiting for this save to finish.
+    final CompletableFuture<Void> saveOperation =
+        startSaveWithBlockedTransactionWrite(saveRestoreTimeout, saveStarted, releaseSave);
 
     try {
-      assertThat(saveStarted.await(2, TimeUnit.SECONDS)).isTrue();
+      assertThat(saveStarted.await(10, TimeUnit.SECONDS)).isTrue();
 
+      // setEnabled delegates to loadFromDisk; the returned future must surface the disk-lock
+      // timeout so callers can observe that restore did not run.
       final CompletableFuture<Void> result = transactionPool.setEnabled();
 
       assertThatThrownBy(result::get)
@@ -328,7 +303,74 @@ public class TransactionPoolSaveRestoreTest extends AbstractTransactionPoolTestB
           .hasMessageContaining("Timeout waiting for disk access lock");
     } finally {
       releaseSave.countDown();
-      saveOperation.get(2, TimeUnit.SECONDS);
+      saveOperation.get(10, TimeUnit.SECONDS);
     }
+  }
+
+  @Test
+  public void diskLockTimeoutDoesNotBlockLaterRestore()
+      throws InterruptedException, ExecutionException, TimeoutException {
+    final Duration saveRestoreTimeout = Duration.ofMillis(100);
+    final CountDownLatch saveStarted = new CountDownLatch(1);
+    final CountDownLatch releaseSave = new CountDownLatch(1);
+    // Hold the disk lock with a save long enough for the first restore attempt to time out.
+    final CompletableFuture<Void> saveOperation =
+        startSaveWithBlockedTransactionWrite(saveRestoreTimeout, saveStarted, releaseSave);
+
+    try {
+      assertThat(saveStarted.await(10, TimeUnit.SECONDS)).isTrue();
+
+      final CompletableFuture<Void> timedOutRestore = transactionPool.setEnabled();
+
+      assertThatThrownBy(timedOutRestore::get)
+          .isInstanceOf(ExecutionException.class)
+          .hasCauseInstanceOf(RuntimeException.class)
+          .hasMessageContaining("Timeout waiting for disk access lock");
+
+      // Once the save releases the disk lock, a later restore must be allowed to create and run a
+      // fresh operation instead of reusing the previous failed future.
+      releaseSave.countDown();
+      saveOperation.get(10, TimeUnit.SECONDS);
+
+      transactionPool.setDisabled().get(10, TimeUnit.SECONDS);
+      transactionPool.setEnabled().get(10, TimeUnit.SECONDS);
+    } finally {
+      releaseSave.countDown();
+    }
+  }
+
+  private CompletableFuture<Void> startSaveWithBlockedTransactionWrite(
+      final Duration saveRestoreTimeout,
+      final CountDownLatch saveStarted,
+      final CountDownLatch releaseSave) {
+    this.transactionPool =
+        createTransactionPool(
+            b ->
+                b.enableSaveRestore(true)
+                    .saveFile(saveFilePath.toFile())
+                    .unstable(
+                        ImmutableTransactionPoolConfiguration.Unstable.builder()
+                            .saveRestoreTimeout(saveRestoreTimeout)
+                            .build()));
+    givenAllTransactionsAreValid();
+
+    final Transaction slowWriteTx = spy(createTransaction(1));
+    // The layered pool stores a detached copy for new transactions. Return the spy from
+    // detachedCopy so the save path still hits the writeTo stub below.
+    doReturn(slowWriteTx).when(slowWriteTx).detachedCopy();
+    doAnswer(
+            invocation -> {
+              // Signal only after save serialization has started; at this point the save operation
+              // has already acquired the disk lock.
+              saveStarted.countDown();
+              releaseSave.await(10, TimeUnit.SECONDS);
+              invocation.callRealMethod();
+              return null;
+            })
+        .when(slowWriteTx)
+        .writeTo(any(), any());
+    addAndAssertTransactionViaApiValid(slowWriteTx, false);
+
+    return transactionPool.setDisabled();
   }
 }


### PR DESCRIPTION
## PR description

- Avoid making txpool save/restore callers wait while acquiring the disk access lock.
- Deduplicate in-progress save/restore operations and clear operation state after failures.
- Add regression tests for disk-lock timeout propagation and retrying restore after a timed-out attempt.

the source issues was this exception, where the backward sync was blocked waiting for the txpool restore disk lock
```
java.util.concurrent.TimeoutException: Timeout waiting for disk access lock
	at org.hyperledger.besu.ethereum.eth.transactions.TransactionPool$SaveRestoreManager.serializeAndDedupOperation(TransactionPool.java:831)
	at org.hyperledger.besu.ethereum.eth.transactions.TransactionPool$SaveRestoreManager.loadFromDisk(TransactionPool.java:794)
	at org.hyperledger.besu.ethereum.eth.transactions.TransactionPool.setEnabled(TransactionPool.java:649)
	at org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolFactory.enableTransactionHandling(TransactionPoolFactory.java:214)
	at org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolFactory.lambda$createTransactionPool$1(TransactionPoolFactory.java:190)
	at java.base/java.util.Optional.ifPresent(Unknown Source)
	at org.hyperledger.besu.ethereum.eth.sync.state.InSyncTracker$InSyncState.ifKnown(InSyncTracker.java:103)
	at org.hyperledger.besu.ethereum.eth.sync.state.InSyncTracker.checkState(InSyncTracker.java:60)
	at org.hyperledger.besu.ethereum.eth.sync.state.SyncState.lambda$checkInSync$1(SyncState.java:320)
	at java.base/java.util.concurrent.ConcurrentHashMap$ValuesView.forEach(Unknown Source)
	at org.hyperledger.besu.ethereum.eth.sync.state.SyncState.checkInSync(SyncState.java:319)
	at org.hyperledger.besu.ethereum.eth.sync.state.SyncState.lambda$new$0(SyncState.java:82)
	at org.hyperledger.besu.ethereum.chain.DefaultBlockchain.lambda$appendBlockHelper$1(DefaultBlockchain.java:627)
	at org.hyperledger.besu.util.Subscribers.lambda$forEach$0(Subscribers.java:136)
	at java.base/java.lang.Iterable.forEach(Unknown Source)
	at org.hyperledger.besu.util.Subscribers.forEach(Subscribers.java:133)
	at org.hyperledger.besu.ethereum.chain.DefaultBlockchain.appendBlockHelper(DefaultBlockchain.java:627)
	at org.hyperledger.besu.ethereum.chain.DefaultBlockchain.appendBlock(DefaultBlockchain.java:518)
	at org.hyperledger.besu.ethereum.eth.sync.backwardsync.BackwardSyncContext.saveBlock(BackwardSyncContext.java:388)
	at org.hyperledger.besu.ethereum.eth.sync.backwardsync.ProcessKnownAncestorsStep.processKnownAncestors(ProcessKnownAncestorsStep.java:67)
	at java.base/java.util.concurrent.CompletableFuture$AsyncRun.run(Unknown Source)
	at java.base/java.util.concurrent.CompletableFuture$AsyncRun.exec(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(Unknown Source)
```

## Fixed Issue(s)

N/A

### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [x] focused unit tests: `timeout 180s ./gradlew :ethereum:eth:test --tests org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolSaveRestoreTest`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)
