### PR TITLE
Layered txpool: allow zero upfront cost txs from zero balance senders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `--rpc-tx-feecap` will treat a value of 0 as limiting fees to 0. Today it treats 0 as "do not cap fees". To achieve similar behaviour set it to a suitably large value to effectively prevent any fee capping.
 
 ### Bug fixes
+- Layered txpool: fix the sender balance check rejecting zero upfront cost transactions from zero balance senders, which caused free gas networks to produce only empty blocks [#10751](https://github.com/besu-eth/besu/pull/10751)
 - Skip DNS discovery records that fail enode conversion (e.g. out-of-range port) instead of dropping the rest of the batch [#10752](https://github.com/besu-eth/besu/pull/10752)
 
 ### Additions and Improvements

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/layered/SenderBalanceChecker.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/layered/SenderBalanceChecker.java
@@ -104,14 +104,6 @@ public interface SenderBalanceChecker {
 
       final var senderBalance = senderBalancesCache.computeIfAbsent(sender, this::getSenderBalance);
 
-      if (senderBalance.equals(Wei.ZERO)) {
-        LOG.atTrace()
-            .setMessage("Sender has zero balance for transaction {}")
-            .addArgument(pendingTransaction::toTraceLog)
-            .log();
-        return false;
-      }
-
       final var gasCalculator =
           protocolSchedule.getByBlockHeader(blockchain.getChainHeadHeader()).getGasCalculator();
       final var upfrontCost = tx.getUpfrontCost(gasCalculator.blobGasCost(tx.getBlobCount()));

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/layered/SenderBalanceCheckerTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/layered/SenderBalanceCheckerTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.eth.transactions.layered;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.hyperledger.besu.datatypes.TransactionType;
+import org.hyperledger.besu.datatypes.Wei;
+import org.hyperledger.besu.ethereum.ProtocolContext;
+import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
+import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
+import org.hyperledger.besu.evm.account.Account;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
+import org.hyperledger.besu.plugin.services.worldstate.MutableWorldState;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class SenderBalanceCheckerTest extends BaseTransactionPoolTest {
+
+  private final ProtocolSchedule protocolSchedule = mock(ProtocolSchedule.class);
+  private final ProtocolSpec protocolSpec = mock(ProtocolSpec.class);
+  private final GasCalculator gasCalculator = mock(GasCalculator.class);
+  private final ProtocolContext protocolContext = mock(ProtocolContext.class);
+  private final MutableBlockchain blockchain = mock(MutableBlockchain.class);
+  private final WorldStateArchive worldStateArchive = mock(WorldStateArchive.class);
+  private final MutableWorldState worldState = mock(MutableWorldState.class);
+  private final BlockHeader chainHeadHeader = new BlockHeaderTestFixture().buildHeader();
+
+  private SenderBalanceChecker balanceChecker;
+
+  @BeforeEach
+  void setup() {
+    when(protocolContext.getBlockchain()).thenReturn(blockchain);
+    when(protocolContext.getWorldStateArchive()).thenReturn(worldStateArchive);
+    when(blockchain.getChainHeadHeader()).thenReturn(chainHeadHeader);
+    when(worldStateArchive.getWorldState(any())).thenReturn(Optional.of(worldState));
+    when(protocolSchedule.getByBlockHeader(chainHeadHeader)).thenReturn(protocolSpec);
+    when(protocolSpec.getGasCalculator()).thenReturn(gasCalculator);
+    balanceChecker = new SenderBalanceChecker.WorldStateChecker(protocolSchedule, protocolContext);
+  }
+
+  private void setSenderBalance(final Wei balance) {
+    final Account account = mock(Account.class);
+    when(account.getBalance()).thenReturn(balance);
+    when(worldState.get(SENDER1)).thenReturn(account);
+  }
+
+  @Test
+  public void zeroBalanceSenderHasEnoughBalanceForZeroUpfrontCostTransaction() {
+    // on free gas networks sender accounts commonly have zero balance,
+    // and a zero gas price, zero value transaction has zero upfront cost
+    setSenderBalance(Wei.ZERO);
+
+    final var zeroCostTx = createTransaction(TransactionType.FRONTIER, 0, Wei.ZERO, 0, null, KEYS1);
+
+    assertThat(balanceChecker.hasEnoughBalanceFor(createRemotePendingTransaction(zeroCostTx)))
+        .isTrue();
+  }
+
+  @Test
+  public void zeroBalanceSenderHasNotEnoughBalanceForPayingTransaction() {
+    setSenderBalance(Wei.ZERO);
+
+    final var payingTx = createTransaction(TransactionType.FRONTIER, 0, Wei.of(10), 0, null, KEYS1);
+
+    assertThat(balanceChecker.hasEnoughBalanceFor(createRemotePendingTransaction(payingTx)))
+        .isFalse();
+  }
+
+  @Test
+  public void senderWithEnoughBalanceCanPayUpfrontCost() {
+    final var payingTx = createTransaction(TransactionType.FRONTIER, 0, Wei.of(10), 0, null, KEYS1);
+    setSenderBalance(payingTx.getUpfrontCost(0L));
+
+    assertThat(balanceChecker.hasEnoughBalanceFor(createRemotePendingTransaction(payingTx)))
+        .isTrue();
+  }
+
+  @Test
+  public void sequentialTransactionsDepleteTheCachedSenderBalance() {
+    final var payingTx0 =
+        createTransaction(TransactionType.FRONTIER, 0, Wei.of(10), 0, null, KEYS1);
+    final var payingTx1 =
+        createTransaction(TransactionType.FRONTIER, 1, Wei.of(10), 0, null, KEYS1);
+    // enough balance for the first transaction only
+    setSenderBalance(payingTx0.getUpfrontCost(0L));
+
+    assertThat(balanceChecker.hasEnoughBalanceFor(createRemotePendingTransaction(payingTx0)))
+        .isTrue();
+    assertThat(balanceChecker.hasEnoughBalanceFor(createRemotePendingTransaction(payingTx1)))
+        .isFalse();
+  }
+}

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/layered/SenderBalanceCheckerTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/layered/SenderBalanceCheckerTest.java
@@ -19,12 +19,15 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.TransactionType;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
+import org.hyperledger.besu.ethereum.core.Transaction;
+import org.hyperledger.besu.ethereum.core.TransactionTestFixture;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
@@ -65,6 +68,18 @@ public class SenderBalanceCheckerTest extends BaseTransactionPoolTest {
     final Account account = mock(Account.class);
     when(account.getBalance()).thenReturn(balance);
     when(worldState.get(SENDER1)).thenReturn(account);
+  }
+
+  // createTransaction sets the transaction value to the nonce, so for non-zero nonces a truly
+  // zero upfront cost transaction must be built explicitly
+  private Transaction createZeroCostTransaction(final long nonce) {
+    return new TransactionTestFixture()
+        .to(Optional.of(Address.fromHexString("0x634316eA0EE79c701c6F67C53A4C54cBAfd2316d")))
+        .value(Wei.ZERO)
+        .nonce(nonce)
+        .type(TransactionType.FRONTIER)
+        .gasPrice(Wei.ZERO)
+        .createTransaction(KEYS1);
   }
 
   @Test
@@ -111,5 +126,33 @@ public class SenderBalanceCheckerTest extends BaseTransactionPoolTest {
         .isTrue();
     assertThat(balanceChecker.hasEnoughBalanceFor(createRemotePendingTransaction(payingTx1)))
         .isFalse();
+  }
+
+  @Test
+  public void zeroCostTransactionIsAcceptedAfterPayingTransactionDepletesCachedBalance() {
+    final var payingTx = createTransaction(TransactionType.FRONTIER, 0, Wei.of(10), 0, null, KEYS1);
+    final var zeroCostTx = createZeroCostTransaction(1);
+    // exactly enough balance for the paying transaction, so the cached balance is depleted to zero
+    setSenderBalance(payingTx.getUpfrontCost(0L));
+
+    assertThat(balanceChecker.hasEnoughBalanceFor(createRemotePendingTransaction(payingTx)))
+        .isTrue();
+    // the depleted cached balance is zero, which still covers a zero upfront cost transaction
+    assertThat(balanceChecker.hasEnoughBalanceFor(createRemotePendingTransaction(zeroCostTx)))
+        .isTrue();
+  }
+
+  @Test
+  public void zeroCostTransactionIsAcceptedAfterRejectedTransactionZeroesCachedBalance() {
+    final var tooExpensiveTx =
+        createTransaction(TransactionType.FRONTIER, 0, Wei.of(10), 0, null, KEYS1);
+    final var zeroCostTx = createZeroCostTransaction(1);
+    // not enough balance for the paying transaction: the rejection sets the cached balance to zero
+    setSenderBalance(Wei.ONE);
+
+    assertThat(balanceChecker.hasEnoughBalanceFor(createRemotePendingTransaction(tooExpensiveTx)))
+        .isFalse();
+    assertThat(balanceChecker.hasEnoughBalanceFor(createRemotePendingTransaction(zeroCostTx)))
+        .isTrue();
   }
 }


### PR DESCRIPTION
## PR description

Since #10175 enabled the sender balance check by default, free gas networks (e.g. zero gas price QBFT networks, typically running with `--min-gas-price=0` and zero-balance sender accounts) produce only empty blocks: transactions are accepted into the pool and gossiped to peers, but are never promoted to the prioritized layer, so the block transaction selector never sees them.

The root cause is in `SenderBalanceChecker.WorldStateChecker.hasEnoughBalanceFor`: a sender with zero balance is rejected unconditionally, *before* the upfront cost is computed. On a free gas network a zero gas price, zero value transaction has an upfront cost of zero, which a zero balance sender can afford.

This PR removes the zero balance shortcut and relies on the existing `senderBalance.lessThan(upfrontCost)` comparison, which already covers the insufficient balance case (`0 < 0` is false, so zero cost transactions from zero balance senders now pass; any positive cost still fails).

Includes unit tests for `SenderBalanceChecker.WorldStateChecker` covering:
- zero balance sender + zero upfront cost transaction → accepted (the fix)
- zero balance sender + paying transaction → rejected
- sufficient balance → accepted
- sequential transactions depleting the cached balance → rejected once depleted

Workaround for affected networks on current releases: `--tx-pool-enable-balance-check=false`.

## Fixed Issue(s)

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR if updates are required in the [Besu documentation](https://github.com/besu-eth/besu-docs). (No doc update needed: this restores the documented behavior of the balance check on free gas networks; no flags or defaults change.)
- [x] Considered the changelog and [included an update if required](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md#changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew build` (ran `:ethereum:eth:test` for the transactions package; the two `PendingTransactionEstimatedMemorySizeTest` failures are pre-existing on a clean checkout of main in this environment)
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [x] hive tests: [Engine or other RPCs modified?](https://github.com/besu-eth/besu/wiki/Working-through-Hive-tests) (N/A — no Engine or other RPC changes in this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
