### PR TITLE
kurtosis nightly task: pin ethereum-package

### DIFF
--- a/.github/workflows/nightly-kurtosis-interop.yml
+++ b/.github/workflows/nightly-kurtosis-interop.yml
@@ -51,7 +51,7 @@ jobs:
         # pin ethereum-package to the last commit before the 2026 May 29 batch that introduced GpuConfig,
         # once the upstream bug is fixed we can drop the pin
         run: |
-          kurtosis run github.com/ethpandaops/ethereum-package@35b770d \
+          kurtosis run github.com/ethpandaops/ethereum-package@35b770d5cddb5c356fd0e9157b8db8acf5809365 \
             --enclave "$ENCLAVE_NAME" \
             --args-file network_params.yaml \
             --image-download always

--- a/.github/workflows/nightly-kurtosis-interop.yml
+++ b/.github/workflows/nightly-kurtosis-interop.yml
@@ -48,8 +48,10 @@ jobs:
           EOF
 
       - name: Start Kurtosis network
+        # pin ethereum-package to the last commit before the 2026 May 29 batch that introduced GpuConfig,
+        # once the upstream bug is fixed we can drop the pin
         run: |
-          kurtosis run github.com/ethpandaops/ethereum-package \
+          kurtosis run github.com/ethpandaops/ethereum-package@35b770d \
             --enclave "$ENCLAVE_NAME" \
             --args-file network_params.yaml \
             --image-download always


### PR DESCRIPTION
## PR description
Fixing a bug - error can be seen here:
https://github.com/besu-eth/besu/actions/runs/26737256702/job/78792941814

The bug is still at HEAD of ethereum-package - GpuConfig on line 314 was introduced in the May 29 batch (6547435) and the "fix" commit (994a63d) didn't remove it. I ran locally against 35b770d (the last commit before that batch) and it worked. The fix is to pin the workflow to that commit.



