### PR TITLE
explicitly include all needed permissions

### DIFF
--- a/.github/workflows/docker-security-scan-daily.yml
+++ b/.github/workflows/docker-security-scan-daily.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      actions: read
       security-events: write
 
     steps:


### PR DESCRIPTION
explicitly list out the actions:read permission, which is required but just happens to work in public contexts.


