### PR TITLE
Reject tx whose calldata floor exceeds the gas-limit cap (EIP-8037)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - BFT option `xemptyblockperiodseconds` has been taken out of experimental and been renamed `emptyblockperiodseconds`. The old config option is deprecated and will be removed in a future release.
 
 ### Bug fixes
+- Reject transactions whose EIP-7976 calldata floor (or regular intrinsic) exceeds the EIP-7825 transaction gas-limit cap (`TX_MAX_GAS_LIMIT`, 2^24) under Amsterdam/EIP-8037. Previously a transaction whose floor exceeded the cap but was at or below `tx.gas` (which EIP-8037 permits to exceed the cap, to fund the state-gas reservoir) was executed instead of rejected, diverging from geth/nethermind/erigon/ethrex and the execution-spec reference.
 
 ### Additions and Improvements
 - The option to set a different block period for empty BFT blocks (`emptyblockperiodseconds`) is no longer experimental. The experimental flag `xemptyblockperiodseconds` will be removed in a future release.

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessor.java
@@ -338,6 +338,26 @@ public class MainnetTransactionProcessor {
                     transaction.getGasLimit())));
       }
 
+      // EIP-8037/EIP-7825: max(intrinsic_regular, calldata_floor) must not exceed the
+      // regular transaction gas limit cap (TX_MAX_GAS_LIMIT; Long.MAX_VALUE pre-Amsterdam).
+      // The runtime enforcement below only bounds regular gas CONSUMED during execution,
+      // and the validation-time tx.gas cap is disabled under EIP-8037 - but the calldata
+      // floor is an intrinsic minimum that must also respect the cap. Without this, a tx
+      // whose calldata floor exceeds the cap yet is <= tx.gas slips past the sufficiency
+      // check above and is wrongly executed (bal-devnet-7 consensus divergence: besu
+      // executed it while geth/nethermind/ethrex/revm/eels rejected).
+      final long calldataFloorGas = gasCalculator.transactionFloorCost(transaction);
+      final long regularGasLimitCap = stateGasCalc.transactionRegularGasLimit();
+      if (Long.compareUnsigned(Math.max(intrinsicRegularGas, calldataFloorGas), regularGasLimitCap)
+          > 0) {
+        return TransactionProcessingResult.invalid(
+            ValidationResult.invalid(
+                TransactionInvalidReason.EXCEEDS_TRANSACTION_GAS_LIMIT,
+                String.format(
+                    "max(intrinsic regular %d, calldata floor %d) exceeds transaction gas limit cap %d",
+                    intrinsicRegularGas, calldataFloorGas, regularGasLimitCap)));
+      }
+
       final long gasAvailable = transaction.getGasLimit() - intrinsicRegularGas;
       LOG.trace(
           "Gas available for execution {} = {} - {} (limit - intrinsic)",

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/Eip8037GasLimitTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/Eip8037GasLimitTest.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.ethereum.mainnet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.datatypes.Address;
@@ -94,8 +95,8 @@ class Eip8037GasLimitTest {
     when(transaction.getType()).thenReturn(TransactionType.EIP1559);
     when(transaction.getPayload()).thenReturn(Bytes.EMPTY);
     when(transaction.getSender()).thenReturn(senderAddress);
-    when(transaction.getValue()).thenReturn(Wei.ZERO);
-    when(transaction.getTo()).thenReturn(Optional.of(toAddress));
+    lenient().when(transaction.getValue()).thenReturn(Wei.ZERO);
+    lenient().when(transaction.getTo()).thenReturn(Optional.of(toAddress));
     when(transaction.getGasLimit()).thenReturn(gasLimit);
 
     when(transactionValidatorFactory.get().validate(any(), any(), any(), any()))
@@ -103,7 +104,7 @@ class Eip8037GasLimitTest {
     when(transactionValidatorFactory.get().validateForSender(any(), any(), any()))
         .thenReturn(ValidationResult.valid());
     when(worldState.getOrCreateSenderAccount(any())).thenReturn(senderAccount);
-    when(worldState.updater()).thenReturn(worldState);
+    lenient().when(worldState.updater()).thenReturn(worldState);
   }
 
   @Test
@@ -221,5 +222,34 @@ class Eip8037GasLimitTest {
     // Total gas exceeds TX_MAX_GAS_LIMIT but only regular gas is checked
     assertThat(result.isSuccessful()).isTrue();
     assertThat(result.getStateGasUsed()).isEqualTo(5_000_000L);
+  }
+
+  @Test
+  void calldataFloorExceedingTxMaxGasLimitIsRejected() {
+    // ~262 KB of non-zero calldata gives an EIP-7976 calldata floor of
+    // 21000 + 262000 * 4 * 16 = 16,789,000 gas, which exceeds TX_MAX_GAS_LIMIT
+    // (2^24 = 16,777,216), while the regular intrinsic (4,213,000) stays below it.
+    // tx.gas is set above the floor (allowed under EIP-8037, which relaxes the cap
+    // on tx.gas itself), so the sufficiency check passes - only the
+    // max(intrinsic_regular, calldata_floor) <= cap rule can reject it.
+    setupCommonMocks(30_000_000L);
+    final byte[] calldata = new byte[262_000];
+    java.util.Arrays.fill(calldata, (byte) 0x01);
+    when(transaction.getPayload()).thenReturn(Bytes.wrap(calldata));
+
+    final TransactionProcessingResult result =
+        createProcessor()
+            .processTransaction(
+                worldState,
+                blockHeader,
+                transaction,
+                Address.fromHexString("0x4242424242424242424242424242424242424242"),
+                blockHashLookup,
+                ImmutableTransactionValidationParams.builder().build(),
+                Wei.ZERO);
+
+    assertThat(result.isSuccessful()).isFalse();
+    assertThat(result.getValidationResult().getInvalidReason())
+        .isEqualTo(TransactionInvalidReason.EXCEEDS_TRANSACTION_GAS_LIMIT);
   }
 }


### PR DESCRIPTION
## Summary

Under Amsterdam/EIP-8037, besu **executes** a transaction whose EIP-7976 calldata floor exceeds the EIP-7825 transaction gas-limit cap (`TX_MAX_GAS_LIMIT = 2^24 = 16,777,216`) instead of **rejecting** it. This is a consensus divergence: geth, nethermind, ethrex, revm, and the execution-spec reference all reject such a transaction.

## Root cause

EIP-8037 relaxes EIP-7825's cap on `tx.gas` (the surplus funds the state-gas reservoir), so `AmsterdamTargetingGasLimitCalculator` sets `transactionGasLimitCap()` to `Long.MAX_VALUE` (disabling the validation-time `tx.gas` cap), and the regular-gas cap is enforced **at runtime** on gas *consumed* during execution (`MainnetTransactionProcessor.regularGasLimitExceeded`).

But the **calldata floor** is an intrinsic minimum, not runtime-consumed gas. A transaction whose floor exceeds `TX_MAX_GAS_LIMIT` while staying at or below `tx.gas` (which EIP-8037 now permits to exceed the cap) slips past **both** the sufficiency check (`max(regular+state, floor) <= tx.gas`) and the runtime regular-gas check, and is executed. The execution-spec rule is `max(intrinsic.regular, calldata_floor) <= TX_MAX_GAS_LIMIT`; the floor side was missing.

## Fix

Adds the intrinsic-stage gate in `MainnetTransactionProcessor`:

```
max(intrinsic_regular, calldata_floor) > transactionRegularGasLimit()  ->  reject (EXCEEDS_TRANSACTION_GAS_LIMIT)
```

`transactionRegularGasLimit()` is `2^24` for Amsterdam and `Long.MAX_VALUE` pre-Amsterdam, so the check is a no-op on earlier forks.

## Reproduction (cross-client)

Type-2 tx, ~262 KB of non-zero calldata: floor = `21000 + 262000*4*16 = 16,789,000` (11,784 over the 2^24 cap), regular intrinsic `4,213,000` (under the cap), `tx.gas` set above the floor.

| client | result |
|---|---|
| geth / nethermind / ethrex / revm / execution-spec | **reject** (stateRoot `0x7826da…`) |
| besu (before this PR) | **executes**, charges the 16,789,000 floor (stateRoot `0x5d78e1…`) |

Found by cross-client differential fuzzing on bal-devnet-7 (goevmlab).

## Testing

Adds `Eip8037GasLimitTest::calldataFloorExceedingTxMaxGasLimitIsRejected`. The matching cross-client EEST regression test (which also *unmasks* the existing intrinsic-cap tests that were satisfied by the sufficiency check before reaching the cap check) is in **ethereum/execution-specs#2956**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
