### PR TITLE
snap/2 - simplify downloaded account range tracking

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/DownloadedAccountRangeTracker.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/DownloadedAccountRangeTracker.java
@@ -18,172 +18,71 @@ import java.util.Collections;
 import java.util.Map.Entry;
 import java.util.NavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.tuweni.bytes.Bytes32;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Tracks which account-hash intervals have been fully downloaded (account leaves + all storage and
- * code for accounts within those intervals). Intervals are identified by a {@code rangeStart}
- * (Bytes32 start hash). An interval moves from pending to completed when all storage and code child
- * requests spawned from accounts in that interval have finished.
+ * Tracks which account-hash intervals have been persisted during snap/2 leaf download. Intervals
+ * are identified by a {@code rangeStart} (Bytes32 start hash). Account leaves and trie nodes are
+ * committed immediately, so we only record which intervals are present in the database.
  */
 public class DownloadedAccountRangeTracker {
 
   private static final Logger LOG = LoggerFactory.getLogger(DownloadedAccountRangeTracker.class);
 
-  private final ConcurrentSkipListMap<Bytes32, PendingRange> pendingRanges =
+  private final ConcurrentSkipListMap<Bytes32, Bytes32> persistedRanges =
       new ConcurrentSkipListMap<>();
-  private final ConcurrentSkipListMap<Bytes32, Bytes32> completedRanges =
-      new ConcurrentSkipListMap<>();
-
-  private static class PendingRange {
-    volatile Bytes32 endInclusive;
-    final AtomicInteger pendingChildRequests;
-
-    PendingRange(final Bytes32 endInclusive, final int initialChildCount) {
-      this.endInclusive = endInclusive;
-      this.pendingChildRequests = new AtomicInteger(initialChildCount);
-    }
-  }
 
   /**
-   * Register an account-hash interval whose account leaves have been downloaded and persisted. The
-   * interval becomes "completed" (BAL-eligible) only after {@code initialChildCount} child storage
-   * and code requests have finished.
+   * Register an account-hash interval whose account leaves have been downloaded and persisted.
    *
    * @param rangeStart the start of the interval (inclusive)
    * @param rangeEnd the end of the interval (inclusive)
-   * @param initialChildCount the number of child storage and code requests spawned from accounts
-   *     within this range
    */
-  public synchronized void registerPending(
-      final Bytes32 rangeStart, final Bytes32 rangeEnd, final int initialChildCount) {
-    if (initialChildCount < 0) {
-      throw new IllegalArgumentException("Initial child count cannot be negative");
-    }
+  public synchronized void registerPersisted(final Bytes32 rangeStart, final Bytes32 rangeEnd) {
     assertNoOverlap(rangeStart, rangeEnd);
-    if (initialChildCount == 0) {
-      completedRanges.put(rangeStart, rangeEnd);
-      LOG.atDebug()
-          .setMessage("Account range completed immediately: [{},{}] (no children)")
-          .addArgument(rangeStart)
-          .addArgument(rangeEnd)
-          .log();
-    } else {
-      pendingRanges.put(rangeStart, new PendingRange(rangeEnd, initialChildCount));
-      LOG.atDebug()
-          .setMessage("Registered pending account range: [{},{}] (pending children: {})")
-          .addArgument(rangeStart)
-          .addArgument(rangeEnd)
-          .addArgument(initialChildCount)
-          .log();
-    }
-  }
-
-  /** Add a newly-spawned child request to an existing pending range. */
-  public void addPendingChild(final Bytes32 rangeStart) {
-    adjustPendingChildren(rangeStart, 1);
+    persistedRanges.put(rangeStart, rangeEnd);
+    LOG.atDebug()
+        .setMessage("Registered persisted account range: [{},{}]")
+        .addArgument(rangeStart)
+        .addArgument(rangeEnd)
+        .log();
   }
 
   /**
-   * Adjust the pending child count for a range by {@code delta}. A positive delta adds child work
-   * (e.g. storage continuations), a negative delta removes it (child completed). When the count
-   * reaches zero, the range is promoted to completed.
+   * Check whether an account hash falls within any persisted interval. Used for selective BAL
+   * application: only accounts whose hash is in a persisted interval have downloaded state and can
+   * be updated by BAL.
    */
-  public synchronized void adjustPendingChildren(final Bytes32 rangeStart, final int delta) {
-    final PendingRange range = pendingRanges.get(rangeStart);
-    if (range == null) {
-      throw new IllegalStateException("No pending range found for start key " + rangeStart);
-    }
-    final int remaining = range.pendingChildRequests.addAndGet(delta);
-    if (remaining < 0) {
-      throw new IllegalStateException(
-          String.format(
-              "Pending child count cannot be negative, but was %d for range %s",
-              remaining, rangeStart));
-    }
-    if (remaining == 0) {
-      pendingRanges.remove(rangeStart);
-      completedRanges.put(rangeStart, range.endInclusive);
-      LOG.atDebug()
-          .setMessage("Account range completed (delta {}): [{},{}]")
-          .addArgument(delta)
-          .addArgument(rangeStart)
-          .addArgument(range.endInclusive)
-          .log();
-    }
-  }
-
-  /**
-   * Notify the tracker that a child storage or code request belonging to {@code rangeStart} has
-   * finished. When the last pending child for a range completes, the range is promoted to
-   * completed.
-   */
-  public void onChildCompleted(final Bytes32 rangeStart) {
-    adjustPendingChildren(rangeStart, -1);
-  }
-
-  /**
-   * Check whether an account hash falls within any completed interval. Used for selective BAL
-   * application: only accounts whose hash is in a completed interval have fully-downloaded state
-   * and can be updated by BAL.
-   */
-  public boolean isAccountHashDownloaded(final Bytes32 accountHash) {
-    final Entry<Bytes32, Bytes32> entry = completedRanges.floorEntry(accountHash);
+  public boolean isAccountHashPersisted(final Bytes32 accountHash) {
+    final Entry<Bytes32, Bytes32> entry = persistedRanges.floorEntry(accountHash);
     return entry != null && accountHash.compareTo(entry.getValue()) <= 0;
   }
 
-  /**
-   * Check whether an account hash falls within any pending interval. The account has been persisted
-   * but still has outstanding storage or code child requests.
-   */
-  public boolean isAccountHashPending(final Bytes32 accountHash) {
-    final Entry<Bytes32, PendingRange> entry = pendingRanges.floorEntry(accountHash);
-    return entry != null && accountHash.compareTo(entry.getValue().endInclusive) <= 0;
+  /** Return an unmodifiable snapshot of persisted ranges for external consumers (e.g. BAL). */
+  public NavigableMap<Bytes32, Bytes32> getPersistedRanges() {
+    return Collections.unmodifiableNavigableMap(new ConcurrentSkipListMap<>(persistedRanges));
   }
 
-  /** Return an unmodifiable snapshot of completed ranges for external consumers (e.g. BAL). */
-  public NavigableMap<Bytes32, Bytes32> getCompletedRanges() {
-    return Collections.unmodifiableNavigableMap(new ConcurrentSkipListMap<>(completedRanges));
-  }
-
-  public long pendingRangeCount() {
-    return pendingRanges.size();
-  }
-
-  public long completedRangeCount() {
-    return completedRanges.size();
+  public long persistedRangeCount() {
+    return persistedRanges.size();
   }
 
   /** Clear all tracked state. */
   public synchronized void clear() {
-    pendingRanges.clear();
-    completedRanges.clear();
+    persistedRanges.clear();
   }
 
   private void assertNoOverlap(final Bytes32 start, final Bytes32 end) {
-    for (var entry : completedRanges.entrySet()) {
+    for (var entry : persistedRanges.entrySet()) {
       // start <= existingEnd && existingStart <= end
       if (start.compareTo(entry.getValue()) <= 0 && entry.getKey().compareTo(end) <= 0) {
         final String message =
             String.format(
-                "Overlapping completed range detected: [%s,%s] vs existing [%s,%s]",
+                "Overlapping persisted range detected: [%s,%s] vs existing [%s,%s]",
                 start, end, entry.getKey(), entry.getValue());
-        LOG.error(message);
-        throw new IllegalStateException(message);
-      }
-    }
-    for (var entry : pendingRanges.entrySet()) {
-      // start <= existingEnd && existingStart <= end
-      if (start.compareTo(entry.getValue().endInclusive) <= 0
-          && entry.getKey().compareTo(end) <= 0) {
-        final String message =
-            String.format(
-                "Overlapping pending range: [%s,%s] vs existing [%s,%s]",
-                start, end, entry.getKey(), entry.getValue().endInclusive);
         LOG.error(message);
         throw new IllegalStateException(message);
       }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/DownloadedAccountRangeTracker.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/DownloadedAccountRangeTracker.java
@@ -59,7 +59,7 @@ public class DownloadedAccountRangeTracker {
    * @param initialChildCount the number of child storage and code requests spawned from accounts
    *     within this range
    */
-  public void registerPending(
+  public synchronized void registerPending(
       final Bytes32 rangeStart, final Bytes32 rangeEnd, final int initialChildCount) {
     if (initialChildCount < 0) {
       throw new IllegalArgumentException("Initial child count cannot be negative");
@@ -93,12 +93,19 @@ public class DownloadedAccountRangeTracker {
    * (e.g. storage continuations), a negative delta removes it (child completed). When the count
    * reaches zero, the range is promoted to completed.
    */
-  public void adjustPendingChildren(final Bytes32 rangeStart, final int delta) {
+  public synchronized void adjustPendingChildren(final Bytes32 rangeStart, final int delta) {
     final PendingRange range = pendingRanges.get(rangeStart);
     if (range == null) {
       throw new IllegalStateException("No pending range found for start key " + rangeStart);
     }
-    if (range.pendingChildRequests.addAndGet(delta) <= 0) {
+    final int remaining = range.pendingChildRequests.addAndGet(delta);
+    if (remaining < 0) {
+      throw new IllegalStateException(
+          String.format(
+              "Pending child count cannot be negative, but was %d for range %s",
+              remaining, rangeStart));
+    }
+    if (remaining == 0) {
       pendingRanges.remove(rangeStart);
       completedRanges.put(rangeStart, range.endInclusive);
       LOG.atDebug()
@@ -129,6 +136,15 @@ public class DownloadedAccountRangeTracker {
     return entry != null && accountHash.compareTo(entry.getValue()) <= 0;
   }
 
+  /**
+   * Check whether an account hash falls within any pending interval. The account has been persisted
+   * but still has outstanding storage or code child requests.
+   */
+  public boolean isAccountHashPending(final Bytes32 accountHash) {
+    final Entry<Bytes32, PendingRange> entry = pendingRanges.floorEntry(accountHash);
+    return entry != null && accountHash.compareTo(entry.getValue().endInclusive) <= 0;
+  }
+
   /** Return an unmodifiable snapshot of completed ranges for external consumers (e.g. BAL). */
   public NavigableMap<Bytes32, Bytes32> getCompletedRanges() {
     return Collections.unmodifiableNavigableMap(new ConcurrentSkipListMap<>(completedRanges));
@@ -143,7 +159,7 @@ public class DownloadedAccountRangeTracker {
   }
 
   /** Clear all tracked state. */
-  public void clear() {
+  public synchronized void clear() {
     pendingRanges.clear();
     completedRanges.clear();
   }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/DownloadedStorageRangeTracker.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/DownloadedStorageRangeTracker.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.eth.sync.snapsync;
+
+import java.util.Collections;
+import java.util.Map.Entry;
+import java.util.NavigableMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+
+import org.apache.tuweni.bytes.Bytes32;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Tracks which storage slot hash intervals have been persisted per account. Used for selective BAL
+ * application on partially-downloaded accounts. Slots outside tracked intervals have not been
+ * persisted yet.
+ */
+public class DownloadedStorageRangeTracker {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DownloadedStorageRangeTracker.class);
+
+  private final ConcurrentHashMap<Bytes32, ConcurrentSkipListMap<Bytes32, Bytes32>>
+      accountStorageRanges = new ConcurrentHashMap<>();
+
+  /**
+   * Register a storage slot hash interval whose slots have been downloaded and persisted for the
+   * given account. Intervals are guaranteed non-overlapping by the storage range continuation
+   * protocol (continuations always start past the last received key).
+   */
+  public synchronized void registerSlotRange(
+      final Bytes32 accountHash, final Bytes32 startSlot, final Bytes32 endSlot) {
+    if (startSlot.compareTo(endSlot) > 0) {
+      throw new IllegalArgumentException(
+          "startSlot must be <= endSlot: " + startSlot + " > " + endSlot);
+    }
+    final ConcurrentSkipListMap<Bytes32, Bytes32> ranges =
+        accountStorageRanges.computeIfAbsent(accountHash, k -> new ConcurrentSkipListMap<>());
+    assertNoOverlap(ranges, startSlot, endSlot);
+    ranges.put(startSlot, endSlot);
+  }
+
+  /**
+   * Check whether a specific storage slot hash has been persisted for the given account. Returns
+   * true if the slot falls within any registered interval.
+   */
+  public boolean isSlotHashDownloaded(final Bytes32 accountHash, final Bytes32 slotHash) {
+    final NavigableMap<Bytes32, Bytes32> ranges = accountStorageRanges.get(accountHash);
+    if (ranges == null) {
+      return false;
+    }
+    final Entry<Bytes32, Bytes32> entry = ranges.floorEntry(slotHash);
+    return entry != null && slotHash.compareTo(entry.getValue()) <= 0;
+  }
+
+  /** Returns an unmodifiable snapshot of completed slot intervals for a given account. */
+  public NavigableMap<Bytes32, Bytes32> getCompletedSlotRanges(final Bytes32 accountHash) {
+    final NavigableMap<Bytes32, Bytes32> ranges = accountStorageRanges.get(accountHash);
+    if (ranges == null) {
+      return Collections.emptyNavigableMap();
+    }
+    return Collections.unmodifiableNavigableMap(new ConcurrentSkipListMap<>(ranges));
+  }
+
+  /** Remove all tracked storage intervals for a given account (e.g. during reorg cleanup). */
+  public synchronized void removeAccount(final Bytes32 accountHash) {
+    accountStorageRanges.remove(accountHash);
+  }
+
+  /** Clear all tracked state. */
+  public synchronized void clear() {
+    accountStorageRanges.clear();
+  }
+
+  private void assertNoOverlap(
+      final ConcurrentSkipListMap<Bytes32, Bytes32> ranges,
+      final Bytes32 start,
+      final Bytes32 end) {
+    for (var entry : ranges.entrySet()) {
+      // start <= existingEnd && existingStart <= end
+      if (start.compareTo(entry.getValue()) <= 0 && entry.getKey().compareTo(end) <= 0) {
+        final String message =
+            String.format(
+                "Overlapping storage slot range detected for account: [%s,%s] vs existing [%s,%s]",
+                start, end, entry.getKey(), entry.getValue());
+        LOG.error(message);
+        throw new IllegalStateException(message);
+      }
+    }
+  }
+}

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/v2/SnapV2BytecodeRequest.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/v2/SnapV2BytecodeRequest.java
@@ -83,6 +83,10 @@ public class SnapV2BytecodeRequest extends SnapV2DataRequest {
     return accountHash;
   }
 
+  public SnapV2BytecodeRequest retarget(final BlockHeader newPivotBlockHeader) {
+    return new SnapV2BytecodeRequest(newPivotBlockHeader, accountHash, codeHash, getRangeStart());
+  }
+
   public Bytes32 getCodeHash() {
     return codeHash;
   }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/v2/SnapV2StorageRangeRequest.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/v2/SnapV2StorageRangeRequest.java
@@ -185,6 +185,17 @@ public class SnapV2StorageRangeRequest extends SnapV2DataRequest {
     return stackTrie.getElement(startKeyHash).keys();
   }
 
+  public SnapV2StorageRangeRequest retarget(
+      final BlockHeader newPivotBlockHeader, final Bytes32 newStorageRoot) {
+    return new SnapV2StorageRangeRequest(
+        newPivotBlockHeader,
+        Bytes32.wrap(accountHash.getBytes()),
+        newStorageRoot,
+        startKeyHash,
+        endKeyHash,
+        getRangeStart());
+  }
+
   public Bytes32 getStartKeyHash() {
     return startKeyHash;
   }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2PersistDataStep.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2PersistDataStep.java
@@ -19,6 +19,7 @@ import static org.hyperledger.besu.ethereum.eth.sync.StorageExceptionManager.err
 import static org.hyperledger.besu.ethereum.eth.sync.StorageExceptionManager.getRetryableErrorCounter;
 
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.DownloadedAccountRangeTracker;
+import org.hyperledger.besu.ethereum.eth.sync.snapsync.DownloadedStorageRangeTracker;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.SnapSyncConfiguration;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.SnapSyncProcessState;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.request.SnapDataRequest;
@@ -33,7 +34,9 @@ import org.hyperledger.besu.services.tasks.Task;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.NavigableMap;
 
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.slf4j.Logger;
@@ -48,19 +51,22 @@ public class SnapV2PersistDataStep {
   private final WorldStateStorageCoordinator worldStateStorageCoordinator;
   private final SnapRequestContext downloadState;
   private final SnapSyncConfiguration snapSyncConfiguration;
-  private final DownloadedAccountRangeTracker rangeTracker;
+  private final DownloadedAccountRangeTracker accountRangeTracker;
+  private final DownloadedStorageRangeTracker storageRangeTracker;
 
   public SnapV2PersistDataStep(
       final SnapSyncProcessState snapSyncState,
       final WorldStateStorageCoordinator worldStateStorageCoordinator,
       final SnapRequestContext downloadState,
       final SnapSyncConfiguration snapSyncConfiguration,
-      final DownloadedAccountRangeTracker rangeTracker) {
+      final DownloadedAccountRangeTracker accountRangeTracker,
+      final DownloadedStorageRangeTracker storageRangeTracker) {
     this.snapSyncState = snapSyncState;
     this.worldStateStorageCoordinator = worldStateStorageCoordinator;
     this.downloadState = downloadState;
     this.snapSyncConfiguration = snapSyncConfiguration;
-    this.rangeTracker = rangeTracker;
+    this.accountRangeTracker = accountRangeTracker;
+    this.storageRangeTracker = storageRangeTracker;
   }
 
   public List<Task<SnapDataRequest>> persist(final List<Task<SnapDataRequest>> tasks) {
@@ -137,7 +143,7 @@ public class SnapV2PersistDataStep {
     } else if (request instanceof SnapV2StorageRangeRequest storageRequest) {
       trackStorageRange(storageRequest, children);
     } else if (request instanceof SnapV2BytecodeRequest codeRequest) {
-      rangeTracker.onChildCompleted(codeRequest.getRangeStart());
+      accountRangeTracker.onChildCompleted(codeRequest.getRangeStart());
     }
 
     downloadState.enqueueRequests(children.stream());
@@ -185,17 +191,26 @@ public class SnapV2PersistDataStep {
 
     final int childCount = children.size() - continuationCount;
 
-    rangeTracker.registerPending(rangeStart, coveredEnd, childCount);
+    accountRangeTracker.registerPending(rangeStart, coveredEnd, childCount);
   }
 
   private void trackStorageRange(
       final SnapV2StorageRangeRequest storageRequest, final List<SnapDataRequest> children) {
     final Bytes32 rangeStart = storageRequest.getRangeStart();
+
+    final NavigableMap<Bytes32, Bytes> slots = storageRequest.getSlots();
+    if (!slots.isEmpty()) {
+      storageRangeTracker.registerSlotRange(
+          Bytes32.wrap(storageRequest.getAccountHash().getBytes()),
+          slots.firstKey(),
+          slots.lastKey());
+    }
+
     final int continuationCount = children.size();
     if (continuationCount == 0) {
-      rangeTracker.onChildCompleted(rangeStart);
+      accountRangeTracker.onChildCompleted(rangeStart);
     } else {
-      rangeTracker.adjustPendingChildren(rangeStart, continuationCount - 1);
+      accountRangeTracker.adjustPendingChildren(rangeStart, continuationCount - 1);
     }
   }
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2PersistDataStep.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2PersistDataStep.java
@@ -25,7 +25,6 @@ import org.hyperledger.besu.ethereum.eth.sync.snapsync.SnapSyncProcessState;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.request.SnapDataRequest;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.request.SnapRequestContext;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.request.v2.SnapV2AccountRangeRequest;
-import org.hyperledger.besu.ethereum.eth.sync.snapsync.request.v2.SnapV2BytecodeRequest;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.request.v2.SnapV2StorageRangeRequest;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateStorageCoordinator;
 import org.hyperledger.besu.plugin.services.exception.StorageException;
@@ -141,9 +140,7 @@ public class SnapV2PersistDataStep {
     if (request instanceof SnapV2AccountRangeRequest accountRequest) {
       trackAccountRange(accountRequest, children);
     } else if (request instanceof SnapV2StorageRangeRequest storageRequest) {
-      trackStorageRange(storageRequest, children);
-    } else if (request instanceof SnapV2BytecodeRequest codeRequest) {
-      accountRangeTracker.onChildCompleted(codeRequest.getRangeStart());
+      trackStorageRange(storageRequest);
     }
 
     downloadState.enqueueRequests(children.stream());
@@ -153,15 +150,12 @@ public class SnapV2PersistDataStep {
       final SnapV2AccountRangeRequest accountRequest, final List<SnapDataRequest> children) {
     final Bytes32 rangeStart = accountRequest.getRangeStart();
 
-    int continuationCount = 0;
     SnapV2AccountRangeRequest continuation = null;
     for (final SnapDataRequest child : children) {
       if (child instanceof SnapV2AccountRangeRequest accountRangeContinuation) {
-        continuationCount++;
-        if (continuationCount > 1) {
+        if (continuation != null) {
           throw new IllegalStateException(
-              "Expected at most one SnapV2AccountRangeRequest continuation, got "
-                  + continuationCount);
+              "Expected at most one SnapV2AccountRangeRequest continuation, got multiple");
         }
         continuation = accountRangeContinuation;
       }
@@ -189,28 +183,16 @@ public class SnapV2PersistDataStep {
       coveredEnd = accountRequest.getEndKeyHash();
     }
 
-    final int childCount = children.size() - continuationCount;
-
-    accountRangeTracker.registerPending(rangeStart, coveredEnd, childCount);
+    accountRangeTracker.registerPersisted(rangeStart, coveredEnd);
   }
 
-  private void trackStorageRange(
-      final SnapV2StorageRangeRequest storageRequest, final List<SnapDataRequest> children) {
-    final Bytes32 rangeStart = storageRequest.getRangeStart();
-
+  private void trackStorageRange(final SnapV2StorageRangeRequest storageRequest) {
     final NavigableMap<Bytes32, Bytes> slots = storageRequest.getSlots();
     if (!slots.isEmpty()) {
       storageRangeTracker.registerSlotRange(
           Bytes32.wrap(storageRequest.getAccountHash().getBytes()),
           slots.firstKey(),
           slots.lastKey());
-    }
-
-    final int continuationCount = children.size();
-    if (continuationCount == 0) {
-      accountRangeTracker.onChildCompleted(rangeStart);
-    } else {
-      accountRangeTracker.adjustPendingChildren(rangeStart, continuationCount - 1);
     }
   }
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldDownloadState.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldDownloadState.java
@@ -19,6 +19,7 @@ import static org.hyperledger.besu.ethereum.worldstate.WorldStateStorageCoordina
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.eth.sync.common.WorldStateHealFinishedListener;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.DownloadedAccountRangeTracker;
+import org.hyperledger.besu.ethereum.eth.sync.snapsync.DownloadedStorageRangeTracker;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.SnapSyncMetricsManager;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.SnapSyncProcessState;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.context.SnapSyncStatePersistenceManager;
@@ -72,6 +73,8 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
   private final AtomicBoolean worldStateFinishedNotified = new AtomicBoolean(false);
   private final WorldStateHealFinishedListener worldStateHealFinishedListener;
   private final DownloadedAccountRangeTracker rangeTracker = new DownloadedAccountRangeTracker();
+  private final DownloadedStorageRangeTracker storageRangeTracker =
+      new DownloadedStorageRangeTracker();
   private final SnapV2PivotCatchupListener pivotCatchupListener;
   private boolean accountRangeRequestsPausedForPivotCatchup = false;
   private boolean pivotCatchupInProgress = false;
@@ -211,6 +214,7 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
     pendingLargeStorageRequests.clear();
     pendingCodeRequests.clear();
     rangeTracker.clear();
+    storageRangeTracker.clear();
     accountRangeRequestsPausedForPivotCatchup = false;
     pivotCatchupInProgress = false;
     pivotCatchupSafePointFuture = null;
@@ -466,7 +470,11 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
     LOG.debug("Ignoring snap/2 healing marker for account {}", account);
   }
 
-  public DownloadedAccountRangeTracker getRangeTracker() {
+  public DownloadedAccountRangeTracker getAccountRangeTracker() {
     return rangeTracker;
+  }
+
+  public DownloadedStorageRangeTracker getStorageRangeTracker() {
+    return storageRangeTracker;
   }
 }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldDownloadState.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldDownloadState.java
@@ -137,16 +137,9 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
         .getMetricsSystem()
         .createLongGauge(
             BesuMetricCategory.SYNCHRONIZER,
-            "snap_v2_world_state_completed_ranges_current",
-            "Number of completed account ranges for snap/2 world state download",
-            accountRangeTracker::completedRangeCount);
-    metricsManager
-        .getMetricsSystem()
-        .createLongGauge(
-            BesuMetricCategory.SYNCHRONIZER,
-            "snap_v2_world_state_pending_ranges_current",
-            "Number of pending account ranges for snap/2 world state download",
-            accountRangeTracker::pendingRangeCount);
+            "snap_v2_world_state_persisted_ranges_current",
+            "Number of persisted account ranges for snap/2 world state download",
+            accountRangeTracker::persistedRangeCount);
     syncDurationMetrics.startTimer(
         SyncDurationMetrics.Labels.SNAP_INITIAL_WORLD_STATE_DOWNLOAD_DURATION);
   }
@@ -158,8 +151,7 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
         && pendingAccountRequests.allTasksCompleted()
         && pendingCodeRequests.allTasksCompleted()
         && pendingStorageRequests.allTasksCompleted()
-        && pendingLargeStorageRequests.allTasksCompleted()
-        && accountRangeTracker.pendingRangeCount() == 0) {
+        && pendingLargeStorageRequests.allTasksCompleted()) {
       persistWorldStateRoot(header);
       notifyWorldStateFinished();
       syncDurationMetrics.stopTimer(
@@ -378,8 +370,8 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
       }
       applyBlockAccessListsNoop(currentPivotBlockHeader, newPivotBlockHeader);
       retargetQueuedRequests(newPivotBlockHeader);
-      // TODO: Simplify account range tracker and clear both here
       storageRangeTracker.clear();
+      accountRangeTracker.clear();
       snapSyncState.setCurrentHeader(newPivotBlockHeader);
       pivotCatchupFuture = null;
       notifyAll();
@@ -390,11 +382,10 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
   private void applyBlockAccessListsNoop(
       final BlockHeader currentPivotBlockHeader, final BlockHeader newPivotBlockHeader) {
     LOG.info(
-        "Snap/2 BAL application placeholder: pivot {} -> {} (completed ranges: {}, pending ranges: {})",
+        "Snap/2 BAL application placeholder: pivot {} -> {} (persisted ranges: {})",
         currentPivotBlockHeader.getNumber(),
         newPivotBlockHeader.getNumber(),
-        accountRangeTracker.completedRangeCount(),
-        accountRangeTracker.pendingRangeCount());
+        accountRangeTracker.persistedRangeCount());
   }
 
   private void retargetQueuedRequests(final BlockHeader newPivotBlockHeader) {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldDownloadState.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldDownloadState.java
@@ -52,7 +52,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Static-pivot snap/2 leaf download state. Healing queues are intentionally absent. */
+/** Static-pivot snap/2 leaf download state. */
 public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest>
     implements SnapRequestContext {
 
@@ -72,13 +72,13 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
   private final SnapSyncMetricsManager metricsManager;
   private final AtomicBoolean worldStateFinishedNotified = new AtomicBoolean(false);
   private final WorldStateHealFinishedListener worldStateHealFinishedListener;
-  private final DownloadedAccountRangeTracker rangeTracker = new DownloadedAccountRangeTracker();
+  private final DownloadedAccountRangeTracker accountRangeTracker =
+      new DownloadedAccountRangeTracker();
   private final DownloadedStorageRangeTracker storageRangeTracker =
       new DownloadedStorageRangeTracker();
   private final SnapV2PivotCatchupListener pivotCatchupListener;
-  private boolean accountRangeRequestsPausedForPivotCatchup = false;
-  private boolean pivotCatchupInProgress = false;
-  private CompletableFuture<Void> pivotCatchupSafePointFuture;
+  // future that completes once every in-flight (already-dequeued) task has finished
+  private CompletableFuture<Void> pivotCatchupFuture; // null unless pivot catchup is in progress
 
   public SnapV2WorldDownloadState(
       final WorldStateStorageCoordinator worldStateStorageCoordinator,
@@ -139,27 +139,27 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
             BesuMetricCategory.SYNCHRONIZER,
             "snap_v2_world_state_completed_ranges_current",
             "Number of completed account ranges for snap/2 world state download",
-            rangeTracker::completedRangeCount);
+            accountRangeTracker::completedRangeCount);
     metricsManager
         .getMetricsSystem()
         .createLongGauge(
             BesuMetricCategory.SYNCHRONIZER,
             "snap_v2_world_state_pending_ranges_current",
             "Number of pending account ranges for snap/2 world state download",
-            rangeTracker::pendingRangeCount);
+            accountRangeTracker::pendingRangeCount);
     syncDurationMetrics.startTimer(
         SyncDurationMetrics.Labels.SNAP_INITIAL_WORLD_STATE_DOWNLOAD_DURATION);
   }
 
   @Override
   public synchronized boolean checkCompletion(final BlockHeader header) {
-    if (!internalFuture.isDone()
-        && !pivotCatchupInProgress
+    if (!isStateDownloadFinished()
+        && !isPivotCatchupInProgress()
         && pendingAccountRequests.allTasksCompleted()
         && pendingCodeRequests.allTasksCompleted()
         && pendingStorageRequests.allTasksCompleted()
         && pendingLargeStorageRequests.allTasksCompleted()
-        && rangeTracker.pendingRangeCount() == 0) {
+        && accountRangeTracker.pendingRangeCount() == 0) {
       persistWorldStateRoot(header);
       notifyWorldStateFinished();
       syncDurationMetrics.stopTimer(
@@ -213,16 +213,14 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
     pendingStorageRequests.clear();
     pendingLargeStorageRequests.clear();
     pendingCodeRequests.clear();
-    rangeTracker.clear();
+    accountRangeTracker.clear();
     storageRangeTracker.clear();
-    accountRangeRequestsPausedForPivotCatchup = false;
-    pivotCatchupInProgress = false;
-    pivotCatchupSafePointFuture = null;
+    pivotCatchupFuture = null;
   }
 
   @Override
   public synchronized void enqueueRequest(final SnapDataRequest request) {
-    if (!internalFuture.isDone()) {
+    if (!isStateDownloadFinished()) {
       if (request instanceof SnapV2BytecodeRequest) {
         pendingCodeRequests.add(request);
       } else if (request instanceof SnapV2StorageRangeRequest storageRangeDataRequest) {
@@ -243,105 +241,90 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
 
   @Override
   public synchronized void enqueueRequests(final Stream<SnapDataRequest> requests) {
-    if (!internalFuture.isDone()) {
+    if (!isStateDownloadFinished()) {
       requests.forEach(this::enqueueRequest);
     }
   }
 
+  private boolean isStateDownloadFinished() {
+    return internalFuture.isDone();
+  }
+
+  private boolean isPivotCatchupInProgress() {
+    return pivotCatchupFuture != null;
+  }
+
+  private boolean isWaitingForInFlightCompletion() {
+    return isPivotCatchupInProgress() && !pivotCatchupFuture.isDone();
+  }
+
   public synchronized Task<SnapDataRequest> dequeueRequestBlocking(
-      final BooleanSupplier areRequestsPaused, final TaskCollection<SnapDataRequest> queue) {
-    while (!internalFuture.isDone()) {
-      while (!internalFuture.isDone() && (areRequestsPaused.getAsBoolean() || queue.isEmpty())) {
-        try {
-          wait();
-        } catch (final InterruptedException e) {
-          Thread.currentThread().interrupt();
-          return null;
-        }
-      }
-      if (internalFuture.isDone()) {
+      final BooleanSupplier extraPauseCondition, final TaskCollection<SnapDataRequest> queue) {
+    while (!isStateDownloadFinished()
+        && (isPivotCatchupInProgress() || extraPauseCondition.getAsBoolean() || queue.isEmpty())) {
+      try {
+        wait();
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
         return null;
       }
-      final Task<SnapDataRequest> task = queue.remove();
-      if (task != null) {
-        return task;
-      }
     }
-    return null;
+    if (isStateDownloadFinished()) {
+      return null;
+    }
+    return queue.remove();
   }
 
   public synchronized Task<SnapDataRequest> dequeueAccountRequestBlocking() {
     return dequeueRequestBlocking(this::shouldPauseAccountRequests, pendingAccountRequests);
   }
 
-  /**
-   * Pauses new account-range dequeues so already-persisted ranges can finish their storage/code
-   * children before a snap/2 pivot catch-up applies BALs.
-   *
-   * <p>Storage and code queues intentionally keep draining while this pause is active. Queued but
-   * not yet dequeued account ranges are not persisted yet, so a catch-up coordinator can retarget
-   * them to the next pivot after the safe point is reached.
-   */
-  public synchronized CompletableFuture<Void> pauseAccountRangeRequestsAndWaitForSafePoint() {
-    accountRangeRequestsPausedForPivotCatchup = true;
-    pivotCatchupSafePointFuture = new CompletableFuture<>();
-    maybeCompletePivotCatchupSafePoint();
-    notifyAll();
-    return pivotCatchupSafePointFuture;
+  public synchronized Task<SnapDataRequest> dequeueLargeStorageRequestBlocking() {
+    return dequeueRequestBlocking(() -> false, pendingLargeStorageRequests);
   }
 
-  public synchronized void resumeAccountRangeRequestsAfterPivotCatchup() {
-    accountRangeRequestsPausedForPivotCatchup = false;
-    pivotCatchupSafePointFuture = null;
-    notifyAll();
+  public synchronized Task<SnapDataRequest> dequeueStorageRequestBlocking() {
+    return dequeueRequestBlocking(() -> false, pendingStorageRequests);
   }
 
-  public synchronized boolean isAccountRangeRequestsPausedForPivotCatchup() {
-    return accountRangeRequestsPausedForPivotCatchup;
+  public synchronized Task<SnapDataRequest> dequeueCodeRequestBlocking() {
+    return dequeueRequestBlocking(() -> false, pendingCodeRequests);
   }
 
   /**
-   * Returns true when no partially persisted snap/2 range can still receive child data.
-   *
-   * <p>The account queue may still contain tasks: those ranges have not been dequeued or persisted
-   * yet and can be safely retargeted by the caller. A dequeued account task is not safe because it
-   * can still persist leaves and spawn storage/code children.
+   * Returns true when no in-flight task remains across any queue. Queued tasks are intentionally
+   * ignored.
    */
-  public synchronized boolean isPivotCatchupSafePoint() {
-    return accountRangeRequestsPausedForPivotCatchup
-        && pendingAccountRequests.outstandingTaskCount() == 0
-        && pendingStorageRequests.allTasksCompleted()
-        && pendingLargeStorageRequests.allTasksCompleted()
-        && pendingCodeRequests.allTasksCompleted()
-        && rangeTracker.pendingRangeCount() == 0;
+  public synchronized boolean areAllInflightTasksComplete() {
+    return pendingAccountRequests.outstandingTaskCount() == 0
+        && pendingStorageRequests.outstandingTaskCount() == 0
+        && pendingLargeStorageRequests.outstandingTaskCount() == 0
+        && pendingCodeRequests.outstandingTaskCount() == 0;
   }
 
-  private synchronized void maybeCompletePivotCatchupSafePoint() {
-    if (pivotCatchupSafePointFuture != null
-        && !pivotCatchupSafePointFuture.isDone()
-        && isPivotCatchupSafePoint()) {
-      pivotCatchupSafePointFuture.complete(null);
+  private synchronized void maybeCompleteInFlightTasks() {
+    if (isWaitingForInFlightCompletion() && areAllInflightTasksComplete()) {
+      pivotCatchupFuture.complete(null);
     }
   }
 
   @Override
   public synchronized void notifyTaskAvailable() {
-    maybeCompletePivotCatchupSafePoint();
+    maybeCompleteInFlightTasks();
     super.notifyTaskAvailable();
   }
 
   public void startPivotCatchup(final BlockHeader newPivotBlockHeader) {
     final BlockHeader currentPivotBlockHeader;
-    final CompletableFuture<Void> safePointFuture;
     synchronized (this) {
-      if (internalFuture.isDone()) {
+      if (isStateDownloadFinished()) {
         return;
       }
       currentPivotBlockHeader = snapSyncState.getPivotBlockHeader().orElseThrow();
       if (newPivotBlockHeader.getNumber() <= currentPivotBlockHeader.getNumber()) {
         return;
       }
-      if (pivotCatchupInProgress) {
+      if (isPivotCatchupInProgress()) {
         LOG.debug(
             "Snap/2 pivot catch-up to {} ignored because another catch-up is in progress",
             newPivotBlockHeader.getNumber());
@@ -352,8 +335,8 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
             new WorldStateDownloaderException("Snap/2 pivot catch-up listener is not available"));
         return;
       }
-      pivotCatchupInProgress = true;
-      safePointFuture = pauseAccountRangeRequestsAndWaitForSafePoint();
+      pivotCatchupFuture = new CompletableFuture<>(); // pause dequeueing
+      maybeCompleteInFlightTasks(); // handle case of 0 in-flight tasks when catchup starts
     }
 
     final CompletableFuture<Void> chainCatchupFuture;
@@ -370,7 +353,7 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
       return;
     }
 
-    CompletableFuture.allOf(safePointFuture, chainCatchupFuture)
+    CompletableFuture.allOf(pivotCatchupFuture, chainCatchupFuture)
         .whenComplete(
             (unused, error) -> {
               if (error != null) {
@@ -382,9 +365,7 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
   }
 
   private synchronized void failPivotCatchup(final Throwable error) {
-    pivotCatchupInProgress = false;
-    accountRangeRequestsPausedForPivotCatchup = false;
-    pivotCatchupSafePointFuture = null;
+    pivotCatchupFuture = null;
     internalFuture.completeExceptionally(error);
     notifyAll();
   }
@@ -392,14 +373,16 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
   private void finishPivotCatchup(
       final BlockHeader currentPivotBlockHeader, final BlockHeader newPivotBlockHeader) {
     synchronized (this) {
-      if (internalFuture.isDone()) {
+      if (isStateDownloadFinished()) {
         return;
       }
       applyBlockAccessListsNoop(currentPivotBlockHeader, newPivotBlockHeader);
-      retargetQueuedAccountRangeRequests(newPivotBlockHeader);
+      retargetQueuedRequests(newPivotBlockHeader);
+      // TODO: Simplify account range tracker and clear both here
+      storageRangeTracker.clear();
       snapSyncState.setCurrentHeader(newPivotBlockHeader);
-      pivotCatchupInProgress = false;
-      resumeAccountRangeRequestsAfterPivotCatchup();
+      pivotCatchupFuture = null;
+      notifyAll();
     }
     checkCompletion(newPivotBlockHeader);
   }
@@ -407,14 +390,23 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
   private void applyBlockAccessListsNoop(
       final BlockHeader currentPivotBlockHeader, final BlockHeader newPivotBlockHeader) {
     LOG.info(
-        "Snap/2 BAL application placeholder: pivot {} -> {}",
+        "Snap/2 BAL application placeholder: pivot {} -> {} (completed ranges: {}, pending ranges: {})",
         currentPivotBlockHeader.getNumber(),
-        newPivotBlockHeader.getNumber());
+        newPivotBlockHeader.getNumber(),
+        accountRangeTracker.completedRangeCount(),
+        accountRangeTracker.pendingRangeCount());
   }
 
-  private void retargetQueuedAccountRangeRequests(final BlockHeader newPivotBlockHeader) {
+  private void retargetQueuedRequests(final BlockHeader newPivotBlockHeader) {
+    retargetQueuedAccountRequests(newPivotBlockHeader);
+    retargetQueuedStorageRequests(pendingStorageRequests, newPivotBlockHeader);
+    retargetQueuedStorageRequests(pendingLargeStorageRequests, newPivotBlockHeader);
+    retargetQueuedCodeRequests(newPivotBlockHeader);
+  }
+
+  private void retargetQueuedAccountRequests(final BlockHeader newPivotBlockHeader) {
     final List<SnapDataRequest> queuedAccountRequests = pendingAccountRequests.asList();
-    pendingAccountRequests.clear();
+    pendingAccountRequests.clearInternalQueue();
     for (final SnapDataRequest request : queuedAccountRequests) {
       if (request instanceof SnapV2AccountRangeRequest accountRangeRequest) {
         pendingAccountRequests.add(accountRangeRequest.retarget(newPivotBlockHeader));
@@ -425,35 +417,40 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
     }
   }
 
-  public synchronized boolean isPivotCatchupInProgress() {
-    return pivotCatchupInProgress;
+  private void retargetQueuedCodeRequests(final BlockHeader newPivotBlockHeader) {
+    final List<SnapDataRequest> queuedCodeRequests = pendingCodeRequests.asList();
+    pendingCodeRequests.clearInternalQueue();
+    for (final SnapDataRequest request : queuedCodeRequests) {
+      if (request instanceof SnapV2BytecodeRequest codeRequest) {
+        pendingCodeRequests.add(codeRequest.retarget(newPivotBlockHeader));
+      } else {
+        throw new IllegalStateException(
+            "Unexpected snap/2 code queue request: " + request.getClass().getSimpleName());
+      }
+    }
   }
 
-  public synchronized Task<SnapDataRequest> dequeueLargeStorageRequestBlocking() {
-    return dequeueRequestBlocking(() -> false, pendingLargeStorageRequests);
-  }
-
-  public synchronized Task<SnapDataRequest> dequeueStorageRequestBlocking() {
-    return dequeueRequestBlocking(() -> false, pendingStorageRequests);
-  }
-
-  public synchronized Task<SnapDataRequest> dequeueCodeRequestBlocking() {
-    return dequeueRequestBlocking(this::shouldPauseCodeRequests, pendingCodeRequests);
+  private void retargetQueuedStorageRequests(
+      final InMemoryTaskQueue<SnapDataRequest> queue, final BlockHeader newPivotBlockHeader) {
+    final List<SnapDataRequest> queuedRequests = queue.asList();
+    queue.clearInternalQueue();
+    for (final SnapDataRequest request : queuedRequests) {
+      if (request instanceof SnapV2StorageRangeRequest storageRequest) {
+        // TODO: Compute new storage root during state root application
+        queue.add(storageRequest.retarget(newPivotBlockHeader, storageRequest.getStorageRoot()));
+      } else {
+        throw new IllegalStateException(
+            "Unexpected snap/2 storage queue request: " + request.getClass().getSimpleName());
+      }
+    }
   }
 
   private boolean shouldPauseAccountRequests() {
     // TODO: Replace this drain-to-zero gate with bounded backpressure. Account ranges should pause
     // only while child queues are above a high-watermark, then resume below a low-watermark.
-    return accountRangeRequestsPausedForPivotCatchup
-        || hasIncompleteTasks(pendingStorageRequests)
+    return hasIncompleteTasks(pendingStorageRequests)
         || hasIncompleteTasks(pendingLargeStorageRequests)
         || hasIncompleteTasks(pendingCodeRequests);
-  }
-
-  private boolean shouldPauseCodeRequests() {
-    // TODO: Revisit this v1-style storage-before-code priority for snap/2. Code downloads may be
-    // able to drain independently once account backpressure is bounded.
-    return hasIncompleteTasks(pendingStorageRequests);
   }
 
   private boolean hasIncompleteTasks(final TaskCollection<SnapDataRequest> queue) {
@@ -471,7 +468,7 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
   }
 
   public DownloadedAccountRangeTracker getAccountRangeTracker() {
-    return rangeTracker;
+    return accountRangeTracker;
   }
 
   public DownloadedStorageRangeTracker getStorageRangeTracker() {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldStateDownloadProcess.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldStateDownloadProcess.java
@@ -148,7 +148,8 @@ public class SnapV2WorldStateDownloadProcess implements WorldStateDownloadProces
             worldStateStorageCoordinator,
             downloadState,
             snapSyncConfiguration,
-            downloadState.getRangeTracker());
+            downloadState.getAccountRangeTracker(),
+            downloadState.getStorageRangeTracker());
     final SnapV2CompleteTaskStep completeTaskStep =
         new SnapV2CompleteTaskStep(snapSyncState, metricsSystem);
 


### PR DESCRIPTION
Since snap/2 now persists trie nodes and flat db entries immediately after download, the pending / completed split and child-counting machinery in `DownloadedAccountRangeTracker` are now unnecessary. Only account and storage ranges which were persisted are needed to apply BALs safely during new pivot catch-up.