### PR TITLE
Push docker `develop` tag name instead of a versioned tag

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -58,9 +58,9 @@ jobs:
       - name: Create and push multi-arch manifest
         run: |
           docker buildx imagetools create \
-            -t "${{ env.registry }}/${{ secrets.DOCKER_ORG }}/besu:${{ needs.compute-version.outputs.version }}" \
+            -t "${{ env.registry }}/${{ secrets.DOCKER_ORG }}/besu:develop" \
             $(find /tmp/digests -type f -printf "${{ env.registry }}/${{ secrets.DOCKER_ORG }}/besu@sha256:%f ")
       - name: Inspect manifest
         run: |
           docker buildx imagetools inspect \
-            "${{ env.registry }}/${{ secrets.DOCKER_ORG }}/besu:${{ needs.compute-version.outputs.version }}"
+            "${{ env.registry }}/${{ secrets.DOCKER_ORG }}/besu:develop"


### PR DESCRIPTION
The idea is for each commit to overwrite the `develop` tag rather than pollute the namespace with a versioned tag for every commit.

This is a bug introduced by #10366 
That PR also removed the `develop-arm64` and `develop-amd64` variants, which I think we should continue doing since `develop` is multiarch.