### PR TITLE
nightly kurtosis interop assertoor test

### DIFF
--- a/.github/workflows/nightly-kurtosis-interop.yml
+++ b/.github/workflows/nightly-kurtosis-interop.yml
@@ -64,21 +64,20 @@ jobs:
 
           for i in $(seq 1 120); do
             sleep 10
-            RESPONSE=$(curl -sf "http://127.0.0.1:${ASSERTOOR_PORT}/api/v1/tests" 2>/dev/null) || continue
+            RESPONSE=$(curl -sf "http://127.0.0.1:${ASSERTOOR_PORT}/api/v1/test_runs" 2>/dev/null) || continue
 
             ALL_DONE=true
             ANY_FAILED=false
-            TEST_COUNT=0
-            while IFS= read -r test; do
-              TEST_COUNT=$((TEST_COUNT + 1))
-              RESULT=$(echo "$test" | jq -r '.result // .status')
-              case "$RESULT" in
-                "success") ;;
-                "failure") ANY_FAILED=true ;;
-                *) ALL_DONE=false ;;
+            RUN_COUNT=0
+            while IFS= read -r STATUS; do
+              RUN_COUNT=$((RUN_COUNT + 1))
+              case "$STATUS" in
+                "success"|"skipped") ;;
+                "failure"|"aborted") ANY_FAILED=true ;;
+                *) ALL_DONE=false ;;  # pending, running
               esac
-            done < <(echo "$RESPONSE" | jq -c '.[]')
-            if [ "$TEST_COUNT" -eq 0 ]; then
+            done < <(echo "$RESPONSE" | jq -r '.data[].status')
+            if [ "$RUN_COUNT" -eq 0 ]; then
               ALL_DONE=false
             fi
 

--- a/.github/workflows/nightly-kurtosis-interop.yml
+++ b/.github/workflows/nightly-kurtosis-interop.yml
@@ -1,0 +1,134 @@
+name: nightly kurtosis interop
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+    inputs:
+      besu_image:
+        description: 'Besu Docker image to test (leave empty to build from branch)'
+        required: false
+        default: ''
+
+env:
+  GRADLE_OPTS: "-Xmx6g -Dorg.gradle.daemon=false -Dorg.gradle.parallel=true"
+  ENCLAVE_NAME: besu-cl-interop
+
+jobs:
+  kurtosis-cl-interop:
+    name: "Besu CL interop (Lighthouse + Prysm)"
+    runs-on: besu-research-ubuntu-8
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Java
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: temurin
+          java-version: 25
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f # v6.0.1
+        with:
+          cache-disabled: true
+
+      - name: Build Besu Docker image
+        if: inputs.besu_image == ''
+        run: |
+          IMAGE_TAG="nightly-ci-${GITHUB_SHA::7}"
+          ./gradlew distDocker -Pdocker.imageName=hyperledger/besu -Pdocker.imageTag="${IMAGE_TAG}"
+          echo "BESU_IMAGE=hyperledger/besu:${IMAGE_TAG}" >> "$GITHUB_ENV"
+
+      - name: Use provided Besu image
+        if: inputs.besu_image != ''
+        run: echo "BESU_IMAGE=${{ inputs.besu_image }}" >> "$GITHUB_ENV"
+
+      - name: Install Kurtosis CLI
+        run: |
+          echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
+          sudo apt-get update -q
+          sudo apt-get install -y kurtosis-cli
+
+      - name: Write network params
+        run: |
+          cat > network_params.yaml <<EOF
+          participants:
+            - el_type: besu
+              el_image: ${BESU_IMAGE}
+              cl_type: lighthouse
+            - el_type: besu
+              el_image: ${BESU_IMAGE}
+              cl_type: prysm
+          network_params:
+            preset: minimal
+          additional_services:
+            - assertoor
+          assertoor_params:
+            run_block_proposal_check: true
+            run_transaction_test: true
+          EOF
+
+      - name: Start Kurtosis network
+        run: |
+          kurtosis run github.com/ethpandaops/ethereum-package \
+            --enclave "$ENCLAVE_NAME" \
+            --args-file network_params.yaml \
+            --image-download always
+
+      - name: Wait for assertoor results
+        run: |
+          ASSERTOOR_PORT=$(kurtosis enclave inspect "$ENCLAVE_NAME" 2>&1 \
+            | grep assertoor \
+            | grep -oP '127\.0\.0\.1:\K\d+' \
+            | head -1)
+          echo "Assertoor at port ${ASSERTOOR_PORT}"
+
+          for i in $(seq 1 120); do
+            sleep 10
+            RESPONSE=$(curl -sf "http://127.0.0.1:${ASSERTOOR_PORT}/api/v1/tests" 2>/dev/null) || continue
+
+            ALL_DONE=true
+            ANY_FAILED=false
+            while IFS= read -r test; do
+              RESULT=$(echo "$test" | jq -r '.result // .status')
+              case "$RESULT" in
+                "success") ;;
+                "failure") ANY_FAILED=true ;;
+                *) ALL_DONE=false ;;
+              esac
+            done < <(echo "$RESPONSE" | jq -c '.[]')
+
+            if $ANY_FAILED; then
+              echo "One or more assertoor tests failed"
+              exit 1
+            fi
+            if $ALL_DONE; then
+              echo "All assertoor tests passed"
+              exit 0
+            fi
+
+            echo "Waiting... (attempt ${i}/120)"
+          done
+
+          echo "Assertoor tests timed out after 20 minutes"
+          exit 1
+
+      - name: Dump enclave logs
+        if: failure()
+        run: kurtosis enclave dump "$ENCLAVE_NAME" ./enclave-dump
+
+      - name: Upload enclave logs
+        if: failure()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: enclave-dump-${{ github.run_id }}
+          path: enclave-dump/
+          retention-days: 7
+
+      - name: Cleanup enclave
+        if: always()
+        run: kurtosis enclave rm -f "$ENCLAVE_NAME" || true

--- a/.github/workflows/nightly-kurtosis-interop.yml
+++ b/.github/workflows/nightly-kurtosis-interop.yml
@@ -68,7 +68,9 @@ jobs:
 
             ALL_DONE=true
             ANY_FAILED=false
+            TEST_COUNT=0
             while IFS= read -r test; do
+              TEST_COUNT=$((TEST_COUNT + 1))
               RESULT=$(echo "$test" | jq -r '.result // .status')
               case "$RESULT" in
                 "success") ;;
@@ -76,6 +78,9 @@ jobs:
                 *) ALL_DONE=false ;;
               esac
             done < <(echo "$RESPONSE" | jq -c '.[]')
+            if [ "$TEST_COUNT" -eq 0 ]; then
+              ALL_DONE=false
+            fi
 
             if $ANY_FAILED; then
               echo "One or more assertoor tests failed"

--- a/.github/workflows/nightly-kurtosis-interop.yml
+++ b/.github/workflows/nightly-kurtosis-interop.yml
@@ -4,14 +4,8 @@ on:
   schedule:
     - cron: '0 2 * * *'
   workflow_dispatch:
-    inputs:
-      besu_image:
-        description: 'Besu Docker image to test (leave empty to build from branch)'
-        required: false
-        default: ''
 
 env:
-  GRADLE_OPTS: "-Xmx6g -Dorg.gradle.daemon=false -Dorg.gradle.parallel=true"
   ENCLAVE_NAME: besu-cl-interop
 
 jobs:
@@ -25,27 +19,8 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Set up Java
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
-        with:
-          distribution: temurin
-          java-version: 25
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f # v6.0.1
-        with:
-          cache-disabled: true
-
-      - name: Build Besu Docker image
-        if: inputs.besu_image == ''
-        run: |
-          IMAGE_TAG="nightly-ci-${GITHUB_SHA::7}"
-          ./gradlew distDocker -Pdocker.imageName=hyperledger/besu -Pdocker.imageTag="${IMAGE_TAG}"
-          echo "BESU_IMAGE=hyperledger/besu:${IMAGE_TAG}" >> "$GITHUB_ENV"
-
-      - name: Use provided Besu image
-        if: inputs.besu_image != ''
-        run: echo "BESU_IMAGE=${{ inputs.besu_image }}" >> "$GITHUB_ENV"
+      - name: Set Besu image
+        run: echo "BESU_IMAGE=docker.io/${{ secrets.DOCKER_ORG }}/besu:develop" >> "$GITHUB_ENV"
 
       - name: Install Kurtosis CLI
         run: |


### PR DESCRIPTION
## PR description
GHA Smoke test to run nightly, or manually triggered. Either way, this uses the develop docker image. Tests interop with Lighthouse + Prysm CLs. 

I can't easily run the new workflow before this PR is merged, but because it's a new workflow (not changing an existing workflow) it is low risk.

What I have verified locally:

  - YAML heredoc indentation - verified: yaml.safe_load parsed all 4 top-level keys correctly
  - besu:develop Docker tag - verified: docker manifest inspect confirmed; image pulled in live run
  - Kurtosis network (besu+lighthouse, besu+prysm, assertoor) - verified: network started, both CL pairs came up
  - assertoor API endpoint + fields - verified: /api/v1/test_runs returns .data[].status; both tests returned success
  - port grep also confirmed - grep assertoor | grep -oP '127\.0\.0\.1:\K\d+' correctly extracts the port from the `http://127.0.0.1:53558` format in the inspect output.

## Fixed Issue(s)
Refs #7196

Signed-off-by: Sally MacFarlane <macfarla.github@gmail.com>