### PR TITLE
JSpecify: enable NullAway for ethereum/mock-p2p module

### DIFF
--- a/ethereum/mock-p2p/build.gradle
+++ b/ethereum/mock-p2p/build.gradle
@@ -28,7 +28,23 @@ jar {
   }
 }
 
+compileJava {
+  options.errorprone {
+    check('NullAway', net.ltgt.gradle.errorprone.ChcekSeverity.ERROR)
+    options('NullAway:AnnotatedPackages', 'org.hyperledger.besu.ethereum.p2p.testing')
+  }
+}
+
+tasks.named('compileTestJava', JavaCompile).configure {
+  options.errorprone {
+    check('NullAway', net.ltgt.gradle.errorprone.CheckSeverity.OFF)
+  }
+}
+
 dependencies {
+  erroeprone 'com.uber.nullaway:nullaway'
+  compileOnly 'org.jspecify:jspecify'
+  
   api project(':plugin-api')
 
   implementation project(':ethereum:p2p')

--- a/ethereum/mock-p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/testing/MockNetwork.java
+++ b/ethereum/mock-p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/testing/MockNetwork.java
@@ -84,6 +84,12 @@ public final class MockNetwork {
           new MockNetwork.MockPeerConnection(source, target, this);
       final MockP2PNetwork sourceNode = nodes.get(source);
       final MockP2PNetwork targetNode = nodes.get(target);
+
+      if (sourceNode == null || targetNode == null) {
+        throw new IllegalStateException(
+            "Both source and target peers must be setup before connecting");
+      }
+
       sourceNode.connections.put(target, establishedConnection);
       final MockNetwork.MockPeerConnection backChannel =
           new MockNetwork.MockPeerConnection(target, source, this);
@@ -99,6 +105,13 @@ public final class MockNetwork {
     synchronized (this) {
       final MockP2PNetwork sourceNode = nodes.get(connection.from);
       final MockP2PNetwork targetNode = nodes.get(connection.to);
+
+      if (sourceNode == null || targetNode == null) {
+        throw new IllegalStateException(
+            String.format(
+                "No nodes found for connection between %s and %s", connection.from, connection.to));
+      }
+
       if (targetNode.connections.remove(connection.from) == null
           || sourceNode.connections.remove(connection.to) == null) {
         throw new IllegalStateException(
@@ -272,12 +285,16 @@ public final class MockNetwork {
         throws PeerNotConnected {
       synchronized (network) {
         final MockNetwork.MockP2PNetwork target = network.nodes.get(to);
-        final MockNetwork.MockPeerConnection backChannel = target.connections.get(from);
-        if (backChannel != null) {
-          final Message msg = new DefaultMessage(backChannel, message);
-          final Subscribers<MessageCallback> callbacks = target.protocolCallbacks.get(capability);
-          if (callbacks != null) {
-            callbacks.forEach(c -> c.onMessage(capability, msg));
+        if (target != null) {
+          final MockNetwork.MockPeerConnection backChannel = target.connections.get(from);
+          if (backChannel != null) {
+            final Message msg = new DefaultMessage(backChannel, message);
+            final Subscribers<MessageCallback> callbacks = target.protocolCallbacks.get(capability);
+            if (callbacks != null) {
+              callbacks.forEach(c -> c.onMessage(capability, msg));
+            }
+          } else {
+            throw new PeerNotConnected(String.format("%s not connected to %s", to, from));
           }
         } else {
           throw new PeerNotConnected(String.format("%s not connected to %s", to, from));


### PR DESCRIPTION
## PR description
Added NullAway to the ethereum/mock-p2p module to catch null-pointer issue early, which is part of the JSpecify migration. I integrated it up using ErrorProne in the build.gradle file. To keep things clean, I also made sure it skips checking our test files so we don't get flooded with strict compilation error testing.

## Fixed Issue(s)
Part of #10442 

### Thanks for sending a pull request! Have you done the following?

- [X] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests