### PR TITLE
Persist state and advance chain on non-adjacent engine_newPayload

### DIFF
--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
@@ -654,11 +654,13 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
 
   @Override
   public BlockProcessingResult validateBlock(final Block block) {
-    return validateBlock(block, Optional.empty());
+    return validateBlock(block, Optional.empty(), false);
   }
 
   private BlockProcessingResult validateBlock(
-      final Block block, final Optional<BlockAccessList> blockAccessList) {
+      final Block block,
+      final Optional<BlockAccessList> blockAccessList,
+      final boolean shouldPersist) {
     final var validationResult =
         protocolSchedule
             .getByBlockHeader(block.getHeader())
@@ -669,7 +671,7 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
                 HeaderValidationMode.FULL,
                 HeaderValidationMode.NONE,
                 blockAccessList,
-                false);
+                shouldPersist);
 
     return validationResult;
   }
@@ -702,15 +704,22 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
       final Block block, final Optional<BlockAccessList> blockAccessList) {
     LOG.atDebug().setMessage("Remember block {}").addArgument(block::toLogString).log();
     final var chain = protocolContext.getBlockchain();
-    final var validationResult = validateBlock(block, blockAccessList);
+    final boolean appendToCanonicalChain =
+        block.getHeader().getNumber() - protocolContext.getBlockchain().getChainHeadBlockNumber()
+            > 1;
+    final var validationResult = validateBlock(block, blockAccessList, appendToCanonicalChain);
     validationResult
         .getYield()
         .ifPresentOrElse(
-            result ->
-                chain.storeBlock(
-                    block,
-                    result.getReceipts(),
-                    validationResult.getYield().flatMap(y -> y.getBlockAccessList())),
+            result -> {
+              final Optional<BlockAccessList> processedBlockAccessList =
+                  validationResult.getYield().flatMap(y -> y.getBlockAccessList());
+              if (appendToCanonicalChain) {
+                chain.appendBlock(block, result.getReceipts(), processedBlockAccessList);
+              } else {
+                chain.storeBlock(block, result.getReceipts(), processedBlockAccessList);
+              }
+            },
             () -> LOG.debug("empty yield in blockProcessingResult"));
     return validationResult;
   }


### PR DESCRIPTION
## Summary
- When `engine_newPayload` receives a block more than one height ahead of the current chain head, persist the world state during validation and append the block to the canonical chain instead of only storing it.
- Keeps the existing `storeBlock` path for adjacent blocks (distance ≤ 1), so forkchoiceUpdated remains responsible for moving the head in the normal case.

## Test plan
- [x] `./gradlew :consensus:merge:test`
- [ ] Run glamsterdam-devnet-6 node and verify `engine_newPayload` without FCU for blocks > 1 ahead of head persists state and advances chain head
- [ ] Confirm adjacent newPayload + FCU flow is unchanged


Made with [Cursor](https://cursor.com)