### PR TITLE
fix(engine): cache world state after rememberBlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 - `--rpc-tx-feecap` will treat a value of 0 as limiting fees to 0. Today it treats 0 as "do not cap fees". To achieve similar behaviour set it to a suitably large value to effectively prevent any fee capping.
 
 ### Bug fixes
-- Fix `engine_newPayload` spuriously returning `SYNCING` for sequential payloads when backward sync is concurrently active [#10600](https://github.com/besu-eth/besu/pull/10600)
+- Fix `engine_newPayload` spuriously returning `SYNCING` for sequential payloads when backward sync is concurrently active [#10690](https://github.com/besu-eth/besu/pull/10690)
 - Fix `eth_getBlockByNumber("safe"/"finalized")` returning `Unknown block` on nodes with a complete chain but no peers. The FCU handler now only returns `SYNCING` when the head block is genuinely not found. [#10658](https://github.com/besu-eth/besu/issues/10658)
 - `--api-gas-price-blocks` fixed to treat `0` as "sample zero blocks" [#10642](https://github.com/besu-eth/besu/pull/10642)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 - `--rpc-tx-feecap` will treat a value of 0 as limiting fees to 0. Today it treats 0 as "do not cap fees". To achieve similar behaviour set it to a suitably large value to effectively prevent any fee capping.
 
 ### Bug fixes
-- Fix `engine_newPayload` spuriously returning `SYNCING` for sequential payloads when backward sync is concurrently active. The Bonsai world state cache is now populated via an isolated layered copy so the Engine API thread never races with backward sync threads mutating the head world state. [#10600](https://github.com/besu-eth/besu/pull/10600)
+- Fix `engine_newPayload` spuriously returning `SYNCING` for sequential payloads when backward sync is concurrently active [#10600](https://github.com/besu-eth/besu/pull/10600)
 - Fix `eth_getBlockByNumber("safe"/"finalized")` returning `Unknown block` on nodes with a complete chain but no peers. The FCU handler now only returns `SYNCING` when the head block is genuinely not found. [#10658](https://github.com/besu-eth/besu/issues/10658)
 - `--api-gas-price-blocks` fixed to treat `0` as "sample zero blocks" [#10642](https://github.com/besu-eth/besu/pull/10642)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - `--rpc-tx-feecap` will treat a value of 0 as limiting fees to 0. Today it treats 0 as "do not cap fees". To achieve similar behaviour set it to a suitably large value to effectively prevent any fee capping.
 
 ### Bug fixes
+- Fix `engine_newPayload` spuriously returning `SYNCING` for sequential payloads when backward sync is concurrently active. The Bonsai world state cache is now populated via an isolated layered copy so the Engine API thread never races with backward sync threads mutating the head world state. [#10600](https://github.com/besu-eth/besu/pull/10600)
 - Fix `eth_getBlockByNumber("safe"/"finalized")` returning `Unknown block` on nodes with a complete chain but no peers. The FCU handler now only returns `SYNCING` when the head block is genuinely not found. [#10658](https://github.com/besu-eth/besu/issues/10658)
 - `--api-gas-price-blocks` fixed to treat `0` as "sample zero blocks" [#10642](https://github.com/besu-eth/besu/pull/10642)
 

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
@@ -695,11 +695,16 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
     validationResult
         .getYield()
         .ifPresentOrElse(
-            result ->
-                chain.storeBlock(
-                    block,
-                    result.getReceipts(),
-                    validationResult.getYield().flatMap(y -> y.getBlockAccessList())),
+            result -> {
+              chain.storeBlock(
+                  block,
+                  result.getReceipts(),
+                  validationResult.getYield().flatMap(y -> y.getBlockAccessList()));
+              // Persist the world state for this block so that subsequent newPayload calls with
+              // this block as parent can satisfy isWorldStateImmediatelyCached without trie-log
+              // replay. This allows sequential newPayload calls without an intervening FCU.
+              protocolContext.getWorldStateArchive().persistWorldStateForBlock(block.getHeader());
+            },
             () -> LOG.debug("empty yield in blockProcessingResult"));
     return validationResult;
   }

--- a/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinatorTest.java
+++ b/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinatorTest.java
@@ -60,6 +60,7 @@ import org.hyperledger.besu.ethereum.core.Difficulty;
 import org.hyperledger.besu.ethereum.core.ImmutableMiningConfiguration;
 import org.hyperledger.besu.ethereum.core.ImmutableMiningConfiguration.MutableInitValues;
 import org.hyperledger.besu.ethereum.core.ImmutableMiningConfiguration.Unstable;
+import org.hyperledger.besu.ethereum.core.InMemoryKeyValueStorageProvider;
 import org.hyperledger.besu.ethereum.core.MiningConfiguration;
 import org.hyperledger.besu.ethereum.core.TransactionTestFixture;
 import org.hyperledger.besu.ethereum.eth.manager.EthContext;
@@ -1262,6 +1263,49 @@ public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
 
     verify(blockchain, never()).setFinalized(block1Header.getHash());
     verify(blockchain, never()).setSafeBlock(block1Header.getHash());
+  }
+
+  @Test
+  public void rememberBlockPopulatesBonsaiCacheSoSubsequentPayloadDoesNotReturnSyncing() {
+    // Use a real Bonsai world state archive so isWorldStateImmediatelyCached exercises the
+    // PathBasedWorldStateProvider implementation rather than the Forest no-op default.
+    final MutableBlockchain bonsaiBlockchain =
+        spy(createInMemoryBlockchain(genesisState.getBlock()));
+    final var bonsaiArchive =
+        InMemoryKeyValueStorageProvider.createBonsaiInMemoryWorldStateArchive(bonsaiBlockchain);
+    final var bonsaiMutable = bonsaiArchive.getWorldState();
+    genesisState.writeStateTo(bonsaiMutable);
+    bonsaiMutable.persist(genesisState.getBlock().getHeader());
+
+    final ProtocolContext bonsaiContext =
+        new ProtocolContext.Builder()
+            .withBlockchain(bonsaiBlockchain)
+            .withWorldStateArchive(bonsaiArchive)
+            .withConsensusContext(mergeContext)
+            .withBadBlockManager(badBlockManager)
+            .build();
+
+    final MergeCoordinator bonsaiCoordinator =
+        new MergeCoordinator(
+            bonsaiContext,
+            protocolSchedule,
+            ethScheduler,
+            transactionPool,
+            miningConfiguration,
+            backwardSyncContext);
+
+    final BlockHeader genesisHeader = genesisState.getBlock().getHeader();
+    final BlockHeader block1Header = nextBlockHeader(genesisHeader);
+    final Block block1 = new Block(block1Header, BlockBody.empty());
+
+    // Before rememberBlock, the parent (genesis) is cached but block1 is not.
+    assertThat(bonsaiArchive.isWorldStateImmediatelyCached(block1Header.getHash())).isFalse();
+
+    assertThat(bonsaiCoordinator.rememberBlock(block1).getYield()).isPresent();
+
+    // After rememberBlock, block1's world state must be immediately cached so that a
+    // subsequent newPayload using block1 as parent does not incorrectly return SYNCING.
+    assertThat(bonsaiArchive.isWorldStateImmediatelyCached(block1Header.getHash())).isTrue();
   }
 
   private static BlockHeader mockBlockHeader() {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/provider/PathBasedWorldStateProvider.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/provider/PathBasedWorldStateProvider.java
@@ -159,9 +159,9 @@ public abstract class PathBasedWorldStateProvider implements WorldStateArchive {
       }
     } catch (Exception e) {
       LOG.atDebug()
-          .setMessage("Exception persisting world state for block {}: {}")
+          .setMessage("Exception persisting world state for block {}")
           .addArgument(blockHeader::toLogString)
-          .addArgument(e::getMessage)
+          .setCause(e)
           .log();
     }
   }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/provider/PathBasedWorldStateProvider.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/provider/PathBasedWorldStateProvider.java
@@ -138,6 +138,34 @@ public abstract class PathBasedWorldStateProvider implements WorldStateArchive {
         || headWorldState.blockHash().equals(blockHash);
   }
 
+  @Override
+  public void persistWorldStateForBlock(final BlockHeader blockHeader) {
+    if (worldStateCacheManager.contains(blockHeader.getBlockHash())) {
+      return;
+    }
+    try {
+      // Roll headWorldState to this block (1 trie-log forward replay from the previous head).
+      // This ensures that the next isWorldStateImmediatelyCached check for this block returns
+      // true, allowing sequential newPayload calls without an intervening FCU.
+      rollFullWorldStateToBlockHash(headWorldState, blockHeader.getBlockHash())
+          .ifPresentOrElse(
+              ws ->
+                  worldStateCacheManager.addCachedLayer(
+                      blockHeader, headWorldState.getWorldStateRootHash(), headWorldState),
+              () ->
+                  LOG.atDebug()
+                      .setMessage("Could not persist world state for block {}")
+                      .addArgument(blockHeader::toLogString)
+                      .log());
+    } catch (Exception e) {
+      LOG.atDebug()
+          .setMessage("Exception persisting world state for block {}: {}")
+          .addArgument(blockHeader::toLogString)
+          .addArgument(e::getMessage)
+          .log();
+    }
+  }
+
   /**
    * Gets a mutable world state based on the provided query parameters.
    *

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/provider/PathBasedWorldStateProvider.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/provider/PathBasedWorldStateProvider.java
@@ -143,20 +143,20 @@ public abstract class PathBasedWorldStateProvider implements WorldStateArchive {
     if (worldStateCacheManager.contains(blockHeader.getBlockHash())) {
       return;
     }
-    try {
-      // Roll headWorldState to this block (1 trie-log forward replay from the previous head).
-      // This ensures that the next isWorldStateImmediatelyCached check for this block returns
-      // true, allowing sequential newPayload calls without an intervening FCU.
-      rollFullWorldStateToBlockHash(headWorldState, blockHeader.getBlockHash())
-          .ifPresentOrElse(
-              ws ->
-                  worldStateCacheManager.addCachedLayer(
-                      blockHeader, headWorldState.getWorldStateRootHash(), headWorldState),
-              () ->
-                  LOG.atDebug()
-                      .setMessage("Could not persist world state for block {}")
-                      .addArgument(blockHeader::toLogString)
-                      .log());
+    // Use a non-head world state from the cache so we do NOT mutate headWorldState.
+    // headWorldState may be concurrently modified by backward sync on EthScheduler threads;
+    // rolling it here from the vert.x thread would race with those mutations.
+    try (final var worldState =
+        (PathBasedWorldState) getFullWorldStateFromCache(blockHeader).orElse(null)) {
+      if (worldState != null) {
+        worldStateCacheManager.addCachedLayer(
+            blockHeader, worldState.getWorldStateRootHash(), worldState);
+      } else {
+        LOG.atDebug()
+            .setMessage("Could not persist world state for block {}")
+            .addArgument(blockHeader::toLogString)
+            .log();
+      }
     } catch (Exception e) {
       LOG.atDebug()
           .setMessage("Exception persisting world state for block {}: {}")

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/worldstate/WorldStateArchive.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/worldstate/WorldStateArchive.java
@@ -48,11 +48,11 @@ public interface WorldStateArchive extends Closeable {
   }
 
   /**
-   * Moves the world state head to the given block and caches a snapshot of that state so that
-   * subsequent calls to {@link #isWorldStateImmediatelyCached(Hash)} return true for that block.
-   * This should be called after a block is successfully validated and stored (e.g. in
-   * rememberBlock) so that sequential newPayload calls without an intervening FCU can find the
-   * parent world state without trie-log replay. For non-Bonsai archives this is a no-op.
+   * Caches a snapshot of the world state for the given block so that subsequent calls to {@link
+   * #isWorldStateImmediatelyCached(Hash)} return true for that block. This should be called after a
+   * block is successfully validated and stored (e.g. in rememberBlock) so that sequential newPayload
+   * calls without an intervening FCU can find the parent world state without trie-log replay. Does
+   * not modify the world state head. For non-Bonsai archives this is a no-op.
    *
    * @param blockHeader the block whose world state should be cached
    */

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/worldstate/WorldStateArchive.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/worldstate/WorldStateArchive.java
@@ -50,9 +50,9 @@ public interface WorldStateArchive extends Closeable {
   /**
    * Caches a snapshot of the world state for the given block so that subsequent calls to {@link
    * #isWorldStateImmediatelyCached(Hash)} return true for that block. This should be called after a
-   * block is successfully validated and stored (e.g. in rememberBlock) so that sequential newPayload
-   * calls without an intervening FCU can find the parent world state without trie-log replay. Does
-   * not modify the world state head. For non-Bonsai archives this is a no-op.
+   * block is successfully validated and stored (e.g. in rememberBlock) so that sequential
+   * newPayload calls without an intervening FCU can find the parent world state without trie-log
+   * replay. Does not modify the world state head. For non-Bonsai archives this is a no-op.
    *
    * @param blockHeader the block whose world state should be cached
    */

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/worldstate/WorldStateArchive.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/worldstate/WorldStateArchive.java
@@ -48,6 +48,19 @@ public interface WorldStateArchive extends Closeable {
   }
 
   /**
+   * Moves the world state head to the given block and caches a snapshot of that state so that
+   * subsequent calls to {@link #isWorldStateImmediatelyCached(Hash)} return true for that block.
+   * This should be called after a block is successfully validated and stored (e.g. in
+   * rememberBlock) so that sequential newPayload calls without an intervening FCU can find the
+   * parent world state without trie-log replay. For non-Bonsai archives this is a no-op.
+   *
+   * @param blockHeader the block whose world state should be cached
+   */
+  default void persistWorldStateForBlock(final BlockHeader blockHeader) {
+    // no-op for non-Bonsai archives
+  }
+
+  /**
    * Gets a mutable world state based on the provided query parameters.
    *
    * <p>This method retrieves the mutable world state using the provided query parameters. The query


### PR DESCRIPTION
 Summary

PR #10600 introduced isWorldStateImmediatelyCached to prevent engine_newPayload from blocking the vert.x worker thread on expensive trie-log replay. This introduced a regression: after rememberBlock successfully validates and stores a  block, the block's world state is not in worldStateCacheManager (the try-with-resources in validateAndProcessBlock closes and discards the frozen layered storage on return). The next sequential newPayload call with that block as parent therefore finds nothing in cache, isWorldStateImmediatelyCached returns false, and Besu incorrectly returns SYNCING.

Fix

Call persistWorldStateForBlock from MergeCoordinator.rememberBlock after a block is successfully stored. This populates the cache so sequential newPayload calls can find the parent world state without trie-log replay.

persistWorldStateForBlock derives the world state via getFullWorldStateFromCache, which creates an isolated layered copy from the cache manager. headWorldState is deliberately not touched — backward sync mutates it from EthScheduler-Services threads and rolling it from the vert.x thread would be a data race.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Signed-off-by: Sally MacFarlane <macfarla.github@gmail.com>## PR description

## Fixed Issue(s)
Running locally:
 * Hive engine-cancun: 51 → 0 failures
 * Hive engine-withdrawal: 1 -> 0 failures
 * Hive engine-api: 9 -> 0 failures

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew build`
- [x] acceptance tests: `./gradlew acceptanceTest`
- [x] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [x] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


