### PR TITLE
gradle metadata verification: trust source and javadoc jars

### DIFF
--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -3,6 +3,10 @@
    <configuration>
       <verify-metadata>true</verify-metadata>
       <verify-signatures>false</verify-signatures>
+      <trusted-artifacts>
+         <trust file=".*-javadoc[.]jar" regex="true"/>
+         <trust file=".*-sources[.]jar" regex="true"/>
+      </trusted-artifacts>
    </configuration>
    <components>
       <component group="aopalliance" name="aopalliance" version="1.0">


### PR DESCRIPTION
## PR description

We previously had this config, eg https://github.com/fab-10/besu/blob/05cf551ee9de661f1252da811ed44ba152356823/gradle/verification-metadata.xml

```
      <trusted-artifacts>
         <trust file=".*-javadoc[.]jar" regex="true"/>
         <trust file=".*-sources[.]jar" regex="true"/>
      </trusted-artifacts>
```

The current method of regenerating the metadata preserves this section so I propose adding it back

`./gradlew --write-verification-metadata sha256 resolveSourceArtifacts`

This would prevent needing to add the sources jars to metadata eg #10781