### PR TITLE
fix start synchronizer when

### DIFF
--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/configuration/BesuNodeFactory.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/configuration/BesuNodeFactory.java
@@ -516,6 +516,11 @@ public class BesuNodeFactory {
 
   public BesuNode createExecutionEngineGenesisNode(final String name, final String genesisPath)
       throws IOException {
+    return createExecutionEngineGenesisNode(name, genesisPath, true);
+  }
+
+  public BesuNode createExecutionEngineGenesisNode(
+      final String name, final String genesisPath, final boolean p2pEnabled) throws IOException {
     final String genesisFile = GenesisConfigurationFactory.readGenesisFile(genesisPath);
 
     return create(
@@ -524,6 +529,7 @@ public class BesuNodeFactory {
             .genesisConfigProvider((a) -> Optional.of(genesisFile))
             .devMode(false)
             .bootnodeEligible(false)
+            .p2pEnabled(p2pEnabled)
             .miningConfiguration(
                 MiningConfiguration.newDefault()
                     .setCoinbase(AddressHelpers.ofValue(1))

--- a/acceptance-tests/tests/src/acceptanceTest/java/org/hyperledger/besu/tests/acceptance/jsonrpc/AbstractJsonRpcTest.java
+++ b/acceptance-tests/tests/src/acceptanceTest/java/org/hyperledger/besu/tests/acceptance/jsonrpc/AbstractJsonRpcTest.java
@@ -55,10 +55,16 @@ abstract class AbstractJsonRpcTest {
     final ObjectMapper mapper;
 
     public JsonRpcTestsContext(final String genesisFile) throws IOException {
+      this(genesisFile, true);
+    }
+
+    public JsonRpcTestsContext(final String genesisFile, final boolean p2pEnabled)
+        throws IOException {
       cluster = new Cluster(new NetConditions(new NetTransactions()));
 
       besuNode =
-          new BesuNodeFactory().createExecutionEngineGenesisNode("executionEngine", genesisFile);
+          new BesuNodeFactory()
+              .createExecutionEngineGenesisNode("executionEngine", genesisFile, p2pEnabled);
       cluster.start(besuNode);
       httpClient = new OkHttpClient();
 

--- a/acceptance-tests/tests/src/acceptanceTest/java/org/hyperledger/besu/tests/acceptance/jsonrpc/ExecutionEngineOsakaP2pDisabledAcceptanceTest.java
+++ b/acceptance-tests/tests/src/acceptanceTest/java/org/hyperledger/besu/tests/acceptance/jsonrpc/ExecutionEngineOsakaP2pDisabledAcceptanceTest.java
@@ -22,6 +22,14 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.provider.Arguments;
 
+/**
+ * Replays the existing Osaka engine API test cases against a node started with {@code
+ * --p2p-enabled=false}, to simulate the environment of benchmark and test harnesses (e.g. hive,
+ * benchmarkoor) that drive Besu standalone over the engine API with no peers.
+ *
+ * <p>Sync mode defaults to FULL — matching how those harnesses run Besu — so this also exercises
+ * the FULL-sync + p2p-disabled path that the controller-level fix targets.
+ */
 public class ExecutionEngineOsakaP2pDisabledAcceptanceTest extends AbstractJsonRpcTest {
   private static final String GENESIS_FILE = "/jsonrpc/engine/osaka/genesis.json";
   private static final String TEST_CASE_PATH = "/jsonrpc/engine/osaka/test-cases/";

--- a/acceptance-tests/tests/src/acceptanceTest/java/org/hyperledger/besu/tests/acceptance/jsonrpc/ExecutionEngineOsakaP2pDisabledAcceptanceTest.java
+++ b/acceptance-tests/tests/src/acceptanceTest/java/org/hyperledger/besu/tests/acceptance/jsonrpc/ExecutionEngineOsakaP2pDisabledAcceptanceTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.tests.acceptance.jsonrpc;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.provider.Arguments;
+
+public class ExecutionEngineOsakaP2pDisabledAcceptanceTest extends AbstractJsonRpcTest {
+  private static final String GENESIS_FILE = "/jsonrpc/engine/osaka/genesis.json";
+  private static final String TEST_CASE_PATH = "/jsonrpc/engine/osaka/test-cases/";
+
+  private static JsonRpcTestsContext testsContext;
+
+  public ExecutionEngineOsakaP2pDisabledAcceptanceTest() {
+    super(testsContext);
+  }
+
+  @BeforeAll
+  public static void init() throws IOException {
+    testsContext = new JsonRpcTestsContext(GENESIS_FILE, false);
+  }
+
+  public static Stream<Arguments> testCases() throws URISyntaxException {
+    return testCasesFromPath(TEST_CASE_PATH);
+  }
+
+  @AfterAll
+  public static void tearDown() {
+    testsContext.cluster.close();
+  }
+}

--- a/app/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/app/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -2114,6 +2114,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
             .cacheLastBlockHeaders(numberOfBlockHeadersToCache)
             .isCacheLastBlockHeadersPreloadEnabled(isCacheLastBlockHeadersPreloadEnabled)
             .senderNonceIndexingEnabled(txSenderNonceIndexEnabled)
+            .p2pEnabled(p2PDiscoveryOptions.p2pEnabled)
             .genesisStateHashCacheEnabled(genesisStateHashCacheEnabled)
             .apiConfiguration(apiConfiguration)
             .balConfiguration(balConfiguration)

--- a/app/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
+++ b/app/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
@@ -210,6 +210,7 @@ public abstract class BesuControllerBuilder implements MiningConfigurationOverri
   private int numberOfBlockHeadersToCache = 0;
   private boolean isCacheLastBlockHeadersPreloadEnabled;
   private boolean senderNonceIndexingEnabled = false;
+  private boolean p2pEnabled = true;
 
   /** whether parallel transaction processing is enabled or not */
   protected boolean isParallelTxProcessingEnabled;
@@ -524,6 +525,17 @@ public abstract class BesuControllerBuilder implements MiningConfigurationOverri
   }
 
   /**
+   * Sets whether p2p networking is enabled.
+   *
+   * @param p2pEnabled {@code true} (default) when p2p networking is enabled
+   * @return the besu controller builder
+   */
+  public BesuControllerBuilder p2pEnabled(final boolean p2pEnabled) {
+    this.p2pEnabled = p2pEnabled;
+    return this;
+  }
+
+  /**
    * Sets whether the block header cache should be preloaded.
    *
    * @param isCacheLastBlockHeadersPreloadEnabled {@code true} to enable preloading of the block
@@ -767,7 +779,9 @@ public abstract class BesuControllerBuilder implements MiningConfigurationOverri
     final EthContext ethContext =
         new EthContext(ethPeers, ethMessages, snapMessages, scheduler, peerTaskExecutor);
     final boolean fullSyncDisabled = syncConfig.getSyncMode() != SyncMode.FULL;
-    final SyncState syncState = new SyncState(blockchain, ethPeers, fullSyncDisabled, checkpoint);
+    final boolean hasInitialSyncPhase = fullSyncDisabled && p2pEnabled;
+    final SyncState syncState =
+        new SyncState(blockchain, ethPeers, hasInitialSyncPhase, checkpoint);
 
     protocolContext
         .safeConsensusContext(MergeContext.class)

--- a/app/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
+++ b/app/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
@@ -210,7 +210,7 @@ public abstract class BesuControllerBuilder implements MiningConfigurationOverri
   private int numberOfBlockHeadersToCache = 0;
   private boolean isCacheLastBlockHeadersPreloadEnabled;
   private boolean senderNonceIndexingEnabled = false;
-  private boolean p2pEnabled = true;
+  protected boolean p2pEnabled = true;
 
   /** whether parallel transaction processing is enabled or not */
   protected boolean isParallelTxProcessingEnabled;

--- a/app/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
+++ b/app/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
@@ -210,6 +210,8 @@ public abstract class BesuControllerBuilder implements MiningConfigurationOverri
   private int numberOfBlockHeadersToCache = 0;
   private boolean isCacheLastBlockHeadersPreloadEnabled;
   private boolean senderNonceIndexingEnabled = false;
+
+  /** Whether p2p networking is enabled. */
   protected boolean p2pEnabled = true;
 
   /** whether parallel transaction processing is enabled or not */

--- a/app/src/main/java/org/hyperledger/besu/controller/MergeBesuControllerBuilder.java
+++ b/app/src/main/java/org/hyperledger/besu/controller/MergeBesuControllerBuilder.java
@@ -264,6 +264,9 @@ public class MergeBesuControllerBuilder extends BesuControllerBuilder {
   public BesuController build() {
     final BesuController controller = super.build();
     postMergeContext.setSyncState(syncState.get());
+    if (!p2pEnabled) {
+      syncState.get().setReachedTerminalDifficulty(true);
+    }
     return controller;
   }
 

--- a/app/src/main/java/org/hyperledger/besu/controller/TransitionBesuControllerBuilder.java
+++ b/app/src/main/java/org/hyperledger/besu/controller/TransitionBesuControllerBuilder.java
@@ -296,6 +296,9 @@ public class TransitionBesuControllerBuilder extends BesuControllerBuilder {
   public BesuController build() {
     final BesuController controller = super.build();
     mergeBesuControllerBuilder.getPostMergeContext().setSyncState(controller.getSyncState());
+    if (!p2pEnabled) {
+      controller.getSyncState().setReachedTerminalDifficulty(true);
+    }
     return controller;
   }
 

--- a/app/src/test/java/org/hyperledger/besu/controller/MergeBesuControllerBuilderTest.java
+++ b/app/src/test/java/org/hyperledger/besu/controller/MergeBesuControllerBuilderTest.java
@@ -233,7 +233,7 @@ public class MergeBesuControllerBuilderTest {
   }
 
   @Test
-  public void p2pEnabledFalseWithNonFullSyncMarksInitialSyncPhaseDone() {
+  public void p2pEnabledFalseWithSnapSyncMarksInitialSyncPhaseDone() {
     when(synchronizerConfiguration.getSyncMode()).thenReturn(SyncMode.SNAP);
 
     final boolean initialSyncPhaseDone =
@@ -247,7 +247,7 @@ public class MergeBesuControllerBuilderTest {
   }
 
   @Test
-  public void p2pEnabledTrueWithNonFullSyncKeepsInitialSyncPhaseInProgress() {
+  public void p2pEnabledTrueWithSnapSyncKeepsInitialSyncPhaseInProgress() {
     when(synchronizerConfiguration.getSyncMode()).thenReturn(SyncMode.SNAP);
 
     final boolean initialSyncPhaseDone =
@@ -261,7 +261,7 @@ public class MergeBesuControllerBuilderTest {
   }
 
   @Test
-  public void p2pEnabledFalseWithNonFullSyncReportsNotSyncing() {
+  public void p2pEnabledFalseWithSnapSyncReportsNotSyncing() {
     when(synchronizerConfiguration.getSyncMode()).thenReturn(SyncMode.SNAP);
 
     final boolean isSyncing =
@@ -290,7 +290,9 @@ public class MergeBesuControllerBuilderTest {
   }
 
   @Test
-  public void p2pEnabledTrueLeavesTerminalDifficultyUnreached() {
+  public void p2pEnabledTrueWithFullSyncLeavesTerminalDifficultyUnreached() {
+    when(synchronizerConfiguration.getSyncMode()).thenReturn(SyncMode.FULL);
+
     final Optional<Boolean> ttdReached =
         visitWithMockConfigs(new MergeBesuControllerBuilder())
             .p2pEnabled(true)
@@ -299,6 +301,20 @@ public class MergeBesuControllerBuilderTest {
             .hasReachedTerminalDifficulty();
 
     assertThat(ttdReached).isNotPresent();
+  }
+
+  @Test
+  public void p2pEnabledTrueWithSnapSyncLeavesTerminalDifficultyUnreached() {
+    when(synchronizerConfiguration.getSyncMode()).thenReturn(SyncMode.SNAP);
+
+    final Optional<Boolean> ttdReached =
+        visitWithMockConfigs(new MergeBesuControllerBuilder())
+            .p2pEnabled(true)
+            .build()
+            .getSyncState()
+            .hasReachedTerminalDifficulty();
+
+    assertThat(ttdReached).contains(false);
   }
 
   @Test

--- a/app/src/test/java/org/hyperledger/besu/controller/MergeBesuControllerBuilderTest.java
+++ b/app/src/test/java/org/hyperledger/besu/controller/MergeBesuControllerBuilderTest.java
@@ -276,6 +276,32 @@ public class MergeBesuControllerBuilderTest {
   }
 
   @Test
+  public void p2pEnabledFalseMarksTerminalDifficultyReachedAtStartup() {
+    when(synchronizerConfiguration.getSyncMode()).thenReturn(SyncMode.SNAP);
+
+    final Optional<Boolean> ttdReached =
+        visitWithMockConfigs(new MergeBesuControllerBuilder())
+            .p2pEnabled(false)
+            .build()
+            .getSyncState()
+            .hasReachedTerminalDifficulty();
+
+    assertThat(ttdReached).contains(true);
+  }
+
+  @Test
+  public void p2pEnabledTrueLeavesTerminalDifficultyUnreached() {
+    final Optional<Boolean> ttdReached =
+        visitWithMockConfigs(new MergeBesuControllerBuilder())
+            .p2pEnabled(true)
+            .build()
+            .getSyncState()
+            .hasReachedTerminalDifficulty();
+
+    assertThat(ttdReached).isNotPresent();
+  }
+
+  @Test
   public void assertConfiguredBlock() {
     final Blockchain mockChain = mock(Blockchain.class);
     when(mockChain.getBlockHeader(anyLong())).thenReturn(Optional.of(mock(BlockHeader.class)));

--- a/app/src/test/java/org/hyperledger/besu/controller/MergeBesuControllerBuilderTest.java
+++ b/app/src/test/java/org/hyperledger/besu/controller/MergeBesuControllerBuilderTest.java
@@ -47,6 +47,7 @@ import org.hyperledger.besu.ethereum.eth.EthProtocolConfiguration;
 import org.hyperledger.besu.ethereum.eth.sync.SyncMode;
 import org.hyperledger.besu.ethereum.eth.sync.SynchronizerConfiguration;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.SnapSyncConfiguration;
+import org.hyperledger.besu.ethereum.eth.sync.state.SyncState;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolConfiguration;
 import org.hyperledger.besu.ethereum.mainnet.MainnetBlockHeaderFunctions;
 import org.hyperledger.besu.ethereum.mainnet.feemarket.BaseFeeMarket;
@@ -72,6 +73,7 @@ import java.time.Clock;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.OptionalLong;
+import java.util.Random;
 
 import com.google.common.collect.Range;
 import org.apache.tuweni.bytes.Bytes;
@@ -233,12 +235,16 @@ public class MergeBesuControllerBuilderTest {
   }
 
   @Test
-  public void p2pEnabledFalseWithSnapSyncMarksInitialSyncPhaseDone() {
-    when(synchronizerConfiguration.getSyncMode()).thenReturn(SyncMode.SNAP);
+  public void marksInitialSyncPhaseDoneWhenFullSync() {
+    when(synchronizerConfiguration.getSyncMode()).thenReturn(SyncMode.FULL);
+    boolean p2pEnabled = new Random().nextBoolean();
+    assertInitialSyncPhaseDone(p2pEnabled);
+  }
 
+  private void assertInitialSyncPhaseDone(final boolean p2pEnabled) {
     final boolean initialSyncPhaseDone =
         visitWithMockConfigs(new MergeBesuControllerBuilder())
-            .p2pEnabled(false)
+            .p2pEnabled(p2pEnabled)
             .build()
             .getSyncState()
             .isInitialSyncPhaseDone();
@@ -247,7 +253,14 @@ public class MergeBesuControllerBuilderTest {
   }
 
   @Test
-  public void p2pEnabledTrueWithSnapSyncKeepsInitialSyncPhaseInProgress() {
+  public void marksInitialSyncPhaseDoneWhenP2pDisabledAndSnapSync() {
+    when(synchronizerConfiguration.getSyncMode()).thenReturn(SyncMode.SNAP);
+    boolean p2pEnabled = false;
+    assertInitialSyncPhaseDone(p2pEnabled);
+  }
+
+  @Test
+  public void keepsInitialSyncPhaseInProgressWhenP2pEnabledAndSnapSync() {
     when(synchronizerConfiguration.getSyncMode()).thenReturn(SyncMode.SNAP);
 
     final boolean initialSyncPhaseDone =
@@ -261,23 +274,9 @@ public class MergeBesuControllerBuilderTest {
   }
 
   @Test
-  public void p2pEnabledFalseWithSnapSyncReportsNotSyncing() {
-    when(synchronizerConfiguration.getSyncMode()).thenReturn(SyncMode.SNAP);
-
-    final boolean isSyncing =
-        visitWithMockConfigs(new MergeBesuControllerBuilder())
-            .p2pEnabled(false)
-            .build()
-            .getProtocolContext()
-            .getConsensusContext(MergeContext.class)
-            .isSyncing();
-
-    assertThat(isSyncing).isFalse();
-  }
-
-  @Test
-  public void p2pEnabledFalseMarksTerminalDifficultyReachedAtStartup() {
-    when(synchronizerConfiguration.getSyncMode()).thenReturn(SyncMode.SNAP);
+  public void marksTerminalDifficultyReachedWhenP2pDisabled() {
+    when(synchronizerConfiguration.getSyncMode())
+        .thenReturn(new Random().nextBoolean() ? SyncMode.FULL : SyncMode.SNAP);
 
     final Optional<Boolean> ttdReached =
         visitWithMockConfigs(new MergeBesuControllerBuilder())
@@ -290,7 +289,7 @@ public class MergeBesuControllerBuilderTest {
   }
 
   @Test
-  public void p2pEnabledTrueWithFullSyncLeavesTerminalDifficultyUnreached() {
+  public void leavesTerminalDifficultyUnreachedWhenP2pEnabledAndFullSync() {
     when(synchronizerConfiguration.getSyncMode()).thenReturn(SyncMode.FULL);
 
     final Optional<Boolean> ttdReached =
@@ -304,17 +303,51 @@ public class MergeBesuControllerBuilderTest {
   }
 
   @Test
-  public void p2pEnabledTrueWithSnapSyncLeavesTerminalDifficultyUnreached() {
+  public void marksTerminalDifficultyUnreachedWhenP2pEnabledAndSnapSyncAndInitialSyncNotDone() {
     when(synchronizerConfiguration.getSyncMode()).thenReturn(SyncMode.SNAP);
 
-    final Optional<Boolean> ttdReached =
+    final SyncState syncState =
         visitWithMockConfigs(new MergeBesuControllerBuilder())
             .p2pEnabled(true)
             .build()
-            .getSyncState()
-            .hasReachedTerminalDifficulty();
+            .getSyncState();
+    boolean initialSyncPhaseDone = syncState.isInitialSyncPhaseDone();
+    final Optional<Boolean> ttdReached = syncState.hasReachedTerminalDifficulty();
 
+    assertThat(initialSyncPhaseDone).isFalse();
     assertThat(ttdReached).contains(false);
+  }
+
+  @Test
+  public void reportNotSyncingWhenP2pDisabled() {
+    when(synchronizerConfiguration.getSyncMode())
+        .thenReturn(new Random().nextBoolean() ? SyncMode.FULL : SyncMode.SNAP);
+
+    final boolean isSyncing =
+        visitWithMockConfigs(new MergeBesuControllerBuilder())
+            .p2pEnabled(false)
+            .build()
+            .getProtocolContext()
+            .getConsensusContext(MergeContext.class)
+            .isSyncing();
+
+    assertThat(isSyncing).isFalse();
+  }
+
+  @Test
+  public void reportSyncingWhenP2pEnabled() {
+    when(synchronizerConfiguration.getSyncMode())
+        .thenReturn(new Random().nextBoolean() ? SyncMode.FULL : SyncMode.SNAP);
+
+    final boolean isSyncing =
+        visitWithMockConfigs(new MergeBesuControllerBuilder())
+            .p2pEnabled(true)
+            .build()
+            .getProtocolContext()
+            .getConsensusContext(MergeContext.class)
+            .isSyncing();
+
+    assertThat(isSyncing).isTrue();
   }
 
   @Test

--- a/app/src/test/java/org/hyperledger/besu/controller/MergeBesuControllerBuilderTest.java
+++ b/app/src/test/java/org/hyperledger/besu/controller/MergeBesuControllerBuilderTest.java
@@ -261,6 +261,21 @@ public class MergeBesuControllerBuilderTest {
   }
 
   @Test
+  public void p2pEnabledFalseWithNonFullSyncReportsNotSyncing() {
+    when(synchronizerConfiguration.getSyncMode()).thenReturn(SyncMode.SNAP);
+
+    final boolean isSyncing =
+        visitWithMockConfigs(new MergeBesuControllerBuilder())
+            .p2pEnabled(false)
+            .build()
+            .getProtocolContext()
+            .getConsensusContext(MergeContext.class)
+            .isSyncing();
+
+    assertThat(isSyncing).isFalse();
+  }
+
+  @Test
   public void assertConfiguredBlock() {
     final Blockchain mockChain = mock(Blockchain.class);
     when(mockChain.getBlockHeader(anyLong())).thenReturn(Optional.of(mock(BlockHeader.class)));

--- a/app/src/test/java/org/hyperledger/besu/controller/MergeBesuControllerBuilderTest.java
+++ b/app/src/test/java/org/hyperledger/besu/controller/MergeBesuControllerBuilderTest.java
@@ -233,6 +233,34 @@ public class MergeBesuControllerBuilderTest {
   }
 
   @Test
+  public void p2pEnabledFalseWithNonFullSyncMarksInitialSyncPhaseDone() {
+    when(synchronizerConfiguration.getSyncMode()).thenReturn(SyncMode.SNAP);
+
+    final boolean initialSyncPhaseDone =
+        visitWithMockConfigs(new MergeBesuControllerBuilder())
+            .p2pEnabled(false)
+            .build()
+            .getSyncState()
+            .isInitialSyncPhaseDone();
+
+    assertThat(initialSyncPhaseDone).isTrue();
+  }
+
+  @Test
+  public void p2pEnabledTrueWithNonFullSyncKeepsInitialSyncPhaseInProgress() {
+    when(synchronizerConfiguration.getSyncMode()).thenReturn(SyncMode.SNAP);
+
+    final boolean initialSyncPhaseDone =
+        visitWithMockConfigs(new MergeBesuControllerBuilder())
+            .p2pEnabled(true)
+            .build()
+            .getSyncState()
+            .isInitialSyncPhaseDone();
+
+    assertThat(initialSyncPhaseDone).isFalse();
+  }
+
+  @Test
   public void assertConfiguredBlock() {
     final Blockchain mockChain = mock(Blockchain.class);
     when(mockChain.getBlockHeader(anyLong())).thenReturn(Optional.of(mock(BlockHeader.class)));

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/PostMergeContext.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/PostMergeContext.java
@@ -130,8 +130,7 @@ public class PostMergeContext implements MergeContext {
     if (state == null) {
       return true;
     }
-    final Optional<Boolean> ttdReached = state.hasReachedTerminalDifficulty();
-    if (ttdReached.isPresent() && !ttdReached.get()) {
+    if (!state.hasReachedTerminalDifficulty().orElse(false)) {
       return true;
     }
     return !state.isInSync();

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/PostMergeContext.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/PostMergeContext.java
@@ -130,13 +130,10 @@ public class PostMergeContext implements MergeContext {
     if (state == null) {
       return true;
     }
-    // Pre-TTD: if terminal difficulty hasn't been reached we're still in PoW sync.
-    if (!state.hasReachedTerminalDifficulty().orElse(false)) {
+    final Optional<Boolean> ttdReached = state.hasReachedTerminalDifficulty();
+    if (ttdReached.isPresent() && !ttdReached.get()) {
       return true;
     }
-    // Post-TTD (post-merge): rely solely on peer sync state. This correctly handles full sync on
-    // post-merge networks where reachedTerminalDifficulty is always true, which previously caused
-    // this method to always return false even while the node was actively downloading the chain.
     return !state.isInSync();
   }
 

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/PostMergeContext.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/PostMergeContext.java
@@ -130,9 +130,15 @@ public class PostMergeContext implements MergeContext {
     if (state == null) {
       return true;
     }
+    // Pre-TTD: if terminal difficulty hasn't been reached we're still in PoW sync.
+    // When started with --p2p-enabled=false the controller marks TTD reached at startup,
+    // so this branch is skipped and the node can serve the engine API immediately.
     if (!state.hasReachedTerminalDifficulty().orElse(false)) {
       return true;
     }
+    // Post-TTD (post-merge): rely solely on peer sync state. This correctly handles full sync on
+    // post-merge networks where reachedTerminalDifficulty is always true, which previously caused
+    // this method to always return false even while the node was actively downloading the chain.
     return !state.isInSync();
   }
 

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/state/SyncStateTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/state/SyncStateTest.java
@@ -124,17 +124,6 @@ public class SyncStateTest {
   }
 
   @Test
-  public void isInitialSyncPhaseDone_trueWhenConstructedWithoutInitialSyncPhase() {
-    final SyncState syncStateNoInitialPhase =
-        new SyncState(blockchain, ethPeers, false, Optional.empty());
-    otherPeer.disconnect(DisconnectReason.REQUESTED);
-    syncTargetPeer.disconnect(DisconnectReason.REQUESTED);
-
-    assertThat(syncStateNoInitialPhase.isInitialSyncPhaseDone()).isTrue();
-    assertThat(syncStateNoInitialPhase.isInSync()).isTrue();
-  }
-
-  @Test
   public void isInSync_singlePeerWithWorseChainBetterHeight() {
     updateChainState(
         otherPeer.getEthPeer(), TARGET_CHAIN_HEIGHT, OUR_CHAIN_DIFFICULTY.subtract(1L));

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/state/SyncStateTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/state/SyncStateTest.java
@@ -124,6 +124,17 @@ public class SyncStateTest {
   }
 
   @Test
+  public void isInitialSyncPhaseDone_trueWhenConstructedWithoutInitialSyncPhase() {
+    final SyncState syncStateNoInitialPhase =
+        new SyncState(blockchain, ethPeers, false, Optional.empty());
+    otherPeer.disconnect(DisconnectReason.REQUESTED);
+    syncTargetPeer.disconnect(DisconnectReason.REQUESTED);
+
+    assertThat(syncStateNoInitialPhase.isInitialSyncPhaseDone()).isTrue();
+    assertThat(syncStateNoInitialPhase.isInSync()).isTrue();
+  }
+
+  @Test
   public void isInSync_singlePeerWithWorseChainBetterHeight() {
     updateChainState(
         otherPeer.getEthPeer(), TARGET_CHAIN_HEIGHT, OUR_CHAIN_DIFFICULTY.subtract(1L));


### PR DESCRIPTION
  p2p disabled


## PR description

## Fixed Issue(s)
SAlternative to #10676: thread `p2pEnabled` from `BesuCommand` into `BesuControllerBuilder` so that `SyncState` is constructed with:

`hasInitialSyncPhase = fullSyncDisabled && p2pEnabled`

(`BesuControllerBuilder.java:769-772`).

This gives correct `isSyncing()` reporting for both FULL and SNAP sync modes, while avoiding any need for the `Synchronizer` to start when `--p2p-enabled=false`.


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


