### PR TITLE
Update links to use updated paths.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -12,7 +12,7 @@ assignees: ''
 <!--     comply with it, including treating everyone with respect: -->
 <!--     https://github.com/besu-eth/besu/blob/main/CODE_OF_CONDUCT.md -->
 <!--   * Reproduced the issue in the latest version of the software -->
-<!--   * Read the debugging docs: https://besu.hyperledger.org/private-networks/how-to -->
+<!--   * Read the docs: https://docs.besu-eth.org/ -->
 <!--   * Duplicate Issue check:  https://github.com/search?q=+is%3Aissue+repo%3Abesu-eth/besu -->
 
 ### Steps to Reproduce

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,8 +9,8 @@
 ### Thanks for sending a pull request! Have you done the following?
 
 - [ ] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
-- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
-- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
+- [ ] Considered documentation and added the `doc-change-required` label to this PR if updates are required in the [Besu documentation](https://github.com/besu-eth/besu-docs).
+- [ ] Considered the changelog and [included an update if required](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md#changelog).
 - [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests
 
 ### Locally, you can run these tests to catch failures early:
@@ -20,6 +20,6 @@
 - [ ] acceptance tests: `./gradlew acceptanceTest`
 - [ ] integration tests: `./gradlew integrationTest`
 - [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
-- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)
+- [ ] hive tests: [Engine or other RPCs modified?](https://github.com/besu-eth/besu/wiki/Working-through-Hive-tests)
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,7 @@ This document covers everything you need to know to decide whether and how you w
 - [Reporting bugs](#reporting-bugs)
 - [Suggesting enhancements](#suggesting-enhancements)
 - [Pull requests](#pull-requests)
+- [Changelog](#changelog)
 - [Code reviews](#code-reviews)
 - [Developer Certificate of Origin (DCO)](#developer-certificate-of-origin-dco)
 - [Copyright and license](#copyright-and-license)
@@ -156,6 +157,16 @@ Please follow these steps to have your contribution considered by the approvers:
 #### What if the status checks are failing?
 
 - If a status check is failing and you believe the failure is unrelated to your change, leave a comment on the pull request explaining why. A maintainer will re-run the status check for you. If we conclude that the failure was a false positive, we will open an issue to track the problem with our status check suite.
+
+## Changelog
+
+Besu maintains a [`CHANGELOG.md`](CHANGELOG.md) so users can see what changed between releases. Include a changelog entry in the same PR as your change when it introduces any of the following:
+
+- Future breaking changes or deprecated functionality.
+- A new feature, with a short description of the functionality.
+- A fixed bug, with a description of the user impact.
+
+Add your entry under the `## Unreleased` section, in the appropriate subsection (for example, **Breaking Changes**, **Additions and Improvements**, or **Bug fixes**), as a single line ending with a link to your PR or issue. Where several PRs contribute to the same feature, the feature developer can add a single entry covering the whole feature.
 
 ## Code reviews
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -99,7 +99,7 @@ The following steps must occur for a contributor to be "upgraded" as a maintaine
 - No veto raised by another maintainer within the voting timeframe.
   - All vetoes must be accompanied by a public explanation as a comment on the
     proposal PR.
-  - The explanation of the veto must be reasonable and follow the [Besu code of conduct](https://wiki.hyperledger.org/display/BESU/Code+of+Conduct).
+  - The explanation of the veto must be reasonable and follow the [Besu code of conduct](CODE_OF_CONDUCT.md).
   - A veto can be retracted, in that case, the voting timeframe is reset, and all approvals are removed.
   - It is bad form to veto, retract, and veto again.
   

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
-Hyperledger Besu
-Copyright contributors to Hyperledger Besu.
+Besu
+Copyright contributors to Besu.
 
 This product includes software adapted from Tuweni. (https://tuweni.tmio.io/)
 Copyright 2023-2024 The Machine Consultancy LLC

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,22 +1,23 @@
-# Hyperledger Security Policy
+# Security Policy
 
 ## Reporting a Security Bug
 
-If you think you have discovered a security issue in any of the Hyperledger projects, we'd love to
-hear from you. We will take all security bugs seriously and if confirmed upon investigation we will
-patch it within a reasonable amount of time and release a public security bulletin discussing the
-impact and credit the discoverer.
+If you think you have discovered a security issue in any of the Linux Foundation Decentralized Trust
+(LF Decentralized Trust) projects, we'd love to hear from you. We will take all security bugs
+seriously and if confirmed upon investigation we will patch it within a reasonable amount of time and
+release a public security bulletin discussing the impact and credit the discoverer.
 
-There are two email addresses where Hyperledger Besu accepts security bugs. The
-first, [security "dash" besu at lists dot hyperledger dot org](mailto:security-besu@lists.hyperledger.org)
-is limited to a subset of Hyperledger Besu maintainers and Hyperledger staff. For highly sensitive
-bugs this is a preferred address. The second email
-address [security at hyperledger dot org](mailto:security@hyperledger.org) is limited to a subset of
-maintainers and staff of all Hyperledger projects, and may be viewed by maintainers outside of
-Hyperledger Besu. When sending information to either of these emails please be sure to include a
-description of the flaw and any related information (e.g. reproduction steps, version, known active
-use).
+Besu accepts security bugs at two email addresses:
 
-The process by which the Hyperledger Security Team handles security bugs is documented further in
+- [security-besu@lists.hyperledger.org](mailto:security-besu@lists.hyperledger.org) is limited to a
+  subset of Besu maintainers and LF Decentralized Trust staff. For highly sensitive bugs, this is the preferred
+  address.
+- [security@hyperledger.org](mailto:security@hyperledger.org) is limited to a subset of maintainers
+  and staff of all LF Decentralized Trust projects, and may be viewed by maintainers outside of Besu.
+
+When sending information to either of these emails, please include a description of the flaw and any
+related information (for example, reproduction steps, version, and known active use).
+
+The process by which the LF Decentralized Trust Security Team handles security bugs is documented further in
 our [Defect Response page](https://wiki.hyperledger.org/display/SEC/Defect+Response) on our
 [wiki](https://wiki.hyperledger.org).

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,24 +1,35 @@
 # Besu Support
 
-Welcome to the Besu repository! The following links are a set of guidelines for contributing to this repo and its packages. These are mostly guidelines, not rules. Use your best judgement, and feel free to propose changes to this document in a pull request. Contributions come in the form of code submissions, writing documentation, raising issues, helping others in chat, and any other actions that help develop Besu.
+Need help with Besu? The following resources are the best places to find answers and reach the
+community.
 
-### Github/Discord/LF Accounts
+## Documentation
 
-Having Github, Discord, and Linux Foundation accounts is necessary for obtaining support for Besu through the community channels, wiki and issue management.  
-* If you want to raise an issue, you can do so [on the github issue tab](https://github.com/besu-eth/besu/issues).   
-* Discord requires a [Discord account].
-* The Besu wiki also requires a [Linux Foundation (LF) account] in order to edit pages.
+The [Besu documentation](https://docs.besu-eth.org/) answers many common questions. Useful starting
+points include:
 
-### Useful support links
+* [Install Besu](https://docs.besu-eth.org/public-networks/get-started/install/binary-distribution)
+* [System requirements](https://docs.besu-eth.org/public-networks/get-started/system-requirements)
+* [Troubleshoot peering](https://docs.besu-eth.org/public-networks/how-to/troubleshoot/peering)
+* [Troubleshoot performance](https://docs.besu-eth.org/public-networks/how-to/troubleshoot/performance)
 
-* [Besu User Documentation]
-* [Besu channel on Discord]
-* [I just have a quick question](https://wiki.hyperledger.org/display/BESU/I+just+have+a+quick+question)
-* [Did you find a bug?](https://wiki.hyperledger.org/display/BESU/Reporting+Bugs)
-* [Issues](https://wiki.hyperledger.org/display/BESU/Issues)
-* [Contributing Guidelines]
+## Chat
 
+Join the [Besu Discord](https://discord.com/invite/hyperledger):
 
-[Besu User Documentation]: https://besu.hyperledger.org
-[Besu channel on Discord]: https://discord.com/invite/hyperledger
-[Contributing Guidelines]: CONTRIBUTING.md
+* `#besu` to ask questions and get support from the team and community.
+* `#besu-contributors` if you are interested in contributing to the client.
+
+## Issues
+
+Besu issues are tracked in the [GitHub issues tab](https://github.com/besu-eth/besu/issues). Before
+opening a new issue, [search the existing issues](https://github.com/besu-eth/besu/issues) to see if
+your problem has already been reported.
+
+For guidance on reporting bugs and what to include, see the
+[contributing guidelines](CONTRIBUTING.md).
+
+## Accounts
+
+A [GitHub account](https://github.com) is required to open issues. Discord is optional, but useful
+for asking questions and chatting with the community.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,5 @@
 Besu user documentation was moved to a separate repository to help manage versions and releases.
 
-If you want to contribute to the doc site, make a pull request against https://github.com/hyperledger/besu-docs
+If you want to contribute to the doc site, make a pull request against https://github.com/besu-eth/besu-docs
 
-The generated doc website is at https://besu.hyperledger.org/
+The generated doc website is at https://docs.besu-eth.org/

--- a/ethereum/evmtool/README.md
+++ b/ethereum/evmtool/README.md
@@ -75,7 +75,7 @@ Assuming homebrew and SDKMan are both installed, the complete script is
 ```zsh
 sdk install java 25.0.3-tem 
 sdk use java 25.0.3-tem
-git clone https://github.com/hyperledger/besu
+git clone https://github.com/besu-eth/besu
 cd besu
 ./gradlew installDist -x test
 cd ..


### PR DESCRIPTION
## PR description

### Changes

- SECURITY.md: Update product branding to Besu and org references to LF Decentralized Trust. Reporting emails, security team, and Defect Response process are unchanged (confirmed still correct). Reformat the two reporting addresses as a bullet list with the real addresses.
- SUPPORT.md: Rewrite as a concise, support-focused page. Remove dead wiki.hyperledger.org links and broken reference-style links; point to docs.besu-eth.org, Discord, and GitHub issues.
- docs/README.md: Repoint to besu-eth/besu-docs and docs.besu-eth.org.
- CONTRIBUTING.md: Add a Changelog section documenting what to include and the entry format (no equivalent existed after the Confluence wiki retired).
- .github/pull_request_template.md: Repoint documentation, changelog, and Hive test links (changelog now links to the new CONTRIBUTING.md#changelog section).
- .github/ISSUE_TEMPLATE/bug-report.md: Update debugging docs URL to docs.besu-eth.org.
- MAINTAINERS.md: Point the Code of Conduct link to the local CODE_OF_CONDUCT.md.
- ethereum/evmtool/README.md: Update clone URL to besu-eth/besu.
- NOTICE: Update the project's own attribution to "Besu" (third-party Tuweni/Apache attribution left verbatim).

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests




