### PR TITLE
fcu before engine new payload

### DIFF
--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
@@ -727,6 +727,27 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
     return applyForkChoice(newHead, finalizedBlockHash, safeBlockHash);
   }
 
+  @Override
+  public ForkchoiceResult updateHeadForExecution(final BlockHeader newHead) {
+    final MutableBlockchain blockchain = protocolContext.getBlockchain();
+    final Optional<Hash> latestValid = getLatestValidAncestor(newHead);
+
+    Optional<BlockHeader> parentOfNewHead = blockchain.getBlockHeader(newHead.getParentHash());
+    if (parentOfNewHead.isPresent()
+        && Long.compareUnsigned(newHead.getTimestamp(), parentOfNewHead.get().getTimestamp())
+            <= 0) {
+      return ForkchoiceResult.withFailure(
+          INVALID, "new head timestamp not greater than parent", latestValid);
+    }
+
+    if (!setNewHead(blockchain, newHead)) {
+      LOG.warn("Failed to move world state to new head {}", newHead.toLogString());
+      return ForkchoiceResult.withFailure(INVALID, "Failed to set new head", latestValid);
+    }
+
+    return ForkchoiceResult.withResult(Optional.empty(), Optional.of(newHead));
+  }
+
   private ForkchoiceResult applyForkChoice(
       final BlockHeader newHead, final Hash finalizedBlockHash, final Hash safeBlockHash) {
     final MutableBlockchain blockchain = protocolContext.getBlockchain();

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeMiningCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeMiningCoordinator.java
@@ -126,6 +126,20 @@ public interface MergeMiningCoordinator extends MiningCoordinator {
       final BlockHeader newHead, final Hash finalizedBlockHash, final Hash safeBlockHash);
 
   /**
+   * Move the canonical chain head without updating forkchoice metadata (finalized or safe).
+   *
+   * <p>Use this for pre-execution head advancement during {@code engine_newPayload}, when the
+   * parent block was previously received via {@code newPayload} but the chain head was not moved
+   * forward yet. Unlike {@link #updateForkChoice}, this does not apply the legacy "ignore update
+   * to old head" optimization. Unlike {@link #updateForkChoice} and {@link
+   * #updateForkChoiceWithoutLegacySkip}, this does not persist finalized or safe block markers.
+   *
+   * @param newHead the new head
+   * @return the forkchoice result
+   */
+  ForkchoiceResult updateHeadForExecution(final BlockHeader newHead);
+
+  /**
    * Returns true if the given block hash is a strict ancestor of the currently finalized block
    * (i.e. an older block on the same chain, not finalized itself). Returns false when no finalized
    * block is known, when the candidate hash cannot be located, or when the candidate IS the

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeMiningCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeMiningCoordinator.java
@@ -130,8 +130,8 @@ public interface MergeMiningCoordinator extends MiningCoordinator {
    *
    * <p>Use this for pre-execution head advancement during {@code engine_newPayload}, when the
    * parent block was previously received via {@code newPayload} but the chain head was not moved
-   * forward yet. Unlike {@link #updateForkChoice}, this does not apply the legacy "ignore update
-   * to old head" optimization. Unlike {@link #updateForkChoice} and {@link
+   * forward yet. Unlike {@link #updateForkChoice}, this does not apply the legacy "ignore update to
+   * old head" optimization. Unlike {@link #updateForkChoice} and {@link
    * #updateForkChoiceWithoutLegacySkip}, this does not persist finalized or safe block markers.
    *
    * @param newHead the new head

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/TransitionCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/TransitionCoordinator.java
@@ -162,6 +162,11 @@ public class TransitionCoordinator extends TransitionUtils<MiningCoordinator>
   }
 
   @Override
+  public ForkchoiceResult updateHeadForExecution(final BlockHeader newHead) {
+    return mergeCoordinator.updateHeadForExecution(newHead);
+  }
+
+  @Override
   public boolean isAncestorOfFinalized(final Hash candidateHeadHash) {
     return mergeCoordinator.isAncestorOfFinalized(candidateHeadHash);
   }

--- a/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinatorTest.java
+++ b/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinatorTest.java
@@ -1082,6 +1082,55 @@ public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
     verify(blockchain, never()).rewindToBlock(any());
   }
 
+  @Test
+  public void updateHeadForExecutionShouldMoveHeadWithoutUpdatingFinalizedOrSafe() {
+    BlockHeader terminalHeader = terminalPowBlock();
+    sendNewPayloadAndForkchoiceUpdate(
+        new Block(terminalHeader, BlockBody.empty()), Optional.empty(), Hash.ZERO);
+
+    BlockHeader parentHeader = nextBlockHeader(terminalHeader);
+    Block parent = new Block(parentHeader, BlockBody.empty());
+    coordinator.rememberBlock(parent);
+
+    BlockHeader childHeader = nextBlockHeader(parentHeader);
+    Block child = new Block(childHeader, BlockBody.empty());
+    sendNewPayloadAndForkchoiceUpdate(child, Optional.empty(), parent.getHash());
+
+    clearInvocations(blockchain, mergeContext);
+
+    ForkchoiceResult result = coordinator.updateHeadForExecution(parentHeader);
+
+    assertThat(result.shouldNotProceedToPayloadBuildProcess()).isFalse();
+    assertThat(result.getNewHead()).contains(parentHeader);
+    assertThat(blockchain.getChainHeadHash()).isEqualTo(parentHeader.getHash());
+
+    verify(blockchain, never()).setFinalized(any());
+    verify(mergeContext, never()).setFinalized(any());
+    verify(blockchain, never()).setSafeBlock(any());
+    verify(mergeContext, never()).setSafeBlock(any());
+  }
+
+  @Test
+  public void updateHeadForExecutionShouldNotIgnoreAncestorOfChainHead() {
+    BlockHeader terminalHeader = terminalPowBlock();
+    sendNewPayloadAndForkchoiceUpdate(
+        new Block(terminalHeader, BlockBody.empty()), Optional.empty(), Hash.ZERO);
+
+    BlockHeader parentHeader = nextBlockHeader(terminalHeader);
+    Block parent = new Block(parentHeader, BlockBody.empty());
+    sendNewPayloadAndForkchoiceUpdate(parent, Optional.empty(), terminalHeader.getHash());
+
+    BlockHeader childHeader = nextBlockHeader(parentHeader);
+    Block child = new Block(childHeader, BlockBody.empty());
+    sendNewPayloadAndForkchoiceUpdate(child, Optional.empty(), parent.getHash());
+
+    ForkchoiceResult result = coordinator.updateHeadForExecution(parentHeader);
+
+    assertThat(result.getStatus()).isEqualTo(ForkchoiceResult.Status.VALID);
+    assertThat(result.getNewHead()).contains(parentHeader);
+    assertThat(blockchain.getChainHeadHash()).isEqualTo(parentHeader.getHash());
+  }
+
   @ParameterizedTest(name = "{index}: {0}")
   @MethodSource("getGasLimits")
   public void shouldSetCorrectTargetGasLimit(final ArgumentsAccessor argumentsAccessor) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayload.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayload.java
@@ -44,6 +44,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcRespon
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.EnginePayloadStatusResult;
+import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockBody;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
@@ -391,6 +392,17 @@ public abstract class AbstractEngineNewPayload extends ExecutionEngineJsonRpcMet
           .addArgument(blockParam::getParentHash)
           .log();
       return respondWith(reqId, blockParam, null, SYNCING);
+    }
+
+    final MutableBlockchain blockchain = protocolContext.getBlockchain();
+    if (!newBlockHeader.getParentHash().equals(blockchain.getChainHeadHash())) {
+      maybeParentHeader.ifPresent(
+          parentHeader -> {
+            mergeCoordinator.updateForkChoice(
+                parentHeader,
+                blockchain.getFinalized().orElse(Hash.ZERO),
+                blockchain.getSafeBlock().orElse(Hash.ZERO));
+          });
     }
 
     // execute block and return result response

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayload.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayload.java
@@ -72,6 +72,7 @@ import java.security.InvalidParameterException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -395,15 +396,14 @@ public abstract class AbstractEngineNewPayload extends ExecutionEngineJsonRpcMet
     }
 
     final MutableBlockchain blockchain = protocolContext.getBlockchain();
-    if (!newBlockHeader.getParentHash().equals(blockchain.getChainHeadHash())) {
-      maybeParentHeader.ifPresent(
-          parentHeader -> {
-            mergeCoordinator.updateForkChoice(
-                parentHeader,
-                blockchain.getFinalized().orElse(Hash.ZERO),
-                blockchain.getSafeBlock().orElse(Hash.ZERO));
-          });
-    }
+    final Hash chainHeadHash = blockchain.getChainHeadHash();
+    maybeParentHeader
+        .filter(
+            parentHeader ->
+                chainHeadHash != null
+                    && !Objects.equals(newBlockHeader.getParentHash(), chainHeadHash)
+                    && Objects.equals(parentHeader.getParentHash(), chainHeadHash))
+        .ifPresent(mergeCoordinator::updateHeadForExecution);
 
     // execute block and return result response
     final long startTimeNs = System.nanoTime();

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayloadTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayloadTest.java
@@ -334,7 +334,8 @@ public abstract class AbstractEngineNewPayloadTest extends AbstractScheduledApiT
             new BlockProcessingResult(Optional.of(new BlockProcessingOutputs(null, List.of()))),
             Optional.empty());
     Hash chainHeadHash =
-        Hash.fromHexStringLenient("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef");
+        Hash.fromHexStringLenient(
+            "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef");
     BlockHeader parentHeader = mock(BlockHeader.class);
     when(blockchain.getBlockHeader(mockHeader.getParentHash()))
         .thenReturn(Optional.of(parentHeader));
@@ -362,9 +363,11 @@ public abstract class AbstractEngineNewPayloadTest extends AbstractScheduledApiT
             new BlockProcessingResult(Optional.of(new BlockProcessingOutputs(null, List.of()))),
             Optional.empty());
     Hash chainHeadHash =
-        Hash.fromHexStringLenient("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef");
+        Hash.fromHexStringLenient(
+            "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef");
     Hash grandparentHash =
-        Hash.fromHexStringLenient("0xcafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabe");
+        Hash.fromHexStringLenient(
+            "0xcafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabe");
     BlockHeader parentHeader = mock(BlockHeader.class);
     when(blockchain.getBlockHeader(mockHeader.getParentHash()))
         .thenReturn(Optional.of(parentHeader));

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayloadTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayloadTest.java
@@ -22,8 +22,10 @@ import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.Executi
 import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.ExecutionEngineJsonRpcMethod.EngineStatus.VALID;
 import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineTestSupport.fromErrorResp;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -31,6 +33,7 @@ import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.consensus.merge.MergeContext;
 import org.hyperledger.besu.consensus.merge.blockcreation.MergeMiningCoordinator;
+import org.hyperledger.besu.consensus.merge.blockcreation.MergeMiningCoordinator.ForkchoiceResult;
 import org.hyperledger.besu.datatypes.BlobGas;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.Wei;
@@ -72,6 +75,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -321,6 +325,83 @@ public abstract class AbstractEngineNewPayloadTest extends AbstractScheduledApiT
     assertThat(res.getStatusAsString()).isEqualTo(SYNCING.name());
     assertThat(res.getError()).isNull();
     verify(engineCallListener, times(1)).executionEngineCalled();
+  }
+
+  @Test
+  public void shouldUpdateHeadForExecutionToParentBeforeExecutionWhenParentIsDirectChildOfHead() {
+    BlockHeader mockHeader =
+        setupValidPayload(
+            new BlockProcessingResult(Optional.of(new BlockProcessingOutputs(null, List.of()))),
+            Optional.empty());
+    Hash chainHeadHash =
+        Hash.fromHexStringLenient("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef");
+    BlockHeader parentHeader = mock(BlockHeader.class);
+    when(blockchain.getBlockHeader(mockHeader.getParentHash()))
+        .thenReturn(Optional.of(parentHeader));
+    when(blockchain.getChainHeadHash()).thenReturn(chainHeadHash);
+    when(parentHeader.getParentHash()).thenReturn(chainHeadHash);
+    when(worldStateArchive.isWorldStateImmediatelyCached(mockHeader.getParentHash()))
+        .thenReturn(true);
+    when(mergeCoordinator.updateHeadForExecution(parentHeader))
+        .thenReturn(ForkchoiceResult.withResult(Optional.empty(), Optional.of(parentHeader)));
+
+    var resp = resp(mockEnginePayload(mockHeader, emptyList()));
+
+    assertValidResponse(mockHeader, resp);
+    InOrder inOrder = inOrder(mergeCoordinator);
+    inOrder.verify(mergeCoordinator).updateHeadForExecution(parentHeader);
+    inOrder.verify(mergeCoordinator).rememberBlock(any(), any());
+    verify(mergeCoordinator, never()).updateForkChoice(any(), any(), any());
+    verify(mergeCoordinator, never()).updateForkChoiceWithoutLegacySkip(any(), any(), any());
+  }
+
+  @Test
+  public void shouldNotUpdateForkChoiceBeforeExecutionWhenParentIsNotDirectChildOfHead() {
+    BlockHeader mockHeader =
+        setupValidPayload(
+            new BlockProcessingResult(Optional.of(new BlockProcessingOutputs(null, List.of()))),
+            Optional.empty());
+    Hash chainHeadHash =
+        Hash.fromHexStringLenient("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef");
+    Hash grandparentHash =
+        Hash.fromHexStringLenient("0xcafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabe");
+    BlockHeader parentHeader = mock(BlockHeader.class);
+    when(blockchain.getBlockHeader(mockHeader.getParentHash()))
+        .thenReturn(Optional.of(parentHeader));
+    when(blockchain.getChainHeadHash()).thenReturn(chainHeadHash);
+    when(parentHeader.getParentHash()).thenReturn(grandparentHash);
+    when(worldStateArchive.isWorldStateImmediatelyCached(mockHeader.getParentHash()))
+        .thenReturn(true);
+
+    var resp = resp(mockEnginePayload(mockHeader, emptyList()));
+
+    assertValidResponse(mockHeader, resp);
+    verify(mergeCoordinator, never()).updateHeadForExecution(any());
+    verify(mergeCoordinator, never()).updateForkChoiceWithoutLegacySkip(any(), any(), any());
+    verify(mergeCoordinator, never()).updateForkChoice(any(), any(), any());
+    verify(mergeCoordinator).rememberBlock(any(), any());
+  }
+
+  @Test
+  public void shouldNotUpdateForkChoiceBeforeExecutionWhenParentIsChainHead() {
+    BlockHeader mockHeader =
+        setupValidPayload(
+            new BlockProcessingResult(Optional.of(new BlockProcessingOutputs(null, List.of()))),
+            Optional.empty());
+    BlockHeader parentHeader = mock(BlockHeader.class);
+    when(blockchain.getBlockHeader(mockHeader.getParentHash()))
+        .thenReturn(Optional.of(parentHeader));
+    when(blockchain.getChainHeadHash()).thenReturn(mockHeader.getParentHash());
+    when(worldStateArchive.isWorldStateImmediatelyCached(mockHeader.getParentHash()))
+        .thenReturn(true);
+
+    var resp = resp(mockEnginePayload(mockHeader, emptyList()));
+
+    assertValidResponse(mockHeader, resp);
+    verify(mergeCoordinator, never()).updateHeadForExecution(any());
+    verify(mergeCoordinator, never()).updateForkChoiceWithoutLegacySkip(any(), any(), any());
+    verify(mergeCoordinator, never()).updateForkChoice(any(), any(), any());
+    verify(mergeCoordinator).rememberBlock(any(), any());
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Call `updateForkChoice` on the parent header **before** executing `engine_newPayload` when the new block’s parent is not the current chain head

## Test plan

- [ ] Engine API acceptance / reference tests for `engine_newPayload` and fork-choice ordering
- [ ] Manual devnet: send FCU then newPayload when parent is not chain head; verify head advances before execution


Made with [Cursor](https://cursor.com)