### PR TITLE
fix(eth): prevent integer overflow in compareConnectionInitiationTimes

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeers.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeers.java
@@ -699,7 +699,7 @@ public class EthPeers implements PeerSelector {
   }
 
   private int compareConnectionInitiationTimes(final PeerConnection a, final PeerConnection b) {
-    return Math.toIntExact(a.getInitiatedAt() - b.getInitiatedAt());
+    return Long.compare(a.getInitiatedAt(), b.getInitiatedAt());
   }
 
   private int compareByMaskedNodeId(final PeerConnection a, final PeerConnection b) {


### PR DESCRIPTION
## PR description

This PR fixes a latent `ArithmeticException` in `EthPeers.compareConnectionInitiationTimes()`.

### The Problem
If two active connections were initiated more than ~24.8 days apart (exceeding `Integer.MAX_VALUE` milliseconds), this cast throws an `ArithmeticException: integer overflow`.

This is a realistic scenario for long-lived blockchain nodes that run continuously for weeks or months. When peer priority sorting runs during limit enforcement (e.g., in `enforceConnectionLimits()` or `enforceRemoteConnectionLimits()`), the comparison method throws, resulting in node instability or crashes in the peer manager.

### The Solution
Replaced the subtraction and `Math.toIntExact()` call with `Long.compare(a.getInitiatedAt(), b.getInitiatedAt())`.

- This avoids arithmetic subtraction entirely.
- It returns `-1`, `0`, or `1`, conforming safely to the `Comparator` contract.
- It eliminates any overflow risk.
- This aligns with the safe comparison logic already implemented in `EthPeer.java` (line 704).

## Fixed Issue(s)
#10787


### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)
