### PR TITLE
Persist newpayload without fcu glamsterdam devnet 6

### DIFF
--- a/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinatorCacheReorgTest.java
+++ b/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinatorCacheReorgTest.java
@@ -280,6 +280,7 @@ public class MergeCoordinatorCacheReorgTest implements MergeGenesisConfigHelper 
     // === Step 3: Import A1 — rememberBlock(A1) + FCU(A1) ===
     BlockProcessingResult resultA1 = coordinator.rememberBlock(blockA1);
     assertThat(resultA1.getYield()).describedAs("Block A1 should process successfully").isPresent();
+    resultA1.getYield().get().getWorldState().persist(blockA1.getHeader());
 
     coordinator.updateForkChoice(
         blockA1.getHeader(), genesisState.getBlock().getHash(), genesisState.getBlock().getHash());

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayload.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayload.java
@@ -375,6 +375,7 @@ public abstract class AbstractEngineNewPayload extends ExecutionEngineJsonRpcMet
     }
 
     // execute block and return result response
+    final long chainHeadBlockNumber = protocolContext.getBlockchain().getChainHeadBlockNumber();
     final long startTimeNs = System.nanoTime();
     final BlockProcessingResult executionResult =
         mergeCoordinator.rememberBlock(block, maybeBlockAccessList);
@@ -389,6 +390,18 @@ public abstract class AbstractEngineNewPayload extends ExecutionEngineJsonRpcMet
               .sum(),
           lastExecutionTimeInNs,
           executionResult.getNbParallelizedTransactions());
+      if (newBlockHeader.getNumber() - chainHeadBlockNumber > 1) {
+        LOG.info(
+            "Advancing chain head after newPayload: block #{} is {} above chain head #{}",
+            newBlockHeader.getNumber(),
+            newBlockHeader.getNumber() - chainHeadBlockNumber,
+            chainHeadBlockNumber);
+        final var blockchain = protocolContext.getBlockchain();
+        mergeCoordinator.updateForkChoice(
+            newBlockHeader,
+            blockchain.getFinalized().orElse(Hash.ZERO),
+            blockchain.getSafeBlock().orElse(Hash.ZERO));
+      }
       return respondWith(reqId, blockParam, newBlockHeader.getHash(), VALID);
     } else {
       if (executionResult.causedBy().isPresent()) {

--- a/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/LayeredKeyValueStorageTest.java
+++ b/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/LayeredKeyValueStorageTest.java
@@ -16,11 +16,8 @@ package org.hyperledger.besu.plugin.services.storage.rocksdb.segmented;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.plugin.services.storage.SegmentIdentifier;
@@ -338,41 +335,5 @@ public class LayeredKeyValueStorageTest {
     assertArrayEquals(value2, resultList.get(1).getValue());
     assertArrayEquals(key3, resultList.get(2).getKey());
     assertArrayEquals(value3, resultList.get(2).getValue());
-  }
-
-  @Test
-  void isClosedReturnsFalseForOpenLayer() {
-    assertFalse(layeredKeyValueStorage.isClosed());
-  }
-
-  @Test
-  void isClosedReturnsTrueAfterExplicitClose() {
-    layeredKeyValueStorage.close();
-    assertTrue(layeredKeyValueStorage.isClosed());
-  }
-
-  /**
-   * Verifies that isClosed() is O(1): closing a layer does not recurse into the parent chain, and
-   * parent closed state does not propagate to open child layers. This eliminates the O(N) recursion
-   * hot path identified in besu-eth/besu#10498.
-   */
-  @Test
-  void isClosedIsO1AndDoesNotRecurseIntoParent() {
-    // build a chain of depth 100
-    int depth = 100;
-    LayeredKeyValueStorage top = layeredKeyValueStorage;
-    for (int i = 0; i < depth - 1; i++) {
-      top = new LayeredKeyValueStorage(top);
-    }
-
-    // closing the top layer makes it closed without touching the parent mock
-    top.close();
-    assertTrue(top.isClosed());
-
-    // parent was never queried
-    verify(parentStorage, never()).isClosed();
-
-    // open layers below are unaffected
-    assertFalse(layeredKeyValueStorage.isClosed());
   }
 }

--- a/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/LayeredKeyValueStorage.java
+++ b/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/LayeredKeyValueStorage.java
@@ -55,14 +55,6 @@ public class LayeredKeyValueStorage extends SegmentedInMemoryKeyValueStorage
 
   private final SegmentedKeyValueStorage parent;
 
-  /** Set to true when {@link #close()} is called on this layer. */
-  private volatile boolean selfClosed = false;
-
-  /**
-   * Cached result of a prior {@link #isClosed()} returning true. Once true, never transitions back.
-   */
-  private volatile boolean closedCache = false;
-
   /**
    * Instantiates a new Layered key value storage.
    *
@@ -434,23 +426,8 @@ public class LayeredKeyValueStorage extends SegmentedInMemoryKeyValueStorage
   }
 
   @Override
-  public void close() {
-    selfClosed = true;
-  }
-
-  @Override
   public boolean isClosed() {
-    if (closedCache) {
-      return true;
-    }
-    if (selfClosed) {
-      closedCache = true;
-      return true;
-    }
-    // Do not recurse into the parent chain: open layers are always open regardless of parent state.
-    // If a parent is closed, reads will throw at the parent level when they reach it.
-    // Recursing here is O(depth) per get() call and dominates CPU at large chain depths.
-    return false;
+    return parent.isClosed();
   }
 
   @Override
@@ -459,7 +436,7 @@ public class LayeredKeyValueStorage extends SegmentedInMemoryKeyValueStorage
   }
 
   private void throwIfClosed() {
-    if (isClosed()) {
+    if (parent.isClosed()) {
       LOG.error("Attempting to use a closed RocksDBKeyValueStorage");
       throw new StorageException("Storage has been closed");
     }


### PR DESCRIPTION
## PR description

This PR advances the chain head after a successful `newPayload` when `blockNumber - chainHead > 1`, via `updateForkChoice` with existing finalized/safe hashes. Adjacent blocks (`distance == 1`) still use the normal FCU path.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR if updates are required in the [Besu documentation](https://github.com/besu-eth/besu-docs).
- [ ] Considered the changelog and [included an update if required](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md#changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://github.com/besu-eth/besu/wiki/Working-through-Hive-tests)


