### PR TITLE
Revert release process changes

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -35,17 +35,17 @@ assignees: ''
   - [ ] `git tag 24.4.0`
   - [ ] `git push upstream 24.4.0`
 - [ ] Manually run https://github.com/besu-eth/besu/actions/workflows/draft-release.yml using `main` branch` and the FULL RELEASE tag name, i.e. `24.4.0`. Note, this workflow should always be run from `main` branch (hotfix tags will still be released even if they were created based on another branch)
-    - publishes the binary artefacts as a GitHub draft release; docker tags and Maven artifacts are published later by `publish-release.yml`
+    - publishes artefacts and version-specific docker tags but does not fully publish the GitHub release so subscribers are not yet notified
 - [ ] Check all draft-release workflow jobs went green
-- [ ] Verify binary artifacts (.tar.gz, .zip, .sha256) are attached to the draft release — if missing, draft-release.yml did not complete successfully; do not publish until they are present
-- [ ] Review release notes in the GitHub draft release (auto-composed from CHANGELOG at the tag); sign-off with team
-- [ ] IMPORTANT: confirm the tag name is the ONLY text in the "Release title", otherwise it will break the Publish Release workflow https://github.com/besu-eth/besu/actions/workflows/publish-release.yml
+- [ ] Check binary SHAs are correct on the release page
+- [ ] Check artifacts exist in https://hyperledger.jfrog.io/ui/repos/tree/General/besu-maven
+- [ ] Update release notes in the GitHub draft release, save draft and sign-off with team
+- [ ] IMPORTANT: confirm the tag name is the ONLY text in the "Release title", otherwise it will break the Docker Promote workflow https://github.com/besu-eth/besu/actions/workflows/docker-promote.yml
 - [ ] Publish draft release ensuring it is marked as latest release (if appropriate)
     - this is now public and notifies subscribed users
     - makes the release "latest" in github
-    - triggers `publish-release.yml`: docker version + latest tags, Maven artifacts to artifactory
-- [ ] Verify https://github.com/besu-eth/besu/actions/workflows/publish-release.yml went green
-- [ ] Check artifacts exist in https://hyperledger.jfrog.io/ui/repos/tree/General/besu-maven
+    - publishes the docker `latest` tag variants
+- [ ] Verify https://github.com/besu-eth/besu/actions/workflows/docker-promote.yml went green
 - [ ] Create homebrew release PR using [update-version workflow](https://github.com/hyperledger/homebrew-besu/actions/workflows/update-version.yml)
   - If the PR has not been automatically created, create the PR manually using the created branch `update-<version>`
 - [ ] Verify homebrew release once the PR has merged using `brew tap hyperledger/besu && brew install besu` on MacOSX to verify latest version has been installed

--- a/.github/workflows/docker-promote.yml
+++ b/.github/workflows/docker-promote.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 25
           cache: gradle
 
       - name: Login to ${{ env.registry }}

--- a/.github/workflows/docker-promote.yml
+++ b/.github/workflows/docker-promote.yml
@@ -1,6 +1,6 @@
-name: Publish Release
+name: Docker Promote
 
-run-name: "Publish Release ${{ github.event.release.name }}"
+run-name: "Docker Promote ${{ github.event.release.name }}"
 
 on:
   release:
@@ -53,45 +53,6 @@ jobs:
           fi
           echo "Matched RC tag: $RC_VERSION"
           echo "rc_version=$RC_VERSION" >> $GITHUB_OUTPUT
-
-      - name: Verify binary artifacts on the GitHub release
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_VERSION: ${{ steps.validate_release_version.outputs.release_version }}
-        run: |
-          # Guards against a draft-release.yml run that didn't finish: if any
-          # of the four expected artifacts are missing, or if a binary's
-          # contents don't match its .sha256 sidecar, fail before docker tags
-          # and Maven artifacts get promoted to point at a broken release.
-          set -euo pipefail
-          expected=(
-            "besu-${RELEASE_VERSION}.tar.gz"
-            "besu-${RELEASE_VERSION}.zip"
-            "besu-${RELEASE_VERSION}.tar.gz.sha256"
-            "besu-${RELEASE_VERSION}.zip.sha256"
-          )
-
-          assets=$(gh release view "$RELEASE_VERSION" --json assets --jq '.assets[].name')
-          missing=()
-          for f in "${expected[@]}"; do
-            if ! grep -qx "$f" <<< "$assets"; then
-              missing+=("$f")
-            fi
-          done
-          if [[ ${#missing[@]} -gt 0 ]]; then
-            echo "::error::Release ${RELEASE_VERSION} is missing expected artifacts:"
-            printf '::error::  - %s\n' "${missing[@]}"
-            echo "::error::draft-release.yml likely did not complete successfully. Re-run it before retrying the publish."
-            exit 1
-          fi
-
-          workdir=$(mktemp -d)
-          cd "$workdir"
-          for f in "${expected[@]}"; do
-            gh release download "$RELEASE_VERSION" --pattern "$f"
-          done
-          sha256sum -c "besu-${RELEASE_VERSION}.tar.gz.sha256"
-          sha256sum -c "besu-${RELEASE_VERSION}.zip.sha256"
 
   docker-promote:
     needs: [validate]
@@ -190,52 +151,3 @@ jobs:
 
       - name: Stop container
         run: docker stop ${{ env.CONTAINER_NAME }}
-
-  artifactory:
-    runs-on: ubuntu-latest
-    needs: [validate]
-    env:
-      RELEASE_VERSION: ${{ needs.validate.outputs.release_version }}
-    steps:
-      - name: checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ env.RELEASE_VERSION }}
-
-      - name: Set up Java
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
-        with:
-          distribution: temurin
-          java-version: 25
-
-      - name: setup gradle
-        uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f # v6.0.1
-        with:
-          cache-disabled: true
-
-      - name: Artifactory Publish
-        env:
-          ARTIFACTORY_USER: ${{ secrets.BESU_ARTIFACTORY_USER }}
-          ARTIFACTORY_KEY: ${{ secrets.BESU_ARTIFACTORY_TOKEN }}
-        run: ./gradlew -Prelease.releaseVersion=${{ env.RELEASE_VERSION }} -Pversion=${{env.RELEASE_VERSION}} artifactoryPublish
-
-  verify_artifactory:
-    runs-on: ubuntu-latest
-    needs: [validate, artifactory]
-    env:
-      RELEASE_VERSION: ${{ needs.validate.outputs.release_version }}
-    steps:
-      - name: checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ env.RELEASE_VERSION }}
-
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: '3.13'
-
-      - name: Install dependencies
-        run: pip install requests argparse
-
-      - name: Run the script
-        run: python3 .github/workflows/verify_artifacts.py --besu_version="${{ needs.validate.outputs.release_version }}"

--- a/.github/workflows/docker-promote.yml
+++ b/.github/workflows/docker-promote.yml
@@ -8,59 +8,43 @@ on:
 
 env:
   registry: docker.io
+  GRADLE_OPTS: "-Dorg.gradle.parallel=true -Dorg.gradle.caching=true"
 
 jobs:
   validate:
     runs-on: ubuntu-latest
-    outputs:
-      release_version: ${{ steps.validate_release_version.outputs.release_version }}
-      rc_version: ${{ steps.find_rc_tag.outputs.rc_version }}
+    env:
+      RELEASE_VERSION: "${{ github.event.release.name }}"
     steps:
       - name: Pre-process Release Name
-        id: validate_release_version
-        env:
-          RELEASE_VERSION: "${{ github.event.release.name }}"
-        run: |
+        id: pre_process_release_version
+        run: |       
           # strip all whitespace
           RELEASE_VERSION="${RELEASE_VERSION//[[:space:]]/}"
           if [[ ! "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?(-.*)?$ ]]; then
             echo "Release name does not conform to a valid besu release format YY.M.v[-suffix], e.g. 24.8.0-RC1."
             exit 1
           fi
-          echo "release_version=$RELEASE_VERSION" >> $GITHUB_OUTPUT
-
-      - name: Checkout tags
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-          fetch-tags: true
-
-      - name: Find RC tag matching release sha
-        id: find_rc_tag
-        env:
-          RELEASE_VERSION: ${{ steps.validate_release_version.outputs.release_version }}
-        run: |
-          # Find the latest RC tag (e.g. 26.4.0-RC3) pointing to the same commit
-          # as the release tag. That RC is what burn-in validated — we retag its
-          # docker images rather than rebuilding, so the published binaries are
-          # byte-identical to what was tested.
-          set -euo pipefail
-          SHA=$(git rev-list -n 1 "$RELEASE_VERSION")
-          RC_VERSION=$(git tag --points-at "$SHA" | grep -E "^${RELEASE_VERSION}-RC[0-9]+$" | sort -V | tail -n 1 || true)
-          if [[ -z "$RC_VERSION" ]]; then
-            echo "::error::No RC tag of the form ${RELEASE_VERSION}-RC<n> found at sha $SHA. Docker promote requires an RC tag to retag from."
-            exit 1
-          fi
-          echo "Matched RC tag: $RC_VERSION"
-          echo "rc_version=$RC_VERSION" >> $GITHUB_OUTPUT
+          echo "release_version=$RELEASE_VERSION" >> $GITHUB_OUTPUT  # Set as output using the new syntax
+    outputs:
+      release_version: ${{ steps.pre_process_release_version.outputs.release_version }}
 
   docker-promote:
     needs: [validate]
-    runs-on: ubuntu-latest
     env:
       RELEASE_VERSION: ${{ needs.validate.outputs.release_version }}
-      RC_VERSION: ${{ needs.validate.outputs.rc_version }}
+    runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Java
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: gradle
+
       - name: Login to ${{ env.registry }}
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
@@ -68,30 +52,19 @@ jobs:
           username: ${{ secrets.DOCKER_USER_RW }}
           password: ${{ secrets.DOCKER_PASSWORD_RW }}
 
-      - name: Retag RC images as version-specific and latest
-        env:
-          IMAGE: ${{ env.registry }}/${{ secrets.DOCKER_ORG }}/besu
-        run: |
-          set -euo pipefail
-          # Per-arch single-platform tags: RC-<arch>  ->  <VERSION>-<arch>, latest-<arch>
-          for ARCH in amd64 arm64; do
-            docker buildx imagetools create \
-              -t "${IMAGE}:${RELEASE_VERSION}-${ARCH}" \
-              "${IMAGE}:${RC_VERSION}-${ARCH}"
-            docker buildx imagetools create \
-              -t "${IMAGE}:latest-${ARCH}" \
-              "${IMAGE}:${RC_VERSION}-${ARCH}"
-          done
-          # Multi-arch manifest: RC  ->  <VERSION>, latest
-          docker buildx imagetools create \
-            -t "${IMAGE}:${RELEASE_VERSION}" \
-            "${IMAGE}:${RC_VERSION}"
-          docker buildx imagetools create \
-            -t "${IMAGE}:latest" \
-            "${IMAGE}:${RC_VERSION}"
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f # v6.0.1
+        with:
+          cache-disabled: true
+
+      - name: Docker upload
+        run: ./gradlew "-Prelease.releaseVersion=${{ env.RELEASE_VERSION }}" "-PdockerOrgName=${{ env.registry }}/${{ secrets.DOCKER_ORG }}" dockerUploadRelease
+
+      - name: Docker manifest
+        run: ./gradlew "-Prelease.releaseVersion=${{ env.RELEASE_VERSION }}" "-PdockerOrgName=${{ env.registry }}/${{ secrets.DOCKER_ORG }}" manifestDockerRelease
 
   docker-verify:
-    needs: [validate, docker-promote]
+    needs: [validate,docker-promote]
     env:
       CONTAINER_NAME: besu-check
       RELEASE_VERSION: ${{ needs.validate.outputs.release_version }}
@@ -100,36 +73,19 @@ jobs:
     strategy:
       matrix:
         combination:
-          # Version-specific tags
-          - tag: ${{ needs.validate.outputs.release_version }}
-            platform: ''
-            runner: ubuntu-latest
-            check_latest: 'false'
-          - tag: ${{ needs.validate.outputs.release_version }}-amd64
-            platform: 'linux/amd64'
-            runner: ubuntu-latest
-            check_latest: 'false'
-          - tag: ${{ needs.validate.outputs.release_version }}-arm64
-            platform: ''
-            runner: besu-arm64
-            check_latest: 'false'
-          # Latest tags
-          - tag: latest
-            platform: ''
-            runner: ubuntu-latest
-            check_latest: 'true'
           - tag: latest-amd64
             platform: 'linux/amd64'
             runner: ubuntu-latest
-            check_latest: 'true'
+          - tag: latest
+            platform: ''
+            runner: ubuntu-latest
           - tag: latest-arm64
             platform: ''
             runner: besu-arm64
-            check_latest: 'true'
           - tag: latest
             platform: ''
             runner: besu-arm64
-            check_latest: 'true'
+
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -147,7 +103,7 @@ jobs:
         env:
           TAG: ${{ matrix.combination.tag }}
           VERSION: ${{ env.RELEASE_VERSION }}
-          CHECK_LATEST: ${{ matrix.combination.check_latest }}
+          CHECK_LATEST: true
 
       - name: Stop container
         run: docker stop ${{ env.CONTAINER_NAME }}

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -376,7 +376,7 @@ jobs:
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 25
 
       - name: setup gradle
         uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f # v6.0.1

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -185,7 +185,7 @@ jobs:
   docker-publish:
     needs: [validate, docker-lint]
     # Only publish docker images for release candidates. Final version tags
-    # (e.g. 26.4.0) are published by the publish-release workflow when the
+    # (e.g. 26.4.0) are published by the docker-promote workflow when the
     # GitHub release comes out of draft, so they aren't publicly available
     # until after burn-in sign-off.
     if: contains(needs.validate.outputs.release_version, '-RC')
@@ -342,51 +342,24 @@ jobs:
           pattern: besu-${{env.RELEASE_VERSION}}*
           merge-multiple: true
 
-      - name: Compose release notes from CHANGELOG at tag
+      - name: Draft release notes
         run: |
-          set -euo pipefail
-          # RC and final tags share the same CHANGELOG section, so strip any
-          # -RC<n> suffix when looking up the heading.
-          CHANGELOG_VERSION="${RELEASE_VERSION%-RC*}"
-
-          extract_section() {
-            awk -v heading="## $1" '
-              { sub(/[[:space:]]+$/, "") }
-              $0 == heading { found = 1; next }
-              found && /^## / { exit }
-              found { print }
-            ' CHANGELOG.md
-          }
-
-          # Prefer ## <version> if the rename PR has already landed at the
-          # tag; otherwise fall back to ## Unreleased, which is where new
-          # entries live until the rename happens.
-          extract_section "$CHANGELOG_VERSION" > release-body.md
-          if ! [[ -s release-body.md ]]; then
-            extract_section "Unreleased" > release-body.md
-          fi
-          if ! [[ -s release-body.md ]]; then
-            echo "::error::Neither '## ${CHANGELOG_VERSION}' nor '## Unreleased' contain entries in CHANGELOG.md at tag ${RELEASE_VERSION}."
-            echo "Cut a hotfix branch from the tag, fix the CHANGELOG, retag, and rerun."
-            exit 1
-          fi
-
-          {
-            echo
-            echo '## Distribution checksums'
-            echo
-            echo '```'
-            cat besu-${RELEASE_VERSION}.zip.sha256
-            cat besu-${RELEASE_VERSION}.tar.gz.sha256
-            echo '```'
-          } >> release-body.md
+          echo "## ${{env.RELEASE_VERSION}}" > draft-release-notes.md
+          echo "## Upcoming Breaking Changes" >> draft-release-notes.md
+          echo "## Breaking Changes" >> draft-release-notes.md
+          echo "## Additions and Improvements" >> draft-release-notes.md
+          echo "## Bug fixes" >> draft-release-notes.md
+          echo "`$(cat besu-${{env.RELEASE_VERSION}}.zip.sha256)`" >> draft-release-notes.md
+          echo "`$(cat besu-${{env.RELEASE_VERSION}}.tar.gz.sha256)`" >> draft-release-notes.md
+          cat besu-${{env.RELEASE_VERSION}}.zip.sha256 >> draft-release-notes.md
+          cat besu-${{env.RELEASE_VERSION}}.tar.gz.sha256 >> draft-release-notes.md
 
       - name: Draft release
         run: |
           gh release create \
             --draft \
             --title=${{env.RELEASE_VERSION}} \
-            --notes-file release-body.md \
+            --notes-file draft-release-notes.md \
             --verify-tag ${{env.RELEASE_VERSION}} \
             besu-${{env.RELEASE_VERSION}}.tar.gz \
             besu-${{env.RELEASE_VERSION}}.zip \
@@ -395,3 +368,49 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
+  artifactory:
+    runs-on: ubuntu-latest
+    needs: [validate, test-linux, test-windows]
+    env:
+      RELEASE_VERSION: ${{ needs.validate.outputs.release_version }}
+    steps:
+      - name: checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ env.RELEASE_VERSION }}
+
+      - name: Set up Java
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: setup gradle
+        uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f # v6.0.1
+        with:
+          cache-disabled: true
+
+      - name: Artifactory Publish
+        env:
+          ARTIFACTORY_USER: ${{ secrets.BESU_ARTIFACTORY_USER }}
+          ARTIFACTORY_KEY: ${{ secrets.BESU_ARTIFACTORY_TOKEN }}
+        run: ./gradlew -Prelease.releaseVersion=${{ env.RELEASE_VERSION }} -Pversion=${{env.RELEASE_VERSION}} artifactoryPublish
+
+  verify_artifactory:
+    runs-on: ubuntu-latest
+    needs: [artifactory, validate, test-linux, test-windows]
+    steps:
+      - name: checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ env.RELEASE_VERSION }}
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.13'
+
+      - name: Install dependencies
+        run: pip install requests argparse
+
+      - name: Run the script
+        run: python3 .github/workflows/verify_artifacts.py --besu_version="${{ needs.validate.outputs.release_version }}"

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -184,11 +184,6 @@ jobs:
 
   docker-publish:
     needs: [validate, docker-lint]
-    # Only publish docker images for release candidates. Final version tags
-    # (e.g. 26.4.0) are published by the docker-promote workflow when the
-    # GitHub release comes out of draft, so they aren't publicly available
-    # until after burn-in sign-off.
-    if: contains(needs.validate.outputs.release_version, '-RC')
     env:
       RELEASE_VERSION: ${{ needs.validate.outputs.release_version }}  # Use the output from the pre_process_release job
     strategy:
@@ -250,7 +245,6 @@ jobs:
 
   docker-manifest:
     needs: [validate, docker-publish]
-    if: contains(needs.validate.outputs.release_version, '-RC')
     runs-on: ubuntu-latest
     env:
       RELEASE_VERSION: ${{ needs.validate.outputs.release_version }}
@@ -283,7 +277,6 @@ jobs:
 
   docker-verify:
     needs: [validate,docker-manifest]
-    if: contains(needs.validate.outputs.release_version, '-RC')
     env:
       CONTAINER_NAME: besu-check
       RELEASE_VERSION: ${{ needs.validate.outputs.release_version }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -85,8 +85,8 @@ jobs:
             exit 1
           fi
 
-          # Download into the workspace; gh release lookup requires a git
-          # remote, and a fresh mktemp dir has none.
+          workdir=$(mktemp -d)
+          cd "$workdir"
           for f in "${expected[@]}"; do
             gh release download "$RELEASE_VERSION" --pattern "$f"
           done

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,16 +1,10 @@
 name: Publish Release
 
-run-name: "Publish Release ${{ github.event.release.name || inputs.tag }}"
+run-name: "Publish Release ${{ github.event.release.name }}"
 
 on:
   release:
     types: [released]
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: 'Release tag to publish (e.g. 26.5.0). Use to re-fire publish jobs without toggling release draft state.'
-        required: true
-        type: string
 
 env:
   registry: docker.io
@@ -25,7 +19,7 @@ jobs:
       - name: Pre-process Release Name
         id: validate_release_version
         env:
-          RELEASE_VERSION: "${{ github.event.release.name || inputs.tag }}"
+          RELEASE_VERSION: "${{ github.event.release.name }}"
         run: |
           # strip all whitespace
           RELEASE_VERSION="${RELEASE_VERSION//[[:space:]]/}"
@@ -102,12 +96,6 @@ jobs:
   docker-promote:
     needs: [validate]
     runs-on: ubuntu-latest
-    # workflow_dispatch path is gated by the `production` environment in
-    # repo settings (branch policy: main, release-*). The release-event
-    # path is implicitly gated by who can publish a release, so it does
-    # not reference the environment (its github.ref is a tag, which
-    # would not match the branch policy).
-    environment: ${{ github.event_name == 'workflow_dispatch' && 'production' || '' }}
     env:
       RELEASE_VERSION: ${{ needs.validate.outputs.release_version }}
       RC_VERSION: ${{ needs.validate.outputs.rc_version }}
@@ -206,8 +194,6 @@ jobs:
   artifactory:
     runs-on: ubuntu-latest
     needs: [validate]
-    # See docker-promote for why environment is conditional on event.
-    environment: ${{ github.event_name == 'workflow_dispatch' && 'production' || '' }}
     env:
       RELEASE_VERSION: ${{ needs.validate.outputs.release_version }}
     steps:


### PR DESCRIPTION
The publish-release job is broken https://github.com/besu-eth/besu/actions/workflows/publish-release.yml
due to baking in the RC version tag into the full release image, i.e. 26.6.0-RC1 instead of 26.6.0.
This is due to the design of relying on an RC docker build which is retagged instead of promoted to full release.

In addition, it is not possible to publish a pre-release since there is a regex with "-RC" that would result in a failed match for "26.6.0-RC1-RC[0-9]".

Reverting this means we also lose auto copying of the changelog notes.

In order to unblock the next release and some Docker GHA changes, I thought it was prudent to revert and revisit these changes later once we have figured out the current issues with it.

This PR reverts: 
c8ca8a029a7feef70a10fc82afd97d6317aebdfd
be72aa2ae9fca47dfe5a00abf5d8117d01f4c972
f027e9a7a99a2b91976e604e533517a64a836045
f3e26cf2def9dd530fb0acf2014c3e25a15dbe59