### PR TITLE
test(jsonrpc): add empty pool edge case for txpool_besuStatistics

### DIFF
--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TxPoolBesuStatisticsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TxPoolBesuStatisticsTest.java
@@ -77,4 +77,23 @@ public class TxPoolBesuStatisticsTest {
     when(pendingTransaction.isReceivedFromLocalSource()).thenReturn(local);
     return pendingTransaction;
   }
+
+  @Test
+  public void shouldGiveZeroStatisticsWhenPoolIsEmpty() {
+    final JsonRpcRequestContext request =
+        new JsonRpcRequestContext(
+            new JsonRpcRequest(
+                JSON_RPC_VERSION, TXPOOL_PENDING_TRANSACTIONS_METHOD, new Object[] {}));
+
+    when(transactionPool.maxSize()).thenReturn(4096L);
+    when(transactionPool.getPendingTransactions()).thenReturn(Sets.newHashSet());
+
+    final JsonRpcSuccessResponse actualResponse = (JsonRpcSuccessResponse) method.response(request);
+    final PendingTransactionsStatisticsResult result =
+        (PendingTransactionsStatisticsResult) actualResponse.getResult();
+
+    assertThat(result.getRemoteCount()).isEqualTo(0);
+    assertThat(result.getLocalCount()).isEqualTo(0);
+    assertThat(result.getMaxSize()).isEqualTo(4096);
+  }
 }


### PR DESCRIPTION
Fixes #10685

**Description**
This PR introduces targeted unit test coverage for the **txpool_besuStatistics** JSON-RPC administrative method, specifically exercising the boundary condition where the transaction pool is entirely empty.

**Rationale**
Previously, TxPoolBesuStatisticsTest.java only contained a single test case verifying a standard "happy path" mixed state (a pool containing a combination of local and remote pending transactions). It completely lacked test coverage for boundary limits.

By adding an explicit test case for the Empty Queue State, we structurally validate the mathematical safety of the underlying Java Stream filtering and subtraction operations (pendingTransaction.size() - localCount) when elements drop to absolute zero. This introduces regression protection against unexpected runtime errors or mapping bugs during subsequent code refactoring phases.


**Changes Included**
TxPoolBesuStatisticsTest.java: Added the shouldGiveZeroStatisticsWhenPoolIsEmpty() unit test to verify that an empty TransactionPool safely returns 0 counts for both local and remote components without throwing edge-case exceptions.