### PR TITLE
Use Long.compare when comparing peer connection initiation times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `--rpc-tx-feecap` will treat a value of 0 as limiting fees to 0. Today it treats 0 as "do not cap fees". To achieve similar behaviour set it to a suitably large value to effectively prevent any fee capping.
 
 ### Bug fixes
+- Fix potential `ArithmeticException: integer overflow` when prioritizing peer connections whose initiation timestamps are more than ~24.8 days apart. `EthPeers.compareConnectionInitiationTimes` now uses `Long.compare` instead of narrowing the timestamp difference to an `int`. [#10787](https://github.com/besu-eth/besu/issues/10787)
 - Skip DNS discovery records that fail enode conversion (e.g. out-of-range port) instead of dropping the rest of the batch [#10752](https://github.com/besu-eth/besu/pull/10752)
 
 ### Additions and Improvements

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeers.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeers.java
@@ -698,8 +698,11 @@ public class EthPeers implements PeerSelector {
     return rlpxAgent.canExceedConnectionLimits(peerId);
   }
 
-  private int compareConnectionInitiationTimes(final PeerConnection a, final PeerConnection b) {
-    return Math.toIntExact(a.getInitiatedAt() - b.getInitiatedAt());
+  @VisibleForTesting
+  int compareConnectionInitiationTimes(final PeerConnection a, final PeerConnection b) {
+    // Long.compare avoids the integer overflow that subtracting epoch millisecond timestamps
+    // can produce once connections are more than ~24.8 days apart
+    return Long.compare(a.getInitiatedAt(), b.getInitiatedAt());
   }
 
   private int compareByMaskedNodeId(final PeerConnection a, final PeerConnection b) {

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/EthPeersTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/EthPeersTest.java
@@ -33,6 +33,7 @@ import org.hyperledger.besu.ethereum.eth.manager.exceptions.NoAvailablePeersExce
 import org.hyperledger.besu.ethereum.eth.manager.exceptions.PeerDisconnectedException;
 import org.hyperledger.besu.ethereum.eth.messages.BlockBodiesMessage;
 import org.hyperledger.besu.ethereum.eth.sync.ChainHeadTracker;
+import org.hyperledger.besu.ethereum.p2p.rlpx.connections.PeerConnection;
 import org.hyperledger.besu.ethereum.p2p.rlpx.connections.PeerConnection.PeerNotConnected;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.MessageData;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.messages.DisconnectMessage.DisconnectReason;
@@ -43,6 +44,7 @@ import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -377,6 +379,21 @@ public class EthPeersTest {
 
     // Mock works
     assertThat(peerToDisconnect.getEthPeer().isDisconnected()).isTrue(); // peer is disconnected
+  }
+
+  @Test
+  public void comparesConnectionInitiationTimesWithoutOverflowingWhenFarApart() {
+    final PeerConnection oldConnection = mock(PeerConnection.class);
+    final PeerConnection newConnection = mock(PeerConnection.class);
+    // more than Integer.MAX_VALUE milliseconds (~24.8 days) apart
+    when(oldConnection.getInitiatedAt()).thenReturn(0L);
+    when(newConnection.getInitiatedAt()).thenReturn(TimeUnit.DAYS.toMillis(30));
+
+    assertThat(ethPeers.compareConnectionInitiationTimes(oldConnection, newConnection))
+        .isNegative();
+    assertThat(ethPeers.compareConnectionInitiationTimes(newConnection, oldConnection))
+        .isPositive();
+    assertThat(ethPeers.compareConnectionInitiationTimes(oldConnection, oldConnection)).isZero();
   }
 
   @Test


### PR DESCRIPTION
## PR description

`EthPeers.compareConnectionInitiationTimes` compared two peer connections by subtracting their epoch-millisecond initiation timestamps and narrowing the result with `Math.toIntExact`:

```java
return Math.toIntExact(a.getInitiatedAt() - b.getInitiatedAt());
```

`Integer.MAX_VALUE` milliseconds is only ~24.8 days, so on a long-running node the comparison of a month-old connection against a freshly connected peer throws `ArithmeticException: integer overflow` instead of ordering them.

This PR replaces the subtraction with `Long.compare(a.getInitiatedAt(), b.getInitiatedAt())`, which produces the same ordering without overflow. The method is now package-private with `@VisibleForTesting`, and a unit test covers timestamps more than `Integer.MAX_VALUE` milliseconds apart (the test reproduces the `ArithmeticException` on the previous implementation).

Reachability note: the comparator is used by `comparePeerPriorities`, which is exercised via `getActivePrioritizedPeers()` from `enforceRemoteConnectionLimits()`/`enforceConnectionLimits()`. Today those enforcement methods are only invoked on the `randomPeerPriority` path of `addPeerToEthPeers`, and in that mode `comparePeerPriorities` selects `compareByMaskedNodeId` instead, so the overflow is currently latent rather than triggering in production. Fixing it removes the trap before any future change to the call graph (or a direct use of the comparator) turns it into a live crash on nodes that have been up for more than ~25 days.

## Fixed Issue(s)

Fixes #10787

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR if updates are required in the [Besu documentation](https://github.com/besu-eth/besu-docs). (No doc update needed: internal comparator fix, no user-facing behaviour or flags change.)
- [x] Considered the changelog and [included an update if required](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md#changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests (N/A — no database changes.)

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew build` (ran `:ethereum:eth:test --tests EthPeersTest`; all pass, including the new overflow regression test)
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [x] hive tests: [Engine or other RPCs modified?](https://github.com/besu-eth/besu/wiki/Working-through-Hive-tests) (N/A — no Engine or other RPC changes.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
