### PR TITLE
fix(bonsai): prevent unbounded LayeredKeyValueStorage chain growth under engine_newPayload backlog

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/storage/BonsaiWorldStateLayerStorage.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/storage/BonsaiWorldStateLayerStorage.java
@@ -147,4 +147,9 @@ public class BonsaiWorldStateLayerStorage extends BonsaiSnapshotWorldStateKeyVal
   public LayeredKeyValueStorage getComposedWorldStateStorage() {
     return (LayeredKeyValueStorage) super.getComposedWorldStateStorage();
   }
+
+  @Override
+  public int layerDepth() {
+    return getComposedWorldStateStorage().chainDepth();
+  }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/cache/PathBasedCachedWorldStorageManager.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/cache/PathBasedCachedWorldStorageManager.java
@@ -104,13 +104,22 @@ public abstract class PathBasedCachedWorldStorageManager implements StorageSubsc
             new PathBasedCachedWorldView(
                 blockHeader, createSnapshotKeyValueStorage(forWorldState.getWorldStateStorage())));
       } else {
-        // otherwise, add the layer to the cache
-        cachedWorldStatesByHash.put(
-            blockHeader.getBlockHash(),
-            new PathBasedCachedWorldView(
-                blockHeader,
-                ((PathBasedLayeredWorldStateKeyValueStorage) forWorldState.getWorldStateStorage())
-                    .clone()));
+        // only cache if the layer chain is shallow; deep chains indicate a backlog of
+        // engine_newPayload calls without FCU — caching would accumulate memory unboundedly
+        final PathBasedLayeredWorldStateKeyValueStorage layerStorage =
+            (PathBasedLayeredWorldStateKeyValueStorage) forWorldState.getWorldStateStorage();
+        if (layerStorage.layerDepth() <= 1) {
+          cachedWorldStatesByHash.put(
+              blockHeader.getBlockHash(),
+              new PathBasedCachedWorldView(blockHeader, layerStorage.clone()));
+        } else {
+          LOG.atDebug()
+              .setMessage(
+                  "Skipping cache for block {} (layerDepth={}) to prevent unbounded layer accumulation")
+              .addArgument(blockHeader::toLogString)
+              .addArgument(layerStorage::layerDepth)
+              .log();
+        }
       }
       // add stateroot -> blockHeader cache entry
       stateRootToBlockHeaderCache.put(blockHeader.getStateRoot(), blockHeader);
@@ -137,11 +146,20 @@ public abstract class PathBasedCachedWorldStorageManager implements StorageSubsc
       // return a new worldstate using worldstate storage and an isolated copy of the updater
       return Optional.ofNullable(cachedWorldStatesByHash.get(blockHash))
           .map(
-              cached ->
-                  createWorldState(
-                      archive,
-                      createLayeredKeyValueStorage(cached.getWorldStateStorage()),
-                      evmConfiguration));
+              cached -> {
+                final var layeredStorage =
+                    createLayeredKeyValueStorage(cached.getWorldStateStorage());
+                LOG.atInfo()
+                    .setMessage("[LAYER_DEPTH] getWorldState cache hit for {} layerDepth={}")
+                    .addArgument(blockHash.getBytes().toShortHexString())
+                    .addArgument(
+                        () ->
+                            layeredStorage instanceof PathBasedLayeredWorldStateKeyValueStorage lkv
+                                ? lkv.layerDepth()
+                                : -1)
+                    .log();
+                return createWorldState(archive, layeredStorage, evmConfiguration);
+              });
     }
     LOG.atDebug()
         .setMessage("did not find worldstate in cache for {}")
@@ -178,9 +196,20 @@ public abstract class PathBasedCachedWorldStorageManager implements StorageSubsc
                   .findFirst();
             })
         .map(
-            storage ->
-                createWorldState( // wrap the state in a layered worldstate
-                    archive, createLayeredKeyValueStorage(storage), evmConfiguration));
+            storage -> {
+              final var layeredStorage = createLayeredKeyValueStorage(storage);
+              LOG.atInfo()
+                  .setMessage("[LAYER_DEPTH] getNearestWorldState for #{} layerDepth={}")
+                  .addArgument(blockHeader.getNumber())
+                  .addArgument(
+                      () ->
+                          layeredStorage instanceof PathBasedLayeredWorldStateKeyValueStorage lkv
+                              ? lkv.layerDepth()
+                              : -1)
+                  .log();
+              return createWorldState( // wrap the state in a layered worldstate
+                  archive, layeredStorage, evmConfiguration);
+            });
   }
 
   public Optional<PathBasedWorldState> getHeadWorldState(

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/cache/PathBasedCachedWorldStorageManager.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/cache/PathBasedCachedWorldStorageManager.java
@@ -149,9 +149,9 @@ public abstract class PathBasedCachedWorldStorageManager implements StorageSubsc
               cached -> {
                 final var layeredStorage =
                     createLayeredKeyValueStorage(cached.getWorldStateStorage());
-                LOG.atInfo()
+                LOG.atDebug()
                     .setMessage("[LAYER_DEPTH] getWorldState cache hit for {} layerDepth={}")
-                    .addArgument(blockHash.getBytes().toShortHexString())
+                    .addArgument(() -> blockHash.getBytes().toShortHexString())
                     .addArgument(
                         () ->
                             layeredStorage instanceof PathBasedLayeredWorldStateKeyValueStorage lkv
@@ -198,7 +198,7 @@ public abstract class PathBasedCachedWorldStorageManager implements StorageSubsc
         .map(
             storage -> {
               final var layeredStorage = createLayeredKeyValueStorage(storage);
-              LOG.atInfo()
+              LOG.atDebug()
                   .setMessage("[LAYER_DEPTH] getNearestWorldState for #{} layerDepth={}")
                   .addArgument(blockHeader.getNumber())
                   .addArgument(

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/provider/PathBasedWorldStateProvider.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/provider/PathBasedWorldStateProvider.java
@@ -242,8 +242,23 @@ public abstract class PathBasedWorldStateProvider implements WorldStateArchive {
                     blockHeaderHash ->
                         blockchain.getBlockHeader(blockHeaderHash).map(BlockHeader.class::cast)))
         .flatMap(
-            worldState -> rollFullWorldStateToBlockHash(worldState, blockHeader.getBlockHash()))
-        .map(MutableWorldState::freezeStorage);
+            worldState -> {
+              LOG.atInfo()
+                  .setMessage(
+                      "[LAYER_DEPTH] rollFullWorldStateToBlockHash start: worldState.block={} target={}")
+                  .addArgument(worldState.blockHash())
+                  .addArgument(blockHeader::getBlockHash)
+                  .log();
+              return rollFullWorldStateToBlockHash(worldState, blockHeader.getBlockHash());
+            })
+        .map(
+            worldState -> {
+              LOG.atInfo()
+                  .setMessage("[LAYER_DEPTH] rollFullWorldStateToBlockHash done: target={}")
+                  .addArgument(blockHeader::getBlockHash)
+                  .log();
+              return worldState.freezeStorage();
+            });
   }
 
   private Optional<MutableWorldState> rollFullWorldStateToBlockHash(

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/provider/PathBasedWorldStateProvider.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/provider/PathBasedWorldStateProvider.java
@@ -243,7 +243,7 @@ public abstract class PathBasedWorldStateProvider implements WorldStateArchive {
                         blockchain.getBlockHeader(blockHeaderHash).map(BlockHeader.class::cast)))
         .flatMap(
             worldState -> {
-              LOG.atInfo()
+              LOG.atDebug()
                   .setMessage(
                       "[LAYER_DEPTH] rollFullWorldStateToBlockHash start: worldState.block={} target={}")
                   .addArgument(worldState.blockHash())
@@ -253,7 +253,7 @@ public abstract class PathBasedWorldStateProvider implements WorldStateArchive {
             })
         .map(
             worldState -> {
-              LOG.atInfo()
+              LOG.atDebug()
                   .setMessage("[LAYER_DEPTH] rollFullWorldStateToBlockHash done: target={}")
                   .addArgument(blockHeader::getBlockHash)
                   .log();

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/storage/PathBasedLayeredWorldStateKeyValueStorage.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/storage/PathBasedLayeredWorldStateKeyValueStorage.java
@@ -22,4 +22,9 @@ public interface PathBasedLayeredWorldStateKeyValueStorage
   PathBasedWorldStateKeyValueStorage clone();
 
   void mergeTo(final SegmentedKeyValueStorageTransaction transaction);
+
+  /** Returns the depth of the underlying LayeredKeyValueStorage chain, or -1 if not applicable. */
+  default int layerDepth() {
+    return -1;
+  }
 }

--- a/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/LayeredKeyValueStorageTest.java
+++ b/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/LayeredKeyValueStorageTest.java
@@ -378,4 +378,18 @@ public class LayeredKeyValueStorageTest {
     assertArrayEquals(key3, resultList.get(2).getKey());
     assertArrayEquals(value3, resultList.get(2).getValue());
   }
+
+  @Test
+  void chainDepthShouldReflectNumberOfLayeredLayers() {
+    // depth 1: single layer wrapping a non-layered parent
+    assertEquals(1, layeredKeyValueStorage.chainDepth());
+
+    // depth 2: layer on top of the first layer
+    LayeredKeyValueStorage layer2 = new LayeredKeyValueStorage(layeredKeyValueStorage);
+    assertEquals(2, layer2.chainDepth());
+
+    // depth 3: one more on top
+    LayeredKeyValueStorage layer3 = new LayeredKeyValueStorage(layer2);
+    assertEquals(3, layer3.chainDepth());
+  }
 }

--- a/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/LayeredKeyValueStorage.java
+++ b/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/LayeredKeyValueStorage.java
@@ -81,6 +81,14 @@ public class LayeredKeyValueStorage extends SegmentedInMemoryKeyValueStorage
     this.parent = parent;
   }
 
+  /**
+   * Returns the number of {@link LayeredKeyValueStorage} layers in this chain (including this
+   * layer). Used for instrumentation to detect unbounded chain growth.
+   */
+  public int chainDepth() {
+    return 1 + (parent instanceof LayeredKeyValueStorage lkv ? lkv.chainDepth() : 0);
+  }
+
   @Override
   public boolean containsKey(final SegmentIdentifier segmentId, final byte[] key)
       throws StorageException {

--- a/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/LayeredKeyValueStorage.java
+++ b/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/LayeredKeyValueStorage.java
@@ -84,6 +84,8 @@ public class LayeredKeyValueStorage extends SegmentedInMemoryKeyValueStorage
   /**
    * Returns the number of {@link LayeredKeyValueStorage} layers in this chain (including this
    * layer). Used for instrumentation to detect unbounded chain growth.
+   *
+   * @return the chain depth, always &gt;= 1
    */
   public int chainDepth() {
     return 1 + (parent instanceof LayeredKeyValueStorage lkv ? lkv.chainDepth() : 0);


### PR DESCRIPTION
## Summary

Fixes a memory leak where `LayeredKeyValueStorage` chains grow without bound when `engine_newPayload` is called for a backlog of blocks without an intervening FCU (e.g. during initial sync or Prysm post-Fulu backfill retry loops).

### Root cause

`addCachedLayer`'s non-head path stored a `clone()` of the incoming `BonsaiWorldStateLayerStorage`. Each clone shares the same parent `LayeredKeyValueStorage`, so the chain deepens by 1 per call. With 512 retained layers, chains reach depth 512 causing O(depth) `isClosed()` traversals, ~84% CPU, and ~10 GB/day Old Gen growth (reported in #10498).

### Fix

In `addCachedLayer`, skip caching non-head world states when `layerDepth() > 1`. This bounds the in-cache chain depth at 1 (steady state with regular FCU) or 2 (one cold backlog call). Subsequent backlog blocks return SYNCING (via the companion PR) or simply produce uncached world states — neither leaks memory.

### Instrumentation added

To confirm the hypothesis before fixing, `layerDepth()` was added to the `PathBasedLayeredWorldStateKeyValueStorage` interface (backed by `LayeredKeyValueStorage.chainDepth()`), and `[LAYER_DEPTH]` logging was added at the two `getWorldState`/`getNearestWorldState` cache-hit paths.

### Kurtosis validation

**Unfixed:** depth climbed monotonically 1 → 2 → 3 → … → 40 (one leaked layer per `engine_newPayload` call, 39 layers across 39 backlog blocks after restart).

**Fixed:** depth reaches 2 on the first backlog block and stays at 2 for all subsequent blocks. No accumulation. Exec times settle to 3–8 ms after a brief cold-cache spike.

### Related

- Closes #10498
- Companion SYNCING guard PR: #10600 (returns SYNCING when parent world state not immediately cached, preventing expensive trie-log replay on worker threads)

## Changes

- `LayeredKeyValueStorage`: add `chainDepth()` to count depth of the parent chain
- `PathBasedLayeredWorldStateKeyValueStorage`: add `layerDepth()` default method (returns -1)
- `BonsaiWorldStateLayerStorage`: implement `layerDepth()` via `getComposedWorldStateStorage().chainDepth()`
- `PathBasedCachedWorldStorageManager`: skip caching when `layerDepth() > 1`; add `[LAYER_DEPTH]` instrumentation logging
- `PathBasedWorldStateProvider`: add `[LAYER_DEPTH]` logging around `rollFullWorldStateToBlockHash`

## Test plan

- [x] `./gradlew :ethereum:core:test` passes
- [x] `./gradlew :services:kvstore:test` passes
- [x] Kurtosis e2e: depth histogram stays at ≤ 2 after restart with 40-block backlog (verified locally, logs at `/tmp/layer-leak-besu-fixed.log`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)