### PR TITLE
chore: tidy up some references to java 21

### DIFF
--- a/BENCHMARKING.md
+++ b/BENCHMARKING.md
@@ -4,7 +4,7 @@ Besu includes [JMH](https://openjdk.org/projects/code-tools/jmh/) microbenchmark
 
 ## 🛠️ Prerequisites
 
-- Java 21+ (ensure `JAVA_HOME` is set)
+- Java 25+ (ensure `JAVA_HOME` is set)
 - Gradle (you can use the wrapper: `./gradlew`)
 - Optional: [Async Profiler](https://github.com/jvm-profiling-tools/async-profiler) for low-overhead profiling
 

--- a/build.gradle
+++ b/build.gradle
@@ -51,8 +51,8 @@ sonarqube {
 
 project.tasks["sonar"].dependsOn "testCodeCoverageReport"
 
-if (!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_21)) {
-  throw new GradleException("Java 21 or later is required to build Besu.\n" +
+if (!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_25)) {
+  throw new GradleException("Java 25 or later is required to build Besu.\n" +
   "  Detected version ${JavaVersion.current()}")
 }
 

--- a/ethereum/evmtool/README.md
+++ b/ethereum/evmtool/README.md
@@ -44,14 +44,14 @@ pip install -e .\[docs,lint,test\]
 
 ### Building EvmTool on macOS
 
-First you need a Java 21+ JDK installed, if not already installed.
+First you need a Java 25+ JDK installed, if not already installed.
 
 It is recommended you install [SDKMAN](https://sdkman.io/install) to
 manage the jvm install.
 
 ```zsh
-sdk install java 21.0.3-tem 
-sdk use java 21.0.3-tem
+sdk install java 25.0.3-tem 
+sdk use java 25.0.3-tem
 ```
 
 Once a JVM is installed you use the gradle target:
@@ -73,8 +73,8 @@ fill -v tests --evm-bin ../besu/build/install/besu/bin/evmtool
 Assuming homebrew and SDKMan are both installed, the complete script is
 
 ```zsh
-sdk install java 21.0.3-tem 
-sdk use java 21.0.3-tem
+sdk install java 25.0.3-tem 
+sdk use java 25.0.3-tem
 git clone https://github.com/hyperledger/besu
 cd besu
 ./gradlew installDist -x test


### PR DESCRIPTION
## PR description
update readmes and other markdowns.

The build.gradle check - I don't know if we need this any more since gradle magic finds java 25 even if you have java defaulting to 21

- [x] sdk install java 25.0.3-tem
- [x] ./gradlew distTar --no-build-cache


