### PR TITLE
Reset BFT processor shutdown latch on restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `--rpc-tx-feecap` will treat a value of 0 as limiting fees to 0. Today it treats 0 as "do not cap fees". To achieve similar behaviour set it to a suitably large value to effectively prevent any fee capping.
 
 ### Bug fixes
+- Prevent overlapping BFT processors after repeated sync stop/start cycles, avoiding concurrent QBFT and IBFT state access. [#10806](https://github.com/besu-eth/besu/issues/10806)
 - Fix `engine_newPayload` responding with a `-32600 Invalid Request` JSON-RPC error instead of an `INVALID` payload status when the payload contains a legacy transaction with an invalid `v` value. `eth_sendRawTransaction` and `debug_batchSendRawTransaction` now report the standard `Invalid RLP in raw transaction hex` invalid-params error for such transactions instead of an unhandled internal error. [#10784](https://github.com/besu-eth/besu/pull/10784)
 - Fix potential `ArithmeticException: integer overflow` when prioritizing peer connections whose initiation timestamps are more than ~24.8 days apart. `EthPeers.compareConnectionInitiationTimes` now uses `Long.compare` instead of narrowing the timestamp difference to an `int`. [#10787](https://github.com/besu-eth/besu/issues/10787)
 - Layered txpool: fix the sender balance check rejecting zero upfront cost transactions from zero balance senders, which caused free gas networks to produce only empty blocks [#10751](https://github.com/besu-eth/besu/pull/10751)

--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/BftProcessor.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/BftProcessor.java
@@ -31,7 +31,7 @@ public class BftProcessor implements Runnable {
   private final BftEventQueue incomingQueue;
   private volatile boolean shutdown = false;
   private final EventMultiplexer eventMultiplexer;
-  private final CountDownLatch shutdownLatch = new CountDownLatch(1);
+  private volatile CountDownLatch shutdownLatch = new CountDownLatch(1);
 
   /**
    * Construct a new BftProcessor
@@ -46,6 +46,7 @@ public class BftProcessor implements Runnable {
 
   /** Indicate to the processor that it can be started */
   public synchronized void start() {
+    shutdownLatch = new CountDownLatch(1);
     shutdown = false;
   }
 
@@ -65,6 +66,7 @@ public class BftProcessor implements Runnable {
 
   @Override
   public void run() {
+    final CountDownLatch currentShutdownLatch = shutdownLatch;
     try {
       // Start the event queue. Until it is started it won't accept new events from peers
       incomingQueue.start();
@@ -79,7 +81,7 @@ public class BftProcessor implements Runnable {
     }
     // Clean up the executor service the round timer has been utilising
     LOG.info("Shutting down BFT event processor");
-    shutdownLatch.countDown();
+    currentShutdownLatch.countDown();
   }
 
   private Optional<BftEvent> nextEvent() {

--- a/consensus/common/src/test/java/org/hyperledger/besu/consensus/common/bft/BftProcessorTest.java
+++ b/consensus/common/src/test/java/org/hyperledger/besu/consensus/common/bft/BftProcessorTest.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.consensus.common.bft;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -25,10 +26,13 @@ import static org.mockito.Mockito.verify;
 
 import org.hyperledger.besu.consensus.common.bft.events.RoundExpiry;
 
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
@@ -125,6 +129,64 @@ public class BftProcessorTest {
 
     // The processor task has woken up and exited
     assertThat(processorFuture.isDone()).isTrue();
+  }
+
+  @Test
+  public void awaitStopWaitsForProcessorAfterRestart() throws Exception {
+    final BftEventQueue mockQueue = mock(BftEventQueue.class);
+    final AtomicReference<CountDownLatch> pollEntered =
+        new AtomicReference<>(new CountDownLatch(1));
+    final AtomicReference<CountDownLatch> releasePoll =
+        new AtomicReference<>(new CountDownLatch(1));
+    Mockito.when(mockQueue.poll(anyLong(), any()))
+        .thenAnswer(
+            invocation -> {
+              pollEntered.get().countDown();
+              releasePoll.get().await();
+              return null;
+            });
+
+    final BftProcessor processor = new BftProcessor(mockQueue, mockeEventMultiplexer);
+    final ExecutorService processorExecutor = Executors.newSingleThreadExecutor();
+    final ExecutorService awaitExecutor = Executors.newSingleThreadExecutor();
+
+    try {
+      processor.start();
+      final Future<?> firstRun = processorExecutor.submit(processor);
+      assertThat(pollEntered.get().await(1, TimeUnit.SECONDS)).isTrue();
+      processor.stop();
+      releasePoll.get().countDown();
+      processor.awaitStop();
+      firstRun.get(1, TimeUnit.SECONDS);
+
+      pollEntered.set(new CountDownLatch(1));
+      releasePoll.set(new CountDownLatch(1));
+      processor.start();
+      final Future<?> secondRun = processorExecutor.submit(processor);
+      assertThat(pollEntered.get().await(1, TimeUnit.SECONDS)).isTrue();
+      processor.stop();
+
+      final CountDownLatch awaitStarted = new CountDownLatch(1);
+      final Future<Void> secondAwait =
+          awaitExecutor.submit(
+              () -> {
+                awaitStarted.countDown();
+                processor.awaitStop();
+                return null;
+              });
+      assertThat(awaitStarted.await(1, TimeUnit.SECONDS)).isTrue();
+
+      assertThatThrownBy(() -> secondAwait.get(100, TimeUnit.MILLISECONDS))
+          .isInstanceOf(TimeoutException.class);
+
+      releasePoll.get().countDown();
+      secondAwait.get(1, TimeUnit.SECONDS);
+      secondRun.get(1, TimeUnit.SECONDS);
+    } finally {
+      releasePoll.get().countDown();
+      processorExecutor.shutdownNow();
+      awaitExecutor.shutdownNow();
+    }
   }
 
   @Test


### PR DESCRIPTION
## PR description

`BftProcessor` can be stopped and restarted when a node enters and leaves synchronization. However, its shutdown latch was created only once.

After the first shutdown, the latch remained permanently released, causing subsequent `awaitStop()` calls to return before the active processor had exited. This could allow processor executions to overlap and expose QBFT or IBFT round state to concurrent access.

This change:

- creates a fresh shutdown latch for each processor start;
- binds each processor invocation to the latch associated with that run;
- adds a regression test covering two complete start/stop cycles;
- adds an entry to the changelog.

The regression test verifies that `awaitStop()` during the second lifecycle remains blocked until the second processor invocation has actually exited.




## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fixes #10806

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR if updates are required in the [Besu documentation](https://github.com/besu-eth/besu-docs).
- [x] Considered the changelog and [included an update if required](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md#changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew build`
- [x] acceptance tests: `./gradlew acceptanceTest`
- [x] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [x] hive tests: [Engine or other RPCs modified?](https://github.com/besu-eth/besu/wiki/Working-through-Hive-tests)


