### PR TITLE
snap/2 - invalid range proof handling

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/snap/RetryingGetStorageRangeFromPeerTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/snap/RetryingGetStorageRangeFromPeerTask.java
@@ -19,7 +19,6 @@ import org.hyperledger.besu.ethereum.eth.manager.EthContext;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeer;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeerImmutableAttributes;
 import org.hyperledger.besu.ethereum.eth.manager.task.AbstractRetryingSwitchingPeerTask;
-import org.hyperledger.besu.ethereum.eth.manager.task.EthTask;
 import org.hyperledger.besu.ethereum.eth.messages.snap.StorageRangeMessage;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 
@@ -60,7 +59,7 @@ public class RetryingGetStorageRangeFromPeerTask
     this.metricsSystem = metricsSystem;
   }
 
-  public static EthTask<StorageRangeMessage.SlotRangeData> forStorageRange(
+  public static RetryingGetStorageRangeFromPeerTask forStorageRange(
       final EthContext ethContext,
       final List<Bytes32> accountHashes,
       final Bytes32 startKeyHash,

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/v2/ResponseProofStatus.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/v2/ResponseProofStatus.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.eth.sync.snapsync.request.v2;
+
+enum ResponseProofStatus {
+  PENDING,
+  VALID,
+  INVALID
+}

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/v2/SnapV2AccountRangeRequest.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/v2/SnapV2AccountRangeRequest.java
@@ -43,7 +43,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
@@ -61,14 +60,14 @@ public class SnapV2AccountRangeRequest extends SnapV2DataRequest {
   private final Bytes32 startKeyHash;
   private final Bytes32 endKeyHash;
   private final StackTrie stackTrie;
-  private Optional<Boolean> isProofValid;
+  private ResponseProofStatus responseProofStatus;
 
   public SnapV2AccountRangeRequest(
       final BlockHeader pivotBlockHeader, final Bytes32 startKeyHash, final Bytes32 endKeyHash) {
     super(ACCOUNT_RANGE, pivotBlockHeader, startKeyHash);
     this.startKeyHash = startKeyHash;
     this.endKeyHash = endKeyHash;
-    this.isProofValid = Optional.empty();
+    this.responseProofStatus = ResponseProofStatus.PENDING;
     this.stackTrie = new StackTrie(pivotBlockHeader.getStateRoot(), startKeyHash);
   }
 
@@ -117,10 +116,10 @@ public class SnapV2AccountRangeRequest extends SnapV2DataRequest {
     if (!accounts.isEmpty() || !proofs.isEmpty()) {
       if (!worldStateProofProvider.isValidRangeProof(
           startKeyHash, endKeyHash, Bytes32.wrap(getRootHash().getBytes()), proofs, accounts)) {
-        isProofValid = Optional.of(false);
+        responseProofStatus = ResponseProofStatus.INVALID;
       } else {
         stackTrie.addElement(startKeyHash, proofs, accounts);
-        isProofValid = Optional.of(true);
+        responseProofStatus = ResponseProofStatus.VALID;
         LOG.atDebug()
             .setMessage("{} accounts received during sync for account range {} {}")
             .addArgument(accounts.size())
@@ -133,7 +132,11 @@ public class SnapV2AccountRangeRequest extends SnapV2DataRequest {
 
   @Override
   public boolean isResponseReceived() {
-    return isProofValid.orElse(false);
+    return responseProofStatus == ResponseProofStatus.VALID;
+  }
+
+  ResponseProofStatus getResponseProofStatus() {
+    return responseProofStatus;
   }
 
   @Override
@@ -141,6 +144,10 @@ public class SnapV2AccountRangeRequest extends SnapV2DataRequest {
       final SnapRequestContext downloadState,
       final WorldStateStorageCoordinator worldStateStorageCoordinator,
       final SnapSyncProcessState snapSyncState) {
+    if (responseProofStatus != ResponseProofStatus.VALID) {
+      return Stream.empty();
+    }
+
     final List<SnapDataRequest> childRequests = new ArrayList<>();
     final StackTrie.TaskElement taskElement = stackTrie.getElement(startKeyHash);
 
@@ -209,6 +216,6 @@ public class SnapV2AccountRangeRequest extends SnapV2DataRequest {
   @Override
   public void clear() {
     stackTrie.clear();
-    isProofValid = Optional.of(false);
+    responseProofStatus = ResponseProofStatus.PENDING;
   }
 }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/v2/SnapV2AccountRangeRequest.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/v2/SnapV2AccountRangeRequest.java
@@ -135,8 +135,8 @@ public class SnapV2AccountRangeRequest extends SnapV2DataRequest {
     return responseProofStatus == ResponseProofStatus.VALID;
   }
 
-  ResponseProofStatus getResponseProofStatus() {
-    return responseProofStatus;
+  public boolean hasInvalidProof() {
+    return responseProofStatus == ResponseProofStatus.INVALID;
   }
 
   @Override

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/v2/SnapV2StorageRangeRequest.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/v2/SnapV2StorageRangeRequest.java
@@ -39,7 +39,6 @@ import org.hyperledger.besu.plugin.services.storage.WorldStateKeyValueStorage;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NavigableMap;
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
@@ -56,7 +55,7 @@ public class SnapV2StorageRangeRequest extends SnapV2DataRequest {
   private final Bytes32 startKeyHash;
   private final Bytes32 endKeyHash;
   private final StackTrie stackTrie;
-  private Optional<Boolean> isProofValid;
+  private ResponseProofStatus responseProofStatus;
 
   public SnapV2StorageRangeRequest(
       final BlockHeader pivotBlockHeader,
@@ -70,7 +69,7 @@ public class SnapV2StorageRangeRequest extends SnapV2DataRequest {
     this.storageRoot = storageRoot;
     this.startKeyHash = startKeyHash;
     this.endKeyHash = endKeyHash;
-    this.isProofValid = Optional.empty();
+    this.responseProofStatus = ResponseProofStatus.PENDING;
     this.stackTrie = new StackTrie(Hash.wrap(getStorageRoot()), startKeyHash);
   }
 
@@ -120,17 +119,25 @@ public class SnapV2StorageRangeRequest extends SnapV2DataRequest {
     if (!slots.isEmpty() || !proofs.isEmpty()) {
       if (!worldStateProofProvider.isValidRangeProof(
           startKeyHash, endKeyHash, storageRoot, proofs, slots)) {
-        isProofValid = Optional.of(false);
+        responseProofStatus = ResponseProofStatus.INVALID;
       } else {
         stackTrie.addElement(startKeyHash, proofs, slots);
-        isProofValid = Optional.of(true);
+        responseProofStatus = ResponseProofStatus.VALID;
       }
     }
   }
 
   @Override
   public boolean isResponseReceived() {
-    return isProofValid.isPresent();
+    return responseProofStatus == ResponseProofStatus.VALID;
+  }
+
+  ResponseProofStatus getResponseProofStatus() {
+    return responseProofStatus;
+  }
+
+  public boolean hasInvalidProof() {
+    return responseProofStatus == ResponseProofStatus.INVALID;
   }
 
   @Override
@@ -138,6 +145,10 @@ public class SnapV2StorageRangeRequest extends SnapV2DataRequest {
       final SnapRequestContext downloadState,
       final WorldStateStorageCoordinator worldStateStorageCoordinator,
       final SnapSyncProcessState snapSyncState) {
+    if (responseProofStatus != ResponseProofStatus.VALID) {
+      return Stream.empty();
+    }
+
     final List<SnapDataRequest> childRequests = new ArrayList<>();
     final StackTrie.TaskElement taskElement = stackTrie.getElement(startKeyHash);
 
@@ -188,7 +199,7 @@ public class SnapV2StorageRangeRequest extends SnapV2DataRequest {
 
   @Override
   public void clear() {
-    this.isProofValid = Optional.of(false);
+    this.responseProofStatus = ResponseProofStatus.PENDING;
     this.stackTrie.removeElement(startKeyHash);
   }
 }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/v2/SnapV2StorageRangeRequest.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/v2/SnapV2StorageRangeRequest.java
@@ -132,10 +132,6 @@ public class SnapV2StorageRangeRequest extends SnapV2DataRequest {
     return responseProofStatus == ResponseProofStatus.VALID;
   }
 
-  ResponseProofStatus getResponseProofStatus() {
-    return responseProofStatus;
-  }
-
   public boolean hasInvalidProof() {
     return responseProofStatus == ResponseProofStatus.INVALID;
   }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2RequestDataStep.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2RequestDataStep.java
@@ -21,7 +21,6 @@ import org.hyperledger.besu.ethereum.eth.manager.snap.RetryingGetAccountRangeFro
 import org.hyperledger.besu.ethereum.eth.manager.snap.RetryingGetBytecodeFromPeerTask;
 import org.hyperledger.besu.ethereum.eth.manager.snap.RetryingGetStorageRangeFromPeerTask;
 import org.hyperledger.besu.ethereum.eth.manager.task.EthTask;
-import org.hyperledger.besu.ethereum.eth.messages.snap.AccountRangeMessage;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.SnapSyncProcessState;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.request.SnapDataRequest;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.request.SnapRequestContext;
@@ -74,13 +73,14 @@ public class SnapV2RequestDataStep {
       final Task<SnapDataRequest> requestTask) {
     final SnapV2AccountRangeRequest request = (SnapV2AccountRangeRequest) requestTask.getData();
     final BlockHeader blockHeader = request.getPivotBlockHeader();
-    final EthTask<AccountRangeMessage.AccountRangeData> getAccountTask =
-        RetryingGetAccountRangeFromPeerTask.forAccountRange(
-            ethContext,
-            request.getStartKeyHash(),
-            request.getEndKeyHash(),
-            blockHeader,
-            metricsSystem);
+    final RetryingGetAccountRangeFromPeerTask getAccountTask =
+        (RetryingGetAccountRangeFromPeerTask)
+            RetryingGetAccountRangeFromPeerTask.forAccountRange(
+                ethContext,
+                request.getStartKeyHash(),
+                request.getEndKeyHash(),
+                blockHeader,
+                metricsSystem);
     downloadState.addOutstandingTask(getAccountTask);
     return getAccountTask
         .run()
@@ -92,6 +92,19 @@ public class SnapV2RequestDataStep {
                 request.setRootHash(blockHeader.getStateRoot());
                 request.addResponse(
                     worldStateProofProvider, response.accounts(), response.proofs());
+                if (request.hasInvalidProof()) {
+                  getAccountTask
+                      .getAssignedPeer()
+                      .ifPresent(
+                          peer -> {
+                            LOG.atDebug()
+                                .setMessage(
+                                    "Invalid snap/2 account range proof received from peer {}")
+                                .addArgument(peer::getLoggableId)
+                                .log();
+                            peer.recordUselessResponse("invalid snap/2 account range proof");
+                          });
+                }
               }
               if (error != null) {
                 LOG.atDebug()

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2RequestDataStep.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2RequestDataStep.java
@@ -22,7 +22,6 @@ import org.hyperledger.besu.ethereum.eth.manager.snap.RetryingGetBytecodeFromPee
 import org.hyperledger.besu.ethereum.eth.manager.snap.RetryingGetStorageRangeFromPeerTask;
 import org.hyperledger.besu.ethereum.eth.manager.task.EthTask;
 import org.hyperledger.besu.ethereum.eth.messages.snap.AccountRangeMessage;
-import org.hyperledger.besu.ethereum.eth.messages.snap.StorageRangeMessage;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.SnapSyncProcessState;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.request.SnapDataRequest;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.request.SnapRequestContext;
@@ -128,7 +127,7 @@ public class SnapV2RequestDataStep {
         accountHashes.stream()
             .map(hash -> Bytes32.wrap(hash.getBytes()))
             .collect(Collectors.toList());
-    final EthTask<StorageRangeMessage.SlotRangeData> getStorageRangeTask =
+    final RetryingGetStorageRangeFromPeerTask getStorageRangeTask =
         RetryingGetStorageRangeFromPeerTask.forStorageRange(
             ethContext, accountHashesAsBytes32, minRange, maxRange, blockHeader, metricsSystem);
     downloadState.addOutstandingTask(getStorageRangeTask);
@@ -140,6 +139,7 @@ public class SnapV2RequestDataStep {
               downloadState.removeOutstandingTask(getStorageRangeTask);
               if (response != null) {
                 final ArrayDeque<NavigableMap<Bytes32, Bytes>> slots = new ArrayDeque<>();
+                boolean invalidProofReceived = false;
                 try {
                   final boolean isEmptyRange =
                       (response.slots().isEmpty() || response.slots().get(0).isEmpty())
@@ -158,6 +158,22 @@ public class SnapV2RequestDataStep {
                         worldStateProofProvider,
                         slots.get(i),
                         i < slots.size() - 1 ? new ArrayDeque<>() : response.proofs());
+                    if (request.hasInvalidProof()) {
+                      invalidProofReceived = true;
+                    }
+                  }
+                  if (invalidProofReceived) {
+                    getStorageRangeTask
+                        .getAssignedPeer()
+                        .ifPresent(
+                            peer -> {
+                              LOG.atDebug()
+                                  .setMessage(
+                                      "Invalid snap/2 storage range proof received from peer {}")
+                                  .addArgument(peer::getLoggableId)
+                                  .log();
+                              peer.recordUselessResponse("invalid snap/2 storage range proof");
+                            });
                   }
                 } catch (final Exception e) {
                   LOG.error("Error while processing storage range response", e);


### PR DESCRIPTION
Adds an explicit proof status to request state. Requests with invalid proofs are not persisted or tracked, are marked as failed and retried on a different peer (responding peer is marked as useless).