### PR TITLE
fix: reject negative readiness query params

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/health/ReadinessCheck.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/health/ReadinessCheck.java
@@ -60,6 +60,10 @@ public class ReadinessCheck implements HealthService.HealthCheck {
         LOG.debug("Invalid maxBlocksBehind: {}. Reporting as not ready.", maxBlocksBehindParam);
         return false;
       }
+      if (maxBlocksBehind < 0) {
+        LOG.debug("Invalid maxBlocksBehind: {}. Reporting as not ready.", maxBlocksBehindParam);
+        return false;
+      }
     }
     return syncStatus.getHighestBlock() - syncStatus.getCurrentBlock() <= maxBlocksBehind;
   }
@@ -73,6 +77,10 @@ public class ReadinessCheck implements HealthService.HealthCheck {
       try {
         minimumPeers = Integer.parseInt(peersParam);
       } catch (final NumberFormatException e) {
+        LOG.debug("Invalid minPeers: {}. Reporting as not ready.", peersParam);
+        return false;
+      }
+      if (minimumPeers < 0) {
         LOG.debug("Invalid minPeers: {}. Reporting as not ready.", peersParam);
         return false;
       }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/health/ReadinessCheckTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/health/ReadinessCheckTest.java
@@ -92,6 +92,17 @@ public class ReadinessCheckTest {
   }
 
   @Test
+  public void shouldNotBeReadyWhenMinimumPeersParamIsNegative() {
+    when(p2pNetwork.isP2pEnabled()).thenReturn(true);
+    when(p2pNetwork.getPeerCount()).thenReturn(0);
+    when(synchronizer.getSyncStatus()).thenReturn(Optional.empty());
+
+    params.put(MIN_PEERS_PARAM, "-1");
+
+    assertThat(readinessCheck.isHealthy(paramSource)).isFalse();
+  }
+
+  @Test
   public void shouldBeReadyWhenLessThanDefaultMaxBlocksBehind() {
     when(p2pNetwork.isP2pEnabled()).thenReturn(true);
     when(p2pNetwork.getPeerCount()).thenReturn(5);
@@ -138,6 +149,17 @@ public class ReadinessCheckTest {
     when(synchronizer.getSyncStatus()).thenReturn(createSyncStatus(500, 500));
 
     params.put("maxBlocksBehind", "abc");
+
+    assertThat(readinessCheck.isHealthy(paramSource)).isFalse();
+  }
+
+  @Test
+  public void shouldNotBeReadyWhenCustomMaxBlocksBehindIsNegative() {
+    when(p2pNetwork.isP2pEnabled()).thenReturn(true);
+    when(p2pNetwork.getPeerCount()).thenReturn(5);
+    when(synchronizer.getSyncStatus()).thenReturn(createSyncStatus(500, 500));
+
+    params.put("maxBlocksBehind", "-1");
 
     assertThat(readinessCheck.isHealthy(paramSource)).isFalse();
   }


### PR DESCRIPTION
## PR description

Reject negative readiness query parameters for `minPeers` and `maxBlocksBehind`. `minPeers=-1` currently parses as a valid integer and can make a node with zero peers report ready; negative `maxBlocksBehind` is now handled through the same invalid-parameter path as malformed values.

## Fixed Issue(s)
fixes #10451

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation). No doc update needed.
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog). No changelog update needed.
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests. Not applicable.

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew :ethereum:api:spotlessCheck`
- [x] unit tests: `./gradlew :ethereum:api:test --tests org.hyperledger.besu.ethereum.api.jsonrpc.health.ReadinessCheckTest`
- [ ] acceptance tests: not run; readiness unit coverage only
- [ ] integration tests: not run; readiness unit coverage only
- [ ] reference tests: not run; not touched
- [ ] hive tests: not run; not touched