### PR TITLE
Set testing_buildBlockV1 coinbase to suggestedFeeRecipient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - BFT option `xemptyblockperiodseconds` has been taken out of experimental and been renamed `emptyblockperiodseconds`. The old config option is deprecated and will be removed in a future release.
 
 ### Bug fixes
+- `testing_buildBlockV1` now sets the mining coinbase to the requested `suggestedFeeRecipient` before building, so the block header coinbase matches the account credited transaction fees and the EIP-7928 block access list. Previously the header used the node's configured coinbase (`Address.ZERO` on a block builder), so a non-zero `suggestedFeeRecipient` produced a block that self-rejected on `engine_newPayload` re-execution with a block access list hash mismatch.
 
 ### Additions and Improvements
 - The option to set a different block period for empty BFT blocks (`emptyblockperiodseconds`) is no longer experimental. The experimental flag `xemptyblockperiodseconds` will be removed in a future release.

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/testing/TestingBuildBlockV1.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/testing/TestingBuildBlockV1.java
@@ -210,6 +210,15 @@ public class TestingBuildBlockV1 implements JsonRpcMethod {
     try {
       final Address coinbase = payloadAttributes.getSuggestedFeeRecipient();
 
+      // The header coinbase is sourced from miningConfiguration (see
+      // BlockHeaderBuilder.createPending), whereas transaction fees and the EIP-7928
+      // block access list are credited to the mining beneficiary derived from the
+      // suggestedFeeRecipient below. Without aligning the two, the built block's header
+      // records the node's configured coinbase (Address.ZERO on a filler) while the BAL
+      // credits suggestedFeeRecipient, so re-execution on engine_newPayload recomputes a
+      // BAL under the header coinbase and the block self-rejects with a BAL hash mismatch.
+      miningConfiguration.setCoinbase(coinbase);
+
       final TestingBlockCreator blockCreator =
           new TestingBlockCreator(
               miningConfiguration,

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/testing/TestingBuildBlockV1Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/testing/TestingBuildBlockV1Test.java
@@ -16,6 +16,7 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.testing;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.datatypes.Address;
@@ -147,6 +148,31 @@ class TestingBuildBlockV1Test {
     assertThat(response).isInstanceOf(JsonRpcErrorResponse.class);
     final JsonRpcErrorResponse errorResponse = (JsonRpcErrorResponse) response;
     assertThat(errorResponse.getError().getCode()).isEqualTo(RpcErrorType.INVALID_PARAMS.getCode());
+  }
+
+  @Test
+  void shouldPropagateSuggestedFeeRecipientToMiningCoinbase() {
+    // The built block header coinbase is sourced from the mining configuration (see
+    // BlockHeaderBuilder.createPending), whereas transaction fees and the EIP-7928 block
+    // access list are credited to the mining beneficiary derived from suggestedFeeRecipient.
+    // Building must propagate suggestedFeeRecipient into the mining configuration so the two
+    // agree; otherwise the built header records the node's configured coinbase (Address.ZERO
+    // on a block-builder node) while the block access list credits suggestedFeeRecipient, and
+    // the block self-rejects on engine_newPayload re-execution with a BAL hash mismatch.
+    final BlockHeader parentHeader =
+        new BlockHeaderTestFixture().timestamp(DEFAULT_TIMESTAMP).buildHeader();
+    when(blockchain.getBlockHeader(any(Hash.class))).thenReturn(Optional.of(parentHeader));
+    final Address suggestedFeeRecipient =
+        Address.fromHexString("0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba");
+
+    // Block creation itself fails fast under the mocked protocol schedule, but the coinbase
+    // must already have been propagated to the mining configuration before the build is
+    // attempted.
+    method.response(
+        requestWithSuggestedFeeRecipient(
+            parentHeader.getHash().toHexString(), DEFAULT_TIMESTAMP + 1, suggestedFeeRecipient));
+
+    verify(miningConfiguration).setCoinbase(suggestedFeeRecipient);
   }
 
   @Test
@@ -350,6 +376,22 @@ class TestingBuildBlockV1Test {
             "2.0",
             "testing_buildBlockV1",
             new Object[] {parentHash, payloadAttributes, transactions, null}));
+  }
+
+  private JsonRpcRequestContext requestWithSuggestedFeeRecipient(
+      final String parentHash, final long timestamp, final Address suggestedFeeRecipient) {
+    final Map<String, Object> payloadAttributes = new LinkedHashMap<>();
+    payloadAttributes.put("timestamp", Bytes.ofUnsignedLong(timestamp).toQuantityHexString());
+    payloadAttributes.put("prevRandao", Hash.ZERO.toHexString());
+    payloadAttributes.put("suggestedFeeRecipient", suggestedFeeRecipient.toHexString());
+    payloadAttributes.put("withdrawals", Collections.emptyList());
+    payloadAttributes.put("parentBeaconBlockRoot", Bytes32.ZERO.toHexString());
+
+    return new JsonRpcRequestContext(
+        new JsonRpcRequest(
+            "2.0",
+            "testing_buildBlockV1",
+            new Object[] {parentHash, payloadAttributes, new String[0], null}));
   }
 
   private JsonRpcRequestContext requestWithMissingSuggestedFeeRecipient(


### PR DESCRIPTION
## PR description

`testing_buildBlockV1` produces a block whose header coinbase diverges from the
account that is actually credited transaction fees and recorded in the EIP-7928
block access list (BAL). The block therefore fails its own BAL validation when it
is later submitted via `engine_newPayload`.

## Root cause

`TestingBuildBlockV1` derives the mining beneficiary from the request's
`suggestedFeeRecipient` and passes it to `TestingBlockCreator`, so transaction
fees and the block access list are credited to `suggestedFeeRecipient`. The block
**header** coinbase, however, is sourced from the node's `MiningConfiguration` in
`BlockHeaderBuilder.createPending`:

```java
.coinbase(miningConfiguration.getCoinbase().orElse(Address.ZERO))
```

On a block-builder node with no configured coinbase this resolves to
`Address.ZERO`. So for any non-zero `suggestedFeeRecipient` (e.g. the standard
test coinbase `0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba`), the produced block has:

- header coinbase = `0x0`
- block access list crediting the fee balance change to `suggestedFeeRecipient`

When the block is submitted via `engine_newPayload`, re-execution credits the
header coinbase (`0x0`) and recomputes the BAL accordingly, which no longer
matches the supplied BAL. The block is rejected with
`Block access list hash mismatch`. (`--Xbal-log-bals-on-mismatch` shows the two
BALs differ in exactly one entry: the coinbase address.)

## Fix

Propagate `suggestedFeeRecipient` into the `MiningConfiguration` before building,
so the header coinbase matches the fee / BAL beneficiary:

```java
miningConfiguration.setCoinbase(coinbase);
```

## Testing

- Added `TestingBuildBlockV1Test.shouldPropagateSuggestedFeeRecipientToMiningCoinbase`,
  which fails without the fix (`Wanted but not invoked: miningConfiguration.setCoinbase(...)`).
- Verified end-to-end by filling EEST `tests/benchmark/compute` Amsterdam
  (EIP-7928 BAL) fixtures with besu: it went from rejecting **every** block with a
  BAL hash mismatch to filling **1032 of 1041** selected compute fixtures with
  **zero** BAL mismatches; the supplied BAL now matches re-execution. (The 3
  remaining failures are unrelated BLS12-381 precompile benchmark issues.)
