### PR TITLE
Amsterdam: shared resource-price constants foundation

### DIFF
--- a/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/AmsterdamGasCalculator.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/AmsterdamGasCalculator.java
@@ -62,16 +62,10 @@ public class AmsterdamGasCalculator extends OsakaGasCalculator {
   // EIP-8037: New regular gas constants for Amsterdam
   private static final long TX_CREATE_COST = 9_000L;
 
-  // --- Amsterdam shared resource-price constants ---
-  // Foundation prices for the Amsterdam resource-based gas repricing, referenced by the individual
-  // repricing EIPs (EIP-8038 execution access, EIP-2780 intrinsic gas, EIP-8246 SELFDESTRUCT,
-  // EIP-7702 authorization refunds). Declared once here so those EIPs can be reviewed and merged
-  // independently of each other.
-
-  /** Cold account access cost (was 2,600). */
+  /** Cold account access cost. */
   protected static final long COLD_ACCOUNT_ACCESS = 3_000L;
 
-  /** Cold storage slot access cost (was 2,100). */
+  /** Cold storage slot access cost. */
   protected static final long COLD_STORAGE_ACCESS = 3_000L;
 
   /** Account write cost (value-bearing CALL / new account). */

--- a/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/AmsterdamGasCalculator.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/AmsterdamGasCalculator.java
@@ -62,6 +62,21 @@ public class AmsterdamGasCalculator extends OsakaGasCalculator {
   // EIP-8037: New regular gas constants for Amsterdam
   private static final long TX_CREATE_COST = 9_000L;
 
+  // --- Amsterdam shared resource-price constants ---
+  // Foundation prices for the Amsterdam resource-based gas repricing, referenced by the individual
+  // repricing EIPs (EIP-8038 execution access, EIP-2780 intrinsic gas, EIP-8246 SELFDESTRUCT,
+  // EIP-7702 authorization refunds). Declared once here so those EIPs can be reviewed and merged
+  // independently of each other.
+
+  /** Cold account access cost (was 2,600). */
+  protected static final long COLD_ACCOUNT_ACCESS = 3_000L;
+
+  /** Cold storage slot access cost (was 2,100). */
+  protected static final long COLD_STORAGE_ACCESS = 3_000L;
+
+  /** Account write cost (value-bearing CALL / new account). */
+  protected static final long ACCOUNT_WRITE = 8_000L;
+
   // EIP-8037: SSTORE_SET regular gas drops from 20,000 to 2,900 (state portion charged separately)
   private static final long SSTORE_SET_GAS = SSTORE_RESET_GAS;
 


### PR DESCRIPTION
## Amsterdam shared resource-price constants

Declares the shared Amsterdam resource-based gas-repricing constants once on
`AmsterdamGasCalculator`:

- `COLD_ACCOUNT_ACCESS` = 3,000
- `COLD_STORAGE_ACCESS` = 3,000
- `ACCOUNT_WRITE` = 8,000

These prices are referenced by the individual Amsterdam repricing EIPs
(EIP-8038 execution access, EIP-2780 intrinsic gas, EIP-8246 SELFDESTRUCT,
EIP-7702 authorization refunds). Extracting them into a single foundation lets
those EIP PRs be reviewed and merged **independently of each other** rather than
as a linear stack.

Behaviour-neutral on its own (the constants are consumed by the follow-up EIP
PRs); merge this first, then the EIP PRs rebase to drop their copy of it.
