### PR TITLE
perf: eliminate Stream allocations in SnapWorldDownloadState.dequeueRequestBlocking() wait loop

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapWorldDownloadState.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapWorldDownloadState.java
@@ -54,7 +54,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
-import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import org.apache.tuweni.bytes.Bytes;
@@ -357,9 +356,7 @@ public class SnapWorldDownloadState extends WorldDownloadState<SnapDataRequest>
       final Consumer<Void> unBlocked) {
     boolean isWaiting = false;
     while (!internalFuture.isDone()) {
-      while (queueDependencies.stream()
-          .map(TaskCollection::allTasksCompleted)
-          .anyMatch(Predicate.isEqual(false))) {
+      while (hasIncompleteDependency(queueDependencies)) {
         try {
           isWaiting = true;
           wait();
@@ -385,6 +382,24 @@ public class SnapWorldDownloadState extends WorldDownloadState<SnapDataRequest>
       }
     }
     return null;
+  }
+
+  /**
+   * Returns {@code true} if any of the given queue dependencies still has incomplete tasks. This is
+   * a lightweight, allocation-free alternative to the previous stream-based check ({@code
+   * queueDependencies.stream().map(...).anyMatch(...)}) which allocated a new Stream pipeline and
+   * lambda objects on every invocation. Since this method is called inside a {@code synchronized}
+   * wait-loop that is woken on every {@link #enqueueRequest} call, eliminating those allocations
+   * reduces GC pressure and lock contention during snap sync.
+   */
+  private static boolean hasIncompleteDependency(
+      final List<TaskCollection<SnapDataRequest>> queueDependencies) {
+    for (final TaskCollection<SnapDataRequest> dependency : queueDependencies) {
+      if (!dependency.allTasksCompleted()) {
+        return true;
+      }
+    }
+    return false;
   }
 
   public synchronized Task<SnapDataRequest> dequeueAccountRequestBlocking() {


### PR DESCRIPTION

## PR description

`SnapWorldDownloadState.dequeueRequestBlocking()` contains a `synchronized`
while/wait loop that checks whether queue dependencies have completed before
dequeuing snap sync work items. The previous implementation used a Java Stream
pipeline for this check:

```java
while (queueDependencies.stream()
    .map(TaskCollection::allTasksCompleted)
    .anyMatch(Predicate.isEqual(false))) {
  wait();
}
```

This condition is re-evaluated by every waiting worker thread on every
`notifyAll()` call, which is triggered on every `enqueueRequest()` invocation —
millions of times during a snap sync. Each evaluation allocated a new Stream
pipeline, map lambda, and `Predicate` wrapper, generating significant GC
pressure while holding the monitor lock.

**Fix:**
- Added a `private static hasIncompleteDependency()` helper that walks the
  dependency list with a plain enhanced-for loop, short-circuiting on the first
  incomplete dependency — zero heap allocations per call.
- Replaced the stream-based `while` condition with the new helper.
- Removed the now-unused `java.util.function.Predicate` import.

**Impact:** Reduces GC pressure and lock contention during snap sync, improving
throughput of concurrent worker threads that dequeue state download tasks.

## Fixed Issue(s)
#10817 

- [x] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)
- [ ] Considered documentation and added the `doc-change-required` label to this PR if updates are required.
- [ ] Considered the changelog and included an update if required.
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew :ethereum:eth:test --tests SnapWorldDownloadStateTest`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

