### PR TITLE
Add CL target gas limit to engine forkchoiceUpdatedV4

### DIFF
--- a/acceptance-tests/tests/src/acceptanceTest/java/org/hyperledger/besu/tests/acceptance/ethereum/AmsterdamAcceptanceTestHelper.java
+++ b/acceptance-tests/tests/src/acceptanceTest/java/org/hyperledger/besu/tests/acceptance/ethereum/AmsterdamAcceptanceTestHelper.java
@@ -176,6 +176,29 @@ public class AmsterdamAcceptanceTestHelper {
     }
   }
 
+  /**
+   * Sends a payload-building {@code engine_forkchoiceUpdatedV4} whose payload attributes omit the
+   * {@code targetGasLimit} field, which is mandatory from Amsterdam onwards, and returns the parsed
+   * JSON-RPC response so callers can assert the error.
+   *
+   * @return the parsed JSON-RPC response
+   * @throws IOException if the engine call fails
+   */
+  public JsonNode forkChoiceUpdatedWithoutTargetGasLimit() throws IOException {
+    final EthBlock.Block block = besuNode.execute(ethTransactions.block());
+
+    blockTimeStamp += 1;
+    slotNumber += 1;
+    final Call request =
+        createEngineCall(
+            createForkChoiceRequest(block.getHash(), blockTimeStamp, slotNumber, false));
+
+    try (final Response response = request.execute()) {
+      assertThat(response.code()).isEqualTo(200);
+      return mapper.readTree(response.body().string());
+    }
+  }
+
   private Call createEngineCall(final String request) {
     return httpClient.newCall(
         new Request.Builder()
@@ -190,6 +213,14 @@ public class AmsterdamAcceptanceTestHelper {
 
   private String createForkChoiceRequest(
       final String parentBlockHash, final Long timeStamp, final Long slotNum) {
+    return createForkChoiceRequest(parentBlockHash, timeStamp, slotNum, true);
+  }
+
+  private String createForkChoiceRequest(
+      final String parentBlockHash,
+      final Long timeStamp,
+      final Long slotNum,
+      final boolean includeTargetGasLimit) {
     final Optional<Long> maybeTimeStamp = Optional.ofNullable(timeStamp);
     final Optional<Long> maybeSlotNum = Optional.ofNullable(slotNum);
 
@@ -222,8 +253,8 @@ public class AmsterdamAcceptanceTestHelper {
               + "      \"parentBeaconBlockRoot\": \"0x0000000000000000000000000000000000000000000000000000000000000000\","
               + "      \"slotNumber\": \""
               + (maybeSlotNum.isPresent() ? "0x" + Long.toHexString(maybeSlotNum.get()) : "0x0")
-              + "\","
-              + "      \"targetGasLimit\": \"0x1c9c380\""
+              + "\""
+              + (includeTargetGasLimit ? ",      \"targetGasLimit\": \"0x1c9c380\"" : "")
               + "    }";
     }
 

--- a/acceptance-tests/tests/src/acceptanceTest/java/org/hyperledger/besu/tests/acceptance/ethereum/AmsterdamAcceptanceTestHelper.java
+++ b/acceptance-tests/tests/src/acceptanceTest/java/org/hyperledger/besu/tests/acceptance/ethereum/AmsterdamAcceptanceTestHelper.java
@@ -222,7 +222,8 @@ public class AmsterdamAcceptanceTestHelper {
               + "      \"parentBeaconBlockRoot\": \"0x0000000000000000000000000000000000000000000000000000000000000000\","
               + "      \"slotNumber\": \""
               + (maybeSlotNum.isPresent() ? "0x" + Long.toHexString(maybeSlotNum.get()) : "0x0")
-              + "\""
+              + "\","
+              + "      \"targetGasLimit\": \"0x1c9c380\""
               + "    }";
     }
 

--- a/acceptance-tests/tests/src/acceptanceTest/java/org/hyperledger/besu/tests/acceptance/ethereum/EngineForkchoiceUpdatedV4TargetGasLimitAcceptanceTest.java
+++ b/acceptance-tests/tests/src/acceptanceTest/java/org/hyperledger/besu/tests/acceptance/ethereum/EngineForkchoiceUpdatedV4TargetGasLimitAcceptanceTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.tests.acceptance.ethereum;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.hyperledger.besu.tests.acceptance.dsl.AcceptanceTestBase;
+import org.hyperledger.besu.tests.acceptance.dsl.node.BesuNode;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Acceptance test for the {@code targetGasLimit} payload attribute on {@code
+ * engine_forkchoiceUpdatedV4}.
+ *
+ * <p>From Amsterdam onwards the consensus layer must supply {@code targetGasLimit} when requesting
+ * a payload; a payload-building fcU that omits it is rejected with {@code
+ * INVALID_TARGET_GAS_LIMIT_PARAMS} (-32602).
+ */
+public class EngineForkchoiceUpdatedV4TargetGasLimitAcceptanceTest extends AcceptanceTestBase {
+  private static final String GENESIS_FILE = "/dev/dev_amsterdam.json";
+  private static final int INVALID_TARGET_GAS_LIMIT_PARAMS_CODE = -32602;
+
+  private BesuNode besuNode;
+  private AmsterdamAcceptanceTestHelper testHelper;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    besuNode = besu.createExecutionEngineGenesisNode("besuNode", GENESIS_FILE);
+    cluster.start(besuNode);
+    testHelper = new AmsterdamAcceptanceTestHelper(besuNode, ethTransactions);
+  }
+
+  @AfterEach
+  void tearDown() {
+    besuNode.close();
+  }
+
+  @Test
+  public void forkchoiceUpdatedV4WithoutTargetGasLimitIsRejected() throws IOException {
+    final JsonNode response = testHelper.forkChoiceUpdatedWithoutTargetGasLimit();
+
+    assertThat(response.get("result"))
+        .withFailMessage("Expected an error response but got a result: %s", response)
+        .isNull();
+
+    final JsonNode error = response.get("error");
+    assertThat(error).withFailMessage("Missing error object in response: %s", response).isNotNull();
+    assertThat(error.get("code").asInt()).isEqualTo(INVALID_TARGET_GAS_LIMIT_PARAMS_CODE);
+    assertThat(error.get("message").asText()).contains("target gas limit");
+  }
+}

--- a/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/debug/replayBlock/test-cases/01_prepare_payload.json
+++ b/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/debug/replayBlock/test-cases/01_prepare_payload.json
@@ -25,7 +25,7 @@
         "latestValidHash": "0x3b8fb240d288781d4aac94d3fd16809ee413bc99294a085798a589dae51ddd4a",
         "validationError": null
       },
-      "payloadId": "0x0055a77e86e45505"
+      "payloadId": "0x00aa5881791baafa"
     }
   },
   "statusCode" : 200

--- a/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/debug/setHead/test-cases/01_prepare_payload.json
+++ b/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/debug/setHead/test-cases/01_prepare_payload.json
@@ -25,7 +25,7 @@
         "latestValidHash": "0x3b8fb240d288781d4aac94d3fd16809ee413bc99294a085798a589dae51ddd4a",
         "validationError": null
       },
-      "payloadId": "0x0055a77e86e45505"
+      "payloadId": "0x00aa5881791baafa"
     }
   },
   "statusCode" : 200

--- a/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/cancun/test-cases/block-production/10_cancun_build_on_genesis.json
+++ b/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/cancun/test-cases/block-production/10_cancun_build_on_genesis.json
@@ -88,7 +88,7 @@
         "latestValidHash": "0x33235e7b7a78302cdb54e5ddba66c7ae49b01c1f5498bb00cd0c8ed5206784bf",
         "validationError": null
       },
-      "payloadId": "0x3d9d95a10fd37239"
+      "payloadId": "0x3d626a5ef02c8dc6"
     }
   },
   "statusCode": 200

--- a/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/cancun/test-cases/block-production/12_cancun_get_built_block.json
+++ b/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/cancun/test-cases/block-production/12_cancun_get_built_block.json
@@ -4,7 +4,7 @@
     "id": 2,
     "method": "engine_getPayloadV3",
     "params": [
-      "0x3d9d95a10fd37239"
+      "0x3d626a5ef02c8dc6"
     ]
   },
   "response": {

--- a/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/osaka/test-cases/06_prague_forkchoiceUpdatedV3.json
+++ b/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/osaka/test-cases/06_prague_forkchoiceUpdatedV3.json
@@ -27,7 +27,7 @@
         "latestValidHash": "0x0d16454be2446b1f8e013562833b84da2e76536bef3d529cf2f8976ac1eb5905",
         "validationError": null
       },
-      "payloadId": "0x7d82e49c521b3b11"
+      "payloadId": "0x7d7d1b63ade4c4f0"
     }
   },
   "statusCode": 200

--- a/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/osaka/test-cases/07_prague_getPayloadV4.json
+++ b/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/osaka/test-cases/07_prague_getPayloadV4.json
@@ -3,7 +3,7 @@
     "jsonrpc": "2.0",
     "method": "engine_getPayloadV4",
     "params": [
-      "0x7d82e49c521b3b11"
+      "0x7d7d1b63ade4c4f0"
     ],
     "id": 67
   },

--- a/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/osaka/test-cases/08_prague_getPayloadV5.json
+++ b/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/osaka/test-cases/08_prague_getPayloadV5.json
@@ -3,7 +3,7 @@
     "jsonrpc": "2.0",
     "method": "engine_getPayloadV5",
     "params": [
-      "0x7d82e49c521b3b11"
+      "0x7d7d1b63ade4c4f0"
     ],
     "id": 67
   },

--- a/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/osaka/test-cases/09_prague_forkchoiceUpdatedV3.json
+++ b/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/osaka/test-cases/09_prague_forkchoiceUpdatedV3.json
@@ -27,7 +27,7 @@
         "latestValidHash": "0x0d16454be2446b1f8e013562833b84da2e76536bef3d529cf2f8976ac1eb5905",
         "validationError": null
       },
-      "payloadId": "0x7d82e49c521b3b21"
+      "payloadId": "0x7d7d1b63ade4c4e0"
     }
   },
   "statusCode": 200

--- a/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/osaka/test-cases/10_osaka_getPayloadV4.json
+++ b/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/osaka/test-cases/10_osaka_getPayloadV4.json
@@ -3,7 +3,7 @@
     "jsonrpc": "2.0",
     "method": "engine_getPayloadV4",
     "params": [
-      "0x7d82e49c521b3b21"
+      "0x7d7d1b63ade4c4e0"
     ],
     "id": 67
   },

--- a/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/osaka/test-cases/11_osaka_getPayloadV5.json
+++ b/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/osaka/test-cases/11_osaka_getPayloadV5.json
@@ -3,7 +3,7 @@
     "jsonrpc": "2.0",
     "method": "engine_getPayloadV5",
     "params": [
-      "0x7d82e49c521b3b21"
+      "0x7d7d1b63ade4c4e0"
     ],
     "id": 67
   },

--- a/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/osaka/test-cases/14_osaka_forkchoiceUpdatedV3.json
+++ b/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/osaka/test-cases/14_osaka_forkchoiceUpdatedV3.json
@@ -27,7 +27,7 @@
         "latestValidHash": "0xdb6d76ff4c50498f8c701172dbabbbd31650177de40d761caf5fb60a08bd013d",
         "validationError": null
       },
-      "payloadId": "0x7d82e48feb503731"
+      "payloadId": "0x7d7d1b7014afc8d0"
     }
   },
   "statusCode": 200

--- a/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/osaka/test-cases/19_osaka_forkchoiceUpdatedV3.json
+++ b/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/osaka/test-cases/19_osaka_forkchoiceUpdatedV3.json
@@ -27,7 +27,7 @@
         "latestValidHash": "0xdb6d76ff4c50498f8c701172dbabbbd31650177de40d761caf5fb60a08bd013d",
         "validationError": null
       },
-      "payloadId": "0x7d82e48feb503731"
+      "payloadId": "0x7d7d1b7014afc8d0"
     }
   },
   "statusCode": 200

--- a/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/osaka/test-cases/20_osaka_getPayloadV5.json
+++ b/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/osaka/test-cases/20_osaka_getPayloadV5.json
@@ -3,7 +3,7 @@
     "jsonrpc": "2.0",
     "method": "engine_getPayloadV5",
     "params": [
-      "0x7d82e48feb503731"
+      "0x7d7d1b7014afc8d0"
     ],
     "id": 67
   },

--- a/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/paris/test-cases/01_prepare_payload.json
+++ b/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/paris/test-cases/01_prepare_payload.json
@@ -25,7 +25,7 @@
         "latestValidHash": "0x3b8fb240d288781d4aac94d3fd16809ee413bc99294a085798a589dae51ddd4a",
         "validationError": null
       },
-      "payloadId": "0x0055a77e86e45505"
+      "payloadId": "0x00aa5881791baafa"
     }
   },
   "statusCode" : 200

--- a/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/paris/test-cases/02_get_payload.json
+++ b/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/paris/test-cases/02_get_payload.json
@@ -3,7 +3,7 @@
     "jsonrpc": "2.0",
     "method": "engine_getPayloadV1",
     "params": [
-      "0x0055a77e86e45505"
+      "0x00aa5881791baafa"
     ],
     "id": 67
   },

--- a/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/prague/test-cases/01_cancun_prepare_payload.json
+++ b/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/prague/test-cases/01_cancun_prepare_payload.json
@@ -27,7 +27,7 @@
         "latestValidHash": "0x01f5cbf33268c161f1526d704268db760bf82c9772a8f8ca412e0c6ce5684896",
         "validationError": null
       },
-      "payloadId": "0x7d82e4f624bd49ef"
+      "payloadId": "0x7d7d1b09db42b610"
     }
   },
   "statusCode": 200

--- a/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/prague/test-cases/02_cancun_getPayloadV3.json
+++ b/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/prague/test-cases/02_cancun_getPayloadV3.json
@@ -3,7 +3,7 @@
     "jsonrpc": "2.0",
     "method": "engine_getPayloadV3",
     "params": [
-      "0x7d82e4f624bd49ef"
+      "0x7d7d1b09db42b610"
     ],
     "id": 67
   },

--- a/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/prague/test-cases/05_prague_forkchoiceUpdatedV3.json
+++ b/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/prague/test-cases/05_prague_forkchoiceUpdatedV3.json
@@ -27,7 +27,7 @@
         "latestValidHash": "0x7cccf6d9ce3e5acaeac9058959c27ace53af3a30b15763e1703bab2d0ae9438e",
         "validationError": null
       },
-      "payloadId": "0x7d82e496e060bedf"
+      "payloadId": "0x7d7d1b691f9f4120"
     }
   },
   "statusCode": 200

--- a/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/prague/test-cases/06_prague_getPayloadV4.json
+++ b/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/prague/test-cases/06_prague_getPayloadV4.json
@@ -3,7 +3,7 @@
     "jsonrpc": "2.0",
     "method": "engine_getPayloadV4",
     "params": [
-      "0x7d82e496e060bedf"
+      "0x7d7d1b691f9f4120"
     ],
     "id": 67
   },

--- a/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/prague/test-cases/10_prague_forkchoiceUpdatedV3.json
+++ b/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/prague/test-cases/10_prague_forkchoiceUpdatedV3.json
@@ -27,7 +27,7 @@
         "latestValidHash": "0x9c93ae6e647584baeedfd4b53a1b17870797e9a7bd221f8e126a0cf11105064c",
         "validationError": null
       },
-      "payloadId": "0x7d82e4a13c84bb31"
+      "payloadId": "0x7d7d1b5ec37b44d0"
     }
   },
   "statusCode": 200

--- a/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/prague/test-cases/11_prague_getPayloadV4.json
+++ b/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/prague/test-cases/11_prague_getPayloadV4.json
@@ -3,7 +3,7 @@
     "jsonrpc": "2.0",
     "method": "engine_getPayloadV4",
     "params": [
-      "0x7d82e4a13c84bb31"
+      "0x7d7d1b5ec37b44d0"
     ],
     "id": 67
   },

--- a/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/prague/test-cases/15_prague_forkchoiceUpdatedV3.json
+++ b/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/prague/test-cases/15_prague_forkchoiceUpdatedV3.json
@@ -27,7 +27,7 @@
         "latestValidHash": "0x92166cdc0fead978bcdc54ae9d9f2b803c65beb50350aa54baab12bb248b87cc",
         "validationError": null
       },
-      "payloadId": "0x7d82e4b8c3dea2bf"
+      "payloadId": "0x7d7d1b473c215d40"
     }
   },
   "statusCode": 200

--- a/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/prague/test-cases/16_prague_getPayloadV4.json
+++ b/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/prague/test-cases/16_prague_getPayloadV4.json
@@ -3,7 +3,7 @@
     "jsonrpc": "2.0",
     "method": "engine_getPayloadV4",
     "params": [
-      "0x7d82e4b8c3dea2bf"
+      "0x7d7d1b473c215d40"
     ],
     "id": 67
   },

--- a/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/shanghai/test-cases/01_paris_prepare_payload.json
+++ b/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/shanghai/test-cases/01_paris_prepare_payload.json
@@ -25,7 +25,7 @@
         "latestValidHash": "0x274b386b1b268ebb5ca1f717c1279a536faf1f74dda959143dd8a779f8d8a908",
         "validationError": null
       },
-      "payloadId": "0x0055a742b1397c05"
+      "payloadId": "0x00aa58bd4ec683fa"
     }
   },
   "statusCode" : 200

--- a/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/shanghai/test-cases/02_paris_getPayloadV1.json
+++ b/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/shanghai/test-cases/02_paris_getPayloadV1.json
@@ -3,7 +3,7 @@
     "jsonrpc": "2.0",
     "method": "engine_getPayloadV1",
     "params": [
-      "0x0055a742b1397c05"
+      "0x00aa58bd4ec683fa"
     ],
     "id": 67
   },

--- a/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/shanghai/test-cases/06_shanghai_prepare_payload.json
+++ b/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/shanghai/test-cases/06_shanghai_prepare_payload.json
@@ -39,7 +39,7 @@
         "latestValidHash": "0xf4a1d287dd3bb7e877c57476912e6a6052bc4eed8ea70d032b55d77f26ee985f",
         "validationError": null
       },
-      "payloadId": "0x4784a76b4b044b95"
+      "payloadId": "0x477b5894b4fbb46a"
     }
   },
   "statusCode" : 200

--- a/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/shanghai/test-cases/07_shanghai_prepare_payload_replay_different_withdrawals.json
+++ b/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/shanghai/test-cases/07_shanghai_prepare_payload_replay_different_withdrawals.json
@@ -39,7 +39,7 @@
         "latestValidHash": "0xf4a1d287dd3bb7e877c57476912e6a6052bc4eed8ea70d032b55d77f26ee985f",
         "validationError": null
       },
-      "payloadId": "0x4780a76b4b044b95"
+      "payloadId": "0x477f5894b4fbb46a"
     }
   },
   "statusCode" : 200

--- a/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/shanghai/test-cases/08_shanghai_getPayloadV2.json
+++ b/acceptance-tests/tests/src/acceptanceTest/resources/jsonrpc/engine/shanghai/test-cases/08_shanghai_getPayloadV2.json
@@ -3,7 +3,7 @@
     "jsonrpc": "2.0",
     "method": "engine_getPayloadV2",
     "params": [
-      "0x4780a76b4b044b95"
+      "0x477f5894b4fbb46a"
     ],
     "id": 67
   },

--- a/app/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/app/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -1546,7 +1546,11 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
 
   private void validateMiningParams() {
     miningOptions.validate(
-        commandLine, genesisConfigOptionsSupplier.get(), isMergeEnabled(), logger);
+        commandLine,
+        genesisConfigOptionsSupplier.get(),
+        isMergeEnabled(),
+        genesisFile == null,
+        logger);
   }
 
   private void validateP2POptions() {

--- a/app/src/main/java/org/hyperledger/besu/cli/options/MiningOptions.java
+++ b/app/src/main/java/org/hyperledger/besu/cli/options/MiningOptions.java
@@ -199,12 +199,15 @@ public class MiningOptions implements CLIOptions<MiningConfiguration> {
    * @param commandLine the full commandLine to check all the options specified by the user
    * @param genesisConfigOptions genesis config determines whether we are running PoA or PoS
    * @param isMergeEnabled is the Merge enabled?
+   * @param isBuiltInGenesis true when the active genesis is a Besu built-in network (no
+   *     --genesis-file override)
    * @param logger the logger
    */
   public void validate(
       final CommandLine commandLine,
       final GenesisConfigOptions genesisConfigOptions,
       final boolean isMergeEnabled,
+      final boolean isBuiltInGenesis,
       final Logger logger) {
 
     if (unstableOptions.posBlockCreationMaxTime <= 0
@@ -259,6 +262,17 @@ public class MiningOptions implements CLIOptions<MiningConfiguration> {
               + "The block limit will be the binding constraint during block building.",
           maxBlobsPerBlock,
           maxBlobsPerTransaction);
+    }
+
+    if (targetGasLimit != null
+        && isBuiltInGenesis
+        && genesisConfigOptions.getAmsterdamTime().isPresent()) {
+      logger.warn(
+          "--target-gas-limit is set to {} but Amsterdam is scheduled (at timestamp {}). "
+              + "From Amsterdam onwards the consensus layer supplies targetGasLimit via "
+              + "engine_forkchoiceUpdatedV4 and will override this CLI value when building payloads.",
+          targetGasLimit,
+          genesisConfigOptions.getAmsterdamTime().getAsLong());
     }
   }
 

--- a/app/src/test/java/org/hyperledger/besu/cli/options/MiningOptionsTest.java
+++ b/app/src/test/java/org/hyperledger/besu/cli/options/MiningOptionsTest.java
@@ -19,9 +19,16 @@ import static org.hyperledger.besu.ethereum.core.MiningConfiguration.DEFAULT_PLU
 import static org.hyperledger.besu.ethereum.core.MiningConfiguration.DEFAULT_POA_BLOCK_TXS_SELECTION_MAX_TIME;
 import static org.hyperledger.besu.ethereum.core.MiningConfiguration.DEFAULT_POS_BLOCK_TXS_SELECTION_MAX_TIME;
 import static org.hyperledger.besu.ethereum.core.MiningConfiguration.Unstable.DEFAULT_POS_BLOCK_CREATION_MAX_TIME;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atMost;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import org.hyperledger.besu.config.GenesisConfigOptions;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.core.ImmutableMiningConfiguration;
 import org.hyperledger.besu.ethereum.core.ImmutableMiningConfiguration.MutableInitValues;
@@ -33,11 +40,14 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.OptionalLong;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.junit.jupiter.MockitoExtension;
+import picocli.CommandLine;
 
 @ExtendWith(MockitoExtension.class)
 public class MiningOptionsTest extends AbstractCLIOptionsTest<MiningConfiguration, MiningOptions> {
@@ -397,6 +407,59 @@ public class MiningOptionsTest extends AbstractCLIOptionsTest<MiningConfiguratio
         "--max-blobs-per-transaction must be a non-negative value",
         "--max-blobs-per-transaction",
         "-9");
+  }
+
+  @Test
+  public void warnsWhenTargetGasLimitSetOnBuiltInGenesisWithAmsterdamScheduled() {
+    final MiningConfiguration miningConfiguration = MiningConfiguration.newDefault();
+    miningConfiguration.setTargetGasLimit(36_000_000L);
+    final MiningOptions options = MiningOptions.fromConfig(miningConfiguration);
+
+    final GenesisConfigOptions genesisConfigOptions = mock(GenesisConfigOptions.class);
+    when(genesisConfigOptions.getAmsterdamTime()).thenReturn(OptionalLong.of(1_777_000_000L));
+
+    options.validate(new CommandLine(options), genesisConfigOptions, true, true, mockLogger);
+
+    final ArgumentCaptor<String> messageCaptor = ArgumentCaptor.forClass(String.class);
+    verify(mockLogger).warn(messageCaptor.capture(), eq(36_000_000L), eq(1_777_000_000L));
+    assertThat(messageCaptor.getValue()).contains("--target-gas-limit");
+    assertThat(messageCaptor.getValue()).contains("Amsterdam");
+  }
+
+  @Test
+  public void doesNotWarnAboutTargetGasLimitOnCustomGenesis() {
+    final MiningConfiguration miningConfiguration = MiningConfiguration.newDefault();
+    miningConfiguration.setTargetGasLimit(36_000_000L);
+    final MiningOptions options = MiningOptions.fromConfig(miningConfiguration);
+
+    options.validate(
+        new CommandLine(options), mock(GenesisConfigOptions.class), true, false, mockLogger);
+
+    verify(mockLogger, never()).warn(anyString(), any(), any());
+  }
+
+  @Test
+  public void doesNotWarnAboutTargetGasLimitWhenAmsterdamUnscheduled() {
+    final MiningConfiguration miningConfiguration = MiningConfiguration.newDefault();
+    miningConfiguration.setTargetGasLimit(36_000_000L);
+    final MiningOptions options = MiningOptions.fromConfig(miningConfiguration);
+
+    final GenesisConfigOptions genesisConfigOptions = mock(GenesisConfigOptions.class);
+    when(genesisConfigOptions.getAmsterdamTime()).thenReturn(OptionalLong.empty());
+
+    options.validate(new CommandLine(options), genesisConfigOptions, true, true, mockLogger);
+
+    verify(mockLogger, never()).warn(anyString(), any(), any());
+  }
+
+  @Test
+  public void doesNotWarnAboutTargetGasLimitWhenNotSet() {
+    final MiningOptions options = MiningOptions.fromConfig(MiningConfiguration.newDefault());
+
+    options.validate(
+        new CommandLine(options), mock(GenesisConfigOptions.class), true, true, mockLogger);
+
+    verify(mockLogger, never()).warn(anyString(), any(), any());
   }
 
   @Override

--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/blockcreation/BftBlockCreator.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/blockcreation/BftBlockCreator.java
@@ -94,6 +94,7 @@ public class BftBlockCreator extends AbstractBlockCreator {
           Optional.of(Bytes32.wrap(BftHelpers.EXPECTED_MIX_HASH.getBytes())),
           Optional.empty(),
           Optional.empty(),
+          Optional.empty(),
           timestamp,
           true,
           parentHeader);
@@ -128,6 +129,7 @@ public class BftBlockCreator extends AbstractBlockCreator {
         Optional.empty(),
         Optional.of(Collections.emptyList()),
         Optional.of(Bytes32.wrap(BftHelpers.EXPECTED_MIX_HASH.getBytes())),
+        Optional.empty(),
         Optional.empty(),
         Optional.empty(),
         timestamp,

--- a/consensus/merge/src/jmh/java/org/hyperledger/besu/consensus/merge/blockcreation/PayloadIdentifierBenchmark.java
+++ b/consensus/merge/src/jmh/java/org/hyperledger/besu/consensus/merge/blockcreation/PayloadIdentifierBenchmark.java
@@ -124,6 +124,7 @@ public class PayloadIdentifierBenchmark {
         feeRecipient,
         withdrawals,
         parentBeaconBlockRoot,
-        slotNumber);
+        slotNumber,
+        Optional.empty());
   }
 }

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeBlockCreator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeBlockCreator.java
@@ -73,6 +73,7 @@ class MergeBlockCreator extends AbstractBlockCreator {
    * @param withdrawals optional list of withdrawals
    * @param parentBeaconBlockRoot optional root hash of the parent beacon block
    * @param slotNumber optional slot number (EIP-7843)
+   * @param targetGasLimit optional CL-supplied target gas limit for this payload
    * @return the block creation result
    */
   public BlockCreationResult createBlock(
@@ -82,6 +83,7 @@ class MergeBlockCreator extends AbstractBlockCreator {
       final Optional<List<Withdrawal>> withdrawals,
       final Optional<Bytes32> parentBeaconBlockRoot,
       final Optional<Long> slotNumber,
+      final Optional<Long> targetGasLimit,
       final BlockHeader parentHeader) {
 
     return createBlock(
@@ -91,6 +93,7 @@ class MergeBlockCreator extends AbstractBlockCreator {
         Optional.of(random),
         parentBeaconBlockRoot,
         slotNumber,
+        targetGasLimit,
         timestamp,
         false,
         parentHeader);

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
@@ -239,6 +239,7 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
     final Optional<List<Withdrawal>> withdrawals = preparePayloadArgs.withdrawals();
     final Optional<Bytes32> parentBeaconBlockRoot = preparePayloadArgs.parentBeaconBlockRoot();
     final Optional<Long> slotNumber = preparePayloadArgs.slotNumber();
+    final Optional<Long> targetGasLimit = preparePayloadArgs.targetGasLimit();
 
     // we assume that preparePayload is always called sequentially, since the RPC Engine calls
     // are sequential, if this assumption changes then more synchronization should be added to
@@ -252,7 +253,8 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
             feeRecipient,
             withdrawals,
             parentBeaconBlockRoot,
-            slotNumber);
+            slotNumber,
+            targetGasLimit);
 
     if (blockCreationTasks.containsKey(payloadIdentifier)) {
       LOG.debug(
@@ -275,6 +277,7 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
             withdrawals,
             parentBeaconBlockRoot,
             slotNumber,
+            targetGasLimit,
             parentHeader);
     final Block emptyBlock = emptyBlockResult.getBlock();
 
@@ -311,6 +314,7 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
         withdrawals,
         parentBeaconBlockRoot,
         slotNumber,
+        targetGasLimit,
         parentHeader);
 
     return payloadIdentifier;
@@ -414,6 +418,7 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
       final Optional<List<Withdrawal>> withdrawals,
       final Optional<Bytes32> parentBeaconBlockRoot,
       final Optional<Long> slotNumber,
+      final Optional<Long> targetGasLimit,
       final BlockHeader parentHeader) {
 
     final Supplier<BlockCreationResult> blockCreator =
@@ -425,6 +430,7 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
                 withdrawals,
                 parentBeaconBlockRoot,
                 slotNumber,
+                targetGasLimit,
                 parentHeader);
 
     LOG.debug(

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeMiningCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeMiningCoordinator.java
@@ -50,6 +50,7 @@ public interface MergeMiningCoordinator extends MiningCoordinator {
    * @param withdrawals the withdrawals, if present
    * @param parentBeaconBlockRoot the parent beacon block root, if present
    * @param slotNumber the consensus-layer slot number, if present
+   * @param targetGasLimit the CL-supplied target gas limit, if present
    */
   @Value.Builder
   record PreparePayloadArgs(
@@ -59,7 +60,8 @@ public interface MergeMiningCoordinator extends MiningCoordinator {
       Address feeRecipient,
       Optional<List<Withdrawal>> withdrawals,
       Optional<Bytes32> parentBeaconBlockRoot,
-      Optional<Long> slotNumber) {}
+      Optional<Long> slotNumber,
+      Optional<Long> targetGasLimit) {}
 
   /**
    * Prepare payload identifier.

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/PayloadIdentifier.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/PayloadIdentifier.java
@@ -62,6 +62,7 @@ public class PayloadIdentifier implements Quantity {
    * @param withdrawals the optional withdrawals
    * @param parentBeaconBlockRoot the optional parent beacon block root
    * @param slotNumber the optional beacon slot number
+   * @param targetGasLimit the optional target gas limit
    * @return the payload identifier
    */
   public static PayloadIdentifier forPayloadParams(
@@ -71,7 +72,8 @@ public class PayloadIdentifier implements Quantity {
       final Address feeRecipient,
       final Optional<List<Withdrawal>> withdrawals,
       final Optional<Bytes32> parentBeaconBlockRoot,
-      final Optional<Long> slotNumber) {
+      final Optional<Long> slotNumber,
+      final Optional<Long> targetGasLimit) {
 
     // normally timestamp and parentHash should be enough to uniquely identify a payload
     // but in special cases, reorgs, CL configuration changes (feeRecipient), or other edge case
@@ -87,6 +89,8 @@ public class PayloadIdentifier implements Quantity {
 
     final long slotNumberPart = slotNumber.orElse(-1L);
 
+    final long targetGasLimitPart = targetGasLimit.orElse(-1L);
+
     // we finally spread all the values over 64bit, rotating only values where the shift could lose
     // bits
     return new PayloadIdentifier(
@@ -98,7 +102,9 @@ public class PayloadIdentifier implements Quantity {
             ^ slotNumberPart << 40
             ^ slotNumberPart >> 24
             ^ withdrawalPart << 48
-            ^ withdrawalPart >> 16);
+            ^ withdrawalPart >> 16
+            ^ targetGasLimitPart << 56
+            ^ targetGasLimitPart >> 8);
   }
 
   @Override

--- a/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinatorCacheReorgTest.java
+++ b/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinatorCacheReorgTest.java
@@ -334,6 +334,7 @@ public class MergeCoordinatorCacheReorgTest implements MergeGenesisConfigHelper 
             Address.ZERO,
             Optional.empty(),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty()));
 
     boolean built = latch.await(30, TimeUnit.SECONDS);

--- a/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinatorTest.java
+++ b/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinatorTest.java
@@ -309,6 +309,7 @@ public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
                   eq(Optional.empty()),
                   eq(Optional.empty()),
                   eq(Optional.empty()),
+                  eq(Optional.empty()),
                   any());
           return beingSpiedOn;
         };
@@ -420,6 +421,7 @@ public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
                   any(),
                   any(Bytes32.class),
                   anyLong(),
+                  eq(Optional.empty()),
                   eq(Optional.empty()),
                   eq(Optional.empty()),
                   eq(Optional.empty()),

--- a/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/PayloadIdentifierTest.java
+++ b/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/PayloadIdentifierTest.java
@@ -54,6 +54,7 @@ public class PayloadIdentifierTest {
             Address.fromHexString("0x42"),
             Optional.empty(),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
     assertThat(new PayloadIdentifier(idTest.getAsBigInteger().longValue())).isEqualTo(idTest);
   }
@@ -93,6 +94,7 @@ public class PayloadIdentifierTest {
             Address.fromHexString("0x42"),
             Optional.of(withdrawals1),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
     var idForWithdrawals2 =
         PayloadIdentifier.forPayloadParams(
@@ -101,6 +103,7 @@ public class PayloadIdentifierTest {
             prevRandao,
             Address.fromHexString("0x42"),
             Optional.of(withdrawals2),
+            Optional.empty(),
             Optional.empty(),
             Optional.empty());
     assertThat(idForWithdrawals1).isNotEqualTo(idForWithdrawals2);
@@ -141,6 +144,7 @@ public class PayloadIdentifierTest {
             Address.fromHexString("0x42"),
             Optional.of(withdrawals1),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
     var idForWithdrawals2 =
         PayloadIdentifier.forPayloadParams(
@@ -149,6 +153,7 @@ public class PayloadIdentifierTest {
             prevRandao,
             Address.fromHexString("0x42"),
             Optional.of(withdrawals2),
+            Optional.empty(),
             Optional.empty(),
             Optional.empty());
     assertThat(idForWithdrawals1).isEqualTo(idForWithdrawals2);
@@ -165,6 +170,7 @@ public class PayloadIdentifierTest {
             Address.fromHexString("0x42"),
             Optional.empty(),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
     var idForWithdrawals2 =
         PayloadIdentifier.forPayloadParams(
@@ -173,6 +179,7 @@ public class PayloadIdentifierTest {
             prevRandao,
             Address.fromHexString("0x42"),
             Optional.of(emptyList()),
+            Optional.empty(),
             Optional.empty(),
             Optional.empty());
     assertThat(idForWithdrawals1).isNotEqualTo(idForWithdrawals2);
@@ -189,6 +196,7 @@ public class PayloadIdentifierTest {
             Address.fromHexString("0x42"),
             Optional.empty(),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
     var idForWithdrawals2 =
         PayloadIdentifier.forPayloadParams(
@@ -198,6 +206,7 @@ public class PayloadIdentifierTest {
             Address.fromHexString("0x42"),
             Optional.empty(),
             Optional.of(Bytes32.ZERO),
+            Optional.empty(),
             Optional.empty());
     assertThat(idForWithdrawals1).isNotEqualTo(idForWithdrawals2);
   }
@@ -213,6 +222,7 @@ public class PayloadIdentifierTest {
             Address.fromHexString("0x42"),
             Optional.empty(),
             Optional.of(Bytes32.fromHexStringLenient("0x1")),
+            Optional.empty(),
             Optional.empty());
     var idForWithdrawals2 =
         PayloadIdentifier.forPayloadParams(
@@ -222,6 +232,7 @@ public class PayloadIdentifierTest {
             Address.fromHexString("0x42"),
             Optional.empty(),
             Optional.of(Bytes32.ZERO),
+            Optional.empty(),
             Optional.empty());
     assertThat(idForWithdrawals1).isNotEqualTo(idForWithdrawals2);
   }
@@ -237,7 +248,8 @@ public class PayloadIdentifierTest {
             Address.fromHexString("0x42"),
             Optional.empty(),
             Optional.of(Bytes32.fromHexStringLenient("0x1")),
-            Optional.of(100L));
+            Optional.of(100L),
+            Optional.empty());
     var idForWithdrawals2 =
         PayloadIdentifier.forPayloadParams(
             Hash.ZERO,
@@ -246,7 +258,60 @@ public class PayloadIdentifierTest {
             Address.fromHexString("0x42"),
             Optional.empty(),
             Optional.of(Bytes32.fromHexStringLenient("0x1")),
-            Optional.of(101L));
+            Optional.of(101L),
+            Optional.empty());
     assertThat(idForWithdrawals1).isNotEqualTo(idForWithdrawals2);
+  }
+
+  @Test
+  public void differentTargetGasLimitYieldDifferentHash() {
+    final Bytes32 prevRandao = Bytes32.random();
+    var id1 =
+        PayloadIdentifier.forPayloadParams(
+            Hash.ZERO,
+            1337L,
+            prevRandao,
+            Address.fromHexString("0x42"),
+            Optional.empty(),
+            Optional.of(Bytes32.fromHexStringLenient("0x1")),
+            Optional.of(100L),
+            Optional.of(30_000_000L));
+    var id2 =
+        PayloadIdentifier.forPayloadParams(
+            Hash.ZERO,
+            1337L,
+            prevRandao,
+            Address.fromHexString("0x42"),
+            Optional.empty(),
+            Optional.of(Bytes32.fromHexStringLenient("0x1")),
+            Optional.of(100L),
+            Optional.of(60_000_000L));
+    assertThat(id1).isNotEqualTo(id2);
+  }
+
+  @Test
+  public void emptyOptionalAndNonEmptyTargetGasLimitYieldDifferentHash() {
+    final Bytes32 prevRandao = Bytes32.random();
+    var idAbsent =
+        PayloadIdentifier.forPayloadParams(
+            Hash.ZERO,
+            1337L,
+            prevRandao,
+            Address.fromHexString("0x42"),
+            Optional.empty(),
+            Optional.of(Bytes32.fromHexStringLenient("0x1")),
+            Optional.of(100L),
+            Optional.empty());
+    var idPresent =
+        PayloadIdentifier.forPayloadParams(
+            Hash.ZERO,
+            1337L,
+            prevRandao,
+            Address.fromHexString("0x42"),
+            Optional.empty(),
+            Optional.of(Bytes32.fromHexStringLenient("0x1")),
+            Optional.of(100L),
+            Optional.of(30_000_000L));
+    assertThat(idAbsent).isNotEqualTo(idPresent);
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdated.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdated.java
@@ -225,6 +225,7 @@ public abstract class AbstractEngineForkchoiceUpdated extends ExecutionEngineJso
                         .parentBeaconBlockRoot(
                             Optional.ofNullable(payloadAttributes.getParentBeaconBlockRoot()))
                         .slotNumber(Optional.ofNullable(payloadAttributes.getSlotNumber()))
+                        .targetGasLimit(Optional.empty())
                         .build()));
 
     payloadId.ifPresent(

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdatedV4.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdatedV4.java
@@ -277,6 +277,7 @@ public abstract class AbstractEngineForkchoiceUpdatedV4 extends ExecutionEngineJ
                         .parentBeaconBlockRoot(
                             Optional.ofNullable(payloadAttributes.getParentBeaconBlockRoot()))
                         .slotNumber(Optional.ofNullable(payloadAttributes.getSlotNumber()))
+                        .targetGasLimit(Optional.ofNullable(payloadAttributes.getTargetGasLimit()))
                         .build()));
 
     payloadId.ifPresent(

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV4.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV4.java
@@ -74,6 +74,10 @@ public class EngineForkchoiceUpdatedV4 extends AbstractEngineForkchoiceUpdatedV4
         return ValidationResult.invalid(
             RpcErrorType.INVALID_SLOT_NUMBER_PARAMS, "Missing slot number field");
       }
+      if (maybePayloadAttributes.get().getTargetGasLimit() == null) {
+        return ValidationResult.invalid(
+            RpcErrorType.INVALID_TARGET_GAS_LIMIT_PARAMS, "Missing target gas limit field");
+      }
     }
     return ValidationResult.valid();
   }
@@ -97,6 +101,12 @@ public class EngineForkchoiceUpdatedV4 extends AbstractEngineForkchoiceUpdatedV4
       LOG.error("Slot number not present in payload attributes after Amsterdam hardfork");
       return Optional.of(
           new JsonRpcErrorResponse(requestId, RpcErrorType.INVALID_SLOT_NUMBER_PARAMS));
+    }
+
+    if (payloadAttributes.getTargetGasLimit() == null) {
+      LOG.error("Target gas limit not present in payload attributes after Amsterdam hardfork");
+      return Optional.of(
+          new JsonRpcErrorResponse(requestId, RpcErrorType.INVALID_TARGET_GAS_LIMIT_PARAMS));
     }
 
     if (payloadAttributes.getTimestamp() == 0) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EnginePreparePayloadDebug.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EnginePreparePayloadDebug.java
@@ -118,6 +118,7 @@ public class EnginePreparePayloadDebug extends ExecutionEngineJsonRpcMethod {
                         .withdrawals(Optional.of(withdrawals))
                         .parentBeaconBlockRoot(param.getParentBeaconBlockRoot())
                         .slotNumber(Optional.empty())
+                        .targetGasLimit(Optional.empty())
                         .build()));
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/testing/TestingBlockCreator.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/testing/TestingBlockCreator.java
@@ -69,6 +69,7 @@ class TestingBlockCreator extends AbstractBlockCreator {
       final Optional<List<Withdrawal>> withdrawals,
       final Optional<Bytes32> parentBeaconBlockRoot,
       final Optional<Long> slotNumber,
+      final Optional<Long> targetGasLimit,
       final BlockHeader parentHeader) {
 
     return createBlock(
@@ -78,6 +79,7 @@ class TestingBlockCreator extends AbstractBlockCreator {
         Optional.of(random),
         parentBeaconBlockRoot,
         slotNumber,
+        targetGasLimit,
         timestamp,
         false,
         parentHeader);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/testing/TestingBuildBlockV1.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/testing/TestingBuildBlockV1.java
@@ -211,6 +211,7 @@ public class TestingBuildBlockV1 implements JsonRpcMethod {
     final Bytes32 parentBeaconBlockRoot = payloadAttributes.getParentBeaconBlockRoot();
     final Long timestamp = payloadAttributes.getTimestamp();
     final Long slotNumber = payloadAttributes.getSlotNumber();
+    final Long targetGasLimit = payloadAttributes.getTargetGasLimit();
 
     try {
       final Address coinbase = payloadAttributes.getSuggestedFeeRecipient();
@@ -242,6 +243,7 @@ public class TestingBuildBlockV1 implements JsonRpcMethod {
               Optional.of(withdrawals),
               Optional.ofNullable(parentBeaconBlockRoot),
               Optional.ofNullable(slotNumber),
+              Optional.ofNullable(targetGasLimit),
               parentHeader);
 
       // When transactions are explicitly provided, return an error if any were not applied.

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/EnginePayloadAttributesParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/EnginePayloadAttributesParameter.java
@@ -32,6 +32,7 @@ public class EnginePayloadAttributesParameter {
   final List<WithdrawalParameter> withdrawals;
   private final Bytes32 parentBeaconBlockRoot;
   private final Long slotNumber;
+  private final Long targetGasLimit;
 
   @JsonCreator
   public EnginePayloadAttributesParameter(
@@ -40,7 +41,8 @@ public class EnginePayloadAttributesParameter {
       @JsonProperty("suggestedFeeRecipient") final String suggestedFeeRecipient,
       @JsonProperty("withdrawals") final List<WithdrawalParameter> withdrawals,
       @JsonProperty("parentBeaconBlockRoot") final String parentBeaconBlockRoot,
-      @JsonProperty("slotNumber") final String slotNumber) {
+      @JsonProperty("slotNumber") final String slotNumber,
+      @JsonProperty("targetGasLimit") final String targetGasLimit) {
     this.timestamp = Long.decode(timestamp);
     this.prevRandao = Bytes32.fromHexString(prevRandao);
     this.suggestedFeeRecipient = Address.fromHexString(suggestedFeeRecipient);
@@ -48,6 +50,7 @@ public class EnginePayloadAttributesParameter {
     this.parentBeaconBlockRoot =
         parentBeaconBlockRoot == null ? null : Bytes32.fromHexString(parentBeaconBlockRoot);
     this.slotNumber = slotNumber == null ? null : Long.decode(slotNumber);
+    this.targetGasLimit = targetGasLimit == null ? null : Long.decode(targetGasLimit);
   }
 
   public Long getTimestamp() {
@@ -74,6 +77,10 @@ public class EnginePayloadAttributesParameter {
     return slotNumber;
   }
 
+  public Long getTargetGasLimit() {
+    return targetGasLimit;
+  }
+
   public String serialize() {
     final JsonObject json =
         new JsonObject()
@@ -90,6 +97,9 @@ public class EnginePayloadAttributesParameter {
     }
     if (slotNumber != null) {
       json.put("slotNumber", slotNumber);
+    }
+    if (targetGasLimit != null) {
+      json.put("targetGasLimit", targetGasLimit);
     }
     return json.encode();
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdatedTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdatedTest.java
@@ -254,6 +254,7 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
             Address.ECREC.toString(),
             null,
             null,
+            null,
             null);
     var mockPayloadId =
         PayloadIdentifier.forPayloadParams(
@@ -261,6 +262,7 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
             payloadParams.getTimestamp(),
             payloadParams.getPrevRandao(),
             payloadParams.getSuggestedFeeRecipient(),
+            Optional.empty(),
             Optional.empty(),
             Optional.empty(),
             Optional.empty());
@@ -445,6 +447,7 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
             Address.ECREC.toString(),
             null,
             null,
+            null,
             null);
 
     var resp =
@@ -483,6 +486,7 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
             Address.ECREC.toString(),
             emptyList(),
             null,
+            null,
             null);
 
     var resp =
@@ -508,6 +512,7 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
             Bytes32.fromHexStringLenient("0xDEADBEEF").toHexString(),
             Address.ECREC.toString(),
             emptyList(),
+            null,
             null,
             null);
 
@@ -535,6 +540,7 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
             Address.ECREC.toString(),
             null,
             null,
+            null,
             null);
 
     var mockPayloadId =
@@ -543,6 +549,7 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
             payloadParams.getTimestamp(),
             payloadParams.getPrevRandao(),
             payloadParams.getSuggestedFeeRecipient(),
+            Optional.empty(),
             Optional.empty(),
             Optional.empty(),
             Optional.empty());
@@ -572,6 +579,7 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
             String.valueOf(mockHeader.getTimestamp() + 1),
             Bytes32.fromHexStringLenient("0xDEADBEEF").toHexString(),
             Address.ECREC.toString(),
+            null,
             null,
             null,
             null);
@@ -611,6 +619,7 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
             Address.ECREC.toString(),
             withdrawalParameters,
             null,
+            null,
             null);
 
     final Optional<List<Withdrawal>> withdrawals =
@@ -626,6 +635,7 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
             payloadParams.getPrevRandao(),
             payloadParams.getSuggestedFeeRecipient(),
             withdrawals,
+            Optional.empty(),
             Optional.empty(),
             Optional.empty());
 
@@ -655,6 +665,7 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
             Address.ECREC.toString(),
             null,
             null,
+            null,
             null);
 
     var mockPayloadId =
@@ -663,6 +674,7 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
             payloadParams.getTimestamp(),
             payloadParams.getPrevRandao(),
             payloadParams.getSuggestedFeeRecipient(),
+            Optional.empty(),
             Optional.empty(),
             Optional.empty(),
             Optional.empty());

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineGetPayloadTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineGetPayloadTest.java
@@ -93,6 +93,7 @@ public abstract class AbstractEngineGetPayloadTest extends AbstractScheduledApiT
           Address.fromHexString("0x42"),
           Optional.empty(),
           Optional.empty(),
+          Optional.empty(),
           Optional.empty());
   protected static final BlockHeader mockHeader =
       new BlockHeaderTestFixture().prevRandao(Bytes32.random()).buildHeader();
@@ -177,6 +178,7 @@ public abstract class AbstractEngineGetPayloadTest extends AbstractScheduledApiT
                 Address.fromHexString("0x42"),
                 Optional.empty(),
                 Optional.empty(),
+                Optional.empty(),
                 Optional.empty()));
     assertThat(resp).isInstanceOf(JsonRpcErrorResponse.class);
     verify(engineCallListener, times(1)).executionEngineCalled();
@@ -203,6 +205,7 @@ public abstract class AbstractEngineGetPayloadTest extends AbstractScheduledApiT
             timestamp,
             Bytes32.random(),
             Address.fromHexString("0x42"),
+            Optional.empty(),
             Optional.empty(),
             Optional.empty(),
             Optional.empty());
@@ -237,6 +240,7 @@ public abstract class AbstractEngineGetPayloadTest extends AbstractScheduledApiT
             validTimestamp,
             Bytes32.random(),
             Address.fromHexString("0x42"),
+            Optional.empty(),
             Optional.empty(),
             Optional.empty(),
             Optional.empty());

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV1Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV1Test.java
@@ -79,6 +79,7 @@ public class EngineForkchoiceUpdatedV1Test extends AbstractEngineForkchoiceUpdat
             Address.ECREC.toString(),
             null,
             null,
+            null,
             null);
 
     final JsonRpcResponse resp =
@@ -107,6 +108,7 @@ public class EngineForkchoiceUpdatedV1Test extends AbstractEngineForkchoiceUpdat
             String.valueOf(mockHeader.getTimestamp()),
             Bytes32.fromHexStringLenient("0xDEADBEEF").toHexString(),
             Address.ECREC.toString(),
+            null,
             null,
             null,
             null);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV2Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV2Test.java
@@ -77,6 +77,7 @@ public class EngineForkchoiceUpdatedV2Test extends AbstractEngineForkchoiceUpdat
             Address.ECREC.toString(),
             null,
             null,
+            null,
             null);
 
     final JsonRpcResponse resp = resp(param, Optional.of(payloadParams));

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV4Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV4Test.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine;
 
+import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.AMSTERDAM;
 import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.CANCUN;
@@ -28,6 +29,8 @@ import static org.mockito.Mockito.when;
 import org.hyperledger.besu.consensus.merge.MergeContext;
 import org.hyperledger.besu.consensus.merge.blockcreation.MergeMiningCoordinator;
 import org.hyperledger.besu.consensus.merge.blockcreation.MergeMiningCoordinator.ForkchoiceResult;
+import org.hyperledger.besu.consensus.merge.blockcreation.MergeMiningCoordinator.PreparePayloadArgs;
+import org.hyperledger.besu.consensus.merge.blockcreation.PayloadIdentifier;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.Wei;
@@ -59,6 +62,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -274,6 +278,39 @@ public class EngineForkchoiceUpdatedV4Test {
     assertThat(resp.getType()).isEqualTo(RpcResponseType.ERROR);
     final JsonRpcErrorResponse err = (JsonRpcErrorResponse) resp;
     assertThat(err.getErrorType()).isEqualTo(RpcErrorType.INVALID_TARGET_GAS_LIMIT_PARAMS);
+  }
+
+  @Test
+  public void shouldForwardTargetGasLimitToPreparePayload() {
+    final BlockHeader head =
+        blockHeaderBuilder.number(50L).timestamp(AMSTERDAM_MILESTONE + 1).buildHeader();
+    when(mergeCoordinator.getOrSyncHeadByHash(head.getHash(), Hash.ZERO))
+        .thenReturn(Optional.of(head));
+    when(mergeCoordinator.computeReorgDepth(head)).thenReturn(OptionalLong.of(0L));
+    when(mergeCoordinator.updateForkChoiceWithoutLegacySkip(head, Hash.ZERO, Hash.ZERO))
+        .thenReturn(ForkchoiceResult.withResult(Optional.empty(), Optional.of(head)));
+    when(mergeCoordinator.preparePayload(any())).thenReturn(new PayloadIdentifier(1L));
+
+    final EngineForkchoiceUpdatedParameter param =
+        new EngineForkchoiceUpdatedParameter(head.getHash(), Hash.ZERO, Hash.ZERO);
+
+    final EnginePayloadAttributesParameter attrs =
+        new EnginePayloadAttributesParameter(
+            "0x" + Long.toHexString(head.getTimestamp() + 1),
+            Bytes32.ZERO.toHexString(),
+            Address.ZERO.toHexString(),
+            emptyList(),
+            Bytes32.ZERO.toHexString(),
+            "0x1",
+            "0x1c9c380");
+
+    final JsonRpcResponse resp = resp(param, Optional.of(attrs));
+
+    assertThat(resp.getType()).isEqualTo(RpcResponseType.SUCCESS);
+    final ArgumentCaptor<PreparePayloadArgs> argsCaptor =
+        ArgumentCaptor.forClass(PreparePayloadArgs.class);
+    verify(mergeCoordinator).preparePayload(argsCaptor.capture());
+    assertThat(argsCaptor.getValue().targetGasLimit()).contains(30_000_000L);
   }
 
   private void setupValidForkchoiceState(final BlockHeader head, final BlockHeader finalized) {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV4Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV4Test.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.when;
 import org.hyperledger.besu.consensus.merge.MergeContext;
 import org.hyperledger.besu.consensus.merge.blockcreation.MergeMiningCoordinator;
 import org.hyperledger.besu.consensus.merge.blockcreation.MergeMiningCoordinator.ForkchoiceResult;
+import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.ProtocolContext;
@@ -54,6 +55,7 @@ import java.util.OptionalLong;
 import java.util.stream.Stream;
 
 import io.vertx.core.Vertx;
+import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -244,6 +246,34 @@ public class EngineForkchoiceUpdatedV4Test {
     assertThat(resp.getType()).isEqualTo(RpcResponseType.SUCCESS);
     verify(mergeCoordinator, times(1))
         .updateForkChoiceWithoutLegacySkip(head, Hash.ZERO, Hash.ZERO);
+  }
+
+  @Test
+  public void shouldReturnInvalidTargetGasLimitParamsWhenTargetGasLimitMissing() {
+    final BlockHeader head =
+        blockHeaderBuilder.number(50L).timestamp(AMSTERDAM_MILESTONE + 1).buildHeader();
+    when(mergeCoordinator.getOrSyncHeadByHash(head.getHash(), Hash.ZERO))
+        .thenReturn(Optional.of(head));
+    when(mergeCoordinator.computeReorgDepth(head)).thenReturn(OptionalLong.of(0L));
+
+    final EngineForkchoiceUpdatedParameter param =
+        new EngineForkchoiceUpdatedParameter(head.getHash(), Hash.ZERO, Hash.ZERO);
+
+    final EnginePayloadAttributesParameter attrs =
+        new EnginePayloadAttributesParameter(
+            "0x" + Long.toHexString(head.getTimestamp() + 1),
+            Bytes32.ZERO.toHexString(),
+            Address.ZERO.toHexString(),
+            null,
+            Bytes32.ZERO.toHexString(),
+            "0x1",
+            null);
+
+    final JsonRpcResponse resp = resp(param, Optional.of(attrs));
+
+    assertThat(resp.getType()).isEqualTo(RpcResponseType.ERROR);
+    final JsonRpcErrorResponse err = (JsonRpcErrorResponse) resp;
+    assertThat(err.getErrorType()).isEqualTo(RpcErrorType.INVALID_TARGET_GAS_LIMIT_PARAMS);
   }
 
   private void setupValidForkchoiceState(final BlockHeader head, final BlockHeader finalized) {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadV3Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadV3Test.java
@@ -109,6 +109,7 @@ public class EngineGetPayloadV3Test extends AbstractEngineGetPayloadTest {
             Address.fromHexString("0x42"),
             Optional.empty(),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
 
     BlockWithReceipts shanghaiBlock =
@@ -148,6 +149,7 @@ public class EngineGetPayloadV3Test extends AbstractEngineGetPayloadTest {
             cancunHardfork.milestone(),
             Bytes32.random(),
             Address.fromHexString("0x42"),
+            Optional.empty(),
             Optional.empty(),
             Optional.empty(),
             Optional.empty());
@@ -191,6 +193,7 @@ public class EngineGetPayloadV3Test extends AbstractEngineGetPayloadTest {
             cancunHardfork.milestone(),
             Bytes32.random(),
             Address.fromHexString("0x42"),
+            Optional.empty(),
             Optional.empty(),
             Optional.empty(),
             Optional.empty());

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadV4Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadV4Test.java
@@ -139,6 +139,7 @@ public class EngineGetPayloadV4Test extends AbstractEngineGetPayloadTest {
             Address.fromHexString("0x42"),
             Optional.empty(),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
 
     BlobTestFixture blobTestFixture = new BlobTestFixture();
@@ -218,6 +219,7 @@ public class EngineGetPayloadV4Test extends AbstractEngineGetPayloadTest {
             pragueHardfork.milestone(),
             Bytes32.random(),
             Address.fromHexString("0x42"),
+            Optional.empty(),
             Optional.empty(),
             Optional.empty(),
             Optional.empty());

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadV5Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadV5Test.java
@@ -139,6 +139,7 @@ public class EngineGetPayloadV5Test extends AbstractEngineGetPayloadTest {
             Address.fromHexString("0x42"),
             Optional.empty(),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
 
     BlobTestFixture blobTestFixture = new BlobTestFixture();

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadV6Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadV6Test.java
@@ -133,6 +133,7 @@ public class EngineGetPayloadV6Test extends AbstractEngineGetPayloadTest {
             Address.fromHexString("0x42"),
             Optional.empty(),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
 
     final List<Request> requests =
@@ -177,6 +178,7 @@ public class EngineGetPayloadV6Test extends AbstractEngineGetPayloadTest {
             header.getTimestamp(),
             Bytes32.random(),
             Address.fromHexString("0x42"),
+            Optional.empty(),
             Optional.empty(),
             Optional.empty(),
             Optional.empty());

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/EnginePayloadAttributesParameterTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/EnginePayloadAttributesParameterTest.java
@@ -96,15 +96,36 @@ public class EnginePayloadAttributesParameterTest {
                 + "}");
   }
 
+  @Test
+  public void targetGasLimitIsDecodedFromHexString() {
+    final EnginePayloadAttributesParameter parameter =
+        new EnginePayloadAttributesParameter(
+            TIMESTAMP, PREV_RANDAO, SUGGESTED_FEE_RECIPIENT_ADDRESS, null, null, null, "0x1c9c380");
+    assertThat(parameter.getTargetGasLimit()).isEqualTo(30_000_000L);
+  }
+
+  @Test
+  public void serialize_TargetGasLimitPresent() {
+    final EnginePayloadAttributesParameter parameter =
+        new EnginePayloadAttributesParameter(
+            TIMESTAMP, PREV_RANDAO, SUGGESTED_FEE_RECIPIENT_ADDRESS, null, null, null, "0x1c9c380");
+    assertThat(parameter.serialize()).contains("\"targetGasLimit\":30000000");
+  }
+
+  @Test
+  public void serialize_TargetGasLimitOmittedWhenNull() {
+    assertThat(parameterWithdrawalsOmitted().serialize()).doesNotContain("targetGasLimit");
+  }
+
   private EnginePayloadAttributesParameter parameterWithdrawalsOmitted() {
     return new EnginePayloadAttributesParameter(
-        TIMESTAMP, PREV_RANDAO, SUGGESTED_FEE_RECIPIENT_ADDRESS, null, null, null);
+        TIMESTAMP, PREV_RANDAO, SUGGESTED_FEE_RECIPIENT_ADDRESS, null, null, null, null);
   }
 
   private EnginePayloadAttributesParameter parameterWithdrawalsPresent() {
     final List<WithdrawalParameter> withdrawals = List.of(WITHDRAWAL_PARAM_1, WITHDRAWAL_PARAM_2);
     return new EnginePayloadAttributesParameter(
-        TIMESTAMP, PREV_RANDAO, SUGGESTED_FEE_RECIPIENT_ADDRESS, withdrawals, null, null);
+        TIMESTAMP, PREV_RANDAO, SUGGESTED_FEE_RECIPIENT_ADDRESS, withdrawals, null, null, null);
   }
 
   // TODO: add a parent beacon block root test here

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreator.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreator.java
@@ -156,6 +156,7 @@ public abstract class AbstractBlockCreator implements AsyncBlockCreator {
         Optional.empty(),
         Optional.empty(),
         Optional.empty(),
+        Optional.empty(),
         timestamp,
         true,
         parentHeader);
@@ -180,6 +181,7 @@ public abstract class AbstractBlockCreator implements AsyncBlockCreator {
         Optional.empty(),
         Optional.empty(),
         Optional.empty(),
+        Optional.empty(),
         timestamp,
         true,
         parentHeader);
@@ -192,6 +194,7 @@ public abstract class AbstractBlockCreator implements AsyncBlockCreator {
       final Optional<Bytes32> maybePrevRandao,
       final Optional<Bytes32> maybeParentBeaconBlockRoot,
       final Optional<Long> maybeSlotNumber,
+      final Optional<Long> maybeTargetGasLimit,
       final long timestamp,
       final boolean rewardCoinbase,
       final BlockHeader parentHeader) {
@@ -211,7 +214,8 @@ public abstract class AbstractBlockCreator implements AsyncBlockCreator {
                   timestamp,
                   maybePrevRandao,
                   maybeParentBeaconBlockRoot,
-                  maybeSlotNumber)
+                  maybeSlotNumber,
+                  maybeTargetGasLimit)
               .buildProcessableBlockHeader();
 
       final Address miningBeneficiary =

--- a/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreatorTest.java
+++ b/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreatorTest.java
@@ -174,6 +174,7 @@ class AbstractBlockCreatorTest extends TrustedSetupClassLoaderExtension {
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
+            Optional.empty(),
             1L,
             false,
             miningOn.parentHeader);
@@ -188,6 +189,7 @@ class AbstractBlockCreatorTest extends TrustedSetupClassLoaderExtension {
     final AbstractBlockCreator blockCreator = miningOn.blockCreator;
     final BlockCreationResult blockCreationResult =
         blockCreator.createBlock(
+            Optional.empty(),
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
@@ -216,6 +218,7 @@ class AbstractBlockCreatorTest extends TrustedSetupClassLoaderExtension {
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
+            Optional.empty(),
             1L,
             false,
             miningOn.parentHeader);
@@ -238,6 +241,7 @@ class AbstractBlockCreatorTest extends TrustedSetupClassLoaderExtension {
             Optional.empty(),
             Optional.empty(),
             Optional.of(withdrawals),
+            Optional.empty(),
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
@@ -271,6 +275,7 @@ class AbstractBlockCreatorTest extends TrustedSetupClassLoaderExtension {
     final BlockCreationResult blockCreationResult =
         blockCreator.createBlock(
             Optional.of(List.of(fullOfBlobs)),
+            Optional.empty(),
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/BlockHeaderBuilder.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/BlockHeaderBuilder.java
@@ -230,12 +230,9 @@ public class BlockHeaderBuilder {
       final Optional<Long> maybeTargetGasLimit) {
 
     final long newBlockNumber = parentHeader.getNumber() + 1;
-    final long targetGasLimit;
-    if (maybeTargetGasLimit.isPresent()) {
-      targetGasLimit = maybeTargetGasLimit.get();
-    } else {
-      targetGasLimit = miningConfiguration.getTargetGasLimit().orElse(parentHeader.getGasLimit());
-    }
+    final long targetGasLimit =
+        maybeTargetGasLimit.orElseGet(
+            () -> miningConfiguration.getTargetGasLimit().orElse(parentHeader.getGasLimit()));
     final long gasLimit =
         protocolSpec
             .getGasLimitCalculator()

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/BlockHeaderBuilder.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/BlockHeaderBuilder.java
@@ -208,15 +208,38 @@ public class BlockHeaderBuilder {
       final Optional<Bytes32> maybePrevRandao,
       final Optional<Bytes32> maybeParentBeaconBlockRoot,
       final Optional<Long> maybeSlotNumber) {
+    return createPending(
+        protocolSpec,
+        parentHeader,
+        miningConfiguration,
+        timestamp,
+        maybePrevRandao,
+        maybeParentBeaconBlockRoot,
+        maybeSlotNumber,
+        Optional.empty());
+  }
+
+  public static BlockHeaderBuilder createPending(
+      final ProtocolSpec protocolSpec,
+      final BlockHeader parentHeader,
+      final MiningConfiguration miningConfiguration,
+      final long timestamp,
+      final Optional<Bytes32> maybePrevRandao,
+      final Optional<Bytes32> maybeParentBeaconBlockRoot,
+      final Optional<Long> maybeSlotNumber,
+      final Optional<Long> maybeTargetGasLimit) {
 
     final long newBlockNumber = parentHeader.getNumber() + 1;
+    final long targetGasLimit;
+    if (maybeTargetGasLimit.isPresent()) {
+      targetGasLimit = maybeTargetGasLimit.get();
+    } else {
+      targetGasLimit = miningConfiguration.getTargetGasLimit().orElse(parentHeader.getGasLimit());
+    }
     final long gasLimit =
         protocolSpec
             .getGasLimitCalculator()
-            .nextGasLimit(
-                parentHeader.getGasLimit(),
-                miningConfiguration.getTargetGasLimit().orElse(parentHeader.getGasLimit()),
-                newBlockNumber);
+            .nextGasLimit(parentHeader.getGasLimit(), targetGasLimit, newBlockNumber);
 
     final DifficultyCalculator difficultyCalculator = protocolSpec.getDifficultyCalculator();
     final var difficulty =

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/BlockHeaderBuilderCreatePendingTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/BlockHeaderBuilderCreatePendingTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.hyperledger.besu.ethereum.GasLimitCalculator;
+import org.hyperledger.besu.ethereum.mainnet.DifficultyCalculator;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
+import org.hyperledger.besu.ethereum.mainnet.feemarket.FeeMarket;
+
+import java.math.BigInteger;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.junit.jupiter.api.Test;
+
+public class BlockHeaderBuilderCreatePendingTest {
+
+  private static final long PARENT_GAS_LIMIT = 30_000_000L;
+  private static final long CONFIG_TARGET = 36_000_000L;
+  private static final long FCU_TARGET = 45_000_000L;
+
+  @Test
+  public void usesFcuTargetGasLimitWhenPresent() {
+    final AtomicLong observedTarget = new AtomicLong();
+    final ProtocolSpec protocolSpec = stubProtocolSpec(observedTarget);
+    final BlockHeader parent = parentHeader();
+    final MiningConfiguration miningConfiguration = miningConfigurationWithTarget(CONFIG_TARGET);
+
+    BlockHeaderBuilder.createPending(
+        protocolSpec,
+        parent,
+        miningConfiguration,
+        parent.getTimestamp() + 1,
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.of(FCU_TARGET));
+
+    assertThat(observedTarget.get()).isEqualTo(FCU_TARGET);
+  }
+
+  @Test
+  public void fallsBackToMiningConfigurationWhenFcuTargetIsAbsent() {
+    final AtomicLong observedTarget = new AtomicLong();
+    final ProtocolSpec protocolSpec = stubProtocolSpec(observedTarget);
+    final BlockHeader parent = parentHeader();
+    final MiningConfiguration miningConfiguration = miningConfigurationWithTarget(CONFIG_TARGET);
+
+    BlockHeaderBuilder.createPending(
+        protocolSpec,
+        parent,
+        miningConfiguration,
+        parent.getTimestamp() + 1,
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty());
+
+    assertThat(observedTarget.get()).isEqualTo(CONFIG_TARGET);
+  }
+
+  @Test
+  public void fallsBackToParentGasLimitWhenNoTargetConfigured() {
+    final AtomicLong observedTarget = new AtomicLong();
+    final ProtocolSpec protocolSpec = stubProtocolSpec(observedTarget);
+    final BlockHeader parent = parentHeader();
+    final MiningConfiguration miningConfiguration = MiningConfiguration.newDefault();
+
+    BlockHeaderBuilder.createPending(
+        protocolSpec,
+        parent,
+        miningConfiguration,
+        parent.getTimestamp() + 1,
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty());
+
+    assertThat(observedTarget.get()).isEqualTo(PARENT_GAS_LIMIT);
+  }
+
+  private static BlockHeader parentHeader() {
+    return new BlockHeaderTestFixture()
+        .number(100L)
+        .timestamp(1_000L)
+        .gasLimit(PARENT_GAS_LIMIT)
+        .buildHeader();
+  }
+
+  private static MiningConfiguration miningConfigurationWithTarget(final long target) {
+    final MiningConfiguration miningConfiguration = MiningConfiguration.newDefault();
+    miningConfiguration.setTargetGasLimit(target);
+    return miningConfiguration;
+  }
+
+  private static ProtocolSpec stubProtocolSpec(final AtomicLong observedTarget) {
+    final GasLimitCalculator gasLimitCalculator =
+        (currentGasLimit, targetGasLimit, newBlockNumber) -> {
+          observedTarget.set(targetGasLimit);
+          return targetGasLimit;
+        };
+    final DifficultyCalculator difficultyCalculator = (time, parent) -> BigInteger.ZERO;
+    final FeeMarket feeMarket = mock(FeeMarket.class);
+    when(feeMarket.implementsBaseFee()).thenReturn(false);
+
+    final ProtocolSpec protocolSpec = mock(ProtocolSpec.class);
+    when(protocolSpec.getGasLimitCalculator()).thenReturn(gasLimitCalculator);
+    when(protocolSpec.getDifficultyCalculator()).thenReturn(difficultyCalculator);
+    when(protocolSpec.getFeeMarket()).thenReturn(feeMarket);
+    return protocolSpec;
+  }
+}

--- a/ethereum/referencetests/src/reference-test/java/org/hyperledger/besu/consensus/merge/blockcreation/ReferenceTestMergeBlockCreator.java
+++ b/ethereum/referencetests/src/reference-test/java/org/hyperledger/besu/consensus/merge/blockcreation/ReferenceTestMergeBlockCreator.java
@@ -66,6 +66,7 @@ public final class ReferenceTestMergeBlockCreator {
             Optional.of(random),
             parentBeaconBlockRoot,
             slotNumber,
+            Optional.empty(),
             timestamp,
             true,
             parentHeader)


### PR DESCRIPTION
## Description

Thread an optional **CL-supplied target gas limit** through payload building, carried on the engine `forkchoiceUpdatedV4` payload attributes (glamsterdam-devnet, #10564). Independent of EIP-8037.

- `EnginePayloadAttributesParameter` parses/serializes a new `targetGasLimit` field; `EngineForkchoiceUpdatedV4` rejects a payload-building fcU that is missing it after Amsterdam (`INVALID_TARGET_GAS_LIMIT_PARAMS`).
- `PreparePayloadArgs` gains an `Optional<Long> targetGasLimit`; V4 populates it from the attributes, other callers (base fcU, debug `preparePayload`) pass empty.
- `MergeCoordinator` / `MergeBlockCreator` / `AbstractBlockCreator` thread the target gas limit into block creation; `PayloadIdentifier` mixes it into the payloadId hash so distinct targets yield distinct ids.
- CLI `MiningOptions` exposes the default target gas limit.

Because `targetGasLimit` (default `-1L` when empty) now contributes to the payloadId XOR, every fork's payloadId changes; the engine and debug `replayBlock`/`setHead` acceptance fixtures are regenerated accordingly.

### Port notes
The source branch kept the positional `preparePayload(...)` signature; this PR ports the feature onto main's `PreparePayloadArgs` record (adds `targetGasLimit` as a record component, threaded via `PreparePayloadArgsBuilder`). `BftBlockCreator` and the V1 engine test are updated for the widened `createBlock` / attributes-parameter signatures.

## Testing

- `PayloadIdentifierTest`, `MergeCoordinatorTest`, `MergeCoordinatorCacheReorgTest`, `MergeReorgTest`, `BftBlockCreatorTest`, `EngineForkchoiceUpdatedV1/V2/V4Test`, `EngineGetPayloadV*Test`, `EnginePayloadAttributesParameterTest`, `MiningOptionsTest`, `AbstractBlockCreatorTest` — pass.
- Acceptance (live node): `ExecutionEngineParisAcceptanceTest` (9/9), `DebugReplayBlockAcceptanceTest` (7/7) — confirm the regenerated payloadId fixtures.
- Spotless clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
