### PR TITLE
EIP-7928: Disallow empty change set for storage slot

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/encoding/BlockAccessListDecoder.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/encoding/BlockAccessListDecoder.java
@@ -25,6 +25,7 @@ import org.hyperledger.besu.ethereum.mainnet.block.access.list.BlockAccessList.N
 import org.hyperledger.besu.ethereum.mainnet.block.access.list.BlockAccessList.SlotChanges;
 import org.hyperledger.besu.ethereum.mainnet.block.access.list.BlockAccessList.SlotRead;
 import org.hyperledger.besu.ethereum.mainnet.block.access.list.BlockAccessList.StorageChange;
+import org.hyperledger.besu.ethereum.rlp.RLPException;
 import org.hyperledger.besu.ethereum.rlp.RLPInput;
 
 import java.util.ArrayList;
@@ -62,6 +63,10 @@ public final class BlockAccessListDecoder {
                           changeIn.leaveList();
                           return new StorageChange(txIndex, newVal);
                         });
+                if (changes.isEmpty()) {
+                  throw new RLPException(
+                      "Block access list slot changes must contain at least one storage change");
+                }
                 scIn.leaveList();
                 return new SlotChanges(slot, changes);
               });

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetBlockAccessListValidator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetBlockAccessListValidator.java
@@ -246,6 +246,14 @@ public class MainnetBlockAccessListValidator implements BlockAccessListValidator
           return false;
         }
         prevStorageSlot = slot;
+        if (slotChanges.changes().isEmpty()) {
+          LOG.warn(
+              "Block access list storage_changes has empty change list for slot {} address {} block {}",
+              slot,
+              account.address(),
+              blockHeader.getBlockHash());
+          return false;
+        }
         changeSlots.add(slot);
 
         prevStorageTxIndex = -1L;

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/block/access/list/BlockAccessList.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/block/access/list/BlockAccessList.java
@@ -242,6 +242,10 @@ public record BlockAccessList(List<AccountChanges> accountChanges, Optional<Byte
       for (AccountChanges ac : bal.accountChanges()) {
         final AccountBuilder ab = getOrCreateAccountBuilder(ac.address());
         for (SlotChanges sc : ac.storageChanges()) {
+          if (sc.changes().isEmpty()) {
+            throw new IllegalArgumentException(
+                "Block access list slot changes must contain at least one storage change");
+          }
           for (StorageChange change : sc.changes()) {
             ab.addStorageWrite(sc.slot(), change.txIndex(), change.newValue());
           }
@@ -393,6 +397,10 @@ public record BlockAccessList(List<AccountChanges> accountChanges, Optional<Byte
         int i = 0;
         for (Map.Entry<StorageSlotKey, List<StorageChange>> e : slotWrites.entrySet()) {
           final List<StorageChange> changes = new ArrayList<>(e.getValue());
+          if (changes.isEmpty()) {
+            throw new IllegalStateException(
+                "Block access list builder cannot emit slot changes without storage changes");
+          }
           changes.sort(Comparator.comparingLong(StorageChange::txIndex));
           entries[i++] =
               new SortableSlotChanges(

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/encoding/AccessListTransactionEncoderTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/encoding/AccessListTransactionEncoderTest.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.ethereum.core.encoding;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.StorageSlotKey;
@@ -29,6 +30,7 @@ import org.hyperledger.besu.ethereum.mainnet.block.access.list.BlockAccessList.S
 import org.hyperledger.besu.ethereum.mainnet.block.access.list.BlockAccessList.StorageChange;
 import org.hyperledger.besu.ethereum.rlp.BytesValueRLPInput;
 import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
+import org.hyperledger.besu.ethereum.rlp.RLPException;
 
 import java.util.List;
 
@@ -104,6 +106,62 @@ public class AccessListTransactionEncoderTest {
 
     assertThat(decoded.rawRlp()).isPresent();
     assertThat(decoded.accountChanges()).isEmpty();
+  }
+
+  @Test
+  void shouldRoundTripAccountWithNoStorageChanges() {
+    final Address address = Address.fromHexString("0x00000000219ab540356cbb839cbe05303d7705fa");
+    final AccountChanges accountChanges =
+        new AccountChanges(
+            address,
+            List.of(),
+            List.of(),
+            List.of(new BalanceChange(0, Wei.fromEth(1))),
+            List.of(new NonceChange(0, 5L)),
+            List.of());
+
+    final BlockAccessList original = new BlockAccessList(List.of(accountChanges));
+
+    final BytesValueRLPOutput output = new BytesValueRLPOutput();
+    BlockAccessListEncoder.encode(original, output);
+    final Bytes encoded = output.encoded();
+
+    final BytesValueRLPInput input = new BytesValueRLPInput(encoded, false);
+    final BlockAccessList decoded = BlockAccessListDecoder.decode(input);
+
+    assertThat(decoded.rawRlp()).isPresent();
+    assertThat(decoded.accountChanges()).hasSize(1);
+    final AccountChanges decodedAcct = decoded.accountChanges().get(0);
+    assertThat(decodedAcct.address()).isEqualTo(address);
+    assertThat(decodedAcct.storageChanges()).isEmpty();
+    assertThat(decodedAcct.storageReads()).isEmpty();
+    assertThat(decodedAcct.balanceChanges()).hasSize(1);
+    assertThat(decodedAcct.nonceChanges()).hasSize(1);
+    assertThat(decodedAcct.codeChanges()).isEmpty();
+  }
+
+  @Test
+  void shouldRejectSlotChangesWithoutStorageChanges() {
+    final Address address = Address.fromHexString("0x00000000219ab540356cbb839cbe05303d7705fa");
+    final StorageSlotKey slotKey = new StorageSlotKey(Wei.ONE.toUInt256());
+    final BlockAccessList invalidAccessList =
+        new BlockAccessList(
+            List.of(
+                new AccountChanges(
+                    address,
+                    List.of(new SlotChanges(slotKey, List.of())),
+                    List.of(),
+                    List.of(),
+                    List.of(),
+                    List.of())));
+
+    final BytesValueRLPOutput output = new BytesValueRLPOutput();
+    BlockAccessListEncoder.encode(invalidAccessList, output);
+
+    assertThatThrownBy(
+            () -> BlockAccessListDecoder.decode(new BytesValueRLPInput(output.encoded(), false)))
+        .isInstanceOf(RLPException.class)
+        .hasMessageContaining("at least one storage change");
   }
 
   @Test

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/MainnetBlockAccessListValidatorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/MainnetBlockAccessListValidatorTest.java
@@ -242,6 +242,22 @@ class MainnetBlockAccessListValidatorTest {
     }
 
     @Test
+    void failsWhenStorageChangesSlotHasNoChanges() {
+      final BlockAccessList.AccountChanges account =
+          new BlockAccessList.AccountChanges(
+              ADDR_1,
+              List.of(new BlockAccessList.SlotChanges(SLOT_1, List.of())),
+              List.of(),
+              List.of(),
+              List.of(),
+              List.of());
+      final BlockAccessList bal = new BlockAccessList(List.of(account));
+      Assertions.assertThat(
+              validator().validate(Optional.of(bal), headerWithBal(bal, 30_000_000L), 0))
+          .isFalse();
+    }
+
+    @Test
     void failsWhenDuplicateStorageKeyInStorageReads() {
       final BlockAccessList.AccountChanges account =
           new BlockAccessList.AccountChanges(

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/block/access/list/BlockAccessListBuilderEip7928Test.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/block/access/list/BlockAccessListBuilderEip7928Test.java
@@ -18,6 +18,8 @@ import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.StorageSlotKey;
 import org.hyperledger.besu.datatypes.Wei;
 
+import java.util.List;
+
 import org.apache.tuweni.units.bigints.UInt256;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -67,6 +69,24 @@ class BlockAccessListBuilderEip7928Test {
     Assertions.assertThat(viaMerge.eip7928ItemCount())
         .isEqualTo(direct.eip7928ItemCount())
         .isEqualTo(4L);
+  }
+
+  @Test
+  void mergeFromRejectsStorageSlotWithEmptyChanges() {
+    final BlockAccessList invalid =
+        new BlockAccessList(
+            List.of(
+                new BlockAccessList.AccountChanges(
+                    ADDR_1,
+                    List.of(new BlockAccessList.SlotChanges(SLOT_1, List.of())),
+                    List.of(),
+                    List.of(),
+                    List.of(),
+                    List.of())));
+
+    Assertions.assertThatThrownBy(() -> BlockAccessList.builder().mergeFrom(invalid))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("at least one storage change");
   }
 
   private static PartialBlockAccessView partialWithOneAccountAndStorageWrite(final int txIndex) {


### PR DESCRIPTION
Reject `storage_changes` entries with empty `slot_changes` following [this](https://github.com/ethereum/EIPs/pull/11750) update. The decoder, builder, and validator now enforce this at their respective layers. The `new SlotChanges(slot, List.of())` record constructor can still create an invalid object for test purposes.