### PR TITLE
snap/2 - apply BALs during pivot catch-up

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/Blockchain.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/Blockchain.java
@@ -131,6 +131,20 @@ public interface Blockchain {
   }
 
   /**
+   * Checks whether both given blocks are on the canonical chain.
+   *
+   * @param firstBlockHeaderHash The hash of the first block to check.
+   * @param secondBlockHeaderHash The hash of the second block to check.
+   * @return true if both blocks are on the canonical chain, false otherwise (including when either
+   *     block is unknown to the local chain).
+   */
+  default boolean areBothBlocksOnCanonicalChain(
+      final Hash firstBlockHeaderHash, final Hash secondBlockHeaderHash) {
+    return blockIsOnCanonicalChain(firstBlockHeaderHash)
+        && blockIsOnCanonicalChain(secondBlockHeaderHash);
+  }
+
+  /**
    * Returns the block header corresponding to the given block number on the canonical chain.
    *
    * @param blockNumber The reference block number whose header we want to retrieve.

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/DownloadedAccountRangeTracker.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/DownloadedAccountRangeTracker.java
@@ -26,10 +26,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Tracks which account-hash intervals have been fully downloaded (account leaves + all storage and
- * code for accounts within those intervals). Intervals are identified by a {@code rangeStart}
- * (Bytes32 start hash). An interval moves from pending to completed when all storage and code child
- * requests spawned from accounts in that interval have finished.
+ * Tracks account-hash intervals registered during snap sync. An interval starts in a "pending"
+ * state once its account leaves are persisted, and transitions to "completed" when all storage and
+ * code child requests for accounts in that interval have finished. Intervals are identified by a
+ * {@code rangeStart} (Bytes32 start hash).
  */
 public class DownloadedAccountRangeTracker {
 
@@ -53,8 +53,8 @@ public class DownloadedAccountRangeTracker {
 
   /**
    * Register an account-hash interval whose account leaves have been downloaded and persisted. The
-   * interval becomes "completed" (BAL-eligible) only after {@code initialChildCount} child storage
-   * and code requests have finished.
+   * interval becomes completed only after {@code initialChildCount} child storage and code requests
+   * have finished.
    *
    * @param rangeStart the start of the interval (inclusive)
    * @param rangeEnd the end of the interval (inclusive)
@@ -131,9 +131,8 @@ public class DownloadedAccountRangeTracker {
   }
 
   /**
-   * Check whether an account hash falls within any completed interval. Used for selective BAL
-   * application: only accounts whose hash is in a completed interval have fully-downloaded state
-   * and can be updated by BAL.
+   * Check whether an account hash falls within any fully completed interval. The account has no
+   * outstanding child requests.
    */
   public boolean isAccountHashDownloaded(final Bytes32 accountHash) {
     final Entry<Bytes32, Bytes32> entry = completedRanges.floorEntry(accountHash);
@@ -147,6 +146,14 @@ public class DownloadedAccountRangeTracker {
   public boolean isAccountHashPending(final Bytes32 accountHash) {
     final Entry<Bytes32, PendingRange> entry = pendingRanges.floorEntry(accountHash);
     return entry != null && accountHash.compareTo(entry.getValue().endInclusive) <= 0;
+  }
+
+  /**
+   * Check whether an account has been persisted. This is the condition for including an account in
+   * BAL application.
+   */
+  public boolean isAccountHashPersisted(final Bytes32 accountHash) {
+    return isAccountHashDownloaded(accountHash) || isAccountHashPending(accountHash);
   }
 
   /** Return an unmodifiable snapshot of completed ranges for external consumers (e.g. BAL). */

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/DownloadedStorageRangeTracker.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/DownloadedStorageRangeTracker.java
@@ -48,7 +48,7 @@ public class DownloadedStorageRangeTracker {
     }
     final ConcurrentSkipListMap<Bytes32, Bytes32> ranges =
         accountStorageRanges.computeIfAbsent(accountHash, k -> new ConcurrentSkipListMap<>());
-    assertNoOverlap(ranges, startSlot, endSlot);
+    assertNoOverlap(accountHash, ranges, startSlot, endSlot);
     ranges.put(startSlot, endSlot);
   }
 
@@ -99,6 +99,7 @@ public class DownloadedStorageRangeTracker {
   }
 
   private void assertNoOverlap(
+      final Bytes32 accountHash,
       final ConcurrentSkipListMap<Bytes32, Bytes32> ranges,
       final Bytes32 start,
       final Bytes32 end) {
@@ -107,8 +108,8 @@ public class DownloadedStorageRangeTracker {
       if (start.compareTo(entry.getValue()) <= 0 && entry.getKey().compareTo(end) <= 0) {
         final String message =
             String.format(
-                "Overlapping storage slot range detected for account: [%s,%s] vs existing [%s,%s]",
-                start, end, entry.getKey(), entry.getValue());
+                "Overlapping storage slot range detected for account %s: [%s,%s] vs existing [%s,%s]",
+                accountHash, start, end, entry.getKey(), entry.getValue());
         LOG.error(message);
         throw new IllegalStateException(message);
       }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapDownloaderFactory.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapDownloaderFactory.java
@@ -136,6 +136,7 @@ public class SnapDownloaderFactory {
           new SnapV2WorldStateDownloader(
               ethContext,
               snapContext,
+              protocolContext.getBlockchain(),
               worldStateStorageCoordinator,
               snapTaskCollection,
               syncConfig.getSnapSyncConfiguration(),

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapDownloaderFactory.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapDownloaderFactory.java
@@ -138,6 +138,7 @@ public class SnapDownloaderFactory {
               snapContext,
               protocolContext.getBlockchain(),
               worldStateStorageCoordinator,
+              protocolSchedule,
               snapTaskCollection,
               syncConfig.getSnapSyncConfiguration(),
               syncConfig.getWorldStateRequestParallelism(),

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapSyncChainDownloadPipelineFactory.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapSyncChainDownloadPipelineFactory.java
@@ -259,6 +259,12 @@ public class SnapSyncChainDownloadPipelineFactory {
                 "action"),
             true,
             "forwardBal")
+        .thenProcess(
+            "filterBalEnabledHeaders",
+            headers ->
+                headers.stream()
+                    .filter(h -> protocolSchedule.getByBlockHeader(h).isBlockAccessListEnabled())
+                    .toList())
         .thenProcessAsyncOrdered(
             "downloadBlockAccessLists", downloadBlockAccessListsStep, downloaderParallelism)
         .andFinishWith("finishBal", headers -> {});

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/v2/SnapV2AccountRangeRequest.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/v2/SnapV2AccountRangeRequest.java
@@ -173,7 +173,10 @@ public class SnapV2AccountRangeRequest extends SnapV2DataRequest {
                     .notifyRangeProgress(
                         SnapSyncMetricsManager.Step.DOWNLOAD, endKeyHash, endKeyHash));
 
-    for (Map.Entry<Bytes32, Bytes> account : taskElement.keys().entrySet()) {
+    // Peer responses include boundary accounts outside [startKeyHash, endKeyHash] required for
+    // proof verification; only generate children for in-range accounts.
+    for (Map.Entry<Bytes32, Bytes> account :
+        taskElement.keys().subMap(startKeyHash, true, endKeyHash, true).entrySet()) {
       final PmtStateTrieAccountValue accountValue =
           PmtStateTrieAccountValue.readFrom(RLP.input(account.getValue()));
       if (!accountValue.getStorageRoot().equals(Hash.EMPTY_TRIE_HASH)) {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2BlockAccessListApplier.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2BlockAccessListApplier.java
@@ -143,7 +143,7 @@ public class SnapV2BlockAccessListApplier {
         final Hash accountHash = afc.address().addressHash();
         final Bytes32 accountHashBytes = asBytes32(accountHash);
 
-        if (!accountRangeTracker.isAccountHashPersisted(accountHashBytes)) {
+        if (!accountRangeTracker.isAccountHashPersisted(accountHashBytes) || !afc.hasAnyChange()) {
           continue;
         }
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2BlockAccessListApplier.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2BlockAccessListApplier.java
@@ -24,6 +24,7 @@ import org.hyperledger.besu.ethereum.eth.sync.snapsync.DownloadedAccountRangeTra
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.DownloadedStorageRangeTracker;
 import org.hyperledger.besu.ethereum.eth.sync.worldstate.WorldStateDownloaderException;
 import org.hyperledger.besu.ethereum.mainnet.BodyValidation;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.block.access.list.BlockAccessList;
 import org.hyperledger.besu.ethereum.mainnet.block.access.list.BlockAccessListChanges;
 import org.hyperledger.besu.ethereum.rlp.RLP;
@@ -31,7 +32,6 @@ import org.hyperledger.besu.ethereum.trie.MerkleTrie;
 import org.hyperledger.besu.ethereum.trie.NodeLoader;
 import org.hyperledger.besu.ethereum.trie.NodeUpdater;
 import org.hyperledger.besu.ethereum.trie.common.PmtStateTrieAccountValue;
-import org.hyperledger.besu.ethereum.trie.common.StateRootMismatchException;
 import org.hyperledger.besu.ethereum.trie.patricia.StoredMerklePatriciaTrie;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateStorageCoordinator;
 import org.hyperledger.besu.plugin.services.storage.WorldStateKeyValueStorage;
@@ -57,12 +57,15 @@ public class SnapV2BlockAccessListApplier {
 
   private final WorldStateStorageCoordinator worldStateStorageCoordinator;
   private final MutableBlockchain blockchain;
+  private final ProtocolSchedule protocolSchedule;
 
   public SnapV2BlockAccessListApplier(
       final WorldStateStorageCoordinator worldStateStorageCoordinator,
-      final MutableBlockchain blockchain) {
+      final MutableBlockchain blockchain,
+      final ProtocolSchedule protocolSchedule) {
     this.worldStateStorageCoordinator = worldStateStorageCoordinator;
     this.blockchain = blockchain;
+    this.protocolSchedule = protocolSchedule;
   }
 
   public void applyBlockAccessLists(
@@ -104,9 +107,6 @@ public class SnapV2BlockAccessListApplier {
             changes, accountTrie, updater, storageRangeTracker, accountRangeTracker);
 
     stageAccountTrieChanges(accountTrie, updater);
-
-    verifyStateRoot(accountTrie, newPivotBlockHeader);
-
     updater.commit();
 
     LOG.info(
@@ -125,6 +125,12 @@ public class SnapV2BlockAccessListApplier {
 
     for (long blockNumber = fromBlock; blockNumber <= toBlock; blockNumber++) {
       final BlockHeader blockHeader = loadBlockHeader(blockNumber);
+
+      if (!protocolSchedule.getByBlockHeader(blockHeader).isBlockAccessListEnabled()) {
+        LOG.debug("Skipping block {}: BALs not enabled", blockNumber);
+        continue;
+      }
+
       final BlockAccessList bal = loadBal(blockNumber, blockHeader);
       verifyBalHash(blockNumber, blockHeader, bal);
 
@@ -404,22 +410,6 @@ public class SnapV2BlockAccessListApplier {
 
   private static Bytes32 asBytes32(final Hash hash) {
     return Bytes32.wrap(hash.getBytes());
-  }
-
-  private void verifyStateRoot(
-      final MerkleTrie<Bytes, Bytes> accountTrie, final BlockHeader newPivotBlockHeader) {
-
-    final Hash expectedRoot = newPivotBlockHeader.getStateRoot();
-    final Hash actualRoot = Hash.wrap(accountTrie.getRootHash());
-
-    if (!actualRoot.equals(expectedRoot)) {
-      throw new StateRootMismatchException(expectedRoot, actualRoot);
-    }
-
-    LOG.debug(
-        "Verified snap/2 state root for pivot block {}: {}",
-        newPivotBlockHeader.getNumber(),
-        actualRoot);
   }
 
   private record BalApplicationStats(int accounts, int storageSlots, int storageRoots) {}

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2BlockAccessListApplier.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2BlockAccessListApplier.java
@@ -36,9 +36,11 @@ import org.hyperledger.besu.ethereum.trie.patricia.StoredMerklePatriciaTrie;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateStorageCoordinator;
 import org.hyperledger.besu.plugin.services.storage.WorldStateKeyValueStorage;
 
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 
 import org.apache.tuweni.bytes.Bytes;
@@ -152,6 +154,43 @@ public class SnapV2BlockAccessListApplier {
     }
 
     return changesByHash;
+  }
+
+  public Set<Hash> collectPendingStorageAffected(
+      final BlockHeader currentPivotBlockHeader,
+      final BlockHeader newPivotBlockHeader,
+      final DownloadedAccountRangeTracker accountRangeTracker) {
+
+    final long fromBlock = currentPivotBlockHeader.getNumber() + 1;
+    final long toBlock = newPivotBlockHeader.getNumber();
+    final Set<Hash> pendingAffected = new HashSet<>();
+
+    for (long blockNumber = fromBlock; blockNumber <= toBlock; blockNumber++) {
+      final BlockHeader blockHeader = loadBlockHeader(blockNumber);
+
+      if (!protocolSchedule.getByBlockHeader(blockHeader).isBlockAccessListEnabled()) {
+        continue;
+      }
+
+      final BlockAccessList bal = loadBal(blockNumber, blockHeader);
+      verifyBalHash(blockNumber, blockHeader, bal);
+
+      if (bal.isEmpty()) {
+        continue;
+      }
+
+      for (final BlockAccessListChanges.AccountFinalChanges afc :
+          BlockAccessListChanges.latestChanges(bal)) {
+        final Bytes32 accountHashBytes = asBytes32(afc.address().addressHash());
+
+        if (accountRangeTracker.isAccountHashPending(accountHashBytes)
+            && !afc.storageChanges().isEmpty()) {
+          pendingAffected.add(afc.address().addressHash());
+        }
+      }
+    }
+
+    return pendingAffected;
   }
 
   private MerkleTrie<Bytes, Bytes> openAccountTrie(final BlockHeader pivotHeader) {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2BlockAccessListApplier.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2BlockAccessListApplier.java
@@ -1,0 +1,463 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.eth.sync.snapsync.v2;
+
+import static org.hyperledger.besu.ethereum.worldstate.WorldStateStorageCoordinator.applyForStrategy;
+
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.datatypes.Wei;
+import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.eth.sync.snapsync.DownloadedAccountRangeTracker;
+import org.hyperledger.besu.ethereum.eth.sync.snapsync.DownloadedStorageRangeTracker;
+import org.hyperledger.besu.ethereum.eth.sync.worldstate.WorldStateDownloaderException;
+import org.hyperledger.besu.ethereum.mainnet.BodyValidation;
+import org.hyperledger.besu.ethereum.mainnet.block.access.list.BlockAccessList;
+import org.hyperledger.besu.ethereum.mainnet.block.access.list.BlockAccessListChanges;
+import org.hyperledger.besu.ethereum.rlp.RLP;
+import org.hyperledger.besu.ethereum.trie.MerkleTrie;
+import org.hyperledger.besu.ethereum.trie.NodeLoader;
+import org.hyperledger.besu.ethereum.trie.NodeUpdater;
+import org.hyperledger.besu.ethereum.trie.common.PmtStateTrieAccountValue;
+import org.hyperledger.besu.ethereum.trie.common.StateRootMismatchException;
+import org.hyperledger.besu.ethereum.trie.patricia.StoredMerklePatriciaTrie;
+import org.hyperledger.besu.ethereum.worldstate.WorldStateStorageCoordinator;
+import org.hyperledger.besu.plugin.services.storage.WorldStateKeyValueStorage;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.units.bigints.UInt256;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Applies Block Access Lists (BALs) to already-downloaded accounts and storage during snap/2 pivot
+ * catch-up, updating the flat database, trie nodes, and storage roots.
+ */
+public class SnapV2BlockAccessListApplier {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SnapV2BlockAccessListApplier.class);
+
+  private final WorldStateStorageCoordinator worldStateStorageCoordinator;
+  private final MutableBlockchain blockchain;
+
+  public SnapV2BlockAccessListApplier(
+      final WorldStateStorageCoordinator worldStateStorageCoordinator,
+      final MutableBlockchain blockchain) {
+    this.worldStateStorageCoordinator = worldStateStorageCoordinator;
+    this.blockchain = blockchain;
+  }
+
+  /**
+   * Checks whether both the current and new pivot blocks are on the canonical chain.
+   *
+   * @param currentPivot the currently active pivot block header
+   * @param newPivot the candidate new pivot block header
+   * @return true if both pivots are on the canonical chain
+   */
+  public boolean areBothPivotsOnCanonicalChain(
+      final BlockHeader currentPivot, final BlockHeader newPivot) {
+    return blockchain.blockIsOnCanonicalChain(currentPivot.getHash())
+        && blockchain.blockIsOnCanonicalChain(newPivot.getHash());
+  }
+
+  public void applyBlockAccessLists(
+      final BlockHeader currentPivotBlockHeader,
+      final BlockHeader newPivotBlockHeader,
+      final DownloadedAccountRangeTracker accountRangeTracker,
+      final DownloadedStorageRangeTracker storageRangeTracker) {
+
+    if (!worldStateStorageCoordinator.getDataStorageFormat().isBonsaiFormat()) {
+      throw new IllegalStateException(
+          "Cannot apply snap/2 BALs: data storage format "
+              + worldStateStorageCoordinator.getDataStorageFormat()
+              + "not supported");
+    }
+
+    final long fromBlock = currentPivotBlockHeader.getNumber() + 1;
+    final long toBlock = newPivotBlockHeader.getNumber();
+
+    LOG.info(
+        "Applying snap/2 BALs for blocks [{}, {}] (completed ranges: {}, pending ranges: {})",
+        fromBlock,
+        toBlock,
+        accountRangeTracker.completedRangeCount(),
+        accountRangeTracker.pendingRangeCount());
+
+    final WorldStateKeyValueStorage.Updater updater = worldStateStorageCoordinator.updater();
+
+    final Map<Hash, PerAccountChanges> changes =
+        collectAccountChanges(fromBlock, toBlock, accountRangeTracker);
+    if (changes.isEmpty()) {
+      LOG.info("No persisted accounts affected by BALs in blocks [{}, {}]", fromBlock, toBlock);
+      return;
+    }
+
+    final MerkleTrie<Bytes, Bytes> accountTrie = openAccountTrie(currentPivotBlockHeader);
+
+    final BalApplicationStats stats =
+        stageAccountChanges(
+            changes, accountTrie, updater, storageRangeTracker, accountRangeTracker);
+
+    stageAccountTrieChanges(accountTrie, updater);
+
+    verifyStateRoot(accountTrie, newPivotBlockHeader);
+
+    updater.commit();
+
+    LOG.info(
+        "Applied snap/2 BALs: {} accounts, {} storage slots, {} storage roots updated",
+        stats.accounts,
+        stats.storageSlots,
+        stats.storageRoots);
+  }
+
+  private Map<Hash, PerAccountChanges> collectAccountChanges(
+      final long fromBlock,
+      final long toBlock,
+      final DownloadedAccountRangeTracker accountRangeTracker) {
+
+    final Map<Hash, PerAccountChanges> changesByHash = new LinkedHashMap<>();
+
+    for (long blockNumber = fromBlock; blockNumber <= toBlock; blockNumber++) {
+      final BlockHeader blockHeader = loadBlockHeader(blockNumber);
+      final BlockAccessList bal = loadBal(blockNumber, blockHeader);
+      verifyBalHash(blockNumber, blockHeader, bal);
+
+      if (bal.isEmpty()) {
+        continue;
+      }
+
+      for (final BlockAccessListChanges.AccountFinalChanges afc :
+          BlockAccessListChanges.latestChanges(bal)) {
+        final Hash accountHash = afc.address().addressHash();
+        final Bytes32 accountHashBytes = asBytes32(accountHash);
+
+        if (!accountRangeTracker.isAccountHashPersisted(accountHashBytes)) {
+          continue;
+        }
+
+        changesByHash.computeIfAbsent(accountHash, k -> new PerAccountChanges()).mergeFinal(afc);
+      }
+    }
+
+    return changesByHash;
+  }
+
+  private MerkleTrie<Bytes, Bytes> openAccountTrie(final BlockHeader pivotHeader) {
+    final Function<Bytes, Bytes> identity = Function.identity();
+    final NodeLoader accountNodeLoader =
+        (location, hash) -> worldStateStorageCoordinator.getAccountStateTrieNode(location, hash);
+
+    return new StoredMerklePatriciaTrie<>(
+        accountNodeLoader, Bytes32.wrap(pivotHeader.getStateRoot().getBytes()), identity, identity);
+  }
+
+  /**
+   * Stages account, storage, and code changes into the updater batch. Updates the in-memory account
+   * trie values and commits per-account storage tries, staging their trie nodes into the same
+   * updater. Nothing is persisted until the caller invokes {@code updater.commit()}.
+   */
+  private BalApplicationStats stageAccountChanges(
+      final Map<Hash, PerAccountChanges> changesByHash,
+      final MerkleTrie<Bytes, Bytes> accountTrie,
+      final WorldStateKeyValueStorage.Updater updater,
+      final DownloadedStorageRangeTracker storageRangeTracker,
+      final DownloadedAccountRangeTracker accountRangeTracker) {
+
+    int updatedAccounts = 0;
+    int updatedStorageSlots = 0;
+    int updatedStorageRoots = 0;
+
+    for (final Map.Entry<Hash, PerAccountChanges> entry : changesByHash.entrySet()) {
+      final Hash accountHash = entry.getKey();
+      final PerAccountChanges perAccount = entry.getValue();
+
+      final PmtStateTrieAccountValue existingAccount = readExistingAccount(accountHash);
+
+      final long newNonce = computeNewNonce(perAccount, existingAccount);
+      final Wei newBalance = computeNewBalance(perAccount, existingAccount);
+      final Hash newCodeHash = maybeStoreCode(perAccount, existingAccount, accountHash, updater);
+
+      final Hash oldStorageRoot = storageRootOf(existingAccount);
+      final boolean isAccountCompleted =
+          accountRangeTracker.isAccountHashDownloaded(asBytes32(accountHash));
+      final StorageRootResult storageResult =
+          maybeUpdateStorageRoot(
+              accountHash,
+              perAccount,
+              oldStorageRoot,
+              updater,
+              storageRangeTracker,
+              isAccountCompleted);
+
+      final PmtStateTrieAccountValue updatedAccount =
+          new PmtStateTrieAccountValue(newNonce, newBalance, storageResult.root, newCodeHash);
+      final Bytes encodedAccount = RLP.encode(updatedAccount::writeTo);
+
+      applyForStrategy(
+          updater,
+          onBonsai -> onBonsai.putAccountInfoState(accountHash, encodedAccount),
+          // TODO: What would it take to implement support for forest in BAL applier?
+          onForest -> {});
+      updatedAccounts++;
+
+      accountTrie.put(accountHash.getBytes(), encodedAccount);
+
+      if (!storageResult.root.equals(oldStorageRoot)) {
+        updatedStorageRoots++;
+      }
+      updatedStorageSlots += storageResult.downloadedSlots;
+    }
+
+    return new BalApplicationStats(updatedAccounts, updatedStorageSlots, updatedStorageRoots);
+  }
+
+  /**
+   * Walks the account trie and stages dirty merkle nodes into the updater batch. Does not persist
+   * anything; the actual commit happens in the caller via {@code updater.commit()}.
+   */
+  private void stageAccountTrieChanges(
+      final MerkleTrie<Bytes, Bytes> accountTrie, final WorldStateKeyValueStorage.Updater updater) {
+
+    final NodeUpdater nodeUpdater =
+        (location, hash, value) ->
+            applyForStrategy(
+                updater,
+                onBonsai -> onBonsai.putAccountStateTrieNode(location, hash, value),
+                onForest -> {});
+
+    accountTrie.commit(nodeUpdater);
+  }
+
+  private PmtStateTrieAccountValue readExistingAccount(final Hash accountHash) {
+    return worldStateStorageCoordinator
+        .applyForStrategy(
+            bonsai -> bonsai.getAccount(accountHash), forest -> Optional.<Bytes>empty())
+        .map(b -> PmtStateTrieAccountValue.readFrom(RLP.input(b)))
+        .orElse(null);
+  }
+
+  private static long computeNewNonce(
+      final PerAccountChanges perAccount, final PmtStateTrieAccountValue existing) {
+    if (perAccount.latestNonce != null) {
+      return perAccount.latestNonce;
+    }
+    return nonceOf(existing);
+  }
+
+  private static Wei computeNewBalance(
+      final PerAccountChanges perAccount, final PmtStateTrieAccountValue existing) {
+    if (perAccount.latestBalance != null) {
+      return perAccount.latestBalance;
+    }
+    return balanceOf(existing);
+  }
+
+  private Hash maybeStoreCode(
+      final PerAccountChanges perAccount,
+      final PmtStateTrieAccountValue existing,
+      final Hash accountHash,
+      final WorldStateKeyValueStorage.Updater updater) {
+
+    if (perAccount.latestCode == null) {
+      return codeHashOf(existing);
+    }
+
+    final Hash codeHash =
+        perAccount.latestCode.isEmpty() ? Hash.EMPTY : Hash.hash(perAccount.latestCode);
+    applyForStrategy(
+        updater,
+        onBonsai -> onBonsai.putCode(accountHash, codeHash, perAccount.latestCode),
+        onForest -> {});
+    return codeHash;
+  }
+
+  private StorageRootResult maybeUpdateStorageRoot(
+      final Hash accountHash,
+      final PerAccountChanges perAccount,
+      final Hash oldStorageRoot,
+      final WorldStateKeyValueStorage.Updater updater,
+      final DownloadedStorageRangeTracker storageRangeTracker,
+      final boolean isAccountCompleted) {
+
+    if (perAccount.storageChanges.isEmpty()) {
+      return new StorageRootResult(oldStorageRoot, 0);
+    }
+
+    final Bytes32 accountHashBytes = asBytes32(accountHash);
+
+    final NodeLoader storageNodeLoader =
+        (location, hash) ->
+            worldStateStorageCoordinator.getAccountStorageTrieNode(accountHash, location, hash);
+
+    final MerkleTrie<Bytes, Bytes> storageTrie =
+        new StoredMerklePatriciaTrie<>(
+            storageNodeLoader,
+            Bytes32.wrap(oldStorageRoot.getBytes()),
+            Function.identity(),
+            Function.identity());
+
+    final NodeUpdater storageNodeUpdater =
+        (location, hash, value) ->
+            applyForStrategy(
+                updater,
+                onBonsai -> onBonsai.putAccountStorageTrieNode(accountHash, location, hash, value),
+                onForest -> {});
+
+    int downloadedSlots = 0;
+    for (final PerAccountChanges.StorageSlotUpdate update : perAccount.storageChanges.values()) {
+      if (!isAccountCompleted
+          && !storageRangeTracker.isSlotHashDownloaded(
+              accountHashBytes, asBytes32(update.slotHash))) {
+        continue;
+      }
+      downloadedSlots++;
+
+      final Bytes slotPath = update.slotHash.getBytes();
+      if (update.newValue.equals(UInt256.ZERO)) {
+        storageTrie.remove(slotPath);
+        applyForStrategy(
+            updater,
+            onBonsai -> onBonsai.removeStorageValueBySlotHash(accountHash, update.slotHash),
+            onForest -> {});
+      } else {
+        storageTrie.put(slotPath, encodeTrieValue(update.newValue));
+        applyForStrategy(
+            updater,
+            onBonsai ->
+                onBonsai.putStorageValueBySlotHash(
+                    accountHash, update.slotHash, update.newValue.toBytes()),
+            onForest -> {});
+      }
+    }
+
+    storageTrie.commit(storageNodeUpdater);
+    return new StorageRootResult(Hash.wrap(storageTrie.getRootHash()), downloadedSlots);
+  }
+
+  private static Hash storageRootOf(final PmtStateTrieAccountValue account) {
+    return account != null ? account.getStorageRoot() : Hash.EMPTY_TRIE_HASH;
+  }
+
+  private static long nonceOf(final PmtStateTrieAccountValue account) {
+    return account != null ? account.getNonce() : 0L;
+  }
+
+  private static Wei balanceOf(final PmtStateTrieAccountValue account) {
+    return account != null ? account.getBalance() : Wei.ZERO;
+  }
+
+  private static Hash codeHashOf(final PmtStateTrieAccountValue account) {
+    return account != null ? account.getCodeHash() : Hash.EMPTY;
+  }
+
+  private static Bytes encodeTrieValue(final UInt256 storageValue) {
+    return RLP.encode(out -> out.writeBytes(storageValue.toMinimalBytes()));
+  }
+
+  private BlockHeader loadBlockHeader(final long blockNumber) {
+    final long bn = blockNumber;
+    return blockchain
+        .getBlockHeader(bn)
+        .orElseThrow(
+            () ->
+                new IllegalStateException(
+                    "Missing block header " + bn + " for snap/2 BAL application"));
+  }
+
+  private void verifyBalHash(
+      final long blockNumber, final BlockHeader blockHeader, final BlockAccessList bal) {
+
+    final Hash headerBalHash =
+        blockHeader
+            .getBalHash()
+            .orElseThrow(
+                () -> new IllegalStateException("BAL hash missing in block number " + blockNumber));
+
+    final Hash computedBalHash =
+        bal.rawRlp().map(BodyValidation::balHash).orElseGet(() -> BodyValidation.balHash(bal));
+
+    if (computedBalHash.equals(headerBalHash)) {
+      return;
+    }
+
+    throw new WorldStateDownloaderException(
+        String.format(
+            "BAL hash mismatch for block %d: computed=%s header=%s",
+            blockNumber, computedBalHash.toHexString(), headerBalHash.toHexString()));
+  }
+
+  private BlockAccessList loadBal(final long blockNumber, final BlockHeader blockHeader) {
+    final long bn = blockNumber;
+    return blockchain
+        .getBlockAccessList(blockHeader.getHash())
+        .orElseThrow(
+            () ->
+                new IllegalStateException(
+                    "Missing BAL for block " + bn + " (" + blockHeader.getHash() + ")"));
+  }
+
+  private static Bytes32 asBytes32(final Hash hash) {
+    return Bytes32.wrap(hash.getBytes());
+  }
+
+  private void verifyStateRoot(
+      final MerkleTrie<Bytes, Bytes> accountTrie, final BlockHeader newPivotBlockHeader) {
+
+    final Hash expectedRoot = newPivotBlockHeader.getStateRoot();
+    final Hash actualRoot = Hash.wrap(accountTrie.getRootHash());
+
+    if (!actualRoot.equals(expectedRoot)) {
+      throw new StateRootMismatchException(expectedRoot, actualRoot);
+    }
+
+    LOG.debug(
+        "Verified snap/2 state root for pivot block {}: {}",
+        newPivotBlockHeader.getNumber(),
+        actualRoot);
+  }
+
+  private record BalApplicationStats(int accounts, int storageSlots, int storageRoots) {}
+
+  private record StorageRootResult(Hash root, int downloadedSlots) {}
+
+  /** Accumulates account changes across multiple BALs for a single account. */
+  private static class PerAccountChanges {
+    Long latestNonce;
+    Wei latestBalance;
+    Bytes latestCode;
+    final Map<Hash, StorageSlotUpdate> storageChanges = new LinkedHashMap<>();
+
+    void mergeFinal(final BlockAccessListChanges.AccountFinalChanges afc) {
+      afc.balance().ifPresent(b -> latestBalance = b);
+      afc.nonce().ifPresent(n -> latestNonce = n);
+      afc.code().ifPresent(c -> latestCode = c);
+      for (final BlockAccessListChanges.StorageFinalChange sfc : afc.storageChanges()) {
+        final Hash slotHash = sfc.slot().getSlotHash();
+        storageChanges.put(
+            slotHash,
+            new StorageSlotUpdate(slotHash, sfc.slot().getSlotKey().orElseThrow(), sfc.value()));
+      }
+    }
+
+    record StorageSlotUpdate(Hash slotHash, UInt256 slotKey, UInt256 newValue) {}
+  }
+}

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2BlockAccessListApplier.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2BlockAccessListApplier.java
@@ -65,19 +65,6 @@ public class SnapV2BlockAccessListApplier {
     this.blockchain = blockchain;
   }
 
-  /**
-   * Checks whether both the current and new pivot blocks are on the canonical chain.
-   *
-   * @param currentPivot the currently active pivot block header
-   * @param newPivot the candidate new pivot block header
-   * @return true if both pivots are on the canonical chain
-   */
-  public boolean areBothPivotsOnCanonicalChain(
-      final BlockHeader currentPivot, final BlockHeader newPivot) {
-    return blockchain.blockIsOnCanonicalChain(currentPivot.getHash())
-        && blockchain.blockIsOnCanonicalChain(newPivot.getHash());
-  }
-
   public void applyBlockAccessLists(
       final BlockHeader currentPivotBlockHeader,
       final BlockHeader newPivotBlockHeader,

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2PersistDataStep.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2PersistDataStep.java
@@ -31,6 +31,7 @@ import org.hyperledger.besu.ethereum.eth.sync.snapsync.request.v2.SnapV2AccountR
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.request.v2.SnapV2BytecodeRequest;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.request.v2.SnapV2StorageRangeRequest;
 import org.hyperledger.besu.ethereum.rlp.RLP;
+import org.hyperledger.besu.ethereum.trie.RangeManager;
 import org.hyperledger.besu.ethereum.trie.common.PmtStateTrieAccountValue;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateStorageCoordinator;
 import org.hyperledger.besu.plugin.services.exception.StorageException;
@@ -43,7 +44,6 @@ import java.util.NavigableMap;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
-import org.apache.tuweni.units.bigints.UInt256;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -189,7 +189,7 @@ public class SnapV2PersistDataStep {
                 + lastReceivedAccount);
       }
 
-      coveredEnd = prevKey(continuationStart);
+      coveredEnd = RangeManager.prevKey(continuationStart);
     } else {
       coveredEnd = accountRequest.getEndKeyHash();
     }
@@ -241,7 +241,7 @@ public class SnapV2PersistDataStep {
                 + ", last received "
                 + slots.lastKey());
       }
-      coveredEnd = prevKey(continuationStart);
+      coveredEnd = RangeManager.prevKey(continuationStart);
     } else {
       coveredEnd = storageRequest.getEndKeyHash();
     }
@@ -253,9 +253,5 @@ public class SnapV2PersistDataStep {
     } else {
       accountRangeTracker.adjustPendingChildren(rangeStart, continuationCount - 1);
     }
-  }
-
-  private static Bytes32 prevKey(final Bytes32 key) {
-    return UInt256.fromBytes(key).subtract(UInt256.ONE);
   }
 }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2PersistDataStep.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2PersistDataStep.java
@@ -196,8 +196,11 @@ public class SnapV2PersistDataStep {
 
     final int childCount = children.size() - continuationCount;
 
+    // Peer responses include boundary accounts outside [rangeStart, coveredEnd] required for
+    // proof verification; only track in-range accounts.
     accountRequest
         .getAccounts()
+        .subMap(rangeStart, true, coveredEnd, true)
         .forEach(
             (accountHash, accountData) -> {
               final PmtStateTrieAccountValue accountValue =

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldDownloadState.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldDownloadState.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.ethereum.eth.sync.snapsync.v2;
 import static org.hyperledger.besu.ethereum.worldstate.WorldStateStorageCoordinator.applyForStrategy;
 
 import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.eth.sync.common.WorldStateHealFinishedListener;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.DownloadedAccountRangeTracker;
@@ -82,6 +83,7 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
       new DownloadedStorageRangeTracker();
   private final SnapV2PivotCatchupListener pivotCatchupListener;
   private final SnapV2BlockAccessListApplier blockAccessListApplier;
+  private final Blockchain blockchain;
   // future that completes once every in-flight (already-dequeued) task has finished
   private CompletableFuture<Void> pivotCatchupFuture; // null unless pivot catchup is in progress
 
@@ -97,7 +99,8 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
       final SyncDurationMetrics syncDurationMetrics,
       final WorldStateHealFinishedListener worldStateHealFinishedListener,
       final SnapV2PivotCatchupListener pivotCatchupListener,
-      final SnapV2BlockAccessListApplier blockAccessListApplier) {
+      final SnapV2BlockAccessListApplier blockAccessListApplier,
+      final Blockchain blockchain) {
     super(
         worldStateStorageCoordinator,
         pendingRequests,
@@ -111,6 +114,7 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
     this.worldStateHealFinishedListener = worldStateHealFinishedListener;
     this.pivotCatchupListener = pivotCatchupListener;
     this.blockAccessListApplier = blockAccessListApplier;
+    this.blockchain = blockchain;
 
     accountRangeTracker.setOnRangeCompleted(
         (rangeStart, rangeEnd) ->
@@ -342,22 +346,6 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
         return;
       }
 
-      if (!blockAccessListApplier.areBothPivotsOnCanonicalChain(
-          currentPivotBlockHeader, newPivotBlockHeader)) {
-        failPivotCatchup(
-            new WorldStateDownloaderException(
-                "Chain reorg detected during snap/2 pivot catch-up: current pivot "
-                    + currentPivotBlockHeader.getNumber()
-                    + " ("
-                    + currentPivotBlockHeader.getHash()
-                    + ") and new pivot "
-                    + newPivotBlockHeader.getNumber()
-                    + " ("
-                    + newPivotBlockHeader.getHash()
-                    + ") are not both on the canonical chain. Sync restart required."));
-        return;
-      }
-
       if (pivotCatchupListener == null) {
         internalFuture.completeExceptionally(
             new WorldStateDownloaderException("Snap/2 pivot catch-up listener is not available"));
@@ -386,9 +374,24 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
             (unused, error) -> {
               if (error != null) {
                 failPivotCatchup(error);
-              } else {
-                finishPivotCatchup(currentPivotBlockHeader, newPivotBlockHeader);
+                return;
               }
+              if (!blockchain.areBothBlocksOnCanonicalChain(
+                  currentPivotBlockHeader.getHash(), newPivotBlockHeader.getHash())) {
+                failPivotCatchup(
+                    new WorldStateDownloaderException(
+                        "Chain reorg detected during snap/2 pivot catch-up: current pivot "
+                            + currentPivotBlockHeader.getNumber()
+                            + " ("
+                            + currentPivotBlockHeader.getHash()
+                            + ") and new pivot "
+                            + newPivotBlockHeader.getNumber()
+                            + " ("
+                            + newPivotBlockHeader.getHash()
+                            + ") are not both on the canonical chain. Sync restart required."));
+                return;
+              }
+              finishPivotCatchup(currentPivotBlockHeader, newPivotBlockHeader);
             });
   }
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldDownloadState.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldDownloadState.java
@@ -19,6 +19,8 @@ import static org.hyperledger.besu.ethereum.worldstate.WorldStateStorageCoordina
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.eth.manager.EthContext;
+import org.hyperledger.besu.ethereum.eth.manager.snap.RetryingGetAccountRangeFromPeerTask;
 import org.hyperledger.besu.ethereum.eth.sync.common.WorldStateHealFinishedListener;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.DownloadedAccountRangeTracker;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.DownloadedStorageRangeTracker;
@@ -32,6 +34,7 @@ import org.hyperledger.besu.ethereum.eth.sync.snapsync.request.v2.SnapV2Bytecode
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.request.v2.SnapV2StorageRangeRequest;
 import org.hyperledger.besu.ethereum.eth.sync.worldstate.WorldDownloadState;
 import org.hyperledger.besu.ethereum.eth.sync.worldstate.WorldStateDownloaderException;
+import org.hyperledger.besu.ethereum.proof.WorldStateProofProvider;
 import org.hyperledger.besu.ethereum.rlp.RLP;
 import org.hyperledger.besu.ethereum.trie.MerkleTrie;
 import org.hyperledger.besu.ethereum.trie.NodeLoader;
@@ -49,9 +52,14 @@ import org.hyperledger.besu.services.tasks.Task;
 import org.hyperledger.besu.services.tasks.TaskCollection;
 
 import java.time.Clock;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BooleanSupplier;
 import java.util.function.Function;
@@ -89,6 +97,7 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
   private final SnapV2PivotCatchupListener pivotCatchupListener;
   private final SnapV2BlockAccessListApplier blockAccessListApplier;
   private final Blockchain blockchain;
+  private final EthContext ethContext;
 
   // Completes once every in-flight (already-dequeued) world-state task has finished.
   // Non-null only while a pivot catch-up is in progress.
@@ -110,7 +119,8 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
       final WorldStateHealFinishedListener worldStateHealFinishedListener,
       final SnapV2PivotCatchupListener pivotCatchupListener,
       final SnapV2BlockAccessListApplier blockAccessListApplier,
-      final Blockchain blockchain) {
+      final Blockchain blockchain,
+      final EthContext ethContext) {
     super(
         worldStateStorageCoordinator,
         pendingRequests,
@@ -125,6 +135,7 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
     this.pivotCatchupListener = pivotCatchupListener;
     this.blockAccessListApplier = blockAccessListApplier;
     this.blockchain = blockchain;
+    this.ethContext = ethContext;
 
     accountRangeTracker.setOnRangeCompleted(
         (rangeStart, rangeEnd) ->
@@ -464,8 +475,14 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
         }
       }
       try {
+        final Set<Hash> pendingAffected =
+            blockAccessListApplier.collectPendingStorageAffected(
+                currentPivotBlockHeader, newPivotBlockHeader, accountRangeTracker);
+        final CompletableFuture<Map<Hash, Bytes32>> rootsFuture =
+            fetchAccountStorageRoots(pendingAffected, newPivotBlockHeader);
         applyBlockAccessLists(currentPivotBlockHeader, newPivotBlockHeader);
-        retargetQueuedRequests(newPivotBlockHeader);
+        final Map<Hash, Bytes32> correctRoots = rootsFuture.join();
+        retargetQueuedRequests(newPivotBlockHeader, correctRoots);
         snapSyncState.setCurrentHeader(newPivotBlockHeader);
       } catch (final Throwable e) {
         LOG.error(
@@ -495,10 +512,11 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
         currentPivotBlockHeader, newPivotBlockHeader, accountRangeTracker, storageRangeTracker);
   }
 
-  private void retargetQueuedRequests(final BlockHeader newPivotBlockHeader) {
+  private void retargetQueuedRequests(
+      final BlockHeader newPivotBlockHeader, final Map<Hash, Bytes32> correctRoots) {
     retargetQueuedAccountRequests(newPivotBlockHeader);
-    retargetQueuedStorageRequests(pendingStorageRequests, newPivotBlockHeader);
-    retargetQueuedStorageRequests(pendingLargeStorageRequests, newPivotBlockHeader);
+    retargetQueuedStorageRequests(pendingStorageRequests, newPivotBlockHeader, correctRoots);
+    retargetQueuedStorageRequests(pendingLargeStorageRequests, newPivotBlockHeader, correctRoots);
     retargetQueuedCodeRequests(newPivotBlockHeader);
   }
 
@@ -529,12 +547,17 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
   }
 
   private void retargetQueuedStorageRequests(
-      final InMemoryTaskQueue<SnapDataRequest> queue, final BlockHeader newPivotBlockHeader) {
+      final InMemoryTaskQueue<SnapDataRequest> queue,
+      final BlockHeader newPivotBlockHeader,
+      final Map<Hash, Bytes32> correctRoots) {
     final List<SnapDataRequest> queuedRequests = queue.asList();
     queue.clearInternalQueue();
     for (final SnapDataRequest request : queuedRequests) {
       if (request instanceof SnapV2StorageRangeRequest storageRequest) {
-        final Bytes32 newRoot = readStorageRoot(storageRequest.getAccountHash());
+        // Old root is still valid for pending without changes
+        final Bytes32 newRoot =
+            correctRoots.getOrDefault(
+                storageRequest.getAccountHash(), readStorageRoot(storageRequest.getAccountHash()));
         queue.add(storageRequest.retarget(newPivotBlockHeader, newRoot));
       } else {
         throw new IllegalStateException(
@@ -557,6 +580,68 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
                     "Storage root not found for account "
                         + accountHash
                         + " after BAL application during pivot catch-up"));
+  }
+
+  private CompletableFuture<Map<Hash, Bytes32>> fetchAccountStorageRoots(
+      final Set<Hash> accountHashes, final BlockHeader pivotHeader) {
+    if (accountHashes.isEmpty()) {
+      return CompletableFuture.completedFuture(Map.of());
+    }
+
+    final ConcurrentHashMap<Hash, Bytes32> results = new ConcurrentHashMap<>();
+    final List<CompletableFuture<Void>> futures = new ArrayList<>();
+    final WorldStateProofProvider proofProvider =
+        new WorldStateProofProvider(worldStateStorageCoordinator);
+
+    for (final Hash accountHash : accountHashes) {
+      final Bytes32 startKey = Bytes32.wrap(accountHash.getBytes());
+      final Bytes32 endKey = RangeManager.nextKey(startKey);
+
+      futures.add(
+          RetryingGetAccountRangeFromPeerTask.forAccountRange(
+                  ethContext, startKey, endKey, pivotHeader, metricsManager.getMetricsSystem())
+              .run()
+              .orTimeout(10, TimeUnit.SECONDS)
+              .handle(
+                  (response, error) -> {
+                    if (response == null) {
+                      throw storageRootFetchError(
+                          "Failed to fetch storage root for account %s at pivot %s",
+                          accountHash, pivotHeader.getNumber(), error);
+                    }
+                    if (!proofProvider.isValidRangeProof(
+                        startKey,
+                        endKey,
+                        Bytes32.wrap(pivotHeader.getStateRoot().getBytes()),
+                        response.proofs(),
+                        response.accounts())) {
+                      throw storageRootFetchError(
+                          "Invalid range proof for account %s at pivot %s",
+                          accountHash, pivotHeader.getNumber(), null);
+                    }
+                    final Bytes accountData = response.accounts().get(startKey);
+                    if (accountData == null) {
+                      throw storageRootFetchError(
+                          "Account data missing for account %s at pivot %s",
+                          accountHash, pivotHeader.getNumber(), null);
+                    }
+                    final PmtStateTrieAccountValue accountValue =
+                        PmtStateTrieAccountValue.readFrom(RLP.input(accountData));
+                    results.put(
+                        accountHash, Bytes32.wrap(accountValue.getStorageRoot().getBytes()));
+                    return null;
+                  }));
+    }
+
+    return CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new))
+        .thenApply(v -> Map.copyOf(results));
+  }
+
+  private WorldStateDownloaderException storageRootFetchError(
+      final String fmt, final Hash accountHash, final long pivotNumber, final Throwable cause) {
+    final String msg = String.format(fmt, accountHash, pivotNumber);
+    LOG.error(msg, cause);
+    return new WorldStateDownloaderException(msg);
   }
 
   private boolean shouldPauseAccountRequests() {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldDownloadState.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldDownloadState.java
@@ -16,6 +16,7 @@ package org.hyperledger.besu.ethereum.eth.sync.snapsync.v2;
 
 import static org.hyperledger.besu.ethereum.worldstate.WorldStateStorageCoordinator.applyForStrategy;
 
+import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.eth.sync.common.WorldStateHealFinishedListener;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.DownloadedAccountRangeTracker;
@@ -30,7 +31,9 @@ import org.hyperledger.besu.ethereum.eth.sync.snapsync.request.v2.SnapV2Bytecode
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.request.v2.SnapV2StorageRangeRequest;
 import org.hyperledger.besu.ethereum.eth.sync.worldstate.WorldDownloadState;
 import org.hyperledger.besu.ethereum.eth.sync.worldstate.WorldStateDownloaderException;
+import org.hyperledger.besu.ethereum.rlp.RLP;
 import org.hyperledger.besu.ethereum.trie.RangeManager;
+import org.hyperledger.besu.ethereum.trie.common.PmtStateTrieAccountValue;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateStorageCoordinator;
 import org.hyperledger.besu.metrics.BesuMetricCategory;
 import org.hyperledger.besu.metrics.SyncDurationMetrics;
@@ -42,6 +45,7 @@ import org.hyperledger.besu.services.tasks.TaskCollection;
 
 import java.time.Clock;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BooleanSupplier;
@@ -77,6 +81,7 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
   private final DownloadedStorageRangeTracker storageRangeTracker =
       new DownloadedStorageRangeTracker();
   private final SnapV2PivotCatchupListener pivotCatchupListener;
+  private final SnapV2BlockAccessListApplier blockAccessListApplier;
   // future that completes once every in-flight (already-dequeued) task has finished
   private CompletableFuture<Void> pivotCatchupFuture; // null unless pivot catchup is in progress
 
@@ -91,7 +96,8 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
       final Clock clock,
       final SyncDurationMetrics syncDurationMetrics,
       final WorldStateHealFinishedListener worldStateHealFinishedListener,
-      final SnapV2PivotCatchupListener pivotCatchupListener) {
+      final SnapV2PivotCatchupListener pivotCatchupListener,
+      final SnapV2BlockAccessListApplier blockAccessListApplier) {
     super(
         worldStateStorageCoordinator,
         pendingRequests,
@@ -104,6 +110,7 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
     this.metricsManager = metricsManager;
     this.worldStateHealFinishedListener = worldStateHealFinishedListener;
     this.pivotCatchupListener = pivotCatchupListener;
+    this.blockAccessListApplier = blockAccessListApplier;
 
     accountRangeTracker.setOnRangeCompleted(
         (rangeStart, rangeEnd) ->
@@ -334,6 +341,23 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
             newPivotBlockHeader.getNumber());
         return;
       }
+
+      if (!blockAccessListApplier.areBothPivotsOnCanonicalChain(
+          currentPivotBlockHeader, newPivotBlockHeader)) {
+        failPivotCatchup(
+            new WorldStateDownloaderException(
+                "Chain reorg detected during snap/2 pivot catch-up: current pivot "
+                    + currentPivotBlockHeader.getNumber()
+                    + " ("
+                    + currentPivotBlockHeader.getHash()
+                    + ") and new pivot "
+                    + newPivotBlockHeader.getNumber()
+                    + " ("
+                    + newPivotBlockHeader.getHash()
+                    + ") are not both on the canonical chain. Sync restart required."));
+        return;
+      }
+
       if (pivotCatchupListener == null) {
         internalFuture.completeExceptionally(
             new WorldStateDownloaderException("Snap/2 pivot catch-up listener is not available"));
@@ -380,7 +404,7 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
       if (isStateDownloadFinished()) {
         return;
       }
-      applyBlockAccessListsNoop(currentPivotBlockHeader, newPivotBlockHeader);
+      applyBlockAccessLists(currentPivotBlockHeader, newPivotBlockHeader);
       retargetQueuedRequests(newPivotBlockHeader);
       snapSyncState.setCurrentHeader(newPivotBlockHeader);
       pivotCatchupFuture = null;
@@ -389,14 +413,16 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
     checkCompletion(newPivotBlockHeader);
   }
 
-  private void applyBlockAccessListsNoop(
+  private void applyBlockAccessLists(
       final BlockHeader currentPivotBlockHeader, final BlockHeader newPivotBlockHeader) {
     LOG.info(
-        "Snap/2 BAL application placeholder: pivot {} -> {} (completed ranges: {}, pending ranges: {})",
+        "Snap/2 applying BALs: pivot {} -> {} (completed ranges: {}, pending ranges: {})",
         currentPivotBlockHeader.getNumber(),
         newPivotBlockHeader.getNumber(),
         accountRangeTracker.completedRangeCount(),
         accountRangeTracker.pendingRangeCount());
+    blockAccessListApplier.applyBlockAccessLists(
+        currentPivotBlockHeader, newPivotBlockHeader, accountRangeTracker, storageRangeTracker);
   }
 
   private void retargetQueuedRequests(final BlockHeader newPivotBlockHeader) {
@@ -438,13 +464,29 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
     queue.clearInternalQueue();
     for (final SnapDataRequest request : queuedRequests) {
       if (request instanceof SnapV2StorageRangeRequest storageRequest) {
-        // TODO: Compute new storage root during state root application
-        queue.add(storageRequest.retarget(newPivotBlockHeader, storageRequest.getStorageRoot()));
+        final Bytes32 newRoot = readStorageRoot(storageRequest.getAccountHash());
+        queue.add(storageRequest.retarget(newPivotBlockHeader, newRoot));
       } else {
         throw new IllegalStateException(
             "Unexpected snap/2 storage queue request: " + request.getClass().getSimpleName());
       }
     }
+  }
+
+  private Bytes32 readStorageRoot(final Hash accountHash) {
+    return worldStateStorageCoordinator
+        .applyForStrategy(
+            bonsai -> bonsai.getAccount(accountHash), forest -> Optional.<Bytes>empty())
+        .map(
+            b ->
+                Bytes32.wrap(
+                    PmtStateTrieAccountValue.readFrom(RLP.input(b)).getStorageRoot().getBytes()))
+        .orElseThrow(
+            () ->
+                new WorldStateDownloaderException(
+                    "Storage root not found for account "
+                        + accountHash
+                        + " after BAL application during pivot catch-up"));
   }
 
   private boolean shouldPauseAccountRequests() {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldDownloadState.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldDownloadState.java
@@ -33,8 +33,12 @@ import org.hyperledger.besu.ethereum.eth.sync.snapsync.request.v2.SnapV2StorageR
 import org.hyperledger.besu.ethereum.eth.sync.worldstate.WorldDownloadState;
 import org.hyperledger.besu.ethereum.eth.sync.worldstate.WorldStateDownloaderException;
 import org.hyperledger.besu.ethereum.rlp.RLP;
+import org.hyperledger.besu.ethereum.trie.MerkleTrie;
+import org.hyperledger.besu.ethereum.trie.NodeLoader;
 import org.hyperledger.besu.ethereum.trie.RangeManager;
 import org.hyperledger.besu.ethereum.trie.common.PmtStateTrieAccountValue;
+import org.hyperledger.besu.ethereum.trie.common.StateRootMismatchException;
+import org.hyperledger.besu.ethereum.trie.patricia.StoredMerklePatriciaTrie;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateStorageCoordinator;
 import org.hyperledger.besu.metrics.BesuMetricCategory;
 import org.hyperledger.besu.metrics.SyncDurationMetrics;
@@ -50,6 +54,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BooleanSupplier;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 import org.apache.tuweni.bytes.Bytes;
@@ -84,8 +89,13 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
   private final SnapV2PivotCatchupListener pivotCatchupListener;
   private final SnapV2BlockAccessListApplier blockAccessListApplier;
   private final Blockchain blockchain;
-  // future that completes once every in-flight (already-dequeued) task has finished
-  private CompletableFuture<Void> pivotCatchupFuture; // null unless pivot catchup is in progress
+
+  // Completes once every in-flight (already-dequeued) world-state task has finished.
+  // Non-null only while a pivot catch-up is in progress.
+  private CompletableFuture<Void> pivotCatchupFuture;
+  // Completes once the chain-side BAL fetch for the pivot gap is done.
+  // Non-null only while a pivot catch-up is in progress.
+  private CompletableFuture<Void> chainCatchupFuture;
 
   public SnapV2WorldDownloadState(
       final WorldStateStorageCoordinator worldStateStorageCoordinator,
@@ -175,6 +185,9 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
         && pendingStorageRequests.allTasksCompleted()
         && pendingLargeStorageRequests.allTasksCompleted()
         && accountRangeTracker.pendingRangeCount() == 0) {
+      if (!verifyWorldStateRoot(header)) {
+        return false;
+      }
       persistWorldStateRoot(header);
       notifyWorldStateFinished();
       syncDurationMetrics.stopTimer(
@@ -212,6 +225,30 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
     updater.commit();
   }
 
+  private boolean verifyWorldStateRoot(final BlockHeader header) {
+    final Function<Bytes, Bytes> identity = Function.identity();
+    final NodeLoader accountNodeLoader =
+        (location, hash) -> worldStateStorageCoordinator.getAccountStateTrieNode(location, hash);
+    final MerkleTrie<Bytes, Bytes> accountTrie =
+        new StoredMerklePatriciaTrie<>(
+            accountNodeLoader, Bytes32.wrap(header.getStateRoot().getBytes()), identity, identity);
+    final Hash actualRoot = Hash.wrap(accountTrie.getRootHash());
+    final Hash expectedRoot = header.getStateRoot();
+    if (!actualRoot.equals(expectedRoot)) {
+      LOG.error(
+          "Snap/2 state root verification failed at sync completion for pivot block {}: expected {}, actual {}",
+          header.getNumber(),
+          expectedRoot,
+          actualRoot);
+      internalFuture.completeExceptionally(
+          new StateRootMismatchException(expectedRoot, actualRoot));
+      return false;
+    }
+    LOG.info(
+        "Snap/2 world state root verified at pivot block {}: {}", header.getNumber(), actualRoot);
+    return true;
+  }
+
   private void notifyWorldStateFinished() {
     if (worldStateFinishedNotified.compareAndSet(false, true)) {
       if (worldStateHealFinishedListener != null) {
@@ -231,6 +268,7 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
     accountRangeTracker.clear();
     storageRangeTracker.clear();
     pivotCatchupFuture = null;
+    chainCatchupFuture = null;
   }
 
   @Override
@@ -269,14 +307,22 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
     return pivotCatchupFuture != null;
   }
 
+  /**
+   * Blocks dequeueing only during the apply phase (chain catch-up done, BALs being applied). While
+   * the chain catch-up is still running, old-pivot requests keep flowing.
+   */
+  private boolean isDequeueBlocked() {
+    return pivotCatchupFuture != null && chainCatchupFuture != null && chainCatchupFuture.isDone();
+  }
+
   private boolean isWaitingForInFlightCompletion() {
-    return isPivotCatchupInProgress() && !pivotCatchupFuture.isDone();
+    return pivotCatchupFuture != null && !pivotCatchupFuture.isDone();
   }
 
   public synchronized Task<SnapDataRequest> dequeueRequestBlocking(
       final BooleanSupplier extraPauseCondition, final TaskCollection<SnapDataRequest> queue) {
     while (!isStateDownloadFinished()
-        && (isPivotCatchupInProgress() || extraPauseCondition.getAsBoolean() || queue.isEmpty())) {
+        && (isDequeueBlocked() || extraPauseCondition.getAsBoolean() || queue.isEmpty())) {
       try {
         wait();
       } catch (final InterruptedException e) {
@@ -351,11 +397,10 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
             new WorldStateDownloaderException("Snap/2 pivot catch-up listener is not available"));
         return;
       }
-      pivotCatchupFuture = new CompletableFuture<>(); // pause dequeueing
+      pivotCatchupFuture = new CompletableFuture<>();
       maybeCompleteInFlightTasks(); // handle case of 0 in-flight tasks when catchup starts
     }
 
-    final CompletableFuture<Void> chainCatchupFuture;
     try {
       chainCatchupFuture =
           pivotCatchupListener.preparePivotCatchup(currentPivotBlockHeader, newPivotBlockHeader);
@@ -397,6 +442,7 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
 
   private synchronized void failPivotCatchup(final Throwable error) {
     pivotCatchupFuture = null;
+    chainCatchupFuture = null;
     internalFuture.completeExceptionally(error);
     notifyAll();
   }
@@ -407,10 +453,31 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
       if (isStateDownloadFinished()) {
         return;
       }
-      applyBlockAccessLists(currentPivotBlockHeader, newPivotBlockHeader);
-      retargetQueuedRequests(newPivotBlockHeader);
-      snapSyncState.setCurrentHeader(newPivotBlockHeader);
+      // Drain in-flight tasks started when dequeue was allowed while the chain catch-up ran.
+      while (!areAllInflightTasksComplete()) {
+        try {
+          wait();
+        } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
+          failPivotCatchup(e);
+          return;
+        }
+      }
+      try {
+        applyBlockAccessLists(currentPivotBlockHeader, newPivotBlockHeader);
+        retargetQueuedRequests(newPivotBlockHeader);
+        snapSyncState.setCurrentHeader(newPivotBlockHeader);
+      } catch (final Throwable e) {
+        LOG.error(
+            "Snap/2 pivot catch-up failed while applying BALs from pivot {} to {}",
+            currentPivotBlockHeader.getNumber(),
+            newPivotBlockHeader.getNumber(),
+            e);
+        failPivotCatchup(e);
+        return;
+      }
       pivotCatchupFuture = null;
+      chainCatchupFuture = null;
       notifyAll();
     }
     checkCompletion(newPivotBlockHeader);

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldStateDownloader.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldStateDownloader.java
@@ -29,6 +29,7 @@ import org.hyperledger.besu.ethereum.eth.sync.snapsync.context.SnapSyncStatePers
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.request.SnapDataRequest;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.request.v2.SnapV2AccountRangeRequest;
 import org.hyperledger.besu.ethereum.eth.sync.worldstate.WorldStateDownloader;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.trie.RangeManager;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateStorageCoordinator;
 import org.hyperledger.besu.metrics.BesuMetricCategory;
@@ -75,6 +76,7 @@ public class SnapV2WorldStateDownloader implements WorldStateDownloader {
       final SnapSyncStatePersistenceManager snapContext,
       final MutableBlockchain blockchain,
       final WorldStateStorageCoordinator worldStateStorageCoordinator,
+      final ProtocolSchedule protocolSchedule,
       final InMemoryTasksPriorityQueues<SnapDataRequest> snapTaskCollection,
       final SnapSyncConfiguration snapSyncConfiguration,
       final int maxOutstandingRequests,
@@ -96,7 +98,8 @@ public class SnapV2WorldStateDownloader implements WorldStateDownloader {
     this.metricsSystem = metricsSystem;
     this.syncDurationMetrics = syncDurationMetrics;
     this.blockAccessListApplier =
-        new SnapV2BlockAccessListApplier(worldStateStorageCoordinator, blockchain);
+        new SnapV2BlockAccessListApplier(
+            worldStateStorageCoordinator, blockchain, protocolSchedule);
 
     metricsSystem.createIntegerGauge(
         BesuMetricCategory.SYNCHRONIZER,

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldStateDownloader.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldStateDownloader.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.ethereum.eth.sync.snapsync.v2;
 
 import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.eth.manager.EthContext;
 import org.hyperledger.besu.ethereum.eth.sync.ChainDownloader;
@@ -66,10 +67,12 @@ public class SnapV2WorldStateDownloader implements WorldStateDownloader {
   private final SyncDurationMetrics syncDurationMetrics;
   private volatile WorldStateHealFinishedListener worldStateHealFinishedListener;
   private volatile SnapV2PivotCatchupListener pivotCatchupListener;
+  private final SnapV2BlockAccessListApplier blockAccessListApplier;
 
   public SnapV2WorldStateDownloader(
       final EthContext ethContext,
       final SnapSyncStatePersistenceManager snapContext,
+      final MutableBlockchain blockchain,
       final WorldStateStorageCoordinator worldStateStorageCoordinator,
       final InMemoryTasksPriorityQueues<SnapDataRequest> snapTaskCollection,
       final SnapSyncConfiguration snapSyncConfiguration,
@@ -90,6 +93,8 @@ public class SnapV2WorldStateDownloader implements WorldStateDownloader {
     this.clock = clock;
     this.metricsSystem = metricsSystem;
     this.syncDurationMetrics = syncDurationMetrics;
+    this.blockAccessListApplier =
+        new SnapV2BlockAccessListApplier(worldStateStorageCoordinator, blockchain);
 
     metricsSystem.createIntegerGauge(
         BesuMetricCategory.SYNCHRONIZER,
@@ -161,7 +166,8 @@ public class SnapV2WorldStateDownloader implements WorldStateDownloader {
               clock,
               syncDurationMetrics,
               worldStateHealFinishedListener,
-              pivotCatchupListener);
+              pivotCatchupListener,
+              blockAccessListApplier);
 
       final Map<Bytes32, Bytes32> ranges = RangeManager.generateAllRanges(16);
       snapsyncMetricsManager.initRange(ranges);

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldStateDownloader.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldStateDownloader.java
@@ -63,6 +63,7 @@ public class SnapV2WorldStateDownloader implements WorldStateDownloader {
   private final int maxOutstandingRequests;
   private final int maxNodeRequestsWithoutProgress;
   private final WorldStateStorageCoordinator worldStateStorageCoordinator;
+  private final MutableBlockchain blockchain;
   private final AtomicReference<SnapV2WorldDownloadState> downloadState = new AtomicReference<>();
   private final SyncDurationMetrics syncDurationMetrics;
   private volatile WorldStateHealFinishedListener worldStateHealFinishedListener;
@@ -84,6 +85,7 @@ public class SnapV2WorldStateDownloader implements WorldStateDownloader {
       final SyncDurationMetrics syncDurationMetrics) {
     this.ethContext = ethContext;
     this.worldStateStorageCoordinator = worldStateStorageCoordinator;
+    this.blockchain = blockchain;
     this.snapContext = snapContext;
     this.snapTaskCollection = snapTaskCollection;
     this.snapSyncConfiguration = snapSyncConfiguration;
@@ -167,7 +169,8 @@ public class SnapV2WorldStateDownloader implements WorldStateDownloader {
               syncDurationMetrics,
               worldStateHealFinishedListener,
               pivotCatchupListener,
-              blockAccessListApplier);
+              blockAccessListApplier,
+              blockchain);
 
       final Map<Bytes32, Bytes32> ranges = RangeManager.generateAllRanges(16);
       snapsyncMetricsManager.initRange(ranges);

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldStateDownloader.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldStateDownloader.java
@@ -173,7 +173,8 @@ public class SnapV2WorldStateDownloader implements WorldStateDownloader {
               worldStateHealFinishedListener,
               pivotCatchupListener,
               blockAccessListApplier,
-              blockchain);
+              blockchain,
+              ethContext);
 
       final Map<Bytes32, Bytes32> ranges = RangeManager.generateAllRanges(16);
       snapsyncMetricsManager.initRange(ranges);

--- a/ethereum/trie/src/main/java/org/hyperledger/besu/ethereum/trie/RangeManager.java
+++ b/ethereum/trie/src/main/java/org/hyperledger/besu/ethereum/trie/RangeManager.java
@@ -31,6 +31,7 @@ import java.util.function.Function;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.bytes.MutableBytes;
+import org.apache.tuweni.units.bigints.UInt256;
 
 /**
  * This class helps to generate ranges according to several parameters (the start and the end of the
@@ -238,5 +239,17 @@ public class RangeManager {
       path.set(j + 1, (byte) (b & 0x0f));
     }
     return path;
+  }
+
+  public static Bytes32 prevKey(final Bytes32 key) {
+    return UInt256.fromBytes(key).subtract(UInt256.ONE);
+  }
+
+  public static Bytes32 nextKey(final Bytes32 key) {
+    final UInt256 next = UInt256.fromBytes(key).add(UInt256.ONE);
+    if (next.isZero()) {
+      throw new IllegalArgumentException("Hash overflow: " + key);
+    }
+    return next;
   }
 }


### PR DESCRIPTION
Implements incremental healing via BAL application to trie and flat db during snap/2 repivoting.

Adds `SnapV2BlockAccessListApplier`, which performs the following at each pivot change:

1. **Collect account changes** - iterates `(currentPivot, newPivot]`, loads each BAL from storage, verifies its hash against the corresponding header, and accumulates the final account changes for all persisted accounts.
2. **Apply changes** - collects changes to flat db and account + storage tries in updater for batch commit.
3. **Commit changes**

Task dequeue is only blocked during BAL apply, not during chain catch-up.

State root is verified only at completion, after the full world state is reconstructed.

Current pivot and new pivot candidate are verified to lie on the same canonical chain after the chain is downloaded and before applying BALs and switching the pivot.

`SnapSyncChainDownloadPipelineFactory` now silently skips BAL download for pre-activation blocks instead of failing.

 `SnapV2AccountRangeRequest` and `SnapV2PersistDataStep` now filter to in-range accounts only. Peer responses include boundary accounts for proof verification which were previously mishandled as in-range.

`retargetQueuedRequests()` now reads the updated storage root from the database after BAL application.

#### Limitations

- **Bonsai only.** Forest support is planned after successful testing.
- **Reorg recovery not implemented.**
- **Performance can be improved.**
- **No tests.**