### PR TITLE
Thread startKeyHash through v2 snap range probing

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/v2/SnapV2AccountRangeRequest.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/v2/SnapV2AccountRangeRequest.java
@@ -155,6 +155,7 @@ public class SnapV2AccountRangeRequest extends SnapV2DataRequest {
             Bytes32.wrap(getRootHash().getBytes()),
             taskElement.proofs(),
             taskElement.keys(),
+            startKeyHash,
             endKeyHash)
         .ifPresentOrElse(
             missingRightElement -> {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/v2/SnapV2StorageRangeRequest.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/v2/SnapV2StorageRangeRequest.java
@@ -152,7 +152,8 @@ public class SnapV2StorageRangeRequest extends SnapV2DataRequest {
       return Stream.empty();
     }
 
-    findNewBeginElementInRange(storageRoot, taskElement.proofs(), taskElement.keys(), endKeyHash)
+    findNewBeginElementInRange(
+            storageRoot, taskElement.proofs(), taskElement.keys(), startKeyHash, endKeyHash)
         .ifPresent(
             missingRightElement -> {
               final int nbRanges = getRangeCount(startKeyHash, endKeyHash, taskElement.keys());

--- a/evm/src/test/java/org/hyperledger/besu/evm/operation/Create2OperationTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/operation/Create2OperationTest.java
@@ -306,6 +306,46 @@ public class Create2OperationTest {
     assertThat(result.getHaltReason()).isNull();
   }
 
+  @Test
+  void oversizedInitCodeOnStackAbortsBeforeMemoryExpansion() {
+    // EIP-3860: when the declared initcode size on the stack exceeds the limit, the
+    // operation is an early exceptional abort and must not have memory side-effects.
+    // CREATE2 carries an extra salt item on the stack, so this guards getInputSize against a
+    // regression if the stack layout ever diverges from CREATE.
+    final UInt256 memoryOffset = UInt256.ZERO;
+    final UInt256 memoryLength =
+        UInt256.fromHexString("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    final MessageFrame messageFrame =
+        MessageFrame.builder()
+            .type(MessageFrame.Type.CONTRACT_CREATION)
+            .contract(Address.ZERO)
+            .inputData(Bytes.EMPTY)
+            .sender(Address.fromHexString(SENDER))
+            .value(Wei.ZERO)
+            .apparentValue(Wei.ZERO)
+            .code(new Code(SIMPLE_CREATE))
+            .completer(__ -> {})
+            .address(Address.fromHexString(SENDER))
+            .blockHashLookup((__, ___) -> Hash.ZERO)
+            .blockValues(mock(BlockValues.class))
+            .gasPrice(Wei.ZERO)
+            .miningBeneficiary(Address.ZERO)
+            .originator(Address.ZERO)
+            .initialGas(Long.MAX_VALUE)
+            .worldUpdater(worldUpdater)
+            .build();
+    messageFrame.pushStackItem(Bytes.EMPTY); // salt
+    messageFrame.pushStackItem(memoryLength);
+    messageFrame.pushStackItem(memoryOffset);
+    messageFrame.pushStackItem(UInt256.ZERO);
+
+    final EVM evm = MainnetEVMs.shanghai(DEV_NET_CHAIN_ID, EvmConfiguration.DEFAULT);
+    var result = operation.execute(messageFrame, evm);
+
+    assertThat(result.getHaltReason()).isEqualTo(CODE_TOO_LARGE);
+    assertThat(messageFrame.memoryWordSize()).isEqualTo(0);
+  }
+
   @NotNull
   private MessageFrame testMemoryFrame(final UInt256 memoryOffset, final UInt256 memoryLength) {
     final MessageFrame messageFrame =


### PR DESCRIPTION
Follow-up to the review comment from @macfarla on #10634.

## Changes

**snap/2 — remaining unfixed callers**
The 4-param `findNewBeginElementInRange` defaults the probe origin to `MIN_RANGE`. Two v2 snap-sync callers still used it, so for the empty-`receivedKeys` case they probed from `MIN_RANGE` instead of the actual range start:
- `SnapV2AccountRangeRequest.getChildRequests()`
- `SnapV2StorageRangeRequest.getChildRequests()`

Both now pass the explicit `startKeyHash` as the 5th argument, matching their v1 counterparts (`AccountRangeDataRequest` / `StorageRangeDataRequest`).

**Create2 test gap**
`AbstractCreateOperation.getInputSize()` was only exercised for `CreateOperation` (the `oversizedInitCodeOnStackAbortsBeforeMemoryExpansion` test). Added an equivalent test to `Create2OperationTest` using the CREATE2 stack layout (extra `salt`), so the shared `getInputSize` stack-index contract and the EIP-3860 early-abort path are covered for CREATE2. If a subclass diverged in stack layout without overriding `getInputSize`, this would now catch it.

## Verification
- `Create2OperationTest` + `CreateOperationTest` pass
- `:ethereum:eth:compileJava` compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)