### PR TITLE
perf: UInt256.addMod fast path for power-of-two moduli

### DIFF
--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/AddModOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/AddModOperationBenchmark.java
@@ -66,13 +66,10 @@ public class AddModOperationBenchmark extends TernaryArithmeticOperationBenchmar
     "ADDMOD_192_192_256",
     "ADDMOD_128_256_0",
     "ADDMOD_RANDOM_RANDOM_RANDOM",
-    // Randomized power-of-two moduli (2^N): each range targets one UInt256.addMod limb-dispatch
-    // branch so the JIT cannot constant-fold the modulus.
-    "ADDMOD_256_256_POW2_1_63", // u0 limb branch
-    "ADDMOD_256_256_POW2_64_127", // u1 limb branch
-    "ADDMOD_256_256_POW2_128_191", // u2 limb branch — includes 2^160 address mask
-    "ADDMOD_256_256_POW2_192_255", // u3 limb branch
-    "ADDMOD_256_256_POW2_1_255" // full 256-bit span
+    "ADDMOD_256_256_POW2_1_63",
+    "ADDMOD_256_256_POW2_1_255",
+    "ADDMOD_256_256_POW2_100_200",
+    "ADDMOD_256_256_POW2_100_255"
   })
   private String caseName;
 

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/AddModOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/AddModOperationBenchmark.java
@@ -66,13 +66,13 @@ public class AddModOperationBenchmark extends TernaryArithmeticOperationBenchmar
     "ADDMOD_192_192_256",
     "ADDMOD_128_256_0",
     "ADDMOD_RANDOM_RANDOM_RANDOM",
-    // Power-of-two moduli (2^N): exercises each UInt256.addMod dispatch branch.
-    "ADDMOD_256_256_POW2_8",
-    "ADDMOD_256_256_POW2_64",
-    "ADDMOD_256_256_POW2_128",
-    "ADDMOD_256_256_POW2_160",
-    "ADDMOD_256_256_POW2_192",
-    "ADDMOD_256_256_POW2_240"
+    // Randomized power-of-two moduli (2^N): each range targets one UInt256.addMod limb-dispatch
+    // branch so the JIT cannot constant-fold the modulus.
+    "ADDMOD_256_256_POW2_1_63", // u0 limb branch
+    "ADDMOD_256_256_POW2_64_127", // u1 limb branch
+    "ADDMOD_256_256_POW2_128_191", // u2 limb branch — includes 2^160 address mask
+    "ADDMOD_256_256_POW2_192_255", // u3 limb branch
+    "ADDMOD_256_256_POW2_1_255" // full 256-bit span
   })
   private String caseName;
 

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/AddModOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/AddModOperationBenchmark.java
@@ -65,7 +65,14 @@ public class AddModOperationBenchmark extends TernaryArithmeticOperationBenchmar
     "ADDMOD_64_64_128",
     "ADDMOD_192_192_256",
     "ADDMOD_128_256_0",
-    "ADDMOD_RANDOM_RANDOM_RANDOM"
+    "ADDMOD_RANDOM_RANDOM_RANDOM",
+    // Power-of-two moduli (2^N): exercises each UInt256.addMod dispatch branch.
+    "ADDMOD_256_256_POW2_8",
+    "ADDMOD_256_256_POW2_64",
+    "ADDMOD_256_256_POW2_128",
+    "ADDMOD_256_256_POW2_160",
+    "ADDMOD_256_256_POW2_192",
+    "ADDMOD_256_256_POW2_240"
   })
   private String caseName;
 

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/BenchmarkHelper.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/BenchmarkHelper.java
@@ -260,4 +260,12 @@ public class BenchmarkHelper {
     value[0] = (byte) (value[0] | 0x80);
     return Bytes.wrap(value);
   }
+
+  static Bytes pow2(final int n) {
+    final byte[] bytes = new byte[32];
+    int nBytes = Integer.divideUnsigned(n, 8);
+    int nBits = Integer.remainderUnsigned(n, 8);
+    bytes[31 - nBytes] = (byte) (1 << nBits);
+    return Bytes.wrap(bytes);
+  }
 }

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/BinaryArithmeticOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/BinaryArithmeticOperationBenchmark.java
@@ -14,8 +14,9 @@
  */
 package org.hyperledger.besu.ethereum.vm.operations;
 
+import static org.hyperledger.besu.ethereum.vm.operations.BenchmarkHelper.pow2;
+
 import org.hyperledger.besu.ethereum.utils.Range;
-import org.hyperledger.besu.evm.UInt256;
 
 import java.math.BigInteger;
 import java.util.Random;
@@ -125,18 +126,9 @@ public abstract class BinaryArithmeticOperationBenchmark extends BinaryOperation
         byte[] a = new byte[aSize];
         random.nextBytes(a);
 
-        UInt256 bValue = pow2(random.nextInt(pow2BitRange.minimum, pow2BitRange.maximum + 1));
-
         poolA[i] = Bytes.wrap(a);
-        poolB[i] = Bytes.wrap(bValue.toBytesBE());
+        poolB[i] = pow2(random.nextInt(pow2BitRange.minimum, pow2BitRange.maximum + 1));
       }
-    }
-
-    private static UInt256 pow2(final int n) {
-      if (n < 64) return new UInt256(0, 0, 0, 1L << n);
-      if (n < 128) return new UInt256(0, 0, 1L << (n - 64), 0);
-      if (n < 192) return new UInt256(0, 1L << (n - 128), 0, 0);
-      return new UInt256(1L << (n - 192), 0, 0, 0);
     }
   }
 

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/DivOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/DivOperationBenchmark.java
@@ -44,7 +44,8 @@ public class DivOperationBenchmark extends BinaryArithmeticOperationBenchmark {
     "DIV_RANDOM_RANDOM",
     "DIV_256_POW2_1_63",
     "DIV_256_POW2_1_255",
-    "DIV_256_POW2_100_200"
+    "DIV_256_POW2_100_200",
+    "DIV_256_POW2_100_255"
   })
   private String caseName;
 

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/TernaryArithmeticOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/TernaryArithmeticOperationBenchmark.java
@@ -23,14 +23,25 @@ import org.openjdk.jmh.annotations.Setup;
 public abstract class TernaryArithmeticOperationBenchmark extends TernaryOperationBenchmark {
 
   private static class Case {
+    /** Marker value for {@link #cSizeBytes} when the modulus is a known power of two. */
+    static final int C_POWER_OF_TWO = -2;
+
     final int aSizeBytes;
     final int bSizeBytes;
     final int cSizeBytes;
 
+    /** Set when {@link #cSizeBytes} == {@link #C_POWER_OF_TWO}; the bit position N for 2^N. */
+    final int cPow2Bit;
+
     private Case(final int aSize, final int bSize, final int cSize) {
+      this(aSize, bSize, cSize, -1);
+    }
+
+    private Case(final int aSize, final int bSize, final int cSize, final int cPow2Bit) {
       this.aSizeBytes = aSize;
       this.bSizeBytes = bSize;
       this.cSizeBytes = cSize;
+      this.cPow2Bit = cPow2Bit;
     }
 
     static Case fromString(final String opcodeName, final String caseName) {
@@ -39,6 +50,15 @@ public abstract class TernaryArithmeticOperationBenchmark extends TernaryOperati
         if (splitString.length < 4 || !opcodeName.equalsIgnoreCase(splitString[0])) {
           throw new IllegalArgumentException();
         }
+        // `<opcode>_<aSize>_<bSize>_POW2_<N>` builds the modulus as 2^N (e.g. address mask 2^160).
+        if (splitString[3].startsWith("POW2_")) {
+          int bit = Integer.parseInt(splitString[3].substring(5));
+          if (bit < 1 || bit > 255) {
+            throw new IllegalArgumentException("POW2 bit position must be in [1, 255]");
+          }
+          return new Case(
+              parseSizeBytes(splitString[1]), parseSizeBytes(splitString[2]), C_POWER_OF_TWO, bit);
+        }
         return new Case(
             parseSizeBytes(splitString[1]),
             parseSizeBytes(splitString[2]),
@@ -46,8 +66,9 @@ public abstract class TernaryArithmeticOperationBenchmark extends TernaryOperati
       } catch (IllegalArgumentException t) {
         throw new IllegalArgumentException(
             String.format(
-                "%s must have the format [%s_size_size_size] where size is #bits",
-                caseName, opcodeName));
+                "%s must have the format [%s_size_size_size] or [%s_size_size_POW2_N],"
+                    + " where size is #bits and N is a bit position in [1, 255]",
+                caseName, opcodeName, opcodeName));
       }
     }
 
@@ -89,7 +110,21 @@ public abstract class TernaryArithmeticOperationBenchmark extends TernaryOperati
       bPool[i] = Bytes.wrap(b);
       cPool[i] = Bytes.wrap(c);
     }
+
+    // Replace random c values with the chosen 2^N modulus. setUp is not on the measured path.
+    if (scenario.cSizeBytes == Case.C_POWER_OF_TWO) {
+      final Bytes pow2Modulus = pow2(scenario.cPow2Bit);
+      for (int i = 0; i < cPool.length; i++) {
+        cPool[i] = pow2Modulus;
+      }
+    }
     index = 0;
+  }
+
+  private static Bytes pow2(final int n) {
+    final byte[] bytes = new byte[32];
+    bytes[31 - (n >>> 3)] = (byte) (1 << (n & 7));
+    return Bytes.wrap(bytes);
   }
 
   /**

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/TernaryArithmeticOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/TernaryArithmeticOperationBenchmark.java
@@ -14,6 +14,8 @@
  */
 package org.hyperledger.besu.ethereum.vm.operations;
 
+import org.hyperledger.besu.ethereum.utils.Range;
+
 import java.util.Random;
 
 import org.apache.tuweni.bytes.Bytes;
@@ -23,41 +25,22 @@ import org.openjdk.jmh.annotations.Setup;
 public abstract class TernaryArithmeticOperationBenchmark extends TernaryOperationBenchmark {
 
   private static class Case {
-    /** Marker value for {@link #cSizeBytes} when the modulus is a known power of two. */
-    static final int C_POWER_OF_TWO = -2;
-
     final int aSizeBytes;
     final int bSizeBytes;
     final int cSizeBytes;
 
-    /** Set when {@link #cSizeBytes} == {@link #C_POWER_OF_TWO}; the bit position N for 2^N. */
-    final int cPow2Bit;
-
     private Case(final int aSize, final int bSize, final int cSize) {
-      this(aSize, bSize, cSize, -1);
-    }
-
-    private Case(final int aSize, final int bSize, final int cSize, final int cPow2Bit) {
       this.aSizeBytes = aSize;
       this.bSizeBytes = bSize;
       this.cSizeBytes = cSize;
-      this.cPow2Bit = cPow2Bit;
     }
 
+    // format OPCODE_INT_INT_INT
     static Case fromString(final String opcodeName, final String caseName) {
       try {
         String[] splitString = caseName.split("_", 4);
         if (splitString.length < 4 || !opcodeName.equalsIgnoreCase(splitString[0])) {
           throw new IllegalArgumentException();
-        }
-        // `<opcode>_<aSize>_<bSize>_POW2_<N>` builds the modulus as 2^N (e.g. address mask 2^160).
-        if (splitString[3].startsWith("POW2_")) {
-          int bit = Integer.parseInt(splitString[3].substring(5));
-          if (bit < 1 || bit > 255) {
-            throw new IllegalArgumentException("POW2 bit position must be in [1, 255]");
-          }
-          return new Case(
-              parseSizeBytes(splitString[1]), parseSizeBytes(splitString[2]), C_POWER_OF_TWO, bit);
         }
         return new Case(
             parseSizeBytes(splitString[1]),
@@ -66,58 +49,120 @@ public abstract class TernaryArithmeticOperationBenchmark extends TernaryOperati
       } catch (IllegalArgumentException t) {
         throw new IllegalArgumentException(
             String.format(
-                "%s must have the format [%s_size_size_size] or [%s_size_size_POW2_N],"
-                    + " where size is #bits and N is a bit position in [1, 255]",
-                caseName, opcodeName, opcodeName));
+                "%s must have the format [%s_size_size_size] where size is #bits",
+                caseName, opcodeName));
       }
     }
 
-    private static int parseSizeBytes(final String s) {
-      return "RANDOM".equalsIgnoreCase(s) ? -1 : Integer.parseInt(s) / 8;
+    void runSetup(final Bytes[] poolA, final Bytes[] poolB, final Bytes[] poolC) {
+      final Random random = new Random();
+      int aSize;
+      int bSize;
+      int cSize;
+
+      for (int i = 0; i < SAMPLE_SIZE; i++) {
+        if (aSizeBytes < 0) aSize = random.nextInt(1, 33);
+        else aSize = aSizeBytes;
+        if (bSizeBytes < 0) bSize = random.nextInt(1, 33);
+        else bSize = bSizeBytes;
+        if (cSizeBytes < 0) cSize = random.nextInt(1, 33);
+        else cSize = cSizeBytes;
+
+        final byte[] a = new byte[aSize];
+        final byte[] b = new byte[bSize];
+        final byte[] c = new byte[cSize];
+        random.nextBytes(a);
+        random.nextBytes(b);
+        random.nextBytes(c);
+
+        poolA[i] = Bytes.wrap(a);
+        poolB[i] = Bytes.wrap(b);
+        poolC[i] = Bytes.wrap(c);
+      }
     }
+  }
+
+  private static class Pow2Case {
+    final int aSizeBytes;
+    final int bSizeBytes;
+    final Range<Integer> pow2BitRange;
+
+    private Pow2Case(final int aSize, final int bSize, final Range<Integer> pow2BitRange) {
+      this.aSizeBytes = aSize;
+      this.bSizeBytes = bSize;
+      this.pow2BitRange = pow2BitRange;
+    }
+
+    // format OPCODE_INT_INT_POW2_INT_INT
+    static Pow2Case fromString(final String opcodeName, final String caseName) {
+      try {
+        String[] splitString = caseName.split("_", 6);
+        if (splitString.length < 6
+            || !opcodeName.equalsIgnoreCase(splitString[0])
+            || !splitString[3].equalsIgnoreCase("POW2")) {
+          throw new IllegalArgumentException();
+        }
+        Range<Integer> pow2BitRange =
+            new Range<>(
+                Integer.parseInt(splitString[4]),
+                Integer.parseInt(splitString[5]),
+                Integer::compare);
+        if (!pow2BitRange.isWithin(1, 255)) {
+          throw new IllegalArgumentException();
+        }
+        return new Pow2Case(
+            parseSizeBytes(splitString[1]), parseSizeBytes(splitString[2]), pow2BitRange);
+      } catch (IllegalArgumentException t) {
+        throw new IllegalArgumentException(
+            String.format(
+                "%s must have the format [%s_size_size_POW2_bit_bit] where bit_bit is the range of bits to set in the modulus",
+                caseName, opcodeName));
+      }
+    }
+
+    void runSetup(final Bytes[] poolA, final Bytes[] poolB, final Bytes[] poolC) {
+      final Random random = new Random();
+      int aSize;
+      int bSize;
+
+      for (int i = 0; i < SAMPLE_SIZE; i++) {
+        if (aSizeBytes < 0) aSize = random.nextInt(1, 33);
+        else aSize = aSizeBytes;
+        if (bSizeBytes < 0) bSize = random.nextInt(1, 33);
+        else bSize = bSizeBytes;
+
+        final byte[] a = new byte[aSize];
+        final byte[] b = new byte[bSize];
+        random.nextBytes(a);
+        random.nextBytes(b);
+
+        poolA[i] = Bytes.wrap(a);
+        poolB[i] = Bytes.wrap(b);
+        poolC[i] = pow2(random.nextInt(pow2BitRange.minimum, pow2BitRange.maximum + 1));
+      }
+    }
+  }
+
+  private static int parseSizeBytes(final String s) {
+    return "RANDOM".equalsIgnoreCase(s) ? -1 : Integer.parseInt(s) / 8;
   }
 
   @Setup(Level.Iteration)
   @Override
+  @SuppressWarnings("StringCaseLocaleUsage")
   public void setUp() {
     frame = BenchmarkHelper.createMessageCallFrame();
 
-    Case scenario = Case.fromString(opCode(), caseName());
     aPool = new Bytes[SAMPLE_SIZE];
     bPool = new Bytes[SAMPLE_SIZE];
     cPool = new Bytes[SAMPLE_SIZE];
 
-    final Random random = new Random();
-    int aSize;
-    int bSize;
-    int cSize;
-
-    for (int i = 0; i < SAMPLE_SIZE; i++) {
-      if (scenario.aSizeBytes < 0) aSize = random.nextInt(1, 33);
-      else aSize = scenario.aSizeBytes;
-      if (scenario.bSizeBytes < 0) bSize = random.nextInt(1, 33);
-      else bSize = scenario.bSizeBytes;
-      if (scenario.cSizeBytes < 0) cSize = random.nextInt(1, 33);
-      else cSize = scenario.cSizeBytes;
-
-      final byte[] a = new byte[aSize];
-      final byte[] b = new byte[bSize];
-      final byte[] c = new byte[cSize];
-      random.nextBytes(a);
-      random.nextBytes(b);
-      random.nextBytes(c);
-      aPool[i] = Bytes.wrap(a);
-      bPool[i] = Bytes.wrap(b);
-      cPool[i] = Bytes.wrap(c);
+    if (caseName().toLowerCase().matches(".*_\\d+_\\d+_pow2_\\d+_\\d+")) {
+      Pow2Case.fromString(opCode(), caseName()).runSetup(aPool, bPool, cPool);
+    } else {
+      Case.fromString(opCode(), caseName()).runSetup(aPool, bPool, cPool);
     }
 
-    // Replace random c values with the chosen 2^N modulus. setUp is not on the measured path.
-    if (scenario.cSizeBytes == Case.C_POWER_OF_TWO) {
-      final Bytes pow2Modulus = pow2(scenario.cPow2Bit);
-      for (int i = 0; i < cPool.length; i++) {
-        cPool[i] = pow2Modulus;
-      }
-    }
     index = 0;
   }
 

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/TernaryArithmeticOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/TernaryArithmeticOperationBenchmark.java
@@ -14,13 +14,13 @@
  */
 package org.hyperledger.besu.ethereum.vm.operations;
 
+import static org.hyperledger.besu.ethereum.vm.operations.BenchmarkHelper.pow2;
+
 import org.hyperledger.besu.ethereum.utils.Range;
 
 import java.util.Random;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.openjdk.jmh.annotations.Level;
-import org.openjdk.jmh.annotations.Setup;
 
 public abstract class TernaryArithmeticOperationBenchmark extends TernaryOperationBenchmark {
 
@@ -147,7 +147,6 @@ public abstract class TernaryArithmeticOperationBenchmark extends TernaryOperati
     return "RANDOM".equalsIgnoreCase(s) ? -1 : Integer.parseInt(s) / 8;
   }
 
-  @Setup(Level.Iteration)
   @Override
   @SuppressWarnings("StringCaseLocaleUsage")
   public void setUp() {
@@ -164,12 +163,6 @@ public abstract class TernaryArithmeticOperationBenchmark extends TernaryOperati
     }
 
     index = 0;
-  }
-
-  private static Bytes pow2(final int n) {
-    final byte[] bytes = new byte[32];
-    bytes[31 - (n >>> 3)] = (byte) (1 << (n & 7));
-    return Bytes.wrap(bytes);
   }
 
   /**

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/v2/AddModOperationBenchmarkV2.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/v2/AddModOperationBenchmarkV2.java
@@ -62,7 +62,11 @@ public class AddModOperationBenchmarkV2 extends TernaryArithmeticBenchmarkV2 {
     "ADDMOD_64_64_128",
     "ADDMOD_192_192_256",
     "ADDMOD_128_256_0",
-    "ADDMOD_RANDOM_RANDOM_RANDOM"
+    "ADDMOD_RANDOM_RANDOM_RANDOM",
+    "ADDMOD_256_256_POW2_1_63",
+    "ADDMOD_256_256_POW2_1_255",
+    "ADDMOD_256_256_POW2_100_200",
+    "ADDMOD_256_256_POW2_100_255"
   })
   private String caseName;
 

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/v2/BenchmarkHelperV2.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/v2/BenchmarkHelperV2.java
@@ -20,6 +20,7 @@ import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.evm.Code;
+import org.hyperledger.besu.evm.UInt256;
 import org.hyperledger.besu.evm.frame.BlockValues;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.worldstate.WorldUpdater;
@@ -65,7 +66,7 @@ public class BenchmarkHelperV2 {
    *
    * @param pool the destination array
    */
-  public static void fillUInt256Pool(final org.hyperledger.besu.evm.UInt256[] pool) {
+  public static void fillUInt256Pool(final UInt256[] pool) {
     final Random random = new Random();
     for (int i = 0; i < pool.length; i++) {
       final byte[] a = new byte[1 + random.nextInt(32)];
@@ -80,10 +81,10 @@ public class BenchmarkHelperV2 {
    * @param bytes the byte array
    * @return the UInt256 value
    */
-  static org.hyperledger.besu.evm.UInt256 bytesToUInt256(final byte[] bytes) {
+  static UInt256 bytesToUInt256(final byte[] bytes) {
     final byte[] padded = new byte[32];
     System.arraycopy(bytes, 0, padded, 32 - bytes.length, bytes.length);
-    return org.hyperledger.besu.evm.UInt256.fromBytesBE(padded);
+    return UInt256.fromBytesBE(padded);
   }
 
   /**
@@ -92,7 +93,7 @@ public class BenchmarkHelperV2 {
    * @param frame the message frame
    * @param value the UInt256 value to push
    */
-  static void pushUInt256(final MessageFrame frame, final org.hyperledger.besu.evm.UInt256 value) {
+  static void pushUInt256(final MessageFrame frame, final UInt256 value) {
     final long[] s = frame.stackDataV2();
     final int top = frame.stackTopV2();
     final int dst = top << 2;
@@ -109,10 +110,10 @@ public class BenchmarkHelperV2 {
    * @param random thread-local random source
    * @return random UInt256 value
    */
-  static org.hyperledger.besu.evm.UInt256 randomUInt256Value(final ThreadLocalRandom random) {
+  static UInt256 randomUInt256Value(final ThreadLocalRandom random) {
     final byte[] value = new byte[32];
     random.nextBytes(value);
-    return org.hyperledger.besu.evm.UInt256.fromBytesBE(value);
+    return UInt256.fromBytesBE(value);
   }
 
   /**
@@ -121,12 +122,11 @@ public class BenchmarkHelperV2 {
    * @param random thread-local random source
    * @return random positive UInt256 value
    */
-  static org.hyperledger.besu.evm.UInt256 randomPositiveUInt256Value(
-      final ThreadLocalRandom random) {
+  static UInt256 randomPositiveUInt256Value(final ThreadLocalRandom random) {
     final byte[] value = new byte[32];
     random.nextBytes(value);
     value[0] = (byte) (value[0] & 0x7F);
-    return org.hyperledger.besu.evm.UInt256.fromBytesBE(value);
+    return UInt256.fromBytesBE(value);
   }
 
   /**
@@ -135,11 +135,18 @@ public class BenchmarkHelperV2 {
    * @param random thread-local random source
    * @return random negative UInt256 value
    */
-  static org.hyperledger.besu.evm.UInt256 randomNegativeUInt256Value(
-      final ThreadLocalRandom random) {
+  static UInt256 randomNegativeUInt256Value(final ThreadLocalRandom random) {
     final byte[] value = new byte[32];
     random.nextBytes(value);
     value[0] = (byte) (value[0] | 0x80);
-    return org.hyperledger.besu.evm.UInt256.fromBytesBE(value);
+    return UInt256.fromBytesBE(value);
+  }
+
+  static UInt256 pow2(final int n) {
+    final byte[] bytes = new byte[32];
+    int nBytes = Integer.divideUnsigned(n, 8);
+    int nBits = Integer.remainderUnsigned(n, 8);
+    bytes[31 - nBytes] = (byte) (1 << nBits);
+    return bytesToUInt256(bytes);
   }
 }

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/v2/TernaryArithmeticBenchmarkV2.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/v2/TernaryArithmeticBenchmarkV2.java
@@ -14,12 +14,12 @@
  */
 package org.hyperledger.besu.ethereum.vm.operations.v2;
 
+import static org.hyperledger.besu.ethereum.vm.operations.v2.BenchmarkHelperV2.pow2;
+
+import org.hyperledger.besu.ethereum.utils.Range;
 import org.hyperledger.besu.evm.UInt256;
 
 import java.util.Random;
-
-import org.openjdk.jmh.annotations.Level;
-import org.openjdk.jmh.annotations.Setup;
 
 public abstract class TernaryArithmeticBenchmarkV2 extends TernaryOperationBenchmarkV2 {
   private static class Case {
@@ -33,6 +33,7 @@ public abstract class TernaryArithmeticBenchmarkV2 extends TernaryOperationBench
       this.cSizeBytes = cSize;
     }
 
+    // format OPCODE_INT_INT_INT
     static Case fromString(final String opcodeName, final String caseName) {
       try {
         String[] splitString = caseName.split("_", 4);
@@ -51,44 +52,113 @@ public abstract class TernaryArithmeticBenchmarkV2 extends TernaryOperationBench
       }
     }
 
-    private static int parseSizeBytes(final String s) {
-      return "RANDOM".equalsIgnoreCase(s) ? -1 : Integer.parseInt(s) / 8;
+    void runSetup(final UInt256[] poolA, final UInt256[] poolB, final UInt256[] poolC) {
+      final Random random = new Random();
+      int aSize;
+      int bSize;
+      int cSize;
+
+      for (int i = 0; i < SAMPLE_SIZE; i++) {
+        if (aSizeBytes < 0) aSize = random.nextInt(1, 33);
+        else aSize = aSizeBytes;
+        if (bSizeBytes < 0) bSize = random.nextInt(1, 33);
+        else bSize = bSizeBytes;
+        if (cSizeBytes < 0) cSize = random.nextInt(1, 33);
+        else cSize = cSizeBytes;
+
+        final byte[] a = new byte[aSize];
+        final byte[] b = new byte[bSize];
+        final byte[] c = new byte[cSize];
+        random.nextBytes(a);
+        random.nextBytes(b);
+        random.nextBytes(c);
+        poolA[i] = BenchmarkHelperV2.bytesToUInt256(a);
+        poolB[i] = BenchmarkHelperV2.bytesToUInt256(b);
+        poolC[i] = BenchmarkHelperV2.bytesToUInt256(c);
+      }
     }
   }
 
-  @Setup(Level.Iteration)
+  private static class Pow2Case {
+    final int aSizeBytes;
+    final int bSizeBytes;
+    final Range<Integer> pow2BitRange;
+
+    private Pow2Case(final int aSize, final int bSize, final Range<Integer> pow2BitRange) {
+      this.aSizeBytes = aSize;
+      this.bSizeBytes = bSize;
+      this.pow2BitRange = pow2BitRange;
+    }
+
+    // format OPCODE_INT_INT_POW2_INT_INT
+    static Pow2Case fromString(final String opcodeName, final String caseName) {
+      try {
+        String[] splitString = caseName.split("_", 6);
+        if (splitString.length < 6
+            || !opcodeName.equalsIgnoreCase(splitString[0])
+            || !splitString[3].equalsIgnoreCase("POW2")) {
+          throw new IllegalArgumentException();
+        }
+        Range<Integer> pow2BitRange =
+            new Range<>(
+                Integer.parseInt(splitString[4]),
+                Integer.parseInt(splitString[5]),
+                Integer::compare);
+        if (!pow2BitRange.isWithin(1, 255)) {
+          throw new IllegalArgumentException();
+        }
+        return new Pow2Case(
+            parseSizeBytes(splitString[1]), parseSizeBytes(splitString[2]), pow2BitRange);
+      } catch (IllegalArgumentException t) {
+        throw new IllegalArgumentException(
+            String.format(
+                "%s must have the format [%s_size_size_POW2_bit_bit] where bit_bit is the range of bits to set in the modulus",
+                caseName, opcodeName));
+      }
+    }
+
+    void runSetup(final UInt256[] poolA, final UInt256[] poolB, final UInt256[] poolC) {
+      final Random random = new Random();
+      int aSize;
+      int bSize;
+
+      for (int i = 0; i < SAMPLE_SIZE; i++) {
+        if (aSizeBytes < 0) aSize = random.nextInt(1, 33);
+        else aSize = aSizeBytes;
+        if (bSizeBytes < 0) bSize = random.nextInt(1, 33);
+        else bSize = bSizeBytes;
+
+        final byte[] a = new byte[aSize];
+        final byte[] b = new byte[bSize];
+        random.nextBytes(a);
+        random.nextBytes(b);
+
+        poolA[i] = BenchmarkHelperV2.bytesToUInt256(a);
+        poolB[i] = BenchmarkHelperV2.bytesToUInt256(b);
+        poolC[i] = pow2(random.nextInt(pow2BitRange.minimum, pow2BitRange.maximum + 1));
+      }
+    }
+  }
+
+  private static int parseSizeBytes(final String s) {
+    return "RANDOM".equalsIgnoreCase(s) ? -1 : Integer.parseInt(s) / 8;
+  }
+
   @Override
+  @SuppressWarnings("StringCaseLocaleUsage")
   public void setUp() {
     frame = BenchmarkHelperV2.createMessageCallFrame();
 
-    Case scenario = Case.fromString(opCode(), caseName());
     aPool = new UInt256[SAMPLE_SIZE];
     bPool = new UInt256[SAMPLE_SIZE];
     cPool = new UInt256[SAMPLE_SIZE];
 
-    final Random random = new Random();
-    int aSize;
-    int bSize;
-    int cSize;
-
-    for (int i = 0; i < SAMPLE_SIZE; i++) {
-      if (scenario.aSizeBytes < 0) aSize = random.nextInt(1, 33);
-      else aSize = scenario.aSizeBytes;
-      if (scenario.bSizeBytes < 0) bSize = random.nextInt(1, 33);
-      else bSize = scenario.bSizeBytes;
-      if (scenario.cSizeBytes < 0) cSize = random.nextInt(1, 33);
-      else cSize = scenario.cSizeBytes;
-
-      final byte[] a = new byte[aSize];
-      final byte[] b = new byte[bSize];
-      final byte[] c = new byte[cSize];
-      random.nextBytes(a);
-      random.nextBytes(b);
-      random.nextBytes(c);
-      aPool[i] = BenchmarkHelperV2.bytesToUInt256(a);
-      bPool[i] = BenchmarkHelperV2.bytesToUInt256(b);
-      cPool[i] = BenchmarkHelperV2.bytesToUInt256(c);
+    if (caseName().toLowerCase().matches(".*_\\d+_\\d+_pow2_\\d+_\\d+")) {
+      Pow2Case.fromString(opCode(), caseName()).runSetup(aPool, bPool, cPool);
+    } else {
+      Case.fromString(opCode(), caseName()).runSetup(aPool, bPool, cPool);
     }
+
     index = 0;
   }
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/UInt256.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/UInt256.java
@@ -683,6 +683,12 @@ public record UInt256(long u3, long u2, long u1, long u0) {
     if (isZero()) return other.mod(modulus);
     if (other.isZero()) return this.mod(modulus);
     if (modulus.isZeroOrOne()) return ZERO;
+    // Fast path: when the modulus is a power of two, reduction is a bitmask of the low bits.
+    // A non-zero value x is a power of two iff (x & (x - 1)) == 0. Subtracting 1 from a power of
+    // two flips its single set bit to 0 and sets all lower bits to 1 (e.g. 0b1000 - 1 == 0b0111),
+    // so x and x - 1 share no bits and the AND is 0. For any non-power-of-two there are at least
+    // two set bits; the lowest stays set in x - 1, so the AND is non-zero. The highest non-zero
+    // limb must be a power of two and every lower limb must be zero for the whole value to qualify.
     if (modulus.u3 != 0) {
       if ((modulus.u3 & (modulus.u3 - 1)) == 0 && (modulus.u2 | modulus.u1 | modulus.u0) == 0) {
         return add(other).maskLow(192 + Long.numberOfTrailingZeros(modulus.u3));

--- a/evm/src/main/java/org/hyperledger/besu/evm/UInt256.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/UInt256.java
@@ -468,6 +468,24 @@ public record UInt256(long u3, long u2, long u1, long u0) {
         (s0 >>> bitShift) | (s1 << inv));
   }
 
+  /**
+   * Keep the low {@code n} bits, zero the rest; used by the power-of-two modulus fast path in
+   * {@link #addMod(UInt256, UInt256)} where mod-by-2^n is a bitmask.
+   *
+   * @param n number of low bits to keep; caller guarantees {@code 1 <= n < 256}.
+   * @return {@code this & ((1 << n) - 1)}.
+   */
+  private UInt256 maskLow(final int n) {
+    final int limbsKept = n >>> 6;
+    final int bitsInTop = n & 63;
+    final long topMask = bitsInTop == 0 ? 0L : (1L << bitsInTop) - 1L;
+    final long m0 = limbsKept > 0 ? u0 : (u0 & topMask);
+    final long m1 = limbsKept > 1 ? u1 : (limbsKept == 1 ? (u1 & topMask) : 0L);
+    final long m2 = limbsKept > 2 ? u2 : (limbsKept == 2 ? (u2 & topMask) : 0L);
+    final long m3 = limbsKept == 3 ? (u3 & topMask) : 0L;
+    return new UInt256(m3, m2, m1, m0);
+  }
+
   // --------------------------------------------------------------------------
   // endregion
 
@@ -665,9 +683,27 @@ public record UInt256(long u3, long u2, long u1, long u0) {
     if (isZero()) return other.mod(modulus);
     if (other.isZero()) return this.mod(modulus);
     if (modulus.isZeroOrOne()) return ZERO;
-    if (modulus.u3 != 0) return modulus.sum(this, other);
-    if (modulus.u2 != 0) return modulus.asUInt192().sum(this, other);
-    if (modulus.u1 != 0) return modulus.asUInt128().sum(this, other);
+    if (modulus.u3 != 0) {
+      if ((modulus.u3 & (modulus.u3 - 1)) == 0 && (modulus.u2 | modulus.u1 | modulus.u0) == 0) {
+        return add(other).maskLow(192 + Long.numberOfTrailingZeros(modulus.u3));
+      }
+      return modulus.sum(this, other);
+    }
+    if (modulus.u2 != 0) {
+      if ((modulus.u2 & (modulus.u2 - 1)) == 0 && (modulus.u1 | modulus.u0) == 0) {
+        return add(other).maskLow(128 + Long.numberOfTrailingZeros(modulus.u2));
+      }
+      return modulus.asUInt192().sum(this, other);
+    }
+    if (modulus.u1 != 0) {
+      if ((modulus.u1 & (modulus.u1 - 1)) == 0 && modulus.u0 == 0) {
+        return add(other).maskLow(64 + Long.numberOfTrailingZeros(modulus.u1));
+      }
+      return modulus.asUInt128().sum(this, other);
+    }
+    if ((modulus.u0 & (modulus.u0 - 1)) == 0) {
+      return add(other).maskLow(Long.numberOfTrailingZeros(modulus.u0));
+    }
     return modulus.asUInt64().sum(this, other);
   }
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/UInt256.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/UInt256.java
@@ -623,12 +623,8 @@ public record UInt256(long u3, long u2, long u1, long u0) {
    */
   public UInt256 div(final UInt256 divisor) {
     if (isZero()) return ZERO;
-    // Fast path: when the divisor is a power of two, division is a right-shift by its exponent.
-    // A non-zero value x is a power of two iff (x & (x - 1)) == 0. Subtracting 1 from a power of
-    // two flips its single set bit to 0 and sets all lower bits to 1 (e.g. 0b1000 - 1 == 0b0111),
-    // so x and x - 1 share no bits and the AND is 0. For any non-power-of-two there are at least
-    // two set bits; the lowest stays set in x - 1, so the AND is non-zero. The highest non-zero
-    // limb must be a power of two and every lower limb must be zero for the whole value to qualify.
+    // Fast path: when the divisor is a power of two:
+    // x / 2^N == x >> N
     if (divisor.u3 != 0) {
       if ((divisor.u3 & (divisor.u3 - 1)) == 0 && (divisor.u2 | divisor.u1 | divisor.u0) == 0) {
         return shiftRightWide(192 + Long.numberOfTrailingZeros(divisor.u3));
@@ -683,12 +679,9 @@ public record UInt256(long u3, long u2, long u1, long u0) {
     if (isZero()) return other.mod(modulus);
     if (other.isZero()) return this.mod(modulus);
     if (modulus.isZeroOrOne()) return ZERO;
-    // Fast path: when the modulus is a power of two, reduction is a bitmask of the low bits.
-    // A non-zero value x is a power of two iff (x & (x - 1)) == 0. Subtracting 1 from a power of
-    // two flips its single set bit to 0 and sets all lower bits to 1 (e.g. 0b1000 - 1 == 0b0111),
-    // so x and x - 1 share no bits and the AND is 0. For any non-power-of-two there are at least
-    // two set bits; the lowest stays set in x - 1, so the AND is non-zero. The highest non-zero
-    // limb must be a power of two and every lower limb must be zero for the whole value to qualify.
+
+    // Fast path: when the modulus is a power of two:
+    // x mod 2^N == x & (2^N - 1)
     if (modulus.u3 != 0) {
       if ((modulus.u3 & (modulus.u3 - 1)) == 0 && (modulus.u2 | modulus.u1 | modulus.u0) == 0) {
         return add(other).maskLow(192 + Long.numberOfTrailingZeros(modulus.u3));

--- a/evm/src/test/java/org/hyperledger/besu/evm/UInt256PropertyBasedTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/UInt256PropertyBasedTest.java
@@ -312,6 +312,27 @@ public class UInt256PropertyBasedTest {
   }
 
   @Property
+  void property_addMod_byPowerOfTwo_matchesBigInteger(
+      @ForAll("unsigned1to32") final byte[] a,
+      @ForAll("unsigned1to32") final byte[] b,
+      @ForAll("powerOfTwoExponent") final int k) {
+    // Arrange
+    final BigInteger M = BigInteger.ONE.shiftLeft(k);
+    final UInt256 ua = UInt256.fromBytesBE(a);
+    final UInt256 ub = UInt256.fromBytesBE(b);
+    final UInt256 um = UInt256.fromBytesBE(bigUnsignedToBytes32(M));
+
+    // Act
+    byte[] got = ua.addMod(ub, um).toBytesBE();
+
+    // Assert
+    BigInteger A = toBigUnsigned(a);
+    BigInteger B = toBigUnsigned(b);
+    byte[] exp = bigUnsignedToBytes32(A.add(B).mod(M));
+    assertThat(got).containsExactly(exp);
+  }
+
+  @Property
   void property_mulMod_matchesBigInteger(
       @ForAll("unsigned1to32") final byte[] a,
       @ForAll("unsigned1to32") final byte[] b,

--- a/evm/src/test/java/org/hyperledger/besu/evm/UInt256PropertyBasedTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/UInt256PropertyBasedTest.java
@@ -75,6 +75,36 @@ public class UInt256PropertyBasedTest {
         Tuple.of(7, edges), Tuple.of(3, Arbitraries.integers().between(0, 255)));
   }
 
+  /**
+   * Moduli of the form {@code 2^k + low}, where {@code 64 <= k <= 255} and {@code 0 < low < 2^k}
+   * rounded down to a limb boundary. The highest non-zero limb is therefore a power of two while at
+   * least one lower limb is non-zero, so the value is <em>not</em> a power of two overall. These
+   * are the near-misses that must fall through to the general reduction path; a power-of-two fast
+   * path that inspects only its top limb would wrongly claim them.
+   */
+  @Provide
+  Arbitrary<byte[]> nearPowerOfTwoModulus() {
+    final Arbitrary<Integer> exponent =
+        Arbitraries.frequencyOf(
+            Tuple.of(7, Arbitraries.of(64, 65, 127, 128, 129, 191, 192, 193, 254, 255)),
+            Tuple.of(3, Arbitraries.integers().between(64, 255)));
+    return exponent.flatMap(
+        k ->
+            Arbitraries.bytes()
+                .array(byte[].class)
+                .ofSize(8 * (k / 64))
+                .map(
+                    lowBytes -> {
+                      BigInteger low = new BigInteger(1, lowBytes);
+                      // A zero draw would make the modulus an exact power of two, which is the
+                      // opposite of what this generator is for.
+                      if (low.signum() == 0) {
+                        low = BigInteger.ONE;
+                      }
+                      return bigUnsignedToBytes32(BigInteger.ONE.shiftLeft(k).add(low));
+                    }));
+  }
+
   // --------------------------------------------------------------------------
   // endregion
 
@@ -328,6 +358,34 @@ public class UInt256PropertyBasedTest {
     // Assert
     BigInteger A = toBigUnsigned(a);
     BigInteger B = toBigUnsigned(b);
+    byte[] exp = bigUnsignedToBytes32(A.add(B).mod(M));
+    assertThat(got).containsExactly(exp);
+  }
+
+  /**
+   * Guards the "every lower limb is zero" half of the power-of-two test in {@link
+   * UInt256#addMod(UInt256, UInt256)}. {@link
+   * #property_addMod_byPowerOfTwo_matchesBigInteger(byte[], byte[], int)} cannot cover it: its
+   * moduli are exact powers of two, so the lower limbs are zero by construction and the condition
+   * holds vacuously.
+   */
+  @Property
+  void property_addMod_byNearPowerOfTwo_matchesBigInteger(
+      @ForAll("unsigned1to32") final byte[] a,
+      @ForAll("unsigned1to32") final byte[] b,
+      @ForAll("nearPowerOfTwoModulus") final byte[] m) {
+    // Arrange
+    final UInt256 ua = UInt256.fromBytesBE(a);
+    final UInt256 ub = UInt256.fromBytesBE(b);
+    final UInt256 um = UInt256.fromBytesBE(m);
+
+    // Act
+    byte[] got = ua.addMod(ub, um).toBytesBE();
+
+    // Assert
+    BigInteger A = toBigUnsigned(a);
+    BigInteger B = toBigUnsigned(b);
+    BigInteger M = toBigUnsigned(m);
     byte[] exp = bigUnsignedToBytes32(A.add(B).mod(M));
     assertThat(got).containsExactly(exp);
   }


### PR DESCRIPTION
## PR description

`UInt256.addMod` routes every power-of-two modulus through the wide-add + mod-reduce path. For pow2 moduli the result is just `(a + b) & ((1<<N) - 1)`, so this PR shortcuts to a single add + bitmask. Mirrors the shape of #10588 (`UInt256.div` pow2 fast path) one level higher.

The pow2 check sits inside each of the four dispatch branches so the existing `isZero` and `isZeroOrOne` short-circuits pay no extra cost. Detection is `(limb & (limb - 1)) == 0` plus a zero-check on the lower limbs. A new private `maskLow(int n)` keeps the low N bits across all four limbs.

Six new `ADDMOD_256_256_POW2_<bit>` benchmark cases cover all four dispatch branches plus the 2^160 address mask. The new harness shape `<op>_<aSize>_<bSize>_POW2_<N>` is also available to future MULMOD/EXP work.

### Benchmarks

JMH fork=3, 5 iterations × 1s, ubuntu-latest, Temurin OpenJDK 21. Both runs on this branch in sequence (UInt256 patch stashed for the baseline).

```
Case                          Before (ns/op)   After (ns/op)   Delta
ADDMOD_256_256_POW2_8         90.63 ± 14.80    52.89 ±  0.86   -42%
ADDMOD_256_256_POW2_192       86.43 ± 28.75    51.82 ±  1.29   -40%
ADDMOD_256_256_POW2_160       82.75 ± 18.40    54.07 ±  5.61   -35%   ← address mask
ADDMOD_256_256_POW2_128       76.71 ±  3.02    53.05 ±  1.82   -31%
ADDMOD_256_256_POW2_64        77.36 ±  1.66    56.00 ±  6.56   -28%
ADDMOD_256_256_POW2_240       67.61 ± 14.17    57.03 ± 18.50   -16%   (noise)
```

5/6 pow2 cases are distinguishable improvements (99.9% CIs don't overlap). Note: v1 ADDMOD pays ~30 ns/call of `Bytes` ↔ `UInt256` conversion in `AddModOperationOptimized.staticOperation`, which masks part of the improvement; a v2 ADDMOD benchmark (when `AddModOperationV2` lands) would show a tighter floor.

Random-modulus cases: no consistent regression across the 32 pre-existing `ADDMOD_<a>_<b>_<c>` scenarios. One distinguishable +13 ns on `ADDMOD_128_256_0` (modulus is zero, hits the existing `isZeroOrOne` short-circuit and never reaches the new code) — appears to be a JIT inlining boundary effect from the larger `addMod` body.

`UInt256PropertyBasedTest` exercises the new path whenever the random fuzz produces a power-of-two modulus.

## Fixed Issue(s)

N/A - performance improvement.


### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew :evm:test --tests 'org.hyperledger.besu.evm.UInt256*'`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)
