### PR TITLE
fix: skip DNSDaemon when --discovery-dns-url is blank or empty

### DIFF
--- a/app/src/main/java/org/hyperledger/besu/cli/options/P2PDiscoveryOptions.java
+++ b/app/src/main/java/org/hyperledger/besu/cli/options/P2PDiscoveryOptions.java
@@ -194,7 +194,8 @@ public class P2PDiscoveryOptions implements CLIOptions<P2PDiscoveryConfiguration
   @SuppressWarnings({"FieldCanBeFinal", "FieldMayBeFinal"}) // PicoCLI requires non-final Strings.
   @CommandLine.Option(
       names = {"--discovery-dns-url"},
-      description = "Specifies the URL to use for DNS discovery")
+      description =
+          "Specifies the URL to use for DNS discovery of peers. Set to empty string to disable DNS peer discovery even on networks that include a DNS URL in their genesis config.")
   public String discoveryDnsUrl = null;
 
   /** Boolean option to allow for incoming connections to be prioritized randomly. */

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetwork.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetwork.java
@@ -212,6 +212,8 @@ public class DefaultP2PNetwork implements P2PNetwork {
     final String address = config.discoveryConfiguration().getAdvertisedHost();
 
     Optional.ofNullable(config.discoveryConfiguration().getDNSDiscoveryURL())
+        .map(String::strip)
+        .filter(url -> !url.isBlank())
         .ifPresent(
             disco -> {
               // These lists are updated every 12h

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetworkTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetworkTest.java
@@ -63,6 +63,8 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -335,6 +337,19 @@ public final class DefaultP2PNetworkTest {
     testClass.start();
     // ensure DnsDaemon is NOT present:
     assertThat(testClass.getDnsDaemon()).isNotPresent();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"", "  ", "\t"})
+  public void shouldNotStartDnsDiscoveryWhenDnsURLIsBlank(final String url) {
+    final DiscoveryConfiguration disco = DiscoveryConfiguration.create().setDnsDiscoveryURL(url);
+    final NetworkingConfiguration blankUrlConfig =
+        when(spy(config).discoveryConfiguration()).thenReturn(disco).getMock();
+    final DefaultP2PNetwork testClass =
+        (DefaultP2PNetwork) builder().config(blankUrlConfig).build();
+    testClass.start();
+    assertThat(testClass.getDnsDaemon()).isNotPresent();
+    testClass.stop();
   }
 
   @Test


### PR DESCRIPTION
## PR description

`DefaultP2PNetwork` guards DNS daemon startup with `Optional.ofNullable(getDNSDiscoveryURL())`,
which passes through an empty string as a present value. On named networks (mainnet, sepolia,
hoodi, etc.) the genesis JSON supplies an `enrtree://` URL, so the daemon always starts unless
the user explicitly provides `--discovery-dns-url`. Passing `--discovery-dns-url ""` to disable
it was not handled and caused an `ArrayIndexOutOfBoundsException` inside the Vert.x verticle
~1 second after startup (Bouncy Castle failing to decode an empty byte array as an EC point).

This PR adds a `.map(String::strip).filter(url -> !url.isBlank())` guard so that:
- `--discovery-dns-url ""` cleanly disables DNS discovery with no crash
- Whitespace-only values (`"  "`, `"\t"`) are also rejected
- Real URLs with accidental leading/trailing whitespace are trimmed before use

The `--discovery-dns-url` CLI description is also updated to document the empty-string disable pattern.

A parameterized test covering all three blank variants is included.

## Fixed Issue(s)
<!-- no dedicated issue — follow-up from DiscV5 PR work -->

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests