### PR TITLE
Revert "Persist newpayload without fcu glamsterdam devnet 6 - fix (#10732)"

### DIFF
--- a/acceptance-tests/tests/build.gradle
+++ b/acceptance-tests/tests/build.gradle
@@ -20,12 +20,19 @@ web3j { generatedPackageName = 'org.hyperledger.besu.tests.web3j.generated' }
 
 sourceSets.main.solidity.srcDirs = ["$projectDir/contracts"]
 
+// Provide solc directly rather than through web3j-sokt's broken release index (see the root
+// build.gradle for details).
+def solcDownload = rootProject.registerSolcDownload('0.8.19')
+
 solidity {
   resolvePackages = false
   // TODO: remove the forced version, when DEV network is upgraded to support latest forks
   version = '0.8.19'
+  executable = rootProject.solcExecutable('0.8.19').absolutePath
   evmVersion = 'london'
 }
+
+tasks.named('compileSolidity').configure { dependsOn solcDownload }
 
 testing {
   suites {

--- a/acceptance-tests/tests/shanghai/build.gradle
+++ b/acceptance-tests/tests/shanghai/build.gradle
@@ -14,8 +14,15 @@ sourceSets.main.solidity.srcDirs = [
   "$projectDir/shanghaicontracts"
 ]
 
+// Provide solc directly rather than through web3j-sokt's broken release index (see the root
+// build.gradle for details).
+def solcDownload = rootProject.registerSolcDownload('0.8.25')
+
 solidity {
   resolvePackages = false
   version = '0.8.25'
+  executable = rootProject.solcExecutable('0.8.25').absolutePath
   evmVersion = 'shanghai'
 }
+
+tasks.named('compileSolidity').configure { dependsOn solcDownload }

--- a/build.gradle
+++ b/build.gradle
@@ -1534,3 +1534,45 @@ artifactoryPublish.dependsOn verifyDistributions
 artifactoryPublish.mustRunAfter(distTar)
 artifactoryPublish.mustRunAfter(distZip)
 artifactoryPublish.mustRunAfter(javadocJar)
+
+// The org.web3j.solidity plugin resolves solc through web3j-sokt, which parses an upstream
+// release index with a strict JSON reader that rejects keys its model does not know; a newer
+// index added such a key, breaking every compileSolidity task, and there is no sokt release
+// that tolerates it. We sidestep the resolver via the plugin's `executable` option:
+// solcExecutable() returns the path a given solc version is downloaded to, and
+// registerSolcDownload() wires a shared, cached download task that compileSolidity depends on.
+ext.solcExecutable = { String version ->
+  def suffix = System.getProperty('os.name').toLowerCase().contains('win') ? '.exe' : ''
+  new File(rootProject.layout.buildDirectory.get().asFile, "solc/solc-${version}${suffix}")
+}
+
+ext.registerSolcDownload = { String version ->
+  def taskName = "downloadSolc_${version.replace('.', '_')}"
+  // Shared across projects that pin the same solc version (e.g. shanghai and osaka both 0.8.25).
+  def existing = rootProject.tasks.findByName(taskName)
+  if (existing != null) {
+    return rootProject.tasks.named(taskName)
+  }
+  return rootProject.tasks.register(taskName) {
+    group = 'build setup'
+    description = "Downloads solc ${version} (bypasses the broken web3j-sokt release index)"
+    def target = rootProject.solcExecutable(version)
+    // Match sokt's own behaviour: select the solc asset by OS only (there are no arm64
+    // static builds for the old pinned versions, and CI runs on linux x64).
+    def os = System.getProperty('os.name').toLowerCase()
+    def asset = os.contains('win') ? 'solc-windows.exe' : os.contains('mac') ? 'solc-macos' : 'solc-static-linux'
+    def url = "https://github.com/ethereum/solidity/releases/download/v${version}/${asset}"
+    outputs.file(target)
+    onlyIf { !target.exists() }
+    doLast {
+      target.parentFile.mkdirs()
+      logger.lifecycle("Downloading solc ${version} from ${url}")
+      target.withOutputStream { out ->
+        new URL(url).withInputStream { input ->
+          out << input
+        }
+      }
+      target.setExecutable(true)
+    }
+  }
+}

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
@@ -747,27 +747,6 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
     return applyForkChoice(newHead, finalizedBlockHash, safeBlockHash);
   }
 
-  @Override
-  public ForkchoiceResult updateHeadForExecution(final BlockHeader newHead) {
-    final MutableBlockchain blockchain = protocolContext.getBlockchain();
-    final Optional<Hash> latestValid = getLatestValidAncestor(newHead);
-
-    Optional<BlockHeader> parentOfNewHead = blockchain.getBlockHeader(newHead.getParentHash());
-    if (parentOfNewHead.isPresent()
-        && Long.compareUnsigned(newHead.getTimestamp(), parentOfNewHead.get().getTimestamp())
-            <= 0) {
-      return ForkchoiceResult.withFailure(
-          INVALID, "new head timestamp not greater than parent", latestValid);
-    }
-
-    if (!setNewHead(blockchain, newHead)) {
-      LOG.warn("Failed to move world state to new head {}", newHead.toLogString());
-      return ForkchoiceResult.withFailure(INVALID, "Failed to set new head", latestValid);
-    }
-
-    return ForkchoiceResult.withResult(Optional.empty(), Optional.of(newHead));
-  }
-
   private ForkchoiceResult applyForkChoice(
       final BlockHeader newHead, final Hash finalizedBlockHash, final Hash safeBlockHash) {
     final MutableBlockchain blockchain = protocolContext.getBlockchain();

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeMiningCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeMiningCoordinator.java
@@ -119,18 +119,6 @@ public interface MergeMiningCoordinator extends MiningCoordinator {
       final BlockHeader newHead, final Hash finalizedBlockHash, final Hash safeBlockHash);
 
   /**
-   * Move the canonical chain head without updating forkchoice metadata (finalized or safe).
-   *
-   * <p>Use this for pre-execution head advancement during {@code engine_newPayload}, when the
-   * parent block was previously received via {@code newPayload} but the chain head was not moved
-   * forward yet.
-   *
-   * @param newHead the new head
-   * @return the update head result
-   */
-  ForkchoiceResult updateHeadForExecution(final BlockHeader newHead);
-
-  /**
    * Returns true if the given block hash is a strict ancestor of the currently finalized block
    * (i.e. an older block on the same chain, not finalized itself). Returns false when no finalized
    * block is known, when the candidate hash cannot be located, or when the candidate IS the

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/TransitionCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/TransitionCoordinator.java
@@ -196,11 +196,6 @@ public class TransitionCoordinator extends TransitionUtils<MiningCoordinator>
   }
 
   @Override
-  public ForkchoiceResult updateHeadForExecution(final BlockHeader newHead) {
-    return mergeCoordinator.updateHeadForExecution(newHead);
-  }
-
-  @Override
   public boolean isAncestorOfFinalized(final Hash candidateHeadHash) {
     return mergeCoordinator.isAncestorOfFinalized(candidateHeadHash);
   }

--- a/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinatorTest.java
+++ b/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinatorTest.java
@@ -24,7 +24,6 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doNothing;
@@ -1110,55 +1109,6 @@ public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
     assertThat(res.getErrorMessage().isEmpty()).isTrue();
 
     verify(blockchain, never()).rewindToBlock(any());
-  }
-
-  @Test
-  public void updateHeadForExecutionShouldMoveHeadWithoutUpdatingFinalizedOrSafe() {
-    BlockHeader terminalHeader = terminalPowBlock();
-    sendNewPayloadAndForkchoiceUpdate(
-        new Block(terminalHeader, BlockBody.empty()), Optional.empty(), Hash.ZERO);
-
-    BlockHeader parentHeader = nextBlockHeader(terminalHeader);
-    Block parent = new Block(parentHeader, BlockBody.empty());
-    coordinator.rememberBlock(parent);
-
-    BlockHeader childHeader = nextBlockHeader(parentHeader);
-    Block child = new Block(childHeader, BlockBody.empty());
-    sendNewPayloadAndForkchoiceUpdate(child, Optional.empty(), parent.getHash());
-
-    clearInvocations(blockchain, mergeContext);
-
-    ForkchoiceResult result = coordinator.updateHeadForExecution(parentHeader);
-
-    assertThat(result.shouldNotProceedToPayloadBuildProcess()).isFalse();
-    assertThat(result.getNewHead()).contains(parentHeader);
-    assertThat(blockchain.getChainHeadHash()).isEqualTo(parentHeader.getHash());
-
-    verify(blockchain, never()).setFinalized(any());
-    verify(mergeContext, never()).setFinalized(any());
-    verify(blockchain, never()).setSafeBlock(any());
-    verify(mergeContext, never()).setSafeBlock(any());
-  }
-
-  @Test
-  public void updateHeadForExecutionShouldNotIgnoreAncestorOfChainHead() {
-    BlockHeader terminalHeader = terminalPowBlock();
-    sendNewPayloadAndForkchoiceUpdate(
-        new Block(terminalHeader, BlockBody.empty()), Optional.empty(), Hash.ZERO);
-
-    BlockHeader parentHeader = nextBlockHeader(terminalHeader);
-    Block parent = new Block(parentHeader, BlockBody.empty());
-    sendNewPayloadAndForkchoiceUpdate(parent, Optional.empty(), terminalHeader.getHash());
-
-    BlockHeader childHeader = nextBlockHeader(parentHeader);
-    Block child = new Block(childHeader, BlockBody.empty());
-    sendNewPayloadAndForkchoiceUpdate(child, Optional.empty(), parent.getHash());
-
-    ForkchoiceResult result = coordinator.updateHeadForExecution(parentHeader);
-
-    assertThat(result.getStatus()).isEqualTo(ForkchoiceResult.Status.VALID);
-    assertThat(result.getNewHead()).contains(parentHeader);
-    assertThat(blockchain.getChainHeadHash()).isEqualTo(parentHeader.getHash());
   }
 
   @ParameterizedTest(name = "{index}: {0}")

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayload.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayload.java
@@ -72,7 +72,6 @@ import java.security.InvalidParameterException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -377,14 +376,15 @@ public abstract class AbstractEngineNewPayload extends ExecutionEngineJsonRpcMet
     }
 
     final MutableBlockchain blockchain = protocolContext.getBlockchain();
-    final Hash chainHeadHash = blockchain.getChainHeadHash();
-    maybeParentHeader
-        .filter(
-            parentHeader ->
-                chainHeadHash != null
-                    && !Objects.equals(newBlockHeader.getParentHash(), chainHeadHash)
-                    && Objects.equals(parentHeader.getParentHash(), chainHeadHash))
-        .ifPresent(mergeCoordinator::updateHeadForExecution);
+    if (!newBlockHeader.getParentHash().equals(blockchain.getChainHeadHash())) {
+      maybeParentHeader.ifPresent(
+          parentHeader -> {
+            mergeCoordinator.updateForkChoice(
+                parentHeader,
+                blockchain.getFinalized().orElse(Hash.ZERO),
+                blockchain.getSafeBlock().orElse(Hash.ZERO));
+          });
+    }
 
     // execute block and return result response
     final long startTimeNs = System.nanoTime();


### PR DESCRIPTION
## Summary
- Reverts commit 10d587c96112467e247dca9e76a0da8197cefe91 (#10732), which changed engine `newPayload` handling and added merge coordinator logic to persist payloads without an accompanying `forkchoiceUpdated`.
- Branch is based on `glamsterdam-devnet-6` at 9c02ea98eac57804c73d82f1ce0f2e286528506f.

## Test plan
- [ ] CI passes on this PR
- [ ] Verify glamsterdam devnet-6 engine API behavior with newPayload / forkchoiceUpdated matches pre-#10732 expectations