### PR TITLE
Fix BFT transition fork type regression in 26.6.1.

### DIFF
--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/BaseBftProtocolScheduleBuilder.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/BaseBftProtocolScheduleBuilder.java
@@ -104,8 +104,11 @@ public abstract class BaseBftProtocolScheduleBuilder {
     final BftProtocolSchedule bftSchedule =
         new BftProtocolSchedule((DefaultProtocolSchedule) protocolSchedule);
 
-    // Once we have the schedule we can update the fork schedule with the type of each milestone
-    forksSchedule.applyMilestoneTypes(bftSchedule);
+    // Keep transition milestones block-based.
+    // QBFT/IBFT/Clique `transitions` are configured with block numbers, and forcing
+    // timestamp-based fork type selection can incorrectly activate transitions early.
+    // NOTE: this preserves pre-26.x behavior for BFT transitions.
+    // forksSchedule.applyMilestoneTypes(bftSchedule);
 
     return bftSchedule;
   }


### PR DESCRIPTION
Problem
On QBFT networks that use `transitions` (block-based validator configuration changes), Besu `26.6.1` can incorrectly treat BFT milestones as time-based after milestone type reclassification. In affected configurations, this may activate the validator-contract path too early during startup/sync and fail with:

`Unexpected empty result from validator smart contract call`

Fix
Preserve block-based semantics for BFT transition milestones in `BaseBftProtocolScheduleBuilder` by not applying milestone type reclassification to the BFT protocol schedule (`forksSchedule.applyMilestoneTypes(bftSchedule)`).

This keeps QBFT `transitions` resolved by block number as intended and avoids premature validator-contract resolution.

Test
- Reproduced the failure on an affected QBFT genesis configuration (with `transitions` plus time-fork fields present).
- Built Besu with this patch and re-ran the same scenario.
- Verified node startup and sync proceed normally.
- Verified previous failure signature is no longer observed:
  - `Unexpected empty result from validator smart contract call`