### PR TITLE
Improve BAL prefetcher collectKeys method performance

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/parallelization/prefetch/BalPrefetcher.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/parallelization/prefetch/BalPrefetcher.java
@@ -17,7 +17,7 @@ package org.hyperledger.besu.ethereum.mainnet.parallelization.prefetch;
 import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.ACCOUNT_INFO_STATE;
 import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.ACCOUNT_STORAGE_STORAGE;
 
-import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.StorageSlotKey;
 import org.hyperledger.besu.ethereum.mainnet.block.access.list.BlockAccessList;
 import org.hyperledger.besu.ethereum.trie.pathbased.bonsai.worldview.BonsaiWorldState;
@@ -25,6 +25,7 @@ import org.hyperledger.besu.plugin.services.storage.SegmentIdentifier;
 import org.hyperledger.besu.plugin.services.storage.SegmentedKeyValueStorage;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
@@ -33,7 +34,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ForkJoinPool;
 
-import org.apache.tuweni.bytes.Bytes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,6 +49,7 @@ public class BalPrefetcher {
   private static final Logger LOG = LoggerFactory.getLogger(BalPrefetcher.class);
 
   private static final Executor DEFAULT_PREFETCH_EXECUTOR = ForkJoinPool.commonPool();
+  private static final Comparator<byte[]> STORAGE_KEY_COMPARATOR = Arrays::compareUnsigned;
 
   private final boolean isSortingEnabled;
   private final int batchSize;
@@ -135,34 +136,38 @@ public class BalPrefetcher {
 
   /** Collect all account and storage keys from the block access list. */
   private PrefetchKeys collectKeys(final List<BlockAccessList.AccountChanges> accounts) {
-    final List<byte[]> accountKeys = new ArrayList<>();
+    final List<byte[]> accountKeys = new ArrayList<>(accounts.size());
     final List<byte[]> storageKeys = new ArrayList<>();
-
     for (final BlockAccessList.AccountChanges accountChanges : accounts) {
-      final Hash addressHash = accountChanges.address().addressHash();
-      accountKeys.add(addressHash.getBytes().toArrayUnsafe());
-      // Collect unique storage slots
-      final Set<StorageSlotKey> uniqueSlots = new HashSet<>();
-      accountChanges.storageChanges().forEach(sc -> uniqueSlots.add(sc.slot()));
-      accountChanges.storageReads().forEach(sr -> uniqueSlots.add(sr.slot()));
-
-      // Optionally sort storage slots
-      final List<StorageSlotKey> slots =
-          isSortingEnabled
-              ? uniqueSlots.stream()
-                  .sorted(Comparator.comparing(StorageSlotKey::getSlotHash))
-                  .toList()
-              : new ArrayList<>(uniqueSlots);
-
-      // Build storage keys
-      for (var slot : slots) {
-        final byte[] storageKey =
-            Bytes.concatenate(addressHash.getBytes(), slot.getSlotHash().getBytes())
-                .toArrayUnsafe();
+      final Address address = accountChanges.address();
+      final byte[] addressHash = address.addressHash().getBytes().toArrayUnsafe();
+      accountKeys.add(addressHash);
+      final List<BlockAccessList.SlotChanges> storageChanges = accountChanges.storageChanges();
+      final List<BlockAccessList.SlotRead> storageReads = accountChanges.storageReads();
+      final int rawSlotCount = storageChanges.size() + storageReads.size();
+      if (rawSlotCount == 0) {
+        continue;
+      }
+      // Deduplicate storage slots by hash without streams/lambdas (plain iterator loops).
+      final Set<StorageSlotKey> uniqueSlots = HashSet.newHashSet(rawSlotCount);
+      for (final BlockAccessList.SlotChanges storageChange : storageChanges) {
+        uniqueSlots.add(storageChange.slot());
+      }
+      for (final BlockAccessList.SlotRead storageRead : storageReads) {
+        uniqueSlots.add(storageRead.slot());
+      }
+      final int rangeStart = storageKeys.size();
+      for (final StorageSlotKey slot : uniqueSlots) {
+        final byte[] slotHash = slot.getSlotHash().getBytes().toArrayUnsafe();
+        final byte[] storageKey = new byte[addressHash.length + slotHash.length];
+        System.arraycopy(addressHash, 0, storageKey, 0, addressHash.length);
+        System.arraycopy(slotHash, 0, storageKey, addressHash.length, slotHash.length);
         storageKeys.add(storageKey);
       }
+      if (isSortingEnabled) {
+        storageKeys.subList(rangeStart, storageKeys.size()).sort(STORAGE_KEY_COMPARATOR);
+      }
     }
-
     return new PrefetchKeys(accountKeys, storageKeys);
   }
 


### PR DESCRIPTION
## PR description
Optimise `BalPrefetcher.collectKeys` on the block-processing hot path:
- Pre-size collections and deduplicate storage slots with plain loops instead of streams/lambdas
- Build composed storage keys with `System.arraycopy` instead of `Bytes.concatenate`, avoiding intermediate `Bytes` allocations
- When sorting is enabled, sort each account's composed keys in place (`Arrays::compareUnsigned`) instead of sorting slots via a stream

**JMH results**
```
Benchmark                                            (accounts)  (sortingEnabled)  Mode  Cnt     Score     Error  Units
BalPrefetcherCollectKeysBenchmark.collectKeysAfter          100              true  avgt   15    83,039 ±  13,221  us/op
BalPrefetcherCollectKeysBenchmark.collectKeysAfter          100             false  avgt   15    44,931 ±   3,095  us/op
BalPrefetcherCollectKeysBenchmark.collectKeysAfter         1000              true  avgt   15  1042,560 ± 240,445  us/op
BalPrefetcherCollectKeysBenchmark.collectKeysAfter         1000             false  avgt   15   575,266 ±  77,582  us/op
BalPrefetcherCollectKeysBenchmark.collectKeysBefore         100              true  avgt   15   133,864 ±  32,082  us/op
BalPrefetcherCollectKeysBenchmark.collectKeysBefore         100             false  avgt   15    75,023 ±   7,767  us/op
BalPrefetcherCollectKeysBenchmark.collectKeysBefore        1000              true  avgt   15  1610,735 ± 317,054  us/op
BalPrefetcherCollectKeysBenchmark.collectKeysBefore        1000             false  avgt   15  1040,590 ± 259,021  us/op
```

| Accounts | Sorting | Before | After | Speedup |
|---|---|---|---|---|
| 100 | true | 133.9 | 83.0 | 1.6× |
| 100 | false | 75.0 | 44.9 | 1.7× |
| 1000 | true | 1610.7 | 1042.6 | 1.5× |
| 1000 | false | 1040.6 | 575.3 | 1.8× |

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR if updates are required in the [Besu documentation](https://github.com/besu-eth/besu-docs).
- [ ] Considered the changelog and [included an update if required](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md#changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://github.com/besu-eth/besu/wiki/Working-through-Hive-tests)


