### PR TITLE
Validate minimum glibc version at startup

### DIFF
--- a/app/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/app/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -187,6 +187,7 @@ import org.hyperledger.besu.util.PermissioningConfigurationValidator;
 import org.hyperledger.besu.util.number.Fraction;
 import org.hyperledger.besu.util.number.Percentage;
 import org.hyperledger.besu.util.number.PositiveNumber;
+import org.hyperledger.besu.util.platform.PlatformDetector;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -274,6 +275,8 @@ import picocli.CommandLine.ParseResult;
       "%nMore info and other profiles at https://besu.hyperledger.org%n"
     })
 public class BesuCommand implements DefaultCommandValues, Runnable {
+  private static final String MINIMUM_GLIBC_VERSION = "2.28";
+
   @SuppressWarnings("PrivateStaticFinalLoggers")
   // non-static for testing
   private final Logger logger;
@@ -952,6 +955,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
       }
 
       logger.info("Starting Besu");
+      assertMinimumGlibcVersion();
 
       // set merge config on the basis of genesis config
       setMergeConfigOptions();
@@ -1464,6 +1468,28 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
               System.getProperty("os.name"),
               System.getProperty("os.arch"),
               failures));
+    }
+  }
+
+  @VisibleForTesting
+  void assertMinimumGlibcVersion() {
+    if (!"linux".equals(PlatformDetector.getOSType())) {
+      return;
+    }
+
+    final String glibcVersion = PlatformDetector.getGlibc();
+    if (!PlatformDetector.isKnownGlibcVersion(glibcVersion)) {
+      logger.warn(
+          "Unable to detect glibc version. Required minimum version is {}.",
+          MINIMUM_GLIBC_VERSION);
+      return;
+    }
+
+    if (!PlatformDetector.isGlibcVersionAtLeast(glibcVersion, MINIMUM_GLIBC_VERSION)) {
+      throw new UnsupportedOperationException(
+          String.format(
+              "glibc %s is not supported. Besu requires glibc %s or later.",
+              glibcVersion, MINIMUM_GLIBC_VERSION));
     }
   }
 

--- a/app/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/app/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -2469,6 +2469,75 @@ public class BesuCommandTest extends CommandTestAbstract {
   }
 
   @Test
+  public void assertMinimumGlibcVersionSkipsNonLinuxPlatforms() {
+    final BesuCommand mockCmd = parseCommand();
+
+    try (MockedStatic<PlatformDetector> platformDetector = mockStatic(PlatformDetector.class)) {
+      platformDetector.when(PlatformDetector::getOSType).thenReturn("osx");
+
+      assertThatNoException().isThrownBy(mockCmd::assertMinimumGlibcVersion);
+      platformDetector.verify(PlatformDetector::getOSType);
+      platformDetector.verifyNoMoreInteractions();
+    }
+  }
+
+  @Test
+  public void assertMinimumGlibcVersionAllowsSupportedVersion() {
+    final BesuCommand mockCmd = parseCommand();
+
+    try (MockedStatic<PlatformDetector> platformDetector = mockStatic(PlatformDetector.class)) {
+      platformDetector.when(PlatformDetector::getOSType).thenReturn("linux");
+      platformDetector.when(PlatformDetector::getGlibc).thenReturn("2.28");
+      platformDetector
+          .when(() -> PlatformDetector.isKnownGlibcVersion("2.28"))
+          .thenReturn(true);
+      platformDetector
+          .when(() -> PlatformDetector.isGlibcVersionAtLeast("2.28", "2.28"))
+          .thenReturn(true);
+
+      assertThatNoException().isThrownBy(mockCmd::assertMinimumGlibcVersion);
+    }
+  }
+
+  @Test
+  public void assertMinimumGlibcVersionFailsUnsupportedVersion() {
+    final BesuCommand mockCmd = parseCommand();
+
+    try (MockedStatic<PlatformDetector> platformDetector = mockStatic(PlatformDetector.class)) {
+      platformDetector.when(PlatformDetector::getOSType).thenReturn("linux");
+      platformDetector.when(PlatformDetector::getGlibc).thenReturn("2.27");
+      platformDetector
+          .when(() -> PlatformDetector.isKnownGlibcVersion("2.27"))
+          .thenReturn(true);
+      platformDetector
+          .when(() -> PlatformDetector.isGlibcVersionAtLeast("2.27", "2.28"))
+          .thenReturn(false);
+
+      assertThatExceptionOfType(UnsupportedOperationException.class)
+          .isThrownBy(mockCmd::assertMinimumGlibcVersion)
+          .withMessageContaining("glibc 2.27 is not supported")
+          .withMessageContaining("2.28 or later");
+    }
+  }
+
+  @Test
+  public void assertMinimumGlibcVersionWarnsWhenVersionUnknown() {
+    final BesuCommand mockCmd = parseCommand();
+
+    try (MockedStatic<PlatformDetector> platformDetector = mockStatic(PlatformDetector.class)) {
+      platformDetector.when(PlatformDetector::getOSType).thenReturn("linux");
+      platformDetector.when(PlatformDetector::getGlibc).thenReturn("unknown");
+      platformDetector
+          .when(() -> PlatformDetector.isKnownGlibcVersion("unknown"))
+          .thenReturn(false);
+
+      assertThatNoException().isThrownBy(mockCmd::assertMinimumGlibcVersion);
+      verify(mockLogger)
+          .warn("Unable to detect glibc version. Required minimum version is {}.", "2.28");
+    }
+  }
+
+  @Test
   public void bonsaiFlatDbShouldBeEnabledByDefault() {
     final TestBesuCommand besuCommand = parseCommand();
     assertThat(

--- a/util/src/main/java/org/hyperledger/besu/util/platform/PlatformDetector.java
+++ b/util/src/main/java/org/hyperledger/besu/util/platform/PlatformDetector.java
@@ -123,6 +123,47 @@ public class PlatformDetector {
 
   private static final String UNKNOWN = "unknown";
 
+  /**
+   * Checks whether a glibc version string is at least the required minimum version.
+   *
+   * @param version the glibc version to check
+   * @param minimumVersion the minimum required glibc version
+   * @return true if the glibc version is at least the minimum
+   */
+  public static boolean isGlibcVersionAtLeast(
+      final String version, final String minimumVersion) {
+    final int[] parsedVersion = parseVersion(version);
+    final int[] parsedMinimumVersion = parseVersion(minimumVersion);
+
+    for (int i = 0; i < Math.max(parsedVersion.length, parsedMinimumVersion.length); i++) {
+      final int currentVersionPart = i < parsedVersion.length ? parsedVersion[i] : 0;
+      final int minimumVersionPart =
+          i < parsedMinimumVersion.length ? parsedMinimumVersion[i] : 0;
+      if (currentVersionPart != minimumVersionPart) {
+        return currentVersionPart > minimumVersionPart;
+      }
+    }
+
+    return true;
+  }
+
+  /**
+   * Checks whether a glibc version string was successfully detected.
+   *
+   * @param version the glibc version to check
+   * @return true if the glibc version is known
+   */
+  public static boolean isKnownGlibcVersion(final String version) {
+    return version != null && !UNKNOWN.equals(version);
+  }
+
+  private static int[] parseVersion(final String version) {
+    return Pattern.compile("\\.")
+        .splitAsStream(version)
+        .mapToInt(Integer::parseInt)
+        .toArray();
+  }
+
   private static void detect() {
     final String detectedOS = normalizeOS(normalize("os.name"));
     final String detectedArch = normalizeArch(normalize("os.arch"));

--- a/util/src/test/java/org/hyperledger/besu/util/platform/PlatformDetectorTest.java
+++ b/util/src/test/java/org/hyperledger/besu/util/platform/PlatformDetectorTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.util.platform;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class PlatformDetectorTest {
+
+  @Test
+  void glibcVersionComparisonAllowsEqualVersion() {
+    assertThat(PlatformDetector.isGlibcVersionAtLeast("2.28", "2.28")).isTrue();
+  }
+
+  @Test
+  void glibcVersionComparisonAllowsNewerVersion() {
+    assertThat(PlatformDetector.isGlibcVersionAtLeast("2.29", "2.28")).isTrue();
+  }
+
+  @Test
+  void glibcVersionComparisonRejectsOlderVersion() {
+    assertThat(PlatformDetector.isGlibcVersionAtLeast("2.27", "2.28")).isFalse();
+  }
+
+  @Test
+  void glibcVersionComparisonHandlesPatchVersions() {
+    assertThat(PlatformDetector.isGlibcVersionAtLeast("2.28.1", "2.28")).isTrue();
+    assertThat(PlatformDetector.isGlibcVersionAtLeast("2.28", "2.28.1")).isFalse();
+  }
+
+  @Test
+  void glibcVersionIsKnownWhenDetected() {
+    assertThat(PlatformDetector.isKnownGlibcVersion("2.28")).isTrue();
+    assertThat(PlatformDetector.isKnownGlibcVersion("unknown")).isFalse();
+    assertThat(PlatformDetector.isKnownGlibcVersion(null)).isFalse();
+  }
+}


### PR DESCRIPTION
## PR description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

Fixes #9551.

This adds a startup check for the minimum supported glibc version on Linux. Besu now aborts startup when a detected glibc version is older than 2.28, and warns when the glibc version cannot be detected.

The change also adds version comparison helpers to `PlatformDetector` and covers the new behavior with unit tests.




### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


