### PR TITLE
EIP-7702: refund per-authorization ACCOUNT_WRITE for non-creating authorizations

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/CodeDelegationProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/CodeDelegationProcessor.java
@@ -92,13 +92,19 @@ public class CodeDelegationProcessor {
       final Optional<AccessLocationTracker> eip7928AccessList) {
     LOG.trace("Processing code delegation: {}", codeDelegation);
 
+    // EIP-7702 (#11715): an invalid authorization grows no state, so its full worst-case intrinsic
+    // charge (NEW_ACCOUNT + AUTH_BASE state gas, plus the regular ACCOUNT_WRITE) is refunded — the
+    // wiring in MainnetTransactionProcessor folds invalidAuthorizations into both the
+    // already-existing (ACCOUNT_WRITE / NEW_ACCOUNT) and AUTH_BASE refund counters.
     if (!isCodeDelegationValid(codeDelegation)) {
+      result.incrementInvalidAuthorization();
       return;
     }
 
     final Optional<Address> maybeAuthorizer = codeDelegation.authorizer();
     if (maybeAuthorizer.isEmpty()) {
       LOG.trace("Invalid signature for code delegation");
+      result.incrementInvalidAuthorization();
       return;
     }
 
@@ -114,6 +120,7 @@ public class CodeDelegationProcessor {
     result.addAccessedDelegatorAddress(authorizer);
 
     if (!canSetCodeDelegation(codeDelegation, maybeExistingAccount)) {
+      result.incrementInvalidAuthorization();
       return;
     }
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/CodeDelegationResult.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/CodeDelegationResult.java
@@ -23,6 +23,7 @@ public class CodeDelegationResult {
   private final Set<Address> accessedDelegatorAddresses = new HashSet<>(Address.SIZE);
   private long alreadyExistingDelegators = 0L;
   private long authBaseRefundCount = 0L;
+  private long invalidAuthorizations = 0L;
 
   public void addAccessedDelegatorAddress(final Address address) {
     accessedDelegatorAddresses.add(address);
@@ -34,6 +35,25 @@ public class CodeDelegationResult {
 
   public void incrementAuthBaseRefundCount() {
     authBaseRefundCount += 1;
+  }
+
+  /**
+   * Records an invalid authorization. Per EIP-7702 (#11715) an invalid authorization grows no
+   * state, so the full worst-case intrinsic charge is refunded: NEW_ACCOUNT + AUTH_BASE state gas
+   * and the regular ACCOUNT_WRITE.
+   */
+  public void incrementInvalidAuthorization() {
+    invalidAuthorizations += 1;
+  }
+
+  /**
+   * Returns the count of invalid authorizations, each of which refunds its full worst-case
+   * intrinsic charge (NEW_ACCOUNT + AUTH_BASE state, plus the regular ACCOUNT_WRITE).
+   *
+   * @return the number of invalid authorizations
+   */
+  public long invalidAuthorizations() {
+    return invalidAuthorizations;
   }
 
   public Set<Address> accessedDelegatorAddresses() {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessor.java
@@ -35,6 +35,7 @@ import org.hyperledger.besu.evm.Code;
 import org.hyperledger.besu.evm.account.Account;
 import org.hyperledger.besu.evm.account.MutableAccount;
 import org.hyperledger.besu.evm.blockhash.BlockHashLookup;
+import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.gascalculator.StateGasCostCalculator;
@@ -416,6 +417,21 @@ public class MainnetTransactionProcessor {
                 .code(code)
                 .eip2930AccessListWarmAddresses(eip2930WarmAddressList)
                 .build();
+
+        // EIP-2780: charge NEW_ACCOUNT state gas on the depth-0 frame for a positive value transfer
+        // to a non-alive recipient (mirrors AbstractCallOperation's call-site charge and EELS
+        // process_message_call). Contract creations charge their creation state gas separately, so
+        // this only applies to message calls. On insufficient gas the frame halts before execution.
+        if (stateGasCalc.isActive() && !transaction.getValue().isZero()) {
+          final Account recipient = worldState.get(to);
+          if (recipient == null || recipient.isEmpty()) {
+            if (!initialFrame.consumeStateGas(stateGasCalc.newAccountStateGas())) {
+              initialFrame.setExceptionalHaltReason(
+                  Optional.of(ExceptionalHaltReason.INSUFFICIENT_GAS));
+              initialFrame.setState(MessageFrame.State.EXCEPTIONAL_HALT);
+            }
+          }
+        }
       }
       Deque<MessageFrame> messageFrameStack = initialFrame.getMessageFrameStack();
       while (!messageFrameStack.isEmpty()) {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessor.java
@@ -324,8 +324,16 @@ public class MainnetTransactionProcessor {
                 .get()
                 .process(delegationUpdater, transaction, accessLocationTracker);
         eip2930WarmAddressList.addAll(codeDelegationResult.accessedDelegatorAddresses());
-        alreadyExistingDelegators = codeDelegationResult.alreadyExistingDelegators();
-        authBaseRefundCount = codeDelegationResult.authBaseRefundCount();
+        // EIP-7702 (#11715): an invalid authorization grows no state, so under the Amsterdam gas
+        // regime it refunds its full worst-case intrinsic charge — exactly like an authority whose
+        // account already existed. It thus folds into both the already-existing counter (regular
+        // ACCOUNT_WRITE + state NEW_ACCOUNT) and the AUTH_BASE state refund counter. Pre-Amsterdam
+        // forks refund none.
+        final long invalidAuthorizations =
+            stateGasCalc.isActive() ? codeDelegationResult.invalidAuthorizations() : 0L;
+        alreadyExistingDelegators =
+            codeDelegationResult.alreadyExistingDelegators() + invalidAuthorizations;
+        authBaseRefundCount = codeDelegationResult.authBaseRefundCount() + invalidAuthorizations;
         codeDelegationRefund =
             gasCalculator.calculateDelegateCodeGasRefund(alreadyExistingDelegators);
         delegationUpdater.commit();

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessor.java
@@ -550,10 +550,12 @@ public class MainnetTransactionProcessor {
         coinbase.incrementBalance(coinbaseWeiDelta);
       }
 
-      // EIP-7708: Emit closure logs for accounts with remaining balance before deletion
-      // Noop before Amsterdam
-      transferLogEmitter.emitClosureLogs(
-          worldState, initialFrame.getSelfDestructs(), initialFrame::addLog);
+      // EIP-7708: Emit closure (burn) logs for self-destructed accounts whose balance is burned.
+      // EIP-8246 preserves the balance instead of burning it, so no closure log is emitted then.
+      if (!gasCalculator.isSelfDestructBalancePreserved()) {
+        transferLogEmitter.emitClosureLogs(
+            worldState, initialFrame.getSelfDestructs(), initialFrame::addLog);
+      }
 
       operationTracer.traceEndTransaction(
           worldState.updater(),
@@ -565,7 +567,7 @@ public class MainnetTransactionProcessor {
           initialFrame.getSelfDestructs(),
           0L);
 
-      initialFrame.getSelfDestructs().forEach(worldState::deleteAccount);
+      settleSelfDestructs(worldState, initialFrame.getSelfDestructs());
 
       if (clearEmptyAccounts) {
         worldState.clearAccountsThatAreEmpty();
@@ -673,6 +675,32 @@ public class MainnetTransactionProcessor {
 
   public GasCalculator getGasCalculator() {
     return gasCalculator;
+  }
+
+  /**
+   * Settles accounts marked for self-destruction at transaction finalization. Under EIP-8246 each
+   * account is cleared (nonce reset, code and storage removed) but keeps its balance — EIP-161
+   * state clearing (via {@code clearAccountsThatAreEmpty}) then removes any account left with a
+   * zero balance. Pre-EIP-8246 the accounts are deleted outright.
+   *
+   * @param worldState the world state updater
+   * @param selfDestructs the addresses marked for self-destruction
+   */
+  private void settleSelfDestructs(
+      final WorldUpdater worldState, final Set<Address> selfDestructs) {
+    if (gasCalculator.isSelfDestructBalancePreserved()) {
+      selfDestructs.forEach(
+          address -> {
+            final MutableAccount account = worldState.getAccount(address);
+            if (account != null) {
+              account.setNonce(0L);
+              account.setCode(Bytes.EMPTY);
+              account.clearStorage();
+            }
+          });
+    } else {
+      selfDestructs.forEach(worldState::deleteAccount);
+    }
   }
 
   /**

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/AbstractBlockProcessorIntegrationTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/AbstractBlockProcessorIntegrationTest.java
@@ -218,7 +218,7 @@ class AbstractBlockProcessorIntegrationTest {
     MutableWorldState worldState = worldStateArchive.getWorldState();
     Block blockWithTransactions =
         createBlockWithTransactions(
-            "0x3e09cb932146fa6c57c1d41b444805a9547c7cc380505a0ee47ef8f561e9aeed",
+            "0x5c678a566eba906ef244cd4f8e9d98a20dd09b7ffc5d7aa73dd48a71ef475a79",
             Wei.of(5),
             transactionTransfer1,
             transactionTransfer2);
@@ -252,7 +252,7 @@ class AbstractBlockProcessorIntegrationTest {
     MutableWorldState worldState = worldStateArchive.getWorldState();
     Block blockWithTransactions =
         createBlockWithTransactions(
-            "0x5c3eb9b66ee0016bbd4443e2a96de010f1aea042553298fc24aad8c82919acaa",
+            "0xd2156a2c122990a9e0bdfb70f486a97c0b1fee186e18bc8bc9d2cd9e26ebe68b",
             Wei.of(5),
             setSlot1Transaction,
             getSlot1Transaction,
@@ -412,7 +412,7 @@ class AbstractBlockProcessorIntegrationTest {
 
     Block blockWithTransactions =
         createBlockWithTransactions(
-            "0x1473bc3018da0e0e036ab6a11652a75753f8c06d6d63740fc89af2bc0b4d923b",
+            "0x62065c90b39782c92448a49bef2df6d050d92ba4443fab5611d92521ed9abf78",
             Wei.of(5),
             transactionTransfer1,
             transactionTransfer2);
@@ -473,7 +473,7 @@ class AbstractBlockProcessorIntegrationTest {
 
     Block blockWithTransactions =
         createBlockWithTransactions(
-            "0x06e86985eac65057e565f9ab44b825c4560dd1af50856a7ee3a5043fef039187",
+            "0x8e8e108b6fcf49ba09f5dc8499e2830ef8f742d5431c8c5ba86e80a804eac7fd",
             Wei.of(5),
             transferTransaction1,
             transferTransaction2,
@@ -546,7 +546,7 @@ class AbstractBlockProcessorIntegrationTest {
 
     Block blockWithTransactions =
         createBlockWithTransactions(
-            "0xf2f6f0958f608eae7ed6b9b63a6711a8d37c7a9bf1efa45b9dff998fd40f4bd9",
+            "0xb43cee23f387bd924fc6989d85f3572f1cb740982d44d3638da8981fa44b7054",
             Wei.of(5),
             transferTransaction1,
             transferTransaction2);
@@ -573,7 +573,7 @@ class AbstractBlockProcessorIntegrationTest {
         .isEqualTo(
             Wei.of(
                 UInt256.fromHexString(
-                    ("0x00000000000000000000000000000000000000000000003627e8f7123739c024"))));
+                    ("0x00000000000000000000000000000000000000000000003627e8f712372623d4"))));
     assertThat(updatedAccount0x2.getBalance()).isEqualTo(Wei.of(2_000_000_000_000_000_000L));
     assertThat(updatedSenderAccount1.getBalance())
         .isLessThan(transferTransaction1Sender.getBalance());
@@ -624,7 +624,7 @@ class AbstractBlockProcessorIntegrationTest {
         (BonsaiAccount) worldState.get(transferTransaction1.getSender());
     Block blockWithTransactions =
         createBlockWithTransactions(
-            "0x1a4e7899fad518729994f78a991f8a21186007dcba653d96be8cc16027d25c00",
+            "0xd9967f6a9a290881378511ca8287df4fffb4dfe6d4653b10b1aecf38417904d6",
             Wei.of(5),
             transferTransaction1,
             transferTransaction2);
@@ -646,7 +646,7 @@ class AbstractBlockProcessorIntegrationTest {
         .isEqualTo(
             Wei.of(
                 UInt256.fromHexString(
-                    ("0x0000000000000000000000000000000000000000000000001bc8886498566008"))));
+                    ("0x0000000000000000000000000000000000000000000000001bc88864985bfa68"))));
 
     assertThat(updatedSenderAccount1.getBalance())
         .isLessThan(transferTransaction1Sender.getBalance());
@@ -690,7 +690,7 @@ class AbstractBlockProcessorIntegrationTest {
 
     Block blockWithTransactions =
         createBlockWithTransactions(
-            "0x9aab329c4af98f869db7f442984be199a3d48957e812821278e833f3a050913f",
+            "0x8dd0da2e616757fc09e4de8d21761b4209ae054e54648ff750c174f2c3b38270",
             Wei.of(5),
             setSlot1Transaction,
             getSlot1Transaction,
@@ -750,7 +750,7 @@ class AbstractBlockProcessorIntegrationTest {
 
     Block blockWithTransactions =
         createBlockWithTransactions(
-            "0x0dd020feb29c0b4b28b14670361fee996011649a6893729009efb175d04d37b9",
+            "0xd67167ab161f09c49c97f12013ad0460b2fff6101ecfaf80b33b940c0454e609",
             Wei.of(5),
             getSlot1Transaction,
             setSlot1Transaction,
@@ -818,7 +818,7 @@ class AbstractBlockProcessorIntegrationTest {
 
     Block blockWithTransactions =
         createBlockWithTransactions(
-            "0xa222751c4f6a7029e22a33a85a55589643fe5a9f41f9f20656afeab9ef326afd",
+            "0xf43a11ac6b093bf283088a82698e0f92d972b6142df825bc6f6f25ff1355d5fd",
             Wei.of(5),
             transactionTransfer,
             getcontractBalanceTransaction,
@@ -886,7 +886,7 @@ class AbstractBlockProcessorIntegrationTest {
 
     Block blockWithTransactions =
         createBlockWithTransactions(
-            "0x8a78d780cf70d21eeaabd27f3e77b24230d5d7470681da8de09ab1049dacb903",
+            "0xda760882c6091ff94d8d21e10392e3be9d725e7536cebf5639ad7b8615fae896",
             Wei.of(5),
             transactionTransfer,
             sendEthFromContractTransaction,
@@ -953,7 +953,7 @@ class AbstractBlockProcessorIntegrationTest {
 
     Block blockWithTransactions =
         createBlockWithTransactions(
-            "0x384e58316a44ae4ba496f9db5516e6b67c3db31837580d79a4efa4f87e3b77a4",
+            "0xd6bee23ffffcf5b833dd127987e1808a8322a89d5da3eda4f1597f1840490be1",
             Wei.of(5),
             transactionTransfer,
             getcontractBalanceTransaction,
@@ -1022,7 +1022,7 @@ class AbstractBlockProcessorIntegrationTest {
 
     Block blockWithTransactions =
         createBlockWithTransactions(
-            "0x384e58316a44ae4ba496f9db5516e6b67c3db31837580d79a4efa4f87e3b77a4",
+            "0xd6bee23ffffcf5b833dd127987e1808a8322a89d5da3eda4f1597f1840490be1",
             Wei.of(5),
             transactionTransfer,
             sendEthFromContractTransaction,

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/AbstractBlockProcessorIntegrationTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/AbstractBlockProcessorIntegrationTest.java
@@ -252,7 +252,7 @@ class AbstractBlockProcessorIntegrationTest {
     MutableWorldState worldState = worldStateArchive.getWorldState();
     Block blockWithTransactions =
         createBlockWithTransactions(
-            "0x811a7edeb2747665e5e5937310b30154386ef71cda786b46d13f38e0b3005c15",
+            "0x5c3eb9b66ee0016bbd4443e2a96de010f1aea042553298fc24aad8c82919acaa",
             Wei.of(5),
             setSlot1Transaction,
             getSlot1Transaction,
@@ -690,7 +690,7 @@ class AbstractBlockProcessorIntegrationTest {
 
     Block blockWithTransactions =
         createBlockWithTransactions(
-            "0x9e6593d2efd9e4c44345322bf7827e24e1eeb358ff56c243bb68298f26c4bc15",
+            "0x9aab329c4af98f869db7f442984be199a3d48957e812821278e833f3a050913f",
             Wei.of(5),
             setSlot1Transaction,
             getSlot1Transaction,
@@ -750,7 +750,7 @@ class AbstractBlockProcessorIntegrationTest {
 
     Block blockWithTransactions =
         createBlockWithTransactions(
-            "0xdb4e2dc94bbfa48bc713f908900abc327c28e7c219c720b4bdeab52ad8b88616",
+            "0x0dd020feb29c0b4b28b14670361fee996011649a6893729009efb175d04d37b9",
             Wei.of(5),
             getSlot1Transaction,
             setSlot1Transaction,
@@ -818,7 +818,7 @@ class AbstractBlockProcessorIntegrationTest {
 
     Block blockWithTransactions =
         createBlockWithTransactions(
-            "0x99d83e340a1e0a946330e1c5d69f971421d34484747d7417d2d9b246751de56e",
+            "0xa222751c4f6a7029e22a33a85a55589643fe5a9f41f9f20656afeab9ef326afd",
             Wei.of(5),
             transactionTransfer,
             getcontractBalanceTransaction,
@@ -886,7 +886,7 @@ class AbstractBlockProcessorIntegrationTest {
 
     Block blockWithTransactions =
         createBlockWithTransactions(
-            "0xcfbaf7f1806b7858ae1b84c9ff5855910bdc56986afd35fe347391bfb1f7c04e",
+            "0x8a78d780cf70d21eeaabd27f3e77b24230d5d7470681da8de09ab1049dacb903",
             Wei.of(5),
             transactionTransfer,
             sendEthFromContractTransaction,
@@ -953,7 +953,7 @@ class AbstractBlockProcessorIntegrationTest {
 
     Block blockWithTransactions =
         createBlockWithTransactions(
-            "0x83658a178069168ee3d6fb5bbbb266e2faba750236c9913ced10e1ce954907c5",
+            "0x384e58316a44ae4ba496f9db5516e6b67c3db31837580d79a4efa4f87e3b77a4",
             Wei.of(5),
             transactionTransfer,
             getcontractBalanceTransaction,
@@ -1022,7 +1022,7 @@ class AbstractBlockProcessorIntegrationTest {
 
     Block blockWithTransactions =
         createBlockWithTransactions(
-            "0x83658a178069168ee3d6fb5bbbb266e2faba750236c9913ced10e1ce954907c5",
+            "0x384e58316a44ae4ba496f9db5516e6b67c3db31837580d79a4efa4f87e3b77a4",
             Wei.of(5),
             transactionTransfer,
             sendEthFromContractTransaction,

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/CodeDelegationProcessorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/CodeDelegationProcessorTest.java
@@ -77,6 +77,8 @@ class CodeDelegationProcessorTest {
 
     // Assert
     assertThat(result.alreadyExistingDelegators()).isZero();
+    // EIP-7702: an invalid chain id makes the whole authorization invalid.
+    assertThat(result.invalidAuthorizations()).isEqualTo(1);
     verify(worldUpdater, never()).createAccount(any());
     verify(worldUpdater, never()).getAccount(any());
   }
@@ -92,6 +94,8 @@ class CodeDelegationProcessorTest {
 
     // Assert
     assertThat(result.alreadyExistingDelegators()).isZero();
+    // EIP-7702: a MAX_NONCE authorization is invalid.
+    assertThat(result.invalidAuthorizations()).isEqualTo(1);
     verify(worldUpdater, never()).createAccount(any());
     verify(worldUpdater, never()).getAccount(any());
   }
@@ -109,6 +113,7 @@ class CodeDelegationProcessorTest {
 
     // Assert
     assertThat(result.alreadyExistingDelegators()).isZero();
+    assertThat(result.invalidAuthorizations()).isZero();
     verify(worldUpdater).createAccount(any());
     verify(authority).incrementNonce();
   }
@@ -125,6 +130,8 @@ class CodeDelegationProcessorTest {
 
     // Assert
     assertThat(result.alreadyExistingDelegators()).isZero();
+    // EIP-7702: a new-account authorization with a non-zero nonce is invalid.
+    assertThat(result.invalidAuthorizations()).isEqualTo(1);
     verify(worldUpdater, never()).createAccount(any());
     verify(authority, never()).incrementNonce();
   }
@@ -144,6 +151,7 @@ class CodeDelegationProcessorTest {
 
     // Assert
     assertThat(result.alreadyExistingDelegators()).isEqualTo(1);
+    assertThat(result.invalidAuthorizations()).isZero();
     verify(worldUpdater, never()).createAccount(any());
     verify(authority).incrementNonce();
     verify(codeDelegationService).processCodeDelegation(authority, DELEGATE_ADDRESS);
@@ -163,6 +171,8 @@ class CodeDelegationProcessorTest {
 
     // Assert
     assertThat(result.alreadyExistingDelegators()).isZero();
+    // EIP-7702: a nonce that doesn't match the existing account is invalid.
+    assertThat(result.invalidAuthorizations()).isEqualTo(1);
     verify(worldUpdater, never()).getAccount(any());
     verify(authority, never()).incrementNonce();
     verify(codeDelegationService, never()).processCodeDelegation(any(), any());
@@ -208,6 +218,9 @@ class CodeDelegationProcessorTest {
 
     // Assert
     assertThat(result.alreadyExistingDelegators()).isZero();
+    // EIP-7702: cd1 (new account, nonce 2) and cd3 (existing account nonce 1, auth nonce 0) are
+    // both invalid; only cd2 (new account, nonce 0) is valid.
+    assertThat(result.invalidAuthorizations()).isEqualTo(2);
     verify(authority, times(1)).incrementNonce();
     verify(codeDelegationService, times(1)).processCodeDelegation(any(), any());
   }
@@ -224,6 +237,8 @@ class CodeDelegationProcessorTest {
 
     // Assert
     assertThat(result.alreadyExistingDelegators()).isZero();
+    // EIP-7702: an S value above the half curve order is invalid.
+    assertThat(result.invalidAuthorizations()).isEqualTo(1);
     verify(authority, never()).incrementNonce();
     verify(codeDelegationService, never()).processCodeDelegation(any(), any());
   }
@@ -242,6 +257,8 @@ class CodeDelegationProcessorTest {
 
     // Assert
     assertThat(result.alreadyExistingDelegators()).isZero();
+    // EIP-7702: an unrecoverable authority (bad recId) makes the authorization invalid.
+    assertThat(result.invalidAuthorizations()).isEqualTo(1);
     verify(authority, never()).incrementNonce();
     verify(codeDelegationService, never()).processCodeDelegation(any(), any());
   }
@@ -262,6 +279,8 @@ class CodeDelegationProcessorTest {
 
     // Assert
     assertThat(result.alreadyExistingDelegators()).isZero();
+    // EIP-7702: an empty authorizer (unrecoverable signature) is invalid.
+    assertThat(result.invalidAuthorizations()).isEqualTo(1);
     verify(authority, never()).incrementNonce();
     verify(codeDelegationService, never()).processCodeDelegation(any(), any());
   }
@@ -279,6 +298,8 @@ class CodeDelegationProcessorTest {
 
     // Assert
     assertThat(result.alreadyExistingDelegators()).isZero();
+    // EIP-7702: canSetCodeDelegation == false makes the authorization invalid.
+    assertThat(result.invalidAuthorizations()).isEqualTo(1);
     verify(worldUpdater, never()).getAccount(any());
     verify(authority, never()).incrementNonce();
     verify(codeDelegationService, never()).processCodeDelegation(any(), any());

--- a/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/AmsterdamGasCalculator.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/AmsterdamGasCalculator.java
@@ -39,6 +39,7 @@ import org.apache.tuweni.units.bigints.UInt256;
  *
  * <UL>
  *   <LI>EIP-8038: state-access gas repricing (cold access, account/storage write, CALL value)
+ *   <LI>EIP-8246: SELFDESTRUCT no longer burns the originator's balance
  *   <LI>EIP-7928: gas cost per item for block access list size limit
  *   <LI>EIP-7976: calldata floor cost raised to 64 gas per byte
  *   <LI>EIP-7981: access list data priced at the 64 gas/byte floor
@@ -351,9 +352,23 @@ public class AmsterdamGasCalculator extends OsakaGasCalculator {
   }
 
   @Override
+  public boolean isSelfDestructBalancePreserved() {
+    // EIP-8246: SELFDESTRUCT no longer burns the originator's balance. A same-tx-created account is
+    // cleared (nonce/code/storage) at finalization with its balance preserved (EIP-161 then removes
+    // it only if the balance is zero), so no Burn closure log is emitted.
+    return true;
+  }
+
+  @Override
   public long selfDestructOperationGasCost(final Account recipient, final Wei inheritance) {
-    // Always static cost (5,000). State gas (112 * cpsb) for new accounts charged separately.
-    return selfDestructOperationStaticGasCost();
+    // EIP-8038: static cost (5,000) plus ACCOUNT_WRITE (8,000) when a positive balance is sent to a
+    // new (non-existent or empty) beneficiary. The cold-access surcharge is added by the operation;
+    // the NEW_ACCOUNT state gas is charged at the call site in SelfDestructOperation.
+    long cost = selfDestructOperationStaticGasCost();
+    if ((recipient == null || recipient.isEmpty()) && !inheritance.isZero()) {
+      cost += ACCOUNT_WRITE;
+    }
+    return cost;
   }
 
   @Override

--- a/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/AmsterdamGasCalculator.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/AmsterdamGasCalculator.java
@@ -38,6 +38,7 @@ import org.apache.tuweni.units.bigints.UInt256;
  * is reduced.
  *
  * <UL>
+ *   <LI>EIP-8038: state-access gas repricing (cold access, account/storage write, CALL value)
  *   <LI>EIP-7928: gas cost per item for block access list size limit
  *   <LI>EIP-7976: calldata floor cost raised to 64 gas per byte
  *   <LI>EIP-7981: access list data priced at the 64 gas/byte floor
@@ -62,16 +63,30 @@ public class AmsterdamGasCalculator extends OsakaGasCalculator {
   // EIP-8037: New regular gas constants for Amsterdam
   private static final long TX_CREATE_COST = 9_000L;
 
-  // EIP-8037: SSTORE_SET regular gas drops from 20,000 to 2,900 (state portion charged separately)
-  private static final long SSTORE_SET_GAS = SSTORE_RESET_GAS;
+  // --- EIP-8038: state-access gas repricing ---
 
-  // EIP-8037: 0→X→0 refund is 2,800 per spec (GAS_STORAGE_UPDATE - GAS_COLD_SLOAD -
-  // GAS_WARM_ACCESS)
-  private static final long SSTORE_SET_GAS_LESS_SLOAD_GAS = SSTORE_SET_GAS - WARM_STORAGE_READ_COST;
+  /** EIP-8038: cold account access cost (was 2,600). */
+  private static final long COLD_ACCOUNT_ACCESS = 3_000L;
 
-  // SSTORE_CLEARS_SCHEDULE unchanged from EIP-3529 (London): 4,800
-  private static final long SSTORE_CLEARS_SCHEDULE = SSTORE_RESET_GAS + ACCESS_LIST_STORAGE_COST;
-  private static final long NEGATIVE_SSTORE_CLEARS_SCHEDULE = -SSTORE_CLEARS_SCHEDULE;
+  /** EIP-8038: cold storage slot access cost (was 2,100). */
+  private static final long COLD_STORAGE_ACCESS = 3_000L;
+
+  /** EIP-8038: account write cost (value-bearing CALL / new account). */
+  private static final long ACCOUNT_WRITE = 8_000L;
+
+  // EIP-8038: flat write cost charged once per slot on its first change in the transaction
+  // (replaces the Berlin SSTORE_SET 20,000 / SSTORE_RESET 2,900 distinction). The set-from-zero
+  // surcharge moves entirely to state gas (Eip8037StateGasCostCalculator#storageSetStateGas).
+  private static final long STORAGE_WRITE = 10_000L;
+
+  // EIP-8038: storage clear refund = (STORAGE_WRITE + COLD_STORAGE_ACCESS 3,000) * 4800 / 5000 =
+  // 12,480.
+  private static final long REFUND_STORAGE_CLEAR =
+      (STORAGE_WRITE + COLD_STORAGE_ACCESS) * 4800L / 5000L;
+  private static final long NEGATIVE_REFUND_STORAGE_CLEAR = -REFUND_STORAGE_CLEAR;
+
+  /** EIP-8038: per-word copy cost (3 gas) used for EXTCODECOPY memory copy accounting. */
+  private static final long COPY_WORD_GAS_COST = 3L;
 
   /**
    * EIP-7928: gas cost per item for block access list size limit (bal_items <= block_gas_limit /
@@ -150,6 +165,50 @@ public class AmsterdamGasCalculator extends OsakaGasCalculator {
     return bytes;
   }
 
+  // --- EIP-8038 state-access gas repricing ---
+
+  @Override
+  public long getColdSloadCost() {
+    // EIP-8038: cold storage slot access raised to 3,000.
+    return COLD_STORAGE_ACCESS;
+  }
+
+  @Override
+  public long getColdAccountAccessCost() {
+    // EIP-8038: cold account access raised to 3,000.
+    return COLD_ACCOUNT_ACCESS;
+  }
+
+  @Override
+  public long getSStoreColdAccessGasCost() {
+    // EIP-8038: SSTORE access is a full cold/warm cost (3,000 / 100), so the cold surcharge added
+    // on top of the warm base baked into calculateStorageCost is COLD_STORAGE_ACCESS - WARM_ACCESS.
+    return COLD_STORAGE_ACCESS - WARM_STORAGE_READ_COST;
+  }
+
+  @Override
+  public long callValueTransferGasCost() {
+    // EIP-8038: CALL_VALUE = ACCOUNT_WRITE (8,000) + CALL_STIPEND (2,300) = 10,300. The 2,300
+    // stipend is still handed to the callee via getAdditionalCallStipend().
+    return ACCOUNT_WRITE + ADDITIONAL_CALL_STIPEND;
+  }
+
+  @Override
+  public long getExtCodeSizeOperationGasCost() {
+    // EIP-8038: EXTCODESIZE pays an extra WARM_ACCESS (100) "code reading cost" on top of the
+    // cold/warm account access.
+    return WARM_STORAGE_READ_COST;
+  }
+
+  @Override
+  public long extCodeCopyOperationGasCost(
+      final MessageFrame frame, final long offset, final long length) {
+    // EIP-8038: EXTCODECOPY pays an extra WARM_ACCESS (100) "code reading cost" (the base argument)
+    // on top of the cold/warm account access added by the operation.
+    return copyWordsToMemoryGasCost(
+        frame, WARM_STORAGE_READ_COST, COPY_WORD_GAS_COST, offset, length);
+  }
+
   // --- EIP-8037 Gas Cost Overrides ---
 
   @Override
@@ -190,18 +249,19 @@ public class AmsterdamGasCalculator extends OsakaGasCalculator {
       final UInt256 newValue,
       final Supplier<UInt256> currentValue,
       final Supplier<UInt256> originalValue) {
-    // Same Berlin truth table, but SSTORE_SET_GAS is now 2,900 (state portion charged separately)
+    // EIP-8038: warm access base (100) always charged; flat STORAGE_WRITE (10,000) on the first
+    // change to the slot this transaction. The set-from-zero surcharge is state gas, not regular.
     final UInt256 localCurrentValue = currentValue.get();
     if (localCurrentValue.equals(newValue)) {
       return WARM_STORAGE_READ_COST;
-    } else {
-      final UInt256 localOriginalValue = originalValue.get();
-      if (localOriginalValue.equals(localCurrentValue)) {
-        return localOriginalValue.isZero() ? SSTORE_SET_GAS : SSTORE_RESET_GAS;
-      } else {
-        return WARM_STORAGE_READ_COST;
-      }
     }
+    final UInt256 localOriginalValue = originalValue.get();
+    if (localOriginalValue.equals(localCurrentValue)) {
+      // First change to this slot in the transaction.
+      return WARM_STORAGE_READ_COST + STORAGE_WRITE;
+    }
+    // Slot already changed earlier in the transaction (dirty): access only.
+    return WARM_STORAGE_READ_COST;
   }
 
   @Override
@@ -252,39 +312,28 @@ public class AmsterdamGasCalculator extends OsakaGasCalculator {
       final UInt256 newValue,
       final Supplier<UInt256> currentValue,
       final Supplier<UInt256> originalValue) {
-    // Same Berlin truth table structure, but with updated constants
+    // EIP-8038 refund model: no per-set/reset distinction; the flat STORAGE_WRITE is refunded when
+    // the slot is restored to its original value, and the storage-clear refund is the larger
+    // 12,480.
     final UInt256 localCurrentValue = currentValue.get();
     if (localCurrentValue.equals(newValue)) {
       return 0L;
-    } else {
-      final UInt256 localOriginalValue = originalValue.get();
-      if (localOriginalValue.equals(localCurrentValue)) {
-        if (localOriginalValue.isZero()) {
-          return 0L;
-        } else if (newValue.isZero()) {
-          return SSTORE_CLEARS_SCHEDULE;
-        } else {
-          return 0L;
-        }
-      } else {
-        long refund = 0L;
-        if (!localOriginalValue.isZero()) {
-          if (localCurrentValue.isZero()) {
-            refund = NEGATIVE_SSTORE_CLEARS_SCHEDULE;
-          } else if (newValue.isZero()) {
-            refund = SSTORE_CLEARS_SCHEDULE;
-          }
-        }
-
-        if (localOriginalValue.equals(newValue)) {
-          refund =
-              refund
-                  + (localOriginalValue.isZero()
-                      ? SSTORE_SET_GAS_LESS_SLOAD_GAS
-                      : SSTORE_RESET_GAS_LESS_SLOAD_GAS);
-        }
-        return refund;
+    }
+    final UInt256 localOriginalValue = originalValue.get();
+    long refund = 0L;
+    if (!localOriginalValue.isZero()) {
+      if (!localCurrentValue.isZero() && newValue.isZero()) {
+        // Storage cleared for the first time this transaction.
+        refund += REFUND_STORAGE_CLEAR;
+      } else if (localCurrentValue.isZero()) {
+        // A clear refund issued earlier this transaction is being reversed.
+        refund += NEGATIVE_REFUND_STORAGE_CLEAR;
       }
     }
+    if (localOriginalValue.equals(newValue)) {
+      // Slot restored to its original value: refund the STORAGE_WRITE charged on the first change.
+      refund += STORAGE_WRITE;
+    }
+    return refund;
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/AmsterdamGasCalculator.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/AmsterdamGasCalculator.java
@@ -380,8 +380,10 @@ public class AmsterdamGasCalculator extends OsakaGasCalculator {
 
   @Override
   public long calculateDelegateCodeGasRefund(final long alreadyExistingAccounts) {
-    // No refund needed — regular cost is lower, state gas uses its own refund path
-    return 0L;
+    // EIP-7702: the worst-case ACCOUNT_WRITE charged per authorization in intrinsic gas is refunded
+    // (via the regular refund counter) for authorizations whose authority account already existed
+    // or that were invalid — neither grows a new account.
+    return ACCOUNT_WRITE * alreadyExistingAccounts;
   }
 
   @Override

--- a/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/AmsterdamGasCalculator.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/AmsterdamGasCalculator.java
@@ -60,9 +60,6 @@ public class AmsterdamGasCalculator extends OsakaGasCalculator {
   private static final long ACCESS_LIST_STORAGE_KEY_FLOOR_COST =
       ACCESS_LIST_STORAGE_KEY_BYTES * TOTAL_COST_FLOOR_PER_BYTE;
 
-  // EIP-8037: New regular gas constants for Amsterdam
-  private static final long TX_CREATE_COST = 9_000L;
-
   // --- EIP-8038: state-access gas repricing ---
 
   /** EIP-8038: cold account access cost (was 2,600). */
@@ -87,6 +84,46 @@ public class AmsterdamGasCalculator extends OsakaGasCalculator {
 
   /** EIP-8038: per-word copy cost (3 gas) used for EXTCODECOPY memory copy accounting. */
   private static final long COPY_WORD_GAS_COST = 3L;
+
+  // --- EIP-2780: resource-based intrinsic transaction gas ---
+
+  /** EIP-2780: sender cost (ECDSA recovery + sender access + sender write). Replaces 21,000. */
+  private static final long TX_BASE = 12_000L;
+
+  /** EIP-2780: per data token; a calldata token is 1 (zero byte) or 4 (non-zero byte). */
+  private static final long TX_DATA_TOKEN_STANDARD = 4L;
+
+  /**
+   * EIP-2780: contract-creation recipient access = ACCOUNT_WRITE + COLD_STORAGE_ACCESS = 11,000.
+   */
+  private static final long CREATE_ACCESS = ACCOUNT_WRITE + COLD_STORAGE_ACCESS;
+
+  /**
+   * EIP-2780: top-level contract-creation transaction cost, equal to the CREATE recipient access.
+   */
+  private static final long TX_CREATE_COST = CREATE_ACCESS;
+
+  /** EIP-2780: recipient balance-write cost charged in intrinsic gas on a value transfer. */
+  private static final long TX_VALUE_COST = 4_244L;
+
+  /** EIP-2780/EIP-7708: transfer-log cost charged in intrinsic gas on a value transfer. */
+  private static final long TRANSFER_LOG_COST = 1_756L;
+
+  /** EIP-2780: access-list entry costs now align with cold access (3,000 each). */
+  private static final long TX_ACCESS_LIST_ADDRESS = COLD_ACCOUNT_ACCESS;
+
+  private static final long TX_ACCESS_LIST_STORAGE_KEY = COLD_STORAGE_ACCESS;
+
+  /**
+   * EIP-2780: regular gas per EIP-7702 authorization, in addition to {@link #ACCOUNT_WRITE}:
+   * AUTH_TUPLE_BYTES(101) * TX_DATA_TOKEN_FLOOR(16) + ECRECOVER(3000) + COLD_ACCOUNT_ACCESS(3000) +
+   * 2 * WARM_ACCESS(100) = 7,816.
+   */
+  private static final long REGULAR_PER_AUTH_BASE_COST =
+      101L * 16L + 3_000L + COLD_ACCOUNT_ACCESS + 2L * 100L;
+
+  /** EIP-3860 init code word cost (2 gas per 32-byte word), charged in intrinsic for creations. */
+  private static final long CODE_INIT_PER_WORD = 2L;
 
   /**
    * EIP-7928: gas cost per item for block access list size limit (bal_items <= block_gas_limit /
@@ -146,14 +183,63 @@ public class AmsterdamGasCalculator extends OsakaGasCalculator {
 
   @Override
   public long accessListGasCost(final int addresses, final int storageSlots) {
-    // EIP-2930 baseline (2400 per address, 1900 per key) plus EIP-7981 data floor
+    // EIP-2780/EIP-8038 baseline (3000 per address, 3000 per key) plus EIP-7981 data floor
     // (1280 per address, 2048 per storage key), so access list data is always charged
     // at floor rate regardless of which branch of the gasUsed max() wins.
     return clampedAdd(
-        super.accessListGasCost(addresses, storageSlots),
-        clampedAdd(
-            clampedMultiply(addresses, ACCESS_LIST_ADDRESS_FLOOR_COST),
-            clampedMultiply(storageSlots, ACCESS_LIST_STORAGE_KEY_FLOOR_COST)));
+        clampedMultiply(addresses, TX_ACCESS_LIST_ADDRESS + ACCESS_LIST_ADDRESS_FLOOR_COST),
+        clampedMultiply(
+            storageSlots, TX_ACCESS_LIST_STORAGE_KEY + ACCESS_LIST_STORAGE_KEY_FLOOR_COST));
+  }
+
+  @Override
+  public long getMinimumTransactionCost() {
+    // EIP-2780: TX_BASE replaces the flat 21,000 minimum.
+    return TX_BASE;
+  }
+
+  @Override
+  public long transactionIntrinsicGasCost(final Transaction transaction, final long baselineGas) {
+    // EIP-2780: regular intrinsic gas =
+    //   TX_BASE + data_cost + recipient_regular + access_list_cost + auth_regular
+    // where baselineGas already carries access_list_cost + auth_regular (accessListGasCost +
+    // delegateCodeGasCost from transactionIntrinsicRegularGas).
+    final int payloadSize = transaction.getPayload().size();
+    final long zeroBytes = transaction.getPayloadZeroBytes();
+    final long nonZeroBytes = payloadSize - zeroBytes;
+    // tokens_in_calldata = zeroBytes * 1 + nonZeroBytes * 4; data_cost = tokens * TX_DATA_TOKEN_STD
+    final long tokens = clampedAdd(zeroBytes, nonZeroBytes * 4L);
+    final long dataCost = tokens * TX_DATA_TOKEN_STANDARD;
+
+    final long recipientRegular;
+    final boolean valueTransfer = transaction.getValue().getAsBigInteger().signum() > 0;
+    if (transaction.isContractCreation()) {
+      long create = CREATE_ACCESS + initCodeCost(payloadSize);
+      if (valueTransfer) {
+        create += TRANSFER_LOG_COST;
+      }
+      recipientRegular = create;
+    } else if (isSelfTransfer(transaction)) {
+      recipientRegular = 0L;
+    } else {
+      long call = COLD_ACCOUNT_ACCESS;
+      if (valueTransfer) {
+        call += TRANSFER_LOG_COST + TX_VALUE_COST;
+      }
+      recipientRegular = call;
+    }
+
+    return clampedAdd(clampedAdd(TX_BASE, dataCost), clampedAdd(recipientRegular, baselineGas));
+  }
+
+  /** EIP-2780: a self-transfer (sender == recipient) skips the recipient and value charges. */
+  private static boolean isSelfTransfer(final Transaction transaction) {
+    return transaction.getTo().map(to -> to.equals(transaction.getSender())).orElse(false);
+  }
+
+  /** EIP-3860 init code cost: CODE_INIT_PER_WORD * ceil(len / 32). */
+  private static long initCodeCost(final int initCodeLength) {
+    return CODE_INIT_PER_WORD * ((initCodeLength + 31L) / 32L);
   }
 
   private static long accessListBytes(final List<AccessListEntry> accessList) {
@@ -272,8 +358,9 @@ public class AmsterdamGasCalculator extends OsakaGasCalculator {
 
   @Override
   public long delegateCodeGasCost(final int delegateCodeListLength) {
-    // 7,500 per delegation (regular portion only, state gas charged separately)
-    return stateGasCostCalc.authBaseRegularGas() * delegateCodeListLength;
+    // EIP-2780: (ACCOUNT_WRITE + REGULAR_PER_AUTH_BASE_COST) = 8,000 + 7,816 = 15,816 per
+    // delegation (regular portion only; state gas charged separately).
+    return (ACCOUNT_WRITE + REGULAR_PER_AUTH_BASE_COST) * delegateCodeListLength;
   }
 
   @Override

--- a/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/GasCalculator.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/GasCalculator.java
@@ -477,6 +477,17 @@ public interface GasCalculator {
   }
 
   /**
+   * Returns the cold access surcharge charged for an SSTORE to a storage slot not previously
+   * accessed in the TX context. By default this equals the cold SLOAD cost; EIP-8038 overrides it
+   * to exclude the warm access base already included in {@link #calculateStorageCost}.
+   *
+   * @return the SSTORE cold access surcharge.
+   */
+  default long getSStoreColdAccessGasCost() {
+    return getColdSloadCost();
+  }
+
+  /**
    * Returns the cost to access an account not previously accessed in the TX context.
    *
    * @return the cost to access an account not previously accessed in the TX context.

--- a/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/GasCalculator.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/GasCalculator.java
@@ -422,6 +422,19 @@ public interface GasCalculator {
   }
 
   /**
+   * EIP-8246: whether SELFDESTRUCT preserves the originator's balance instead of burning it. When
+   * true, a same-tx-created account is cleared (nonce/code/storage) at transaction finalization
+   * with its balance preserved (EIP-161 state clearing then removes a zero-balance result) and no
+   * Burn log is emitted while the balance is preserved.
+   *
+   * @return true if the originator's balance is preserved on self destruct, false (pre-Amsterdam)
+   *     otherwise
+   */
+  default boolean isSelfDestructBalancePreserved() {
+    return false;
+  }
+
+  /**
    * Returns the cost for executing a {@link Keccak256Operation}.
    *
    * @param frame The current frame

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/SStoreOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/SStoreOperation.java
@@ -85,7 +85,7 @@ public class SStoreOperation extends AbstractOperation {
     final Address address = frame.getRecipientAddress();
 
     final long sloadCost =
-        frame.warmUpStorage(address, key) ? 0L : gasCalculator().getColdSloadCost();
+        frame.warmUpStorage(address, key) ? 0L : gasCalculator().getSStoreColdAccessGasCost();
     if (remainingGas < sloadCost) {
       return new OperationResult(sloadCost, ExceptionalHaltReason.INSUFFICIENT_GAS);
     }

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/SelfDestructOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/SelfDestructOperation.java
@@ -128,19 +128,26 @@ public class SelfDestructOperation extends AbstractOperation {
     originatorAccount.decrementBalance(originatorBalance);
     beneficiaryAccount.incrementBalance(originatorBalance);
 
-    // EIP-7708: if the contract will actually be destroyed, and it is not a self transfer emit
-    // a burn log or a transfer log depending on if it's a self transfer or not
-    if (!originatorAddress.equals(beneficiaryAddress) || willBeDestroyed) {
+    // EIP-7708: emit a transfer log for the value moved to the beneficiary. Pre-EIP-8246 a
+    // self-referential destruction additionally emitted a burn log (the balance was burned); under
+    // EIP-8246 the balance is preserved, so only a genuine transfer (beneficiary != originator)
+    // logs.
+    final boolean emitBurnLog =
+        willBeDestroyed && !gasCalculator().isSelfDestructBalancePreserved();
+    if (!originatorAddress.equals(beneficiaryAddress) || emitBurnLog) {
       transferLogEmitter.emitSelfDestructLog(
           frame, originatorAddress, beneficiaryAddress, originatorBalance);
     }
 
-    // If we are actually destroying the originator (pre-Cancun or same-tx-create) we need to
-    // explicitly zero out the account balance (destroying ether/value if the originator is the
-    // beneficiary) as well as tag it for later self-destruct cleanup.
+    // If we are actually destroying the originator (pre-Cancun or same-tx-create) we tag it for
+    // later self-destruct cleanup. Pre-EIP-8246 we also explicitly zero the balance here, which
+    // burns ether when the originator is its own beneficiary. EIP-8246 removes that burn: the
+    // balance is preserved and the account is merely cleared at transaction finalization.
     if (willBeDestroyed) {
       frame.addSelfDestruct(originatorAccount.getAddress());
-      originatorAccount.setBalance(Wei.ZERO);
+      if (!gasCalculator().isSelfDestructBalancePreserved()) {
+        originatorAccount.setBalance(Wei.ZERO);
+      }
     }
 
     // Add refund in message frame.

--- a/evm/src/test/java/org/hyperledger/besu/evm/gascalculator/AmsterdamGasCalculatorTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/gascalculator/AmsterdamGasCalculatorTest.java
@@ -181,4 +181,18 @@ class AmsterdamGasCalculatorTest {
     assertThat(amsterdamGasCalculator.selfDestructOperationGasCost(null, Wei.ZERO))
         .isEqualTo(5_000L);
   }
+
+  @Test
+  void eip7702DelegateCodeGasRefund() {
+    // EIP-7702: intrinsic gas charges ACCOUNT_WRITE (8,000) per authorization worst-case (assuming
+    // each grows a new delegated account). Authorizations whose authority account already existed —
+    // or that were invalid — grow no new account, so their ACCOUNT_WRITE is refunded via the
+    // regular refund counter. refund = ACCOUNT_WRITE * count.
+    // no refundable authorizations => 0
+    assertThat(amsterdamGasCalculator.calculateDelegateCodeGasRefund(0L)).isZero();
+    // 1 refundable authorization => 8,000 * 1 = 8,000
+    assertThat(amsterdamGasCalculator.calculateDelegateCodeGasRefund(1L)).isEqualTo(8_000L);
+    // 3 refundable authorizations => 8,000 * 3 = 24,000
+    assertThat(amsterdamGasCalculator.calculateDelegateCodeGasRefund(3L)).isEqualTo(24_000L);
+  }
 }

--- a/evm/src/test/java/org/hyperledger/besu/evm/gascalculator/AmsterdamGasCalculatorTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/gascalculator/AmsterdamGasCalculatorTest.java
@@ -15,11 +15,14 @@
 package org.hyperledger.besu.evm.gascalculator;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.datatypes.AccessListEntry;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Transaction;
+import org.hyperledger.besu.datatypes.Wei;
+import org.hyperledger.besu.evm.account.Account;
 
 import java.util.List;
 import java.util.Optional;
@@ -144,5 +147,38 @@ class AmsterdamGasCalculatorTest {
     when(transaction.getAccessList()).thenReturn(Optional.of(List.of(entryA, entryB, entryC)));
 
     assertThat(amsterdamGasCalculator.transactionFloorCost(transaction)).isEqualTo(24288L);
+  }
+
+  @Test
+  void eip8246SelfDestructBalancePreserved() {
+    // EIP-8246: Amsterdam preserves the originator's balance on SELFDESTRUCT instead of burning it.
+    assertThat(amsterdamGasCalculator.isSelfDestructBalancePreserved()).isTrue();
+  }
+
+  @Test
+  void eip8246SelfDestructOperationGasCost() {
+    // EIP-8038/EIP-8246: static SELFDESTRUCT cost is 5,000; sending a positive balance to a new
+    // (non-existent or empty) beneficiary adds ACCOUNT_WRITE (8,000) => 13,000. The cold-access
+    // surcharge and NEW_ACCOUNT state gas are charged elsewhere (in SelfDestructOperation).
+
+    // null beneficiary + positive balance => 5,000 + 8,000 = 13,000
+    assertThat(amsterdamGasCalculator.selfDestructOperationGasCost(null, Wei.ONE))
+        .isEqualTo(13_000L);
+
+    // empty beneficiary + positive balance => 5,000 + 8,000 = 13,000
+    final Account emptyBeneficiary = mock(Account.class);
+    when(emptyBeneficiary.isEmpty()).thenReturn(true);
+    assertThat(amsterdamGasCalculator.selfDestructOperationGasCost(emptyBeneficiary, Wei.ONE))
+        .isEqualTo(13_000L);
+
+    // existing (non-empty) beneficiary + positive balance => static 5,000 only
+    final Account aliveBeneficiary = mock(Account.class);
+    when(aliveBeneficiary.isEmpty()).thenReturn(false);
+    assertThat(amsterdamGasCalculator.selfDestructOperationGasCost(aliveBeneficiary, Wei.ONE))
+        .isEqualTo(5_000L);
+
+    // null beneficiary + zero balance (nothing sent) => static 5,000 only
+    assertThat(amsterdamGasCalculator.selfDestructOperationGasCost(null, Wei.ZERO))
+        .isEqualTo(5_000L);
   }
 }

--- a/evm/src/test/java/org/hyperledger/besu/evm/gascalculator/AmsterdamGasCalculatorTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/gascalculator/AmsterdamGasCalculatorTest.java
@@ -23,9 +23,11 @@ import org.hyperledger.besu.datatypes.Transaction;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.units.bigints.UInt256;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -67,6 +69,32 @@ class AmsterdamGasCalculatorTest {
     assertThat(amsterdamGasCalculator.accessListGasCost(1, 1)).isEqualTo(7628L);
     // Three addresses + five keys = 3*3680 + 5*(1900+2048) = 11040 + 19740 = 30780
     assertThat(amsterdamGasCalculator.accessListGasCost(3, 5)).isEqualTo(30780L);
+  }
+
+  @Test
+  void eip8038StateAccessGasRepricing() {
+    // EIP-8038: cold access raised to 3,000 (account was 2,600, storage slot was 2,100).
+    assertThat(amsterdamGasCalculator.getColdAccountAccessCost()).isEqualTo(3_000L);
+    assertThat(amsterdamGasCalculator.getColdSloadCost()).isEqualTo(3_000L);
+    // SSTORE cold surcharge excludes the warm base (100) folded into calculateStorageCost:
+    // COLD_STORAGE_ACCESS 3,000 - WARM_ACCESS 100 = 2,900.
+    assertThat(amsterdamGasCalculator.getSStoreColdAccessGasCost()).isEqualTo(2_900L);
+    // CALL value cost = ACCOUNT_WRITE (8,000) + CALL_STIPEND (2,300) = 10,300.
+    assertThat(amsterdamGasCalculator.callValueTransferGasCost()).isEqualTo(10_300L);
+    // EXTCODESIZE base = extra WARM_ACCESS "code reading cost" (100).
+    assertThat(amsterdamGasCalculator.getExtCodeSizeOperationGasCost()).isEqualTo(100L);
+  }
+
+  @Test
+  void eip8038SStoreFlatWriteCost() {
+    final Supplier<UInt256> zero = () -> UInt256.ZERO;
+    final Supplier<UInt256> nonZero = () -> UInt256.valueOf(42);
+    // No change: warm access base only (100).
+    assertThat(amsterdamGasCalculator.calculateStorageCost(UInt256.valueOf(42), nonZero, nonZero))
+        .isEqualTo(100L);
+    // First change (0 -> nonzero): warm base (100) + flat STORAGE_WRITE (10,000) = 10,100.
+    assertThat(amsterdamGasCalculator.calculateStorageCost(UInt256.valueOf(42), zero, zero))
+        .isEqualTo(10_100L);
   }
 
   @Test

--- a/evm/src/test/java/org/hyperledger/besu/evm/gascalculator/AmsterdamGasCalculatorTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/gascalculator/AmsterdamGasCalculatorTest.java
@@ -42,33 +42,34 @@ class AmsterdamGasCalculatorTest {
 
   @Test
   void transactionFloorCostShouldBeAtLeastTransactionBaseCost() {
-    // floor cost = 21000 (base cost) + 0
+    // EIP-2780: TX_BASE (12000) replaces the flat 21000 minimum.
+    // floor cost = 12000 (base cost) + 0
     when(transaction.getPayload()).thenReturn(Bytes.EMPTY);
     when(transaction.getAccessList()).thenReturn(Optional.empty());
-    assertThat(amsterdamGasCalculator.transactionFloorCost(transaction)).isEqualTo(21000L);
+    assertThat(amsterdamGasCalculator.transactionFloorCost(transaction)).isEqualTo(12000L);
 
-    // EIP-7976: floor cost = 21000 + 256 * 64 (uniform per-byte floor)
+    // EIP-7976: floor cost = 12000 + 256 * 64 (uniform per-byte floor) = 28384
     when(transaction.getPayload()).thenReturn(Bytes.repeat((byte) 0x0, 256));
-    assertThat(amsterdamGasCalculator.transactionFloorCost(transaction)).isEqualTo(37384L);
+    assertThat(amsterdamGasCalculator.transactionFloorCost(transaction)).isEqualTo(28384L);
 
     // EIP-7976: non-zero bytes priced identically to zero bytes for the floor
     when(transaction.getPayload()).thenReturn(Bytes.repeat((byte) 0x1, 256));
-    assertThat(amsterdamGasCalculator.transactionFloorCost(transaction)).isEqualTo(37384L);
+    assertThat(amsterdamGasCalculator.transactionFloorCost(transaction)).isEqualTo(28384L);
 
-    // 11-byte mixed payload: 21000 + 11 * 64 = 21704
+    // 11-byte mixed payload: 12000 + 11 * 64 = 12704
     when(transaction.getPayload()).thenReturn(Bytes.fromHexString("0x0001000100010001000101"));
-    assertThat(amsterdamGasCalculator.transactionFloorCost(transaction)).isEqualTo(21704L);
+    assertThat(amsterdamGasCalculator.transactionFloorCost(transaction)).isEqualTo(12704L);
   }
 
   @Test
   void accessListGasCostIncludesDataFloor() {
-    // EIP-2930: 2400/address + 1900/key; EIP-7981: +1280/address + 2048/key
-    // One address + zero keys  = 2400 + 1280 = 3680
-    assertThat(amsterdamGasCalculator.accessListGasCost(1, 0)).isEqualTo(3680L);
-    // One address + one key    = 3680 + 1900 + 2048 = 7628
-    assertThat(amsterdamGasCalculator.accessListGasCost(1, 1)).isEqualTo(7628L);
-    // Three addresses + five keys = 3*3680 + 5*(1900+2048) = 11040 + 19740 = 30780
-    assertThat(amsterdamGasCalculator.accessListGasCost(3, 5)).isEqualTo(30780L);
+    // EIP-2780/EIP-8038: 3000/address + 3000/key; EIP-7981: +1280/address + 2048/key
+    // One address + zero keys  = 3000 + 1280 = 4280
+    assertThat(amsterdamGasCalculator.accessListGasCost(1, 0)).isEqualTo(4280L);
+    // One address + one key    = 4280 + 3000 + 2048 = 9328
+    assertThat(amsterdamGasCalculator.accessListGasCost(1, 1)).isEqualTo(9328L);
+    // Three addresses + five keys = 3*4280 + 5*(3000+2048) = 12840 + 25240 = 38080
+    assertThat(amsterdamGasCalculator.accessListGasCost(3, 5)).isEqualTo(38080L);
   }
 
   @Test
@@ -102,14 +103,14 @@ class AmsterdamGasCalculatorTest {
     when(transaction.getPayload()).thenReturn(Bytes.repeat((byte) 0x1, 256));
     when(transaction.getAccessList()).thenReturn(Optional.empty());
 
-    // 21000 + 256 * 64 = 37384
-    assertThat(amsterdamGasCalculator.transactionFloorCost(transaction)).isEqualTo(37384L);
+    // EIP-2780: 12000 + 256 * 64 = 28384
+    assertThat(amsterdamGasCalculator.transactionFloorCost(transaction)).isEqualTo(28384L);
   }
 
   @Test
   void transactionFloorCostIncludesAccessListBytes() {
     // 10 calldata bytes + 1 address (20 bytes) + 2 keys (2*32 = 64 bytes) = 94 bytes
-    // 21000 + 94 * 64 = 21000 + 6016 = 27016
+    // EIP-2780: 12000 + 94 * 64 = 12000 + 6016 = 18016
     final AccessListEntry entry =
         new AccessListEntry(
             Address.fromHexString("0x00000000000000000000000000000000000000aa"),
@@ -117,7 +118,7 @@ class AmsterdamGasCalculatorTest {
     when(transaction.getPayload()).thenReturn(Bytes.repeat((byte) 0x1, 10));
     when(transaction.getAccessList()).thenReturn(Optional.of(List.of(entry)));
 
-    assertThat(amsterdamGasCalculator.transactionFloorCost(transaction)).isEqualTo(27016L);
+    assertThat(amsterdamGasCalculator.transactionFloorCost(transaction)).isEqualTo(18016L);
   }
 
   @Test
@@ -127,7 +128,7 @@ class AmsterdamGasCalculatorTest {
     // entry B: 20 address bytes + 1 key  (1*32 = 32)    = 52 bytes
     // entry C: 20 address bytes + 3 keys (3*32 = 96)    = 116 bytes
     // total bytes = 4 + 20 + 52 + 116 = 192
-    // floor = 21000 + 192 * 64 = 21000 + 12288 = 33288
+    // EIP-2780: floor = 12000 + 192 * 64 = 12000 + 12288 = 24288
     final AccessListEntry entryA =
         new AccessListEntry(
             Address.fromHexString("0x00000000000000000000000000000000000000aa"), List.of());
@@ -142,6 +143,6 @@ class AmsterdamGasCalculatorTest {
     when(transaction.getPayload()).thenReturn(Bytes.repeat((byte) 0x1, 4));
     when(transaction.getAccessList()).thenReturn(Optional.of(List.of(entryA, entryB, entryC)));
 
-    assertThat(amsterdamGasCalculator.transactionFloorCost(transaction)).isEqualTo(33288L);
+    assertThat(amsterdamGasCalculator.transactionFloorCost(transaction)).isEqualTo(24288L);
   }
 }

--- a/evm/src/test/java/org/hyperledger/besu/evm/operation/SStoreOperationTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/operation/SStoreOperationTest.java
@@ -222,8 +222,10 @@ class SStoreOperationTest {
 
     // EIP-8037: state gas refund is credited directly to
     // state_gas_reservoir (not refund_counter, bypassing the 20% cap) and stateGasUsed is
-    // decremented. Regular SSTORE refund for 0→X→0 (2,800) still goes via refund_counter.
-    assertThat(frame.getGasRefund()).isEqualTo(2_800L);
+    // decremented. EIP-8038: the regular refund for 0→X→0 is the flat STORAGE_WRITE (10,000)
+    // charged on the first change, refunded when the slot is restored to its original (zero) value;
+    // it still goes via refund_counter.
+    assertThat(frame.getGasRefund()).isEqualTo(10_000L);
     assertThat(frame.getStateGasUsed()).isZero();
     assertThat(frame.getStateGasReservoir()).isEqualTo(100_000L);
   }
@@ -269,8 +271,9 @@ class SStoreOperationTest {
 
     // No state gas for clearing when original was nonzero
     assertThat(frame.getStateGasUsed()).isEqualTo(0L);
-    // Only the regular SSTORE_CLEARS_SCHEDULE refund (4,800)
-    assertThat(frame.getGasRefund()).isEqualTo(4_800L);
+    // EIP-8038: storage-clear refund = (STORAGE_WRITE 10,000 + COLD_STORAGE_ACCESS 3,000) * 4800 /
+    // 5000 = 12,480 (replaces the London SSTORE_CLEARS_SCHEDULE of 4,800).
+    assertThat(frame.getGasRefund()).isEqualTo(12_480L);
   }
 
   @Test
@@ -294,7 +297,11 @@ class SStoreOperationTest {
             .address(address)
             .worldUpdater(txUpdater)
             .blockValues(new FakeBlockValues(1337))
-            .initialGas(100_000L)
+            // EIP-8038: the regular SSTORE cost for a cold 0->nonzero set is now 13,000
+            // (2,900 cold access + 100 warm base + 10,000 STORAGE_WRITE), up from 5,000. The frame
+            // must retain enough gas after that deduction to absorb the state-gas spill
+            // (97,920 - 10,000 = 87,920), so initialGas is raised accordingly.
+            .initialGas(200_000L)
             .build();
 
     // Set reservoir to less than what the SSTORE will need


### PR DESCRIPTION
## Description

**EIP-7702** authorization gas refund for the Amsterdam fork, on top of EIP-8037/8038/2780/8246.

EIP-2780 charges `ACCOUNT_WRITE` (8,000) per EIP-7702 authorization in intrinsic gas — the worst case, assuming each authorization grows a new delegated account. EIP-7702 **refunds** that charge for authorizations that grew no new account: whose authority account already existed, or that were invalid.

- `AmsterdamGasCalculator.calculateDelegateCodeGasRefund(count)` now returns `ACCOUNT_WRITE * count` (was a `0` stub left by the EIP-2780 PR).
- `CodeDelegationResult` gains an `invalidAuthorizations` counter; `CodeDelegationProcessor` increments it on every invalid-authorization return path (chain id / `MAX_NONCE` / high-S, unrecoverable signature, and `canSetCodeDelegation` failures).
- `MainnetTransactionProcessor` folds the invalid-authorization count into the already-existing-delegator and auth-base refund counts (gated on the state-gas calculator being active) and adds the code-delegation refund.

Completes the Amsterdam gas-repricing model.

## Stacked series — PR 4 of 4 (final)

**Stacked on #10766 (EIP-8246) → #10765 (EIP-2780) → #10764 (EIP-8038) → `main`.** Merge in order; rebasing onto `main` after the lower three land leaves only the EIP-7702 delta.

1. EIP-8038 (#10764)
2. EIP-2780 (#10765)
3. EIP-8246 (#10766)
4. **EIP-7702** ← *this PR*

With all four merged, `AmsterdamGasCalculator` + `MainnetTransactionProcessor` carry the complete Amsterdam repricing, validated against the `tests-glamsterdam-devnet` Amsterdam reference fixtures.

## Testing

`./gradlew :evm:test :ethereum:core:test` — BUILD SUCCESSFUL (no integration fixture shift — the refund only fires for invalid/already-existing 7702 authorizations, which those suites don't exercise). Unit coverage: `calculateDelegateCodeGasRefund` values + `invalidAuthorizations` counters across all reject paths in `CodeDelegationProcessorTest`. Spotless clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
