### PR TITLE
perf: UInt256.mulMod fast path for power-of-two moduli

### DIFF
--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/MulModOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/MulModOperationBenchmark.java
@@ -65,7 +65,11 @@ public class MulModOperationBenchmark extends TernaryArithmeticOperationBenchmar
     "MULMOD_64_64_128",
     "MULMOD_192_192_256",
     "MULMOD_128_256_0",
-    "MULMOD_RANDOM_RANDOM_RANDOM"
+    "MULMOD_RANDOM_RANDOM_RANDOM",
+    "MULMOD_256_256_POW2_1_63",
+    "MULMOD_256_256_POW2_1_255",
+    "MULMOD_256_256_POW2_100_200",
+    "MULMOD_256_256_POW2_100_255"
   })
   private String caseName;
 

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/v2/MulModOperationBenchmarkV2.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/v2/MulModOperationBenchmarkV2.java
@@ -63,7 +63,11 @@ public class MulModOperationBenchmarkV2 extends TernaryArithmeticBenchmarkV2 {
     "MULMOD_64_64_128",
     "MULMOD_192_192_256",
     "MULMOD_128_256_0",
-    "MULMOD_RANDOM_RANDOM_RANDOM"
+    "MULMOD_RANDOM_RANDOM_RANDOM",
+    "MULMOD_256_256_POW2_1_63",
+    "MULMOD_256_256_POW2_1_255",
+    "MULMOD_256_256_POW2_100_200",
+    "MULMOD_256_256_POW2_100_255"
   })
   private String caseName;
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/UInt256.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/UInt256.java
@@ -470,7 +470,8 @@ public record UInt256(long u3, long u2, long u1, long u0) {
 
   /**
    * Keep the low {@code n} bits, zero the rest; used by the power-of-two modulus fast path in
-   * {@link #addMod(UInt256, UInt256)} where mod-by-2^n is a bitmask.
+   * {@link #addMod(UInt256, UInt256)} and {@link #mulMod(UInt256, UInt256)} where mod-by-2^n is a
+   * bitmask.
    *
    * @param n number of low bits to keep; caller guarantees {@code 1 <= n < 256}.
    * @return {@code this & ((1 << n) - 1)}.
@@ -717,9 +718,30 @@ public record UInt256(long u3, long u2, long u1, long u0) {
     if (this.isZero() || other.isZero() || modulus.isZeroOrOne()) return ZERO;
     if (this.isOne()) return other.mod(modulus);
     if (other.isOne()) return this.mod(modulus);
-    if (modulus.u3 != 0) return modulus.mul(this, other);
-    if (modulus.u2 != 0) return modulus.asUInt192().mul(this, other);
-    if (modulus.u1 != 0) return modulus.asUInt128().mul(this, other);
+
+    // Fast path: when the modulus is a power of two:
+    // (a * b) mod 2^N == (a * b mod 2^256) & (2^N - 1), valid since N <= 255
+    if (modulus.u3 != 0) {
+      if ((modulus.u3 & (modulus.u3 - 1)) == 0 && (modulus.u2 | modulus.u1 | modulus.u0) == 0) {
+        return mul(other).maskLow(192 + Long.numberOfTrailingZeros(modulus.u3));
+      }
+      return modulus.mul(this, other);
+    }
+    if (modulus.u2 != 0) {
+      if ((modulus.u2 & (modulus.u2 - 1)) == 0 && (modulus.u1 | modulus.u0) == 0) {
+        return mul(other).maskLow(128 + Long.numberOfTrailingZeros(modulus.u2));
+      }
+      return modulus.asUInt192().mul(this, other);
+    }
+    if (modulus.u1 != 0) {
+      if ((modulus.u1 & (modulus.u1 - 1)) == 0 && modulus.u0 == 0) {
+        return mul(other).maskLow(64 + Long.numberOfTrailingZeros(modulus.u1));
+      }
+      return modulus.asUInt128().mul(this, other);
+    }
+    if ((modulus.u0 & (modulus.u0 - 1)) == 0) {
+      return mul(other).maskLow(Long.numberOfTrailingZeros(modulus.u0));
+    }
     return modulus.asUInt64().mul(this, other);
   }
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/UInt256.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/UInt256.java
@@ -720,7 +720,7 @@ public record UInt256(long u3, long u2, long u1, long u0) {
     if (other.isOne()) return this.mod(modulus);
 
     // Fast path: when the modulus is a power of two:
-    // (a * b) mod 2^N == (a * b mod 2^256) & (2^N - 1), valid since N <= 255
+    // (a * b) mod 2^N == (a * b) & (2^N - 1)
     if (modulus.u3 != 0) {
       if ((modulus.u3 & (modulus.u3 - 1)) == 0 && (modulus.u2 | modulus.u1 | modulus.u0) == 0) {
         return mul(other).maskLow(192 + Long.numberOfTrailingZeros(modulus.u3));

--- a/evm/src/test/java/org/hyperledger/besu/evm/UInt256PropertyBasedTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/UInt256PropertyBasedTest.java
@@ -415,6 +415,55 @@ public class UInt256PropertyBasedTest {
   }
 
   @Property
+  void property_mulMod_byPowerOfTwo_matchesBigInteger(
+      @ForAll("unsigned1to32") final byte[] a,
+      @ForAll("unsigned1to32") final byte[] b,
+      @ForAll("powerOfTwoExponent") final int k) {
+    // Arrange
+    final BigInteger M = BigInteger.ONE.shiftLeft(k);
+    final UInt256 ua = UInt256.fromBytesBE(a);
+    final UInt256 ub = UInt256.fromBytesBE(b);
+    final UInt256 um = UInt256.fromBytesBE(bigUnsignedToBytes32(M));
+
+    // Act
+    byte[] got = ua.mulMod(ub, um).toBytesBE();
+
+    // Assert
+    BigInteger A = toBigUnsigned(a);
+    BigInteger B = toBigUnsigned(b);
+    byte[] exp = bigUnsignedToBytes32(A.multiply(B).mod(M));
+    assertThat(got).containsExactly(exp);
+  }
+
+  /**
+   * Guards the "every lower limb is zero" half of the power-of-two test in {@link
+   * UInt256#mulMod(UInt256, UInt256)}. {@link
+   * #property_mulMod_byPowerOfTwo_matchesBigInteger(byte[], byte[], int)} cannot cover it: its
+   * moduli are exact powers of two, so the lower limbs are zero by construction and the condition
+   * holds vacuously.
+   */
+  @Property
+  void property_mulMod_byNearPowerOfTwo_matchesBigInteger(
+      @ForAll("unsigned1to32") final byte[] a,
+      @ForAll("unsigned1to32") final byte[] b,
+      @ForAll("nearPowerOfTwoModulus") final byte[] m) {
+    // Arrange
+    final UInt256 ua = UInt256.fromBytesBE(a);
+    final UInt256 ub = UInt256.fromBytesBE(b);
+    final UInt256 um = UInt256.fromBytesBE(m);
+
+    // Act
+    byte[] got = ua.mulMod(ub, um).toBytesBE();
+
+    // Assert
+    BigInteger A = toBigUnsigned(a);
+    BigInteger B = toBigUnsigned(b);
+    BigInteger M = toBigUnsigned(m);
+    byte[] exp = bigUnsignedToBytes32(A.multiply(B).mod(M));
+    assertThat(got).containsExactly(exp);
+  }
+
+  @Property
   void property_divByZero_invariants() {
     // Arrange
     UInt256 x = UInt256.fromBytesBE(new byte[] {1, 2, 3, 4});


### PR DESCRIPTION
## PR description

Follow-up to #10623, now that it has merged. `UInt256.mulMod` routes every power-of-two modulus through the full multiply + Knuth reduction path, even though the result is just the low N bits of the product. For `m = 2^N` with `N <= 255`:

```
(a × b) mod 2^N  =  ((a × b) mod 2^256) mod 2^N  =  a.mul(b).maskLow(N)
```

`UInt256.mul(other)` already returns the wrapping product (the low 256 bits), and `maskLow` landed with #10623, so this reuses both rather than adding a helper. N is at most 255, so truncating the product to 256 bits before masking discards only bits the mask would have cleared anyway. The pow2 check sits inside each of the four dispatch branches, same shape as #10623.

Rebased onto current main — the branch now holds only the mulMod change; the addMod commit it was originally stacked on is gone.

### Test coverage

`UInt256PropertyBasedTest` gains two properties mirroring the addMod pair from #10623, reusing the `powerOfTwoExponent` and `nearPowerOfTwoModulus` providers that merged with it (no new generators):

- `property_mulMod_byPowerOfTwo_matchesBigInteger` — exact powers of two, weighted toward the limb-boundary exponents (0, 1, 63, 64, 65, 127, 128, 129, 191, 192, 193, 254, 255) so all four dispatch branches are hit.
- `property_mulMod_byNearPowerOfTwo_matchesBigInteger` — moduli of the form `2^k + low`, where the top limb is a power of two but a lower limb is non-zero. These are the near-misses that must fall through to the general path. They cover the `(modulus.u2 | modulus.u1 | modulus.u0) == 0` half of each condition, which the exact-power-of-two property leaves vacuous.

Checked with jacoco rather than assumed. Every new line in `mulMod` is fully covered, and every condition reports all branches covered — including the four-branch compound conditions and both fall-through returns per branch. `maskLow`'s limb-count ternaries come out fully covered too.

### Benchmarks

`MulModOperationBenchmark`, JMH 1.37, fork=3, 3 warmup + 5 measurement iterations x 1s (Cnt 15 per case), OpenJDK 25.0.3, Ubuntu 24.04, 12 cores. Baseline and patched differ only in `UInt256.java` — the benchmark case names are identical across both runs.

Baseline ran **first**, on the colder machine, so any thermal drift over the session penalises the patched run. The improvements below are a lower bound.

Cases use the randomized `POW2_<lo>_<hi>` form from #10623, so the modulus varies per invocation across the requested bit range instead of being one constant. "Distinguishable" means the two 99.9% confidence intervals are disjoint.

**Power-of-two moduli (the targeted path)**

```
Case                          Before (ns/op)     After (ns/op)   Delta   Distinguishable
MULMOD_256_256_POW2_1_63      108.85 ±  6.62     58.82 ± 2.00     -46%   yes
MULMOD_256_256_POW2_1_255     149.76 ± 10.36     90.85 ± 3.32     -39%   yes
MULMOD_256_256_POW2_100_200   142.20 ±  3.19     78.36 ± 1.38     -45%   yes
MULMOD_256_256_POW2_100_255   150.07 ± 14.46     86.35 ± 1.56     -42%   yes
```

**Random moduli (control)**

```
Case                          Before (ns/op)     After (ns/op)   Delta   Distinguishable
MULMOD_RANDOM_RANDOM_RANDOM   178.90 ±  9.25    172.07 ±  6.80     -4%   no
MULMOD_256_192_128            184.26 ± 19.68    172.06 ± 14.72     -7%   no
MULMOD_256_192_192            172.94 ± 12.44    169.11 ±  9.02     -2%   no
MULMOD_256_256_128            189.12 ±  8.58    177.38 ±  6.89     -6%   no
MULMOD_256_256_192            181.89 ±  4.07    174.97 ±  4.48     -4%   no
MULMOD_256_256_256            176.25 ± 13.69    169.47 ±  3.86     -4%   no
```

The random-modulus bands are the control: a random modulus never enters the fast path, so the only change on that route is the extra branch test. None of the six moves is distinguishable — every interval overlaps — so that path is unchanged, which is the expected result. No distinguishable regression anywhere.

The same four cases were added to `MulModOperationBenchmarkV2`. All four were run to confirm they parse and execute under the V2 harness — 34.34 ± 4.25, 79.73 ± 2.58, 64.42 ± 2.25 and 74.83 ± 2.64 ns/op for `POW2_1_63`, `POW2_1_255`, `POW2_100_200` and `POW2_100_255` respectively. These are patched-side only; no V2 before/after comparison is claimed here.

Correcting the record on the table I posted earlier in this PR: it was measured against the fixed-single-exponent benchmark this PR no longer contains, and it reported a uniform ~20% gain on the random-modulus bands. That was drift between two separately-taken runs, not a real effect — there is no mechanism by which this patch speeds up a non-power-of-two modulus. It also cited JDK 21, whereas these runs are on JDK 25.0.3. The numbers above supersede it.

## Fixed Issue(s)

N/A - performance improvement. Follows up on #10623.

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew :evm:test --tests 'org.hyperledger.besu.evm.UInt256*'`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)
