### PR TITLE
Return -32602 for invalid engine BAL params (EIP-7928)

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayload.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayload.java
@@ -233,8 +233,7 @@ public abstract class AbstractEngineNewPayload extends ExecutionEngineJsonRpcMet
     } catch (final InvalidBlockAccessListException e) {
       return new JsonRpcErrorResponse(
           reqId,
-          ValidationResult.invalid(
-              RpcErrorType.INVALID_ENGINE_NEW_PAYLOAD_PARAMS, e.getMessage()));
+          ValidationResult.invalid(RpcErrorType.INVALID_ENGINE_NEW_PAYLOAD_PARAMS, e.getMessage()));
     }
 
     if (mergeContext.get().isSyncing()) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayload.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayload.java
@@ -231,12 +231,10 @@ public abstract class AbstractEngineNewPayload extends ExecutionEngineJsonRpcMet
     try {
       maybeBlockAccessList = extractBlockAccessList(blockParam);
     } catch (final InvalidBlockAccessListException e) {
-      return respondWithInvalid(
+      return new JsonRpcErrorResponse(
           reqId,
-          blockParam,
-          mergeCoordinator.getLatestValidAncestor(blockParam.getParentHash()).orElse(null),
-          INVALID,
-          e.getMessage());
+          ValidationResult.invalid(
+              RpcErrorType.INVALID_ENGINE_NEW_PAYLOAD_PARAMS, e.getMessage()));
     }
 
     if (mergeContext.get().isSyncing()) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV4.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV4.java
@@ -82,6 +82,9 @@ public class EngineNewPayloadV4 extends AbstractEngineNewPayload {
     } else if (maybeRequestsParam.isEmpty()) {
       return ValidationResult.invalid(
           RpcErrorType.INVALID_EXECUTION_REQUESTS_PARAMS, "Missing execution requests field");
+    } else if (payloadParameter.getBlockAccessList() != null) {
+      return ValidationResult.invalid(
+          RpcErrorType.INVALID_ENGINE_NEW_PAYLOAD_PARAMS, "Unexpected block access list field");
     } else {
       return ValidationResult.valid();
     }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV4Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV4Test.java
@@ -141,8 +141,7 @@ public class EngineNewPayloadV4Test extends EngineNewPayloadV3Test {
   @Test
   public void shouldReturnInvalidParamsIfBlockAccessListPresentOnV4() {
     final BlockHeader header = createValidBlockHeader(Optional.empty());
-    final EnginePayloadParameter payload =
-        mockEnginePayload(header, emptyList(), null, "0xc0");
+    final EnginePayloadParameter payload = mockEnginePayload(header, emptyList(), null, "0xc0");
 
     var resp = resp(payload);
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV4Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV4Test.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.AMSTERDAM;
 import static org.hyperledger.besu.ethereum.api.graphql.internal.response.GraphQLError.INVALID_PARAMS;
 import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineTestSupport.fromErrorResp;
+import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType.INVALID_ENGINE_NEW_PAYLOAD_PARAMS;
 import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType.INVALID_EXECUTION_REQUESTS_PARAMS;
 import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType.UNSUPPORTED_FORK;
 import static org.mockito.ArgumentMatchers.any;
@@ -134,6 +135,20 @@ public class EngineNewPayloadV4Test extends EngineNewPayloadV3Test {
 
     final JsonRpcError jsonRpcError = fromErrorResp(resp);
     assertThat(jsonRpcError.getCode()).isEqualTo(UNSUPPORTED_FORK.getCode());
+    verify(engineCallListener, times(1)).executionEngineCalled();
+  }
+
+  @Test
+  public void shouldReturnInvalidParamsIfBlockAccessListPresentOnV4() {
+    final BlockHeader header = createValidBlockHeader(Optional.empty());
+    final EnginePayloadParameter payload =
+        mockEnginePayload(header, emptyList(), null, "0xc0");
+
+    var resp = resp(payload);
+
+    assertThat(fromErrorResp(resp).getCode()).isEqualTo(INVALID_PARAMS.getCode());
+    assertThat(fromErrorResp(resp).getMessage())
+        .isEqualTo(INVALID_ENGINE_NEW_PAYLOAD_PARAMS.getMessage());
     verify(engineCallListener, times(1)).executionEngineCalled();
   }
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV5Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV5Test.java
@@ -135,8 +135,7 @@ public class EngineNewPayloadV5Test extends EngineNewPayloadV4Test {
   @Override
   @Test
   @Disabled("blockAccessList is valid on engine_newPayloadV5")
-  public void shouldReturnInvalidParamsIfBlockAccessListPresentOnV4() {
-  }
+  public void shouldReturnInvalidParamsIfBlockAccessListPresentOnV4() {}
 
   @Test
   public void shouldReturnInvalidIfBlockAccessListHasInvalidHexEncoding() {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV5Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV5Test.java
@@ -17,7 +17,9 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.AMSTERDAM;
-import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.ExecutionEngineJsonRpcMethod.EngineStatus.INVALID;
+import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineTestSupport.fromErrorResp;
+import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType.INVALID_ENGINE_NEW_PAYLOAD_PARAMS;
+import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType.INVALID_PARAMS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -33,8 +35,8 @@ import org.hyperledger.besu.ethereum.BlockProcessingOutputs;
 import org.hyperledger.besu.ethereum.BlockProcessingResult;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.EnginePayloadParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.WithdrawalParameter;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.EnginePayloadStatusResult;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.Withdrawal;
@@ -60,6 +62,7 @@ import java.util.Set;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 public class EngineNewPayloadV5Test extends EngineNewPayloadV4Test {
@@ -123,11 +126,16 @@ public class EngineNewPayloadV5Test extends EngineNewPayloadV4Test {
 
     final JsonRpcResponse resp = resp(super.mockEnginePayload(header, emptyList(), null, null));
 
-    final EnginePayloadStatusResult result = fromSuccessResp(resp);
-    assertThat(result.getStatusAsString()).isEqualTo(INVALID.name());
-    assertThat(result.getError()).isEqualTo("Missing block access list field");
-    assertThat(result.getLatestValidHash()).isEmpty();
+    final JsonRpcError jsonRpcError = fromErrorResp(resp);
+    assertThat(jsonRpcError.getCode()).isEqualTo(INVALID_PARAMS.getCode());
+    assertThat(jsonRpcError.getMessage()).isEqualTo(INVALID_ENGINE_NEW_PAYLOAD_PARAMS.getMessage());
     verify(engineCallListener, times(1)).executionEngineCalled();
+  }
+
+  @Override
+  @Test
+  @Disabled("blockAccessList is valid on engine_newPayloadV5")
+  public void shouldReturnInvalidParamsIfBlockAccessListPresentOnV4() {
   }
 
   @Test
@@ -138,10 +146,9 @@ public class EngineNewPayloadV5Test extends EngineNewPayloadV4Test {
         resp(
             super.mockEnginePayload(header, emptyList(), null, INVALID_BLOCK_ACCESS_LIST_ENCODING));
 
-    final EnginePayloadStatusResult result = fromSuccessResp(resp);
-    assertThat(result.getStatusAsString()).isEqualTo(INVALID.name());
-    assertThat(result.getError()).isEqualTo("Invalid block access list encoding");
-    assertThat(result.getLatestValidHash()).isEmpty();
+    final JsonRpcError jsonRpcError = fromErrorResp(resp);
+    assertThat(jsonRpcError.getCode()).isEqualTo(INVALID_PARAMS.getCode());
+    assertThat(jsonRpcError.getMessage()).isEqualTo(INVALID_ENGINE_NEW_PAYLOAD_PARAMS.getMessage());
     verify(engineCallListener, times(1)).executionEngineCalled();
   }
 
@@ -152,10 +159,9 @@ public class EngineNewPayloadV5Test extends EngineNewPayloadV4Test {
     final JsonRpcResponse resp =
         resp(super.mockEnginePayload(header, emptyList(), null, INVALID_BLOCK_ACCESS_LIST_RLP));
 
-    final EnginePayloadStatusResult result = fromSuccessResp(resp);
-    assertThat(result.getStatusAsString()).isEqualTo(INVALID.name());
-    assertThat(result.getError()).isEqualTo("Invalid block access list encoding");
-    assertThat(result.getLatestValidHash()).isEmpty();
+    final JsonRpcError jsonRpcError = fromErrorResp(resp);
+    assertThat(jsonRpcError.getCode()).isEqualTo(INVALID_PARAMS.getCode());
+    assertThat(jsonRpcError.getMessage()).isEqualTo(INVALID_ENGINE_NEW_PAYLOAD_PARAMS.getMessage());
     verify(engineCallListener, times(1)).executionEngineCalled();
   }
 


### PR DESCRIPTION
## Summary
- Return JSON-RPC `-32602` (`INVALID_ENGINE_NEW_PAYLOAD_PARAMS`) for malformed or missing `blockAccessList` on `engine_newPayloadV5`, instead of `payload status: INVALID`
- Reject unexpected `blockAccessList` on `engine_newPayloadV4` with `-32602`
- Aligns Besu with execution-specs engine tests from https://github.com/ethereum/execution-specs/pull/3082

fixing this tests 

```
::test_bal_invalid_engine_payload_encoding[fork_Amsterdam-blockchain_test_engine-empty_byte_string]
::test_bal_invalid_engine_payload_encoding[fork_Amsterdam-blockchain_test_engine-rlp_non_list]
::test_bal_invalid_engine_payload_encoding[fork_Amsterdam-blockchain_test_engine-rlp_truncated_list]
::test_bal_invalid_engine_payload_field_before_fork[fork_BPO2ToAmsterdamAtTime15k-blockchain_test_engine]
::test_invalid_post_fork_block_without_bal_hash_field[fork_BPO2ToAmsterdamAtTime15k-blockchain_test_engine]
```

## Test plan
- [x] `EngineNewPayloadV4Test` / `EngineNewPayloadV5Test` unit tests pass
- [x] Manual replay of 5 PR #3082 `blockchain_test_engine` fixtures: **5/5 PASS** (`-32602`)
