### PR TITLE
Clear empty accounts when applying partial BAL writes (glamsterdam-devnet-6)

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/parallelization/BalConcurrentTransactionProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/parallelization/BalConcurrentTransactionProcessor.java
@@ -211,7 +211,10 @@ public class BalConcurrentTransactionProcessor extends ParallelBlockTransactionP
           return Optional.empty();
         }
 
-        applyWritesFromPartialBlockAccessView(maybePartialBlockAccessView.get(), blockAccumulator);
+        applyWritesFromPartialBlockAccessView(
+            maybePartialBlockAccessView.get(),
+            blockAccumulator,
+            transactionProcessor.getClearEmptyAccounts());
 
         confirmedParallelizedTransactionCounter.ifPresent(Counter::inc);
         result.setIsProcessedInParallel(Optional.of(Boolean.TRUE));
@@ -242,14 +245,18 @@ public class BalConcurrentTransactionProcessor extends ParallelBlockTransactionP
 
   private void applyWritesFromPartialBlockAccessView(
       final PartialBlockAccessView partialBlockAccessView,
-      final PathBasedWorldStateUpdateAccumulator<?> worldStateUpdater) {
+      final PathBasedWorldStateUpdateAccumulator<?> worldStateUpdater,
+      final boolean clearEmptyAccounts) {
     for (var accountChanges : partialBlockAccessView.accountChanges()) {
       MutableAccount account = null;
+      boolean shouldCheckForEmptyAccount = false;
 
       final Optional<Wei> postBalance = accountChanges.getPostBalance();
       if (postBalance.isPresent()) {
         account = worldStateUpdater.getOrCreate(accountChanges.getAddress());
-        account.setBalance(postBalance.get());
+        final Wei balance = postBalance.get();
+        account.setBalance(balance);
+        shouldCheckForEmptyAccount = clearEmptyAccounts && balance.isZero();
       }
 
       final Optional<Long> nonceChange = accountChanges.getNonceChange();
@@ -257,7 +264,9 @@ public class BalConcurrentTransactionProcessor extends ParallelBlockTransactionP
         if (account == null) {
           account = worldStateUpdater.getOrCreate(accountChanges.getAddress());
         }
-        account.setNonce(nonceChange.get());
+        final long nonce = nonceChange.get();
+        account.setNonce(nonce);
+        shouldCheckForEmptyAccount |= clearEmptyAccounts && nonce == 0L;
       }
 
       final Optional<Bytes> newCode = accountChanges.getNewCode();
@@ -265,7 +274,9 @@ public class BalConcurrentTransactionProcessor extends ParallelBlockTransactionP
         if (account == null) {
           account = worldStateUpdater.getOrCreate(accountChanges.getAddress());
         }
-        account.setCode(newCode.get());
+        final Bytes code = newCode.get();
+        account.setCode(code);
+        shouldCheckForEmptyAccount |= clearEmptyAccounts && code.isEmpty();
       }
 
       for (var slotChange : accountChanges.getStorageChanges()) {
@@ -276,6 +287,10 @@ public class BalConcurrentTransactionProcessor extends ParallelBlockTransactionP
         account.setStorageValue(
             slot.getSlotKey().orElseThrow(),
             slotChange.newValue() != null ? slotChange.newValue() : UInt256.ZERO);
+      }
+
+      if (shouldCheckForEmptyAccount && account != null && account.isEmpty()) {
+        worldStateUpdater.deleteAccount(accountChanges.getAddress());
       }
     }
   }

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/parallelization/BalTransactionProcessorUnitTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/parallelization/BalTransactionProcessorUnitTest.java
@@ -349,6 +349,66 @@ class BalTransactionProcessorUnitTest {
           env.worldState().updater().get(readOnlyAddress),
           "Read-only partial BAL entries should not create account writes");
     }
+
+    @Test
+    @DisplayName("Clears accounts made empty by partial BAL view writes")
+    void clearsAccountsMadeEmptyByPartialBalWrites() {
+      final TestEnvironment env = createTestEnvironment();
+      final BlockAccessList blockAccessList = mockEmptyBlockAccessList();
+      final Transaction transaction = mockTransaction();
+      final Address accountAddress =
+          Address.fromHexString("0x1000000000000000000000000000000000000003");
+
+      final WorldUpdater preStateUpdater = env.worldState().updater();
+      preStateUpdater.createAccount(accountAddress, 0L, Wei.ONE);
+      preStateUpdater.commit();
+
+      final PartialBlockAccessView.PartialBlockAccessViewBuilder partialBuilder =
+          new PartialBlockAccessView.PartialBlockAccessViewBuilder().withTxIndex(0);
+      partialBuilder.getOrCreateAccountBuilder(accountAddress).withPostBalance(Wei.ZERO);
+      final PartialBlockAccessView partialBlockAccessView = partialBuilder.build();
+
+      when(transactionProcessor.processTransaction(
+              any(), any(), any(), any(), any(), any(), any(), any(), any()))
+          .thenReturn(
+              TransactionProcessingResult.successful(
+                  Collections.emptyList(),
+                  0,
+                  0,
+                  Bytes.EMPTY,
+                  Optional.of(partialBlockAccessView),
+                  ValidationResult.valid()));
+      when(transactionProcessor.getClearEmptyAccounts()).thenReturn(true);
+
+      final BalConcurrentTransactionProcessor processor =
+          new BalConcurrentTransactionProcessor(
+              transactionProcessor, blockAccessList, BalConfiguration.DEFAULT);
+
+      processor.runAsyncBlock(
+          env.protocolContext(),
+          env.blockHeader(),
+          Collections.singletonList(transaction),
+          MINING_BENEFICIARY,
+          (__, ___) -> Hash.EMPTY,
+          BLOB_GAS_PRICE,
+          sameThreadExecutor,
+          Optional.empty(),
+          env.maybeParentHeader());
+
+      final Optional<TransactionProcessingResult> result =
+          processor.getProcessingResult(
+              env.worldState(),
+              MINING_BENEFICIARY,
+              transaction,
+              0,
+              Optional.empty(),
+              Optional.empty());
+
+      assertTrue(result.isPresent(), "Expected processing result to be present");
+      assertNull(
+          env.worldState().updater().get(accountAddress),
+          "Account zeroed by partial BAL writes should be cleared from the block accumulator");
+    }
   }
 
   @Nested


### PR DESCRIPTION
## Summary
- Backport the account deletion fix from `applyWritesFromPartialBlockAccessView` landed on `main` via #10606
- When `clearEmptyAccounts` is enabled, accounts zeroed by partial BAL view writes (balance, nonce, or code) are removed from the block accumulator
- Add unit test `clearsAccountsMadeEmptyByPartialBalWrites`

## Context
`glamsterdam-devnet-6` already applies partial BAL writes instead of importing the full transaction accumulator, but it was missing the empty-account cleanup that exists on `main`.

## Test plan
- [x] `./gradlew :ethereum:core:test --tests "org.hyperledger.besu.ethereum.mainnet.parallelization.BalTransactionProcessorUnitTest\$TransactionProcessingTests.clearsAccountsMadeEmptyByPartialBalWrites"`
