### PR TITLE
snap/2 - fixes

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/v2/SnapV2AccountRangeRequest.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/v2/SnapV2AccountRangeRequest.java
@@ -82,9 +82,6 @@ public class SnapV2AccountRangeRequest extends SnapV2DataRequest {
     final AtomicInteger nbNodesSaved = new AtomicInteger();
     final NodeUpdater nodeUpdater =
         (location, hash, value) -> {
-          if (location.isEmpty()) {
-            downloadState.setRootNodeData(value);
-          }
           applyForStrategy(
               updater,
               onBonsai -> onBonsai.putAccountStateTrieNode(location, hash, value),

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2BlockAccessListApplier.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2BlockAccessListApplier.java
@@ -102,7 +102,7 @@ public class SnapV2BlockAccessListApplier {
       return;
     }
 
-    final MerkleTrie<Bytes, Bytes> accountTrie = openAccountTrie(currentPivotBlockHeader);
+    final MerkleTrie<Bytes, Bytes> accountTrie = openAccountTrie();
 
     final BalApplicationStats stats =
         stageAccountChanges(
@@ -193,13 +193,18 @@ public class SnapV2BlockAccessListApplier {
     return pendingAffected;
   }
 
-  private MerkleTrie<Bytes, Bytes> openAccountTrie(final BlockHeader pivotHeader) {
+  private MerkleTrie<Bytes, Bytes> openAccountTrie() {
     final Function<Bytes, Bytes> identity = Function.identity();
     final NodeLoader accountNodeLoader =
         (location, hash) -> worldStateStorageCoordinator.getAccountStateTrieNode(location, hash);
 
-    return new StoredMerklePatriciaTrie<>(
-        accountNodeLoader, Bytes32.wrap(pivotHeader.getStateRoot().getBytes()), identity, identity);
+    final Bytes32 rootHash =
+        worldStateStorageCoordinator
+            .getTrieNodeUnsafe(Bytes.EMPTY)
+            .map(node -> Bytes32.wrap(Hash.hash(node).getBytes()))
+            .orElse(MerkleTrie.EMPTY_TRIE_NODE_HASH);
+
+    return new StoredMerklePatriciaTrie<>(accountNodeLoader, rootHash, identity, identity);
   }
 
   /**
@@ -379,6 +384,10 @@ public class SnapV2BlockAccessListApplier {
                     accountHash, update.slotHash, update.newValue.toBytes()),
             onForest -> {});
       }
+    }
+
+    if (downloadedSlots == 0) {
+      return new StorageRootResult(oldStorageRoot, 0);
     }
 
     storageTrie.commit(storageNodeUpdater);

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2RequestDataStep.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2RequestDataStep.java
@@ -33,6 +33,7 @@ import org.hyperledger.besu.ethereum.worldstate.WorldStateStorageCoordinator;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.services.tasks.Task;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
@@ -51,6 +52,8 @@ import org.slf4j.LoggerFactory;
 public class SnapV2RequestDataStep {
 
   private static final Logger LOG = LoggerFactory.getLogger(SnapV2RequestDataStep.class);
+
+  static final Duration FAILED_REQUEST_BACKOFF = Duration.ofSeconds(1);
 
   private final EthContext ethContext;
   private final WorldStateProofProvider worldStateProofProvider;
@@ -115,7 +118,8 @@ public class SnapV2RequestDataStep {
                     .log();
               }
               return requestTask;
-            });
+            })
+        .thenCompose(this::maybeBackOffFailedRequest);
   }
 
   public CompletableFuture<List<Task<SnapDataRequest>>> requestStorage(
@@ -199,7 +203,8 @@ public class SnapV2RequestDataStep {
                     .log();
               }
               return requestTasks;
-            });
+            })
+        .thenCompose(this::maybeBackOffFailedRequests);
   }
 
   public CompletableFuture<List<Task<SnapDataRequest>>> requestCode(
@@ -240,6 +245,27 @@ public class SnapV2RequestDataStep {
                     .log();
               }
               return requestTasks;
-            });
+            })
+        .thenCompose(this::maybeBackOffFailedRequests);
+  }
+
+  private CompletableFuture<Task<SnapDataRequest>> maybeBackOffFailedRequest(
+      final Task<SnapDataRequest> task) {
+    if (task.getData().isResponseReceived()) {
+      return CompletableFuture.completedFuture(task);
+    }
+    return ethContext
+        .getScheduler()
+        .scheduleFutureTask(() -> CompletableFuture.completedFuture(task), FAILED_REQUEST_BACKOFF);
+  }
+
+  private CompletableFuture<List<Task<SnapDataRequest>>> maybeBackOffFailedRequests(
+      final List<Task<SnapDataRequest>> tasks) {
+    if (tasks.stream().anyMatch(task -> task.getData().isResponseReceived())) {
+      return CompletableFuture.completedFuture(tasks);
+    }
+    return ethContext
+        .getScheduler()
+        .scheduleFutureTask(() -> CompletableFuture.completedFuture(tasks), FAILED_REQUEST_BACKOFF);
   }
 }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldDownloadState.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldDownloadState.java
@@ -37,11 +37,9 @@ import org.hyperledger.besu.ethereum.eth.sync.worldstate.WorldStateDownloaderExc
 import org.hyperledger.besu.ethereum.proof.WorldStateProofProvider;
 import org.hyperledger.besu.ethereum.rlp.RLP;
 import org.hyperledger.besu.ethereum.trie.MerkleTrie;
-import org.hyperledger.besu.ethereum.trie.NodeLoader;
 import org.hyperledger.besu.ethereum.trie.RangeManager;
 import org.hyperledger.besu.ethereum.trie.common.PmtStateTrieAccountValue;
 import org.hyperledger.besu.ethereum.trie.common.StateRootMismatchException;
-import org.hyperledger.besu.ethereum.trie.patricia.StoredMerklePatriciaTrie;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateStorageCoordinator;
 import org.hyperledger.besu.metrics.BesuMetricCategory;
 import org.hyperledger.besu.metrics.SyncDurationMetrics;
@@ -62,7 +60,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BooleanSupplier;
-import java.util.function.Function;
 import java.util.stream.Stream;
 
 import org.apache.tuweni.bytes.Bytes;
@@ -212,51 +209,60 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
   }
 
   private void persistWorldStateRoot(final BlockHeader header) {
+    final Bytes32 expectedRoot = Bytes32.wrap(header.getStateRoot().getBytes());
     final Bytes nodeData =
-        rootNodeData != null
-            ? rootNodeData
-            : worldStateStorageCoordinator
-                .getAccountStateTrieNode(
-                    Bytes.EMPTY, Bytes32.wrap(header.getStateRoot().getBytes()))
-                .orElseThrow(
-                    () ->
-                        new WorldStateDownloaderException(
-                            "Unable to persist snap/2 world state root: root node was not downloaded"));
+        worldStateStorageCoordinator
+            .getAccountStateTrieNode(Bytes.EMPTY, expectedRoot)
+            .orElseThrow(
+                () ->
+                    new WorldStateDownloaderException(
+                        "Unable to persist snap/2 world state root: root node not found in "
+                            + "storage at EMPTY matching state root "
+                            + expectedRoot
+                            + " (pivot block "
+                            + header.getNumber()
+                            + ")"));
 
     final WorldStateKeyValueStorage.Updater updater = worldStateStorageCoordinator.updater();
     applyForStrategy(
         updater,
-        onBonsai ->
-            onBonsai.saveWorldState(
-                header.getHash().getBytes(),
-                Bytes32.wrap(header.getStateRoot().getBytes()),
-                nodeData),
-        onForest ->
-            onForest.saveWorldState(Bytes32.wrap(header.getStateRoot().getBytes()), nodeData));
+        onBonsai -> onBonsai.saveWorldState(header.getHash().getBytes(), expectedRoot, nodeData),
+        onForest -> onForest.saveWorldState(expectedRoot, nodeData));
     updater.commit();
   }
 
   private boolean verifyWorldStateRoot(final BlockHeader header) {
-    final Function<Bytes, Bytes> identity = Function.identity();
-    final NodeLoader accountNodeLoader =
-        (location, hash) -> worldStateStorageCoordinator.getAccountStateTrieNode(location, hash);
-    final MerkleTrie<Bytes, Bytes> accountTrie =
-        new StoredMerklePatriciaTrie<>(
-            accountNodeLoader, Bytes32.wrap(header.getStateRoot().getBytes()), identity, identity);
-    final Hash actualRoot = Hash.wrap(accountTrie.getRootHash());
-    final Hash expectedRoot = header.getStateRoot();
-    if (!actualRoot.equals(expectedRoot)) {
+    final Bytes32 expectedRoot = Bytes32.wrap(header.getStateRoot().getBytes());
+    if (expectedRoot.equals(MerkleTrie.EMPTY_TRIE_NODE_HASH)) {
+      LOG.info("Snap/2 world state root is empty at pivot block {}", header.getNumber());
+      return true;
+    }
+    final Optional<Bytes> rootNode =
+        worldStateStorageCoordinator.getAccountStateTrieNode(Bytes.EMPTY, expectedRoot);
+    if (rootNode.isEmpty()) {
       LOG.error(
-          "Snap/2 state root verification failed at sync completion for pivot block {}: expected {}, actual {}",
+          "Snap/2 state root verification failed at sync completion for pivot block {}: "
+              + "no account trie root node found at EMPTY matching state root {}",
           header.getNumber(),
-          expectedRoot,
-          actualRoot);
+          expectedRoot);
       internalFuture.completeExceptionally(
-          new StateRootMismatchException(expectedRoot, actualRoot));
+          new StateRootMismatchException(header.getStateRoot(), Hash.EMPTY));
+      return false;
+    }
+    final Hash actualRoot = Hash.hash(rootNode.get());
+    if (!actualRoot.getBytes().equals(expectedRoot)) {
+      LOG.error(
+          "Snap/2 state root verification failed at sync completion for pivot block {}: "
+              + "root node RLP hashes to {} but expected state root {}",
+          header.getNumber(),
+          actualRoot,
+          expectedRoot);
+      internalFuture.completeExceptionally(
+          new StateRootMismatchException(header.getStateRoot(), actualRoot));
       return false;
     }
     LOG.info(
-        "Snap/2 world state root verified at pivot block {}: {}", header.getNumber(), actualRoot);
+        "Snap/2 world state root verified at pivot block {}: {}", header.getNumber(), expectedRoot);
     return true;
   }
 
@@ -503,11 +509,15 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
   private void applyBlockAccessLists(
       final BlockHeader currentPivotBlockHeader, final BlockHeader newPivotBlockHeader) {
     LOG.info(
-        "Snap/2 applying BALs: pivot {} -> {} (completed ranges: {}, pending ranges: {})",
+        "Snap/2 applying BALs: pivot {} -> {} (ranges: completed={}, pending={}) outstanding=[account={}, storage={}, largeStorage={}, code={}]",
         currentPivotBlockHeader.getNumber(),
         newPivotBlockHeader.getNumber(),
         accountRangeTracker.completedRangeCount(),
-        accountRangeTracker.pendingRangeCount());
+        accountRangeTracker.pendingRangeCount(),
+        pendingAccountRequests.outstandingTaskCount(),
+        pendingStorageRequests.outstandingTaskCount(),
+        pendingLargeStorageRequests.outstandingTaskCount(),
+        pendingCodeRequests.outstandingTaskCount());
     blockAccessListApplier.applyBlockAccessLists(
         currentPivotBlockHeader, newPivotBlockHeader, accountRangeTracker, storageRangeTracker);
   }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldDownloadState.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldDownloadState.java
@@ -188,6 +188,7 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
   public synchronized boolean checkCompletion(final BlockHeader header) {
     if (!isStateDownloadFinished()
         && !isPivotCatchupInProgress()
+        && accountRangeTracker.completedRangeCount() > 0
         && pendingAccountRequests.allTasksCompleted()
         && pendingCodeRequests.allTasksCompleted()
         && pendingStorageRequests.allTasksCompleted()
@@ -210,18 +211,23 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
 
   private void persistWorldStateRoot(final BlockHeader header) {
     final Bytes32 expectedRoot = Bytes32.wrap(header.getStateRoot().getBytes());
-    final Bytes nodeData =
-        worldStateStorageCoordinator
-            .getAccountStateTrieNode(Bytes.EMPTY, expectedRoot)
-            .orElseThrow(
-                () ->
-                    new WorldStateDownloaderException(
-                        "Unable to persist snap/2 world state root: root node not found in "
-                            + "storage at EMPTY matching state root "
-                            + expectedRoot
-                            + " (pivot block "
-                            + header.getNumber()
-                            + ")"));
+    final Bytes nodeData;
+    if (expectedRoot.equals(MerkleTrie.EMPTY_TRIE_NODE_HASH)) {
+      nodeData = MerkleTrie.EMPTY_TRIE_NODE;
+    } else {
+      nodeData =
+          worldStateStorageCoordinator
+              .getAccountStateTrieNode(Bytes.EMPTY, expectedRoot)
+              .orElseThrow(
+                  () ->
+                      new WorldStateDownloaderException(
+                          "Unable to persist snap/2 world state root: root node not found in "
+                              + "storage at EMPTY matching state root "
+                              + expectedRoot
+                              + " (pivot block "
+                              + header.getNumber()
+                              + ")"));
+    }
 
     final WorldStateKeyValueStorage.Updater updater = worldStateStorageCoordinator.updater();
     applyForStrategy(

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldStateDownloader.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldStateDownloader.java
@@ -38,6 +38,7 @@ import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.services.tasks.InMemoryTasksPriorityQueues;
 
 import java.time.Clock;
+import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -53,6 +54,8 @@ import org.slf4j.LoggerFactory;
 public class SnapV2WorldStateDownloader implements WorldStateDownloader {
 
   private static final Logger LOG = LoggerFactory.getLogger(SnapV2WorldStateDownloader.class);
+
+  static final int NO_PEER_RETRY_DELAY_MILLISECONDS = 5_000;
 
   private final long minMillisBeforeStalling;
   private final Clock clock;
@@ -142,6 +145,17 @@ public class SnapV2WorldStateDownloader implements WorldStateDownloader {
             new IllegalStateException(
                 "Cannot run an already running " + this.getClass().getSimpleName()));
         return failed;
+      }
+
+      if (ethContext.getEthPeers().peerCount() == 0) {
+        LOG.debug(
+            "No peers available, deferring snap/2 world state pipeline start for {} ms",
+            NO_PEER_RETRY_DELAY_MILLISECONDS);
+        return ethContext
+            .getScheduler()
+            .scheduleFutureTask(
+                () -> run(fastSyncActions, snapSyncState),
+                Duration.ofMillis(NO_PEER_RETRY_DELAY_MILLISECONDS));
       }
 
       final BlockHeader header = snapSyncState.getPivotBlockHeader().orElseThrow();


### PR DESCRIPTION
Fixes for problems found during testing.

* make `persistWorldStateRoot` rely on root node data read from storage instead of cached `rootNodeData` which needed to be synchronized and could easily become stale or missing
* defer world state download if no peers are available
* `verifyWorldStateRoot` now fetches the ws root node from disk and compares its hash against the pivot header
* add 1 second backoff on failed requests to avoid a busy loop