### PR TITLE
fix(discv4): tolerate malformed ping fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - `--rpc-tx-feecap` will treat a value of 0 as limiting fees to 0. Today it treats 0 as "do not cap fees". To achieve similar behaviour set it to a suitably large value to effectively prevent any fee capping.
 
 ### Bug fixes
+- Respond to DiscV4 `PING` packets containing malformed endpoint fields or unknown trailing data. [#5914](https://github.com/besu-eth/besu/issues/5914)
 
 ### Additions and Improvements
 

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/discv4/Endpoint.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/discv4/Endpoint.java
@@ -19,10 +19,10 @@ import static org.hyperledger.besu.util.NetworkUtility.checkPort;
 import org.hyperledger.besu.ethereum.p2p.discovery.PeerDiscoveryPacketDecodingException;
 import org.hyperledger.besu.ethereum.p2p.discovery.discv4.internal.DiscoveryPeerV4;
 import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
+import org.hyperledger.besu.ethereum.rlp.RLPException;
 import org.hyperledger.besu.ethereum.rlp.RLPInput;
 import org.hyperledger.besu.ethereum.rlp.RLPOutput;
 import org.hyperledger.besu.plugin.data.EnodeURL;
-import org.hyperledger.besu.util.IllegalPortException;
 import org.hyperledger.besu.util.Preconditions;
 
 import java.net.InetAddress;
@@ -213,16 +213,18 @@ public class Endpoint {
 
   /**
    * Attempts to decodes the RLP stream as a standalone Endpoint instance, which is not part of a
-   * Peer. If the from field is malformed, consumes the rest of the items in the list and returns
-   * Optional.empty().
+   * Peer. If the endpoint is malformed, consumes the endpoint field and returns Optional.empty().
    *
    * @param in The RLP input stream from which to read.
    * @return Some decoded endpoint if it was possible to decode it, empty otherwise.
    */
   public static Optional<Endpoint> maybeDecodeStandalone(final RLPInput in) {
+    final RLPInput endpointInput = in.readAsRlp();
     try {
-      return Optional.of(decodeStandalone(in));
-    } catch (IllegalPortException __) {
+      return Optional.of(decodeStandalone(endpointInput));
+    } catch (final IllegalArgumentException
+        | PeerDiscoveryPacketDecodingException
+        | RLPException __) {
       return Optional.empty();
     }
   }

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/discv4/internal/packet/ping/PingPacketData.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/discv4/internal/packet/ping/PingPacketData.java
@@ -29,8 +29,8 @@ public class PingPacketData implements PacketData {
   /* Source. If the field is garbage this is empty and we might need to recover it another way. From our bonded peers, for example. */
   private final Optional<Endpoint> maybeFrom;
 
-  /* Destination. */
-  private final Endpoint to;
+  /* Destination. If the field is garbage this is empty. */
+  private final Optional<Endpoint> maybeTo;
 
   /* In seconds after epoch. */
   private final long expiration;
@@ -43,8 +43,16 @@ public class PingPacketData implements PacketData {
       final Endpoint to,
       final long expiration,
       final UInt64 enrSeq) {
+    this(maybeFrom, Optional.of(to), expiration, enrSeq);
+  }
+
+  PingPacketData(
+      final Optional<Endpoint> maybeFrom,
+      final Optional<Endpoint> maybeTo,
+      final long expiration,
+      final UInt64 enrSeq) {
     this.maybeFrom = maybeFrom;
-    this.to = to;
+    this.maybeTo = maybeTo;
     this.expiration = expiration;
     this.enrSeq = enrSeq;
   }
@@ -54,7 +62,11 @@ public class PingPacketData implements PacketData {
   }
 
   public Endpoint getTo() {
-    return to;
+    return maybeTo.orElseThrow(() -> new IllegalStateException("PING destination is invalid"));
+  }
+
+  public Optional<Endpoint> getMaybeTo() {
+    return maybeTo;
   }
 
   public long getExpiration() {
@@ -71,7 +83,7 @@ public class PingPacketData implements PacketData {
         + "from="
         + maybeFrom.map(Object::toString).orElse("INVALID")
         + ", to="
-        + to
+        + maybeTo.map(Object::toString).orElse("INVALID")
         + ", expiration="
         + expiration
         + ", enrSeq="

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/discv4/internal/packet/ping/PingPacketDataFactory.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/discv4/internal/packet/ping/PingPacketDataFactory.java
@@ -51,6 +51,15 @@ public class PingPacketDataFactory {
     return new PingPacketData(maybeFrom, to, expiration, enrSeq);
   }
 
+  public PingPacketData createForDecode(
+      final Optional<Endpoint> maybeFrom,
+      final Optional<Endpoint> maybeTo,
+      final long expiration,
+      final UInt64 enrSeq) {
+    expiryValidator.validate(expiration);
+    return new PingPacketData(maybeFrom, maybeTo, expiration, enrSeq);
+  }
+
   public PingPacketData create(
       final Optional<Endpoint> maybeFrom, final Endpoint to, final UInt64 enrSeq) {
     endpointValidator.validate(to, "destination endpoint cannot be null");

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/discv4/internal/packet/ping/PingPacketDataRlpReader.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/discv4/internal/packet/ping/PingPacketDataRlpReader.java
@@ -18,6 +18,7 @@ import org.hyperledger.besu.ethereum.p2p.discovery.discv4.Endpoint;
 import org.hyperledger.besu.ethereum.p2p.discovery.discv4.internal.DevP2PException;
 import org.hyperledger.besu.ethereum.p2p.discovery.discv4.internal.packet.PacketDataDeserializer;
 import org.hyperledger.besu.ethereum.rlp.MalformedRLPInputException;
+import org.hyperledger.besu.ethereum.rlp.RLPException;
 import org.hyperledger.besu.ethereum.rlp.RLPInput;
 
 import java.util.Optional;
@@ -40,34 +41,73 @@ public class PingPacketDataRlpReader implements PacketDataDeserializer<PingPacke
 
   @Override
   public PingPacketData readFrom(final RLPInput in) {
-    in.enterList();
+    final int fieldCount = in.enterList();
     // The first element signifies the "version", but this value is ignored as of EIP-8
     in.readBigIntegerScalar();
-    Optional<Endpoint> from = Optional.empty();
-    Optional<Endpoint> to = Optional.empty();
-    if (in.nextIsList()) {
-      to = Endpoint.maybeDecodeStandalone(in);
-      // https://github.com/ethereum/devp2p/blob/master/discv4.md#ping-packet-0x01
-      if (in.nextIsList()) { // if there are two, the first is the from address, next is the to
-        // address
-        from = to;
-        to = Endpoint.maybeDecodeStandalone(in);
-      }
-    } else {
+
+    if (fieldCount < 3) {
       throw new DevP2PException("missing address in ping packet");
     }
-    final long expiration = in.readLongScalar();
-    UInt64 enrSeq = null;
-    if (!in.isEndOfCurrentList()) {
-      try {
-        enrSeq = UInt64.valueOf(in.readBigIntegerScalar());
-        LOG.trace("read PING enr as long scalar");
-      } catch (MalformedRLPInputException malformed) {
-        LOG.trace("failed to read PING enr as scalar, trying to read bytes instead");
-        enrSeq = UInt64.fromBytes(in.readBytes());
+
+    Optional<Endpoint> from;
+    Optional<Endpoint> to;
+    long expiration;
+    if (fieldCount == 3) {
+      from = Optional.empty();
+      to = Endpoint.maybeDecodeStandalone(in);
+      expiration = in.readLongScalar();
+    } else if (in.nextIsList()) {
+      final Optional<Endpoint> firstEndpoint = Endpoint.maybeDecodeStandalone(in);
+      if (in.nextIsList()) {
+        from = firstEndpoint;
+        to = Endpoint.maybeDecodeStandalone(in);
+        expiration = in.readLongScalar();
+      } else {
+        final RLPInput possibleExpiration = in.readAsRlp();
+        try {
+          // Legacy PING packets can omit the from endpoint and place expiration next.
+          expiration = possibleExpiration.readLongScalar();
+          from = Optional.empty();
+          to = firstEndpoint;
+        } catch (final RLPException invalidExpiration) {
+          from = firstEndpoint;
+          to = Optional.empty();
+          expiration = in.readLongScalar();
+        }
       }
+    } else {
+      from = Endpoint.maybeDecodeStandalone(in);
+      to = Endpoint.maybeDecodeStandalone(in);
+      expiration = in.readLongScalar();
     }
+
+    final UInt64 enrSeq = readEnrSeq(in);
     in.leaveListLenient();
-    return pingPacketDataFactory.create(from, to.get(), expiration, enrSeq);
+    return pingPacketDataFactory.createForDecode(from, to, expiration, enrSeq);
+  }
+
+  private UInt64 readEnrSeq(final RLPInput in) {
+    if (in.isEndOfCurrentList()) {
+      return null;
+    }
+
+    final RLPInput enrSeqInput = in.readAsRlp();
+    try {
+      final UInt64 enrSeq = UInt64.valueOf(enrSeqInput.readBigIntegerScalar());
+      LOG.trace("read PING enr as long scalar");
+      return enrSeq;
+    } catch (final MalformedRLPInputException malformed) {
+      try {
+        LOG.trace("failed to read PING enr as scalar, trying to read bytes instead");
+        enrSeqInput.reset();
+        return UInt64.fromBytes(enrSeqInput.readBytes());
+      } catch (final IllegalArgumentException | RLPException invalidEnrSeq) {
+        LOG.trace("ignoring invalid PING enr sequence", invalidEnrSeq);
+        return null;
+      }
+    } catch (final IllegalArgumentException | RLPException invalidEnrSeq) {
+      LOG.trace("ignoring invalid PING enr sequence", invalidEnrSeq);
+      return null;
+    }
   }
 }

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/discv4/internal/PeerDiscoveryControllerTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/discv4/internal/PeerDiscoveryControllerTest.java
@@ -349,6 +349,45 @@ public class PeerDiscoveryControllerTest {
   }
 
   @Test
+  public void shouldRespondToPingRequestWithInvalidDestination() {
+    final DiscoveryPeerV4 discoPeer = createPeersInLastBucket(localPeer, 1).getFirst();
+    final OutboundMessageHandler outboundMessageHandler = mock(OutboundMessageHandler.class);
+    controller =
+        getControllerBuilder()
+            .peers(discoPeer)
+            .outboundMessageHandler(outboundMessageHandler)
+            .build();
+
+    final PingPacketData outgoingPingData =
+        packetPackage
+            .pingPacketDataFactory()
+            .create(
+                Optional.ofNullable(localPeer.getEndpoint()), discoPeer.getEndpoint(), UInt64.ONE);
+    final Packet outgoingPing =
+        packetPackage.packetFactory().create(PacketType.PING, outgoingPingData, localNodeKey);
+    mockPingPacketCreation(discoPeer, outgoingPing);
+
+    final PingPacketData incomingPingData =
+        packetPackage
+            .pingPacketDataFactory()
+            .createForDecode(
+                Optional.of(discoPeer.getEndpoint()),
+                Optional.empty(),
+                Instant.now().getEpochSecond() + 60,
+                UInt64.ONE);
+    final Packet incomingPing = mock(Packet.class);
+    when(incomingPing.getType()).thenReturn(PacketType.PING);
+    when(incomingPing.getHash()).thenReturn(Bytes32.ZERO);
+    when(incomingPing.getPacketData(PingPacketData.class))
+        .thenReturn(Optional.of(incomingPingData));
+
+    controller.onMessage(incomingPing, discoPeer);
+
+    verify(outboundMessageHandler, times(1))
+        .send(eq(discoPeer), matchPacketOfType(PacketType.PONG));
+  }
+
+  @Test
   public void shouldNotRespondToExpiredPingRequest() throws InterruptedException {
     final List<DiscoveryPeerV4> peers = createPeersInLastBucket(localPeer, 1);
 

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/discv4/internal/packet/ping/PingPacketDataFactoryTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/discv4/internal/packet/ping/PingPacketDataFactoryTest.java
@@ -98,6 +98,23 @@ public class PingPacketDataFactoryTest {
   }
 
   @Test
+  public void testCreateDecodedPacketWithInvalidEndpoints() {
+    final long expiration = 456;
+    final UInt64 enrSeq = UInt64.MAX_VALUE;
+
+    final PingPacketData result =
+        factory.createForDecode(Optional.empty(), Optional.empty(), expiration, enrSeq);
+
+    Mockito.verify(expiryValidator).validate(expiration);
+    Mockito.verifyNoInteractions(endpointValidator);
+
+    Assertions.assertTrue(result.getFrom().isEmpty());
+    Assertions.assertTrue(result.getMaybeTo().isEmpty());
+    Assertions.assertEquals(expiration, result.getExpiration());
+    Assertions.assertEquals(Optional.of(enrSeq), result.getEnrSeq());
+  }
+
+  @Test
   public void testCreateWithoutExpiry() {
     final Optional<Endpoint> maybeFrom = Optional.empty();
     final Endpoint to = Mockito.mock(Endpoint.class);

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/discv4/internal/packet/ping/PingPacketDataRlpReaderTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/discv4/internal/packet/ping/PingPacketDataRlpReaderTest.java
@@ -14,8 +14,11 @@
  */
 package org.hyperledger.besu.ethereum.p2p.discovery.discv4.internal.packet.ping;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import org.hyperledger.besu.ethereum.p2p.discovery.discv4.Endpoint;
 import org.hyperledger.besu.ethereum.rlp.BytesValueRLPInput;
+import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
 
 import java.util.Optional;
 
@@ -49,7 +52,7 @@ public class PingPacketDataRlpReaderTest {
     long expiration = 123;
     UInt64 enrSeq = UInt64.valueOf(123456789);
 
-    Mockito.when(factory.create(Optional.of(from), to, expiration, enrSeq))
+    Mockito.when(factory.createForDecode(Optional.of(from), Optional.of(to), expiration, enrSeq))
         .thenReturn(new PingPacketData(Optional.of(from), to, expiration, enrSeq));
 
     PingPacketData result =
@@ -62,5 +65,100 @@ public class PingPacketDataRlpReaderTest {
     Assertions.assertEquals(expiration, result.getExpiration());
     Assertions.assertTrue(result.getEnrSeq().isPresent());
     Assertions.assertEquals(enrSeq, result.getEnrSeq().get());
+  }
+
+  @Test
+  public void readsLegacyPingWithoutFromEndpoint() {
+    final Endpoint to = new Endpoint("10.0.0.2", 30303, Optional.of(8910));
+    final long expiration = 123;
+    final BytesValueRLPOutput out = new BytesValueRLPOutput();
+    out.startList();
+    out.writeIntScalar(PingPacketData.VERSION);
+    to.encodeStandalone(out);
+    out.writeLongScalar(expiration);
+    out.endList();
+
+    Mockito.when(factory.createForDecode(Optional.empty(), Optional.of(to), expiration, null))
+        .thenReturn(new PingPacketData(Optional.empty(), to, expiration, null));
+
+    final PingPacketData result = reader.readFrom(new BytesValueRLPInput(out.encoded(), false));
+
+    Assertions.assertTrue(result.getFrom().isEmpty());
+    Assertions.assertEquals(to, result.getTo());
+  }
+
+  @Test
+  public void ignoresMalformedFromEndpoint() {
+    final Endpoint to = new Endpoint("10.0.0.2", 30303, Optional.of(8910));
+    final long expiration = 123;
+    final BytesValueRLPOutput out = new BytesValueRLPOutput();
+    out.startList();
+    out.writeIntScalar(PingPacketData.VERSION);
+    writeMalformedEndpoint(out);
+    to.encodeStandalone(out);
+    out.writeLongScalar(expiration);
+    out.endList();
+
+    Mockito.when(factory.createForDecode(Optional.empty(), Optional.of(to), expiration, null))
+        .thenReturn(new PingPacketData(Optional.empty(), to, expiration, null));
+
+    final PingPacketData result = reader.readFrom(new BytesValueRLPInput(out.encoded(), false));
+
+    Assertions.assertTrue(result.getFrom().isEmpty());
+    Assertions.assertEquals(to, result.getTo());
+  }
+
+  @Test
+  public void ignoresMalformedToEndpoint() {
+    final Endpoint from = new Endpoint("10.0.0.1", 30303, Optional.of(4567));
+    final long expiration = 123;
+    final BytesValueRLPOutput out = new BytesValueRLPOutput();
+    out.startList();
+    out.writeIntScalar(PingPacketData.VERSION);
+    from.encodeStandalone(out);
+    writeMalformedEndpoint(out);
+    out.writeLongScalar(expiration);
+    out.endList();
+
+    Mockito.when(factory.createForDecode(Optional.of(from), Optional.empty(), expiration, null))
+        .thenReturn(new PingPacketData(Optional.of(from), Optional.empty(), expiration, null));
+
+    final PingPacketData result = reader.readFrom(new BytesValueRLPInput(out.encoded(), false));
+
+    Assertions.assertEquals(Optional.of(from), result.getFrom());
+    Assertions.assertTrue(result.getMaybeTo().isEmpty());
+  }
+
+  @Test
+  public void ignoresInvalidEnrSequenceAndAdditionalElements() {
+    final Endpoint from = new Endpoint("10.0.0.1", 30303, Optional.of(4567));
+    final Endpoint to = new Endpoint("10.0.0.2", 30303, Optional.of(8910));
+    final long expiration = 123;
+    final BytesValueRLPOutput out = new BytesValueRLPOutput();
+    out.startList();
+    out.writeIntScalar(PingPacketData.VERSION);
+    from.encodeStandalone(out);
+    to.encodeStandalone(out);
+    out.writeLongScalar(expiration);
+    out.writeBytes(malformedField());
+    out.writeBytes(malformedField());
+    out.endList();
+
+    Mockito.when(factory.createForDecode(Optional.of(from), Optional.of(to), expiration, null))
+        .thenReturn(new PingPacketData(Optional.of(from), to, expiration, null));
+
+    final PingPacketData result = reader.readFrom(new BytesValueRLPInput(out.encoded(), false));
+
+    Assertions.assertEquals(Optional.of(from), result.getFrom());
+    Assertions.assertEquals(to, result.getTo());
+    Assertions.assertTrue(result.getEnrSeq().isEmpty());
+  }
+
+  private static void writeMalformedEndpoint(final BytesValueRLPOutput out) {
+    out.writeBytes(malformedField());
+  }
+
+  private static Bytes malformedField() {
+    return Bytes.wrap(".,?%@)2:%-67-".getBytes(UTF_8));
   }
 }


### PR DESCRIPTION
## PR description

DiscV4 `PING` decoding now isolates endpoint and optional `enr-seq` RLP elements before parsing them. Malformed `from` or `to` contents are consumed without shifting the remaining packet, invalid or unknown trailing values are ignored, and Besu can still send the required `PONG`.

The parser also preserves existing support for legacy `PING` packets that omit the `from` endpoint. The root cause was that malformed endpoint contents were parsed directly from the parent RLP stream, while the first trailing field was always interpreted as `enr-seq`; either case could abort or misalign packet decoding.

Tests cover the malformed scalar payload from the issue, invalid trailing fields, legacy packet compatibility, expiration validation, and the controller response.

## Fixed Issue(s)

Fixes #5914

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out the contribution guidelines.
- [x] Considered documentation; no documentation change is required.
- [x] Considered the changelog and added an Unreleased bug-fix entry.
- [x] Considered database compatibility; no database change is involved.

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessCheck`
- [x] license check: `./gradlew --no-parallel checkLicense`
- [x] dependency source metadata: `./gradlew verifySourceArtifacts`
- [x] global compile/build: `./gradlew build -x test -x spotlessCheck`
- [x] unit tests: `./gradlew test`
- [x] full P2P module: `./gradlew :ethereum:p2p:spotlessCheck :ethereum:p2p:test`
- [ ] acceptance tests: awaiting maintainer approval for upstream fork workflow
- [ ] integration tests: awaiting maintainer approval for upstream fork workflow
- [ ] reference tests: awaiting maintainer approval for upstream fork workflow
- [ ] hive tests: not run
