### PR TITLE
Separate Bonsai storage trie nodes into dedicated RocksDB column family

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/storage/keyvalue/KeyValueSegmentIdentifier.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/storage/keyvalue/KeyValueSegmentIdentifier.java
@@ -39,6 +39,8 @@ public enum KeyValueSegmentIdentifier implements SegmentIdentifier {
   ACCOUNT_STORAGE_STORAGE(new byte[] {8}, EnumSet.of(BONSAI, X_BONSAI_ARCHIVE), false, true, false),
   TRIE_BRANCH_STORAGE(new byte[] {9}, EnumSet.of(BONSAI, X_BONSAI_ARCHIVE), false, true, false),
   TRIE_LOG_STORAGE(new byte[] {10}, EnumSet.of(BONSAI, X_BONSAI_ARCHIVE), true, false, true),
+  STORAGE_TRIE_BRANCH_STORAGE(
+      new byte[] {19}, EnumSet.of(BONSAI, X_BONSAI_ARCHIVE), false, true, false),
   ACCOUNT_INFO_STATE_ARCHIVE(
       "ACCOUNT_INFO_STATE_ARCHIVE".getBytes(StandardCharsets.UTF_8),
       EnumSet.of(X_BONSAI_ARCHIVE),

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/storage/BonsaiStorageTrieSegmentMigrator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/storage/BonsaiStorageTrieSegmentMigrator.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.trie.pathbased.bonsai.storage;
+
+import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.STORAGE_TRIE_BRANCH_STORAGE;
+import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.TRIE_BRANCH_STORAGE;
+import static org.hyperledger.besu.ethereum.trie.pathbased.bonsai.storage.BonsaiTrieStorageKeys.STORAGE_TRIE_CF_MIGRATED_KEY;
+
+import org.hyperledger.besu.plugin.services.storage.SegmentedKeyValueStorage;
+import org.hyperledger.besu.plugin.services.storage.SegmentedKeyValueStorageTransaction;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Moves legacy storage trie nodes from {@link
+ * org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier#TRIE_BRANCH_STORAGE} into
+ * {@link
+ * org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier#STORAGE_TRIE_BRANCH_STORAGE}.
+ */
+public final class BonsaiStorageTrieSegmentMigrator {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BonsaiStorageTrieSegmentMigrator.class);
+  private static final byte[] MIGRATION_COMPLETE = new byte[] {1};
+
+  private BonsaiStorageTrieSegmentMigrator() {}
+
+  public static void migrateIfNeeded(final SegmentedKeyValueStorage composedWorldStateStorage) {
+    if (composedWorldStateStorage.get(TRIE_BRANCH_STORAGE, STORAGE_TRIE_CF_MIGRATED_KEY).isPresent()) {
+      return;
+    }
+
+    final AtomicLong migratedEntries = new AtomicLong();
+    final SegmentedKeyValueStorageTransaction transaction =
+        composedWorldStateStorage.startTransaction();
+    try {
+      composedWorldStateStorage
+          .stream(TRIE_BRANCH_STORAGE)
+          .forEach(
+              entry -> {
+                final byte[] key = entry.getKey();
+                if (!BonsaiTrieStorageKeys.isStorageTrieKey(key)) {
+                  return;
+                }
+                transaction.put(STORAGE_TRIE_BRANCH_STORAGE, key, entry.getValue());
+                transaction.remove(TRIE_BRANCH_STORAGE, key);
+                migratedEntries.incrementAndGet();
+              });
+      transaction.put(TRIE_BRANCH_STORAGE, STORAGE_TRIE_CF_MIGRATED_KEY, MIGRATION_COMPLETE);
+      transaction.commit();
+      if (migratedEntries.get() > 0) {
+        LOG.info(
+            "Migrated {} storage trie nodes from TRIE_BRANCH_STORAGE to STORAGE_TRIE_BRANCH_STORAGE",
+            migratedEntries.get());
+      } else {
+        LOG.debug("Marked storage trie column family migration as complete");
+      }
+    } catch (final RuntimeException e) {
+      transaction.rollback();
+      throw e;
+    }
+  }
+}

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/storage/BonsaiTrieStorageKeys.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/storage/BonsaiTrieStorageKeys.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.trie.pathbased.bonsai.storage;
+
+import static org.hyperledger.besu.ethereum.trie.pathbased.common.storage.PathBasedWorldStateKeyValueStorage.WORLD_BLOCK_HASH_KEY;
+import static org.hyperledger.besu.ethereum.trie.pathbased.common.storage.PathBasedWorldStateKeyValueStorage.WORLD_BLOCK_NUMBER_KEY;
+import static org.hyperledger.besu.ethereum.trie.pathbased.common.storage.PathBasedWorldStateKeyValueStorage.WORLD_ROOT_HASH_KEY;
+import static org.hyperledger.besu.ethereum.trie.pathbased.common.storage.flat.FlatDbStrategyProvider.FLAT_DB_MODE;
+
+import org.hyperledger.besu.datatypes.Hash;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import org.apache.tuweni.bytes.Bytes;
+
+/** Helpers for classifying Bonsai trie keys across RocksDB column families. */
+public final class BonsaiTrieStorageKeys {
+
+  public static final byte[] STORAGE_TRIE_CF_MIGRATED_KEY =
+      "storageTrieCfMigrated".getBytes(StandardCharsets.UTF_8);
+
+  private static final int ACCOUNT_HASH_LENGTH_BYTES = 32;
+  private static final int MAX_ACCOUNT_TRIE_LOCATION_BYTES = 64;
+
+  private BonsaiTrieStorageKeys() {}
+
+  public static byte[] storageTrieKey(final Hash accountHash, final Bytes location) {
+    return Bytes.concatenate(accountHash.getBytes(), location).toArrayUnsafe();
+  }
+
+  public static boolean isMetadataKey(final byte[] key) {
+    return Arrays.equals(key, WORLD_ROOT_HASH_KEY)
+        || Arrays.equals(key, WORLD_BLOCK_HASH_KEY)
+        || Arrays.equals(key, WORLD_BLOCK_NUMBER_KEY)
+        || Arrays.equals(key, FLAT_DB_MODE)
+        || Arrays.equals(key, STORAGE_TRIE_CF_MIGRATED_KEY);
+  }
+
+  public static boolean isAccountTrieLocationKey(final byte[] key) {
+    return key.length <= MAX_ACCOUNT_TRIE_LOCATION_BYTES && allBytesAreNibbles(key);
+  }
+
+  public static boolean isStorageTrieKey(final byte[] key) {
+    if (key.length < ACCOUNT_HASH_LENGTH_BYTES || isMetadataKey(key)) {
+      return false;
+    }
+    if (isAccountTrieLocationKey(key)) {
+      return false;
+    }
+    return allBytesAreNibbles(key, ACCOUNT_HASH_LENGTH_BYTES, key.length);
+  }
+
+  public static boolean allBytesAreNibbles(final byte[] key) {
+    return allBytesAreNibbles(key, 0, key.length);
+  }
+
+  private static boolean allBytesAreNibbles(final byte[] key, final int from, final int to) {
+    for (int i = from; i < to; i++) {
+      if ((key[i] & 0xFF) > 0x0F) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/storage/BonsaiWorldStateKeyValueStorage.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/storage/BonsaiWorldStateKeyValueStorage.java
@@ -16,8 +16,9 @@ package org.hyperledger.besu.ethereum.trie.pathbased.bonsai.storage;
 
 import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.ACCOUNT_INFO_STATE;
 import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.ACCOUNT_STORAGE_STORAGE;
-import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.CODE_STORAGE;
+import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.STORAGE_TRIE_BRANCH_STORAGE;
 import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.TRIE_BRANCH_STORAGE;
+import static org.hyperledger.besu.ethereum.trie.pathbased.common.storage.PathBasedWorldStateKeyValueStorage.BONSAI_WORLD_STATE_SEGMENTS;
 
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.StorageSlotKey;
@@ -44,7 +45,6 @@ import org.hyperledger.besu.plugin.services.storage.SegmentedKeyValueStorageTran
 import org.hyperledger.besu.plugin.services.storage.WorldStateKeyValueStorage;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Optional;
@@ -80,10 +80,9 @@ public class BonsaiWorldStateKeyValueStorage extends PathBasedWorldStateKeyValue
       final DataStorageConfiguration dataStorageConfiguration,
       final FlatDbCacheManager cacheManager) {
     super(
-        provider.getStorageBySegmentIdentifiers(
-            List.of(
-                ACCOUNT_INFO_STATE, CODE_STORAGE, ACCOUNT_STORAGE_STORAGE, TRIE_BRANCH_STORAGE)),
+        provider.getStorageBySegmentIdentifiers(BONSAI_WORLD_STATE_SEGMENTS),
         provider.getStorageBySegmentIdentifier(KeyValueSegmentIdentifier.TRIE_LOG_STORAGE));
+    BonsaiStorageTrieSegmentMigrator.migrateIfNeeded(composedWorldStateStorage);
     this.flatDbStrategyProvider =
         new BonsaiFlatDbStrategyProvider(metricsSystem, dataStorageConfiguration);
     flatDbStrategyProvider.loadFlatDbStrategy(composedWorldStateStorage);
@@ -206,16 +205,28 @@ public class BonsaiWorldStateKeyValueStorage extends PathBasedWorldStateKeyValue
     if (nodeHash.equals(MerkleTrie.EMPTY_TRIE_NODE_HASH)) {
       return Optional.of(MerkleTrie.EMPTY_TRIE_NODE);
     }
+    final byte[] key = BonsaiTrieStorageKeys.storageTrieKey(accountHash, location);
     return composedWorldStateStorage
-        .get(
-            TRIE_BRANCH_STORAGE,
-            Bytes.concatenate(accountHash.getBytes(), location).toArrayUnsafe())
+        .get(STORAGE_TRIE_BRANCH_STORAGE, key)
         .map(Bytes::wrap)
-        .filter(b -> Hash.hash(b).getBytes().equals(nodeHash));
+        .filter(b -> Hash.hash(b).getBytes().equals(nodeHash))
+        .or(
+            () ->
+                composedWorldStateStorage
+                    .get(TRIE_BRANCH_STORAGE, key)
+                    .map(Bytes::wrap)
+                    .filter(b -> Hash.hash(b).getBytes().equals(nodeHash)));
   }
 
   public Optional<Bytes> getTrieNodeUnsafe(final Bytes key) {
-    return composedWorldStateStorage.get(TRIE_BRANCH_STORAGE, key.toArrayUnsafe()).map(Bytes::wrap);
+    final byte[] keyBytes = key.toArrayUnsafe();
+    if (BonsaiTrieStorageKeys.isStorageTrieKey(keyBytes)) {
+      return composedWorldStateStorage
+          .get(STORAGE_TRIE_BRANCH_STORAGE, keyBytes)
+          .map(Bytes::wrap)
+          .or(() -> composedWorldStateStorage.get(TRIE_BRANCH_STORAGE, keyBytes).map(Bytes::wrap));
+    }
+    return composedWorldStateStorage.get(TRIE_BRANCH_STORAGE, keyBytes).map(Bytes::wrap);
   }
 
   public NavigableMap<Bytes32, AccountStorageEntry> storageEntriesFrom(
@@ -387,8 +398,8 @@ public class BonsaiWorldStateKeyValueStorage extends PathBasedWorldStateKeyValue
         return this;
       }
       composedWorldStateTransaction.put(
-          TRIE_BRANCH_STORAGE,
-          Bytes.concatenate(accountHash.getBytes(), location).toArrayUnsafe(),
+          STORAGE_TRIE_BRANCH_STORAGE,
+          BonsaiTrieStorageKeys.storageTrieKey(accountHash, location),
           node.toArrayUnsafe());
       return this;
     }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/storage/PathBasedWorldStateKeyValueStorage.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/storage/PathBasedWorldStateKeyValueStorage.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.ethereum.trie.pathbased.common.storage;
 import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.ACCOUNT_INFO_STATE;
 import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.ACCOUNT_STORAGE_STORAGE;
 import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.CODE_STORAGE;
+import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.STORAGE_TRIE_BRANCH_STORAGE;
 import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.TRIE_BRANCH_STORAGE;
 
 import org.hyperledger.besu.datatypes.Hash;
@@ -27,6 +28,7 @@ import org.hyperledger.besu.ethereum.worldstate.FlatDbMode;
 import org.hyperledger.besu.plugin.services.storage.DataStorageFormat;
 import org.hyperledger.besu.plugin.services.storage.KeyValueStorage;
 import org.hyperledger.besu.plugin.services.storage.KeyValueStorageTransaction;
+import org.hyperledger.besu.plugin.services.storage.SegmentIdentifier;
 import org.hyperledger.besu.plugin.services.storage.SegmentedKeyValueStorage;
 import org.hyperledger.besu.plugin.services.storage.SegmentedKeyValueStorageTransaction;
 import org.hyperledger.besu.plugin.services.storage.WorldStateKeyValueStorage;
@@ -60,6 +62,14 @@ public abstract class PathBasedWorldStateKeyValueStorage
   public static final byte[] WORLD_BLOCK_NUMBER_KEY =
       "worldBlockNumber".getBytes(StandardCharsets.UTF_8);
 
+  public static final List<SegmentIdentifier> BONSAI_WORLD_STATE_SEGMENTS =
+      List.of(
+          ACCOUNT_INFO_STATE,
+          CODE_STORAGE,
+          ACCOUNT_STORAGE_STORAGE,
+          TRIE_BRANCH_STORAGE,
+          STORAGE_TRIE_BRANCH_STORAGE);
+
   private final AtomicBoolean shouldClose = new AtomicBoolean(false);
 
   protected final AtomicBoolean isClosed = new AtomicBoolean(false);
@@ -70,9 +80,7 @@ public abstract class PathBasedWorldStateKeyValueStorage
 
   public PathBasedWorldStateKeyValueStorage(final StorageProvider provider) {
     this.composedWorldStateStorage =
-        provider.getStorageBySegmentIdentifiers(
-            List.of(
-                ACCOUNT_INFO_STATE, CODE_STORAGE, ACCOUNT_STORAGE_STORAGE, TRIE_BRANCH_STORAGE));
+        provider.getStorageBySegmentIdentifiers(BONSAI_WORLD_STATE_SEGMENTS);
     this.trieLogStorage =
         provider.getStorageBySegmentIdentifier(KeyValueSegmentIdentifier.TRIE_LOG_STORAGE);
   }
@@ -184,6 +192,7 @@ public abstract class PathBasedWorldStateKeyValueStorage
   public void clearTrie() {
     subscribers.forEach(StorageSubscriber::onClearTrie);
     composedWorldStateStorage.clear(TRIE_BRANCH_STORAGE);
+    composedWorldStateStorage.clear(STORAGE_TRIE_BRANCH_STORAGE);
   }
 
   public void clearFlatDatabase() {

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/RollingImport.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/RollingImport.java
@@ -15,10 +15,7 @@
 package org.hyperledger.besu.ethereum.trie.pathbased.bonsai;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.ACCOUNT_INFO_STATE;
-import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.ACCOUNT_STORAGE_STORAGE;
-import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.CODE_STORAGE;
-import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.TRIE_BRANCH_STORAGE;
+import static org.hyperledger.besu.ethereum.trie.pathbased.common.storage.PathBasedWorldStateKeyValueStorage.BONSAI_WORLD_STATE_SEGMENTS;
 import static org.hyperledger.besu.ethereum.trie.pathbased.common.worldview.WorldStateConfig.createStatefulConfigWithTrie;
 
 import org.hyperledger.besu.ethereum.core.InMemoryKeyValueStorageProvider;
@@ -65,12 +62,7 @@ public class RollingImport {
             new PathBasedCodeCache());
     final SegmentedInMemoryKeyValueStorage worldStateKeyValueStorage =
         (SegmentedInMemoryKeyValueStorage)
-            provider.getStorageBySegmentIdentifiers(
-                List.of(
-                    ACCOUNT_INFO_STATE,
-                    CODE_STORAGE,
-                    ACCOUNT_STORAGE_STORAGE,
-                    TRIE_BRANCH_STORAGE));
+            provider.getStorageBySegmentIdentifiers(BONSAI_WORLD_STATE_SEGMENTS);
 
     final InMemoryKeyValueStorage trieLogStorage =
         (InMemoryKeyValueStorage)

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/archive/BonsaiArchiveReadFlatDbStrategyProviderTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/archive/BonsaiArchiveReadFlatDbStrategyProviderTest.java
@@ -15,10 +15,8 @@
 package org.hyperledger.besu.ethereum.trie.pathbased.bonsai.archive;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.ACCOUNT_INFO_STATE;
-import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.ACCOUNT_STORAGE_STORAGE;
-import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.CODE_STORAGE;
 import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.TRIE_BRANCH_STORAGE;
+import static org.hyperledger.besu.ethereum.trie.pathbased.common.storage.PathBasedWorldStateKeyValueStorage.BONSAI_WORLD_STATE_SEGMENTS;
 import static org.hyperledger.besu.ethereum.trie.pathbased.common.storage.flat.FlatDbStrategyProvider.FLAT_DB_MODE;
 
 import org.hyperledger.besu.ethereum.core.InMemoryKeyValueStorageProvider;
@@ -29,8 +27,6 @@ import org.hyperledger.besu.ethereum.worldstate.ImmutablePathBasedExtraStorageCo
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.plugin.services.storage.DataStorageFormat;
 import org.hyperledger.besu.plugin.services.storage.SegmentedKeyValueStorage;
-
-import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -46,13 +42,7 @@ public class BonsaiArchiveReadFlatDbStrategyProviderTest {
   @Test
   void alwaysReturnsBonsaiArchiveFlatDbStrategy() {
     final SegmentedKeyValueStorage storage =
-        new InMemoryKeyValueStorageProvider()
-            .getStorageBySegmentIdentifiers(
-                List.of(
-                    TRIE_BRANCH_STORAGE,
-                    ACCOUNT_INFO_STATE,
-                    CODE_STORAGE,
-                    ACCOUNT_STORAGE_STORAGE));
+        new InMemoryKeyValueStorageProvider().getStorageBySegmentIdentifiers(BONSAI_WORLD_STATE_SEGMENTS);
 
     final BonsaiArchiveReadFlatDbStrategyProvider provider =
         new BonsaiArchiveReadFlatDbStrategyProvider(new NoOpMetricsSystem(), CONFIG);
@@ -65,13 +55,7 @@ public class BonsaiArchiveReadFlatDbStrategyProviderTest {
   void returnsArchiveStrategyEvenForFullMode() {
     // Simulate a DB that has FlatDbMode.FULL stored — provider should still return archive
     final SegmentedKeyValueStorage storage =
-        new InMemoryKeyValueStorageProvider()
-            .getStorageBySegmentIdentifiers(
-                List.of(
-                    TRIE_BRANCH_STORAGE,
-                    ACCOUNT_INFO_STATE,
-                    CODE_STORAGE,
-                    ACCOUNT_STORAGE_STORAGE));
+        new InMemoryKeyValueStorageProvider().getStorageBySegmentIdentifiers(BONSAI_WORLD_STATE_SEGMENTS);
 
     // Write FULL mode to the DB
     final var tx = storage.startTransaction();

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/storage/BonsaiStorageTrieSegmentMigratorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/storage/BonsaiStorageTrieSegmentMigratorTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.trie.pathbased.bonsai.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.STORAGE_TRIE_BRANCH_STORAGE;
+import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.TRIE_BRANCH_STORAGE;
+import static org.hyperledger.besu.ethereum.trie.pathbased.bonsai.storage.BonsaiTrieStorageKeys.STORAGE_TRIE_CF_MIGRATED_KEY;
+import static org.hyperledger.besu.ethereum.trie.pathbased.common.storage.PathBasedWorldStateKeyValueStorage.BONSAI_WORLD_STATE_SEGMENTS;
+import static org.hyperledger.besu.ethereum.trie.pathbased.common.storage.PathBasedWorldStateKeyValueStorage.WORLD_ROOT_HASH_KEY;
+
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.core.InMemoryKeyValueStorageProvider;
+import org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration;
+import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
+import org.hyperledger.besu.plugin.services.storage.SegmentedKeyValueStorage;
+import org.hyperledger.besu.plugin.services.storage.SegmentedKeyValueStorageTransaction;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+
+class BonsaiStorageTrieSegmentMigratorTest {
+
+  @Test
+  void migratesLegacyStorageTrieNodesIntoDedicatedColumnFamily() {
+    final InMemoryKeyValueStorageProvider provider = new InMemoryKeyValueStorageProvider();
+    final SegmentedKeyValueStorage storage =
+        provider.getStorageBySegmentIdentifiers(BONSAI_WORLD_STATE_SEGMENTS);
+    final Hash accountHash = Hash.wrap(Bytes32.repeat((byte) 0xab));
+    final byte[] storageKey =
+        BonsaiTrieStorageKeys.storageTrieKey(accountHash, Bytes.fromHexString("0x01"));
+    final byte[] accountKey = Bytes.fromHexString("0x02").toArrayUnsafe();
+    final byte[] nodeValue = Bytes.fromHexString("0x1234").toArrayUnsafe();
+
+    final SegmentedKeyValueStorageTransaction tx = storage.startTransaction();
+    tx.put(TRIE_BRANCH_STORAGE, storageKey, nodeValue);
+    tx.put(TRIE_BRANCH_STORAGE, accountKey, nodeValue);
+    tx.put(TRIE_BRANCH_STORAGE, WORLD_ROOT_HASH_KEY, Bytes32.ZERO.toArrayUnsafe());
+    tx.commit();
+
+    BonsaiStorageTrieSegmentMigrator.migrateIfNeeded(storage);
+
+    assertThat(storage.get(TRIE_BRANCH_STORAGE, storageKey)).isEmpty();
+    assertThat(storage.get(STORAGE_TRIE_BRANCH_STORAGE, storageKey)).contains(nodeValue);
+    assertThat(storage.get(TRIE_BRANCH_STORAGE, accountKey)).contains(nodeValue);
+    assertThat(storage.get(TRIE_BRANCH_STORAGE, STORAGE_TRIE_CF_MIGRATED_KEY)).isPresent();
+  }
+
+  @Test
+  void storageWritesUseDedicatedColumnFamilyAfterMigration() {
+    final BonsaiWorldStateKeyValueStorage worldStateStorage =
+        new BonsaiWorldStateKeyValueStorage(
+            new InMemoryKeyValueStorageProvider(),
+            new NoOpMetricsSystem(),
+            DataStorageConfiguration.DEFAULT_BONSAI_CONFIG);
+    final Hash accountHash = Hash.wrap(Bytes32.repeat((byte) 0xcd));
+    final Bytes location = Bytes.fromHexString("0x03");
+    final Bytes node = Bytes.fromHexString("0x5678");
+    final Bytes32 nodeHash = Bytes32.wrap(Hash.hash(node).getBytes());
+
+    worldStateStorage
+        .updater()
+        .putAccountStorageTrieNode(accountHash, location, nodeHash, node)
+        .commit();
+
+    final byte[] storageKey = BonsaiTrieStorageKeys.storageTrieKey(accountHash, location);
+    final SegmentedKeyValueStorage composedStorage = worldStateStorage.getComposedWorldStateStorage();
+    assertThat(composedStorage.get(STORAGE_TRIE_BRANCH_STORAGE, storageKey)).contains(node.toArrayUnsafe());
+    assertThat(composedStorage.get(TRIE_BRANCH_STORAGE, storageKey)).isEmpty();
+    assertThat(worldStateStorage.getAccountStorageTrieNode(accountHash, location, nodeHash))
+        .contains(node);
+  }
+}

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/storage/BonsaiTrieStorageKeysTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/storage/BonsaiTrieStorageKeysTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.trie.pathbased.bonsai.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hyperledger.besu.ethereum.trie.pathbased.common.storage.PathBasedWorldStateKeyValueStorage.WORLD_ROOT_HASH_KEY;
+
+import org.hyperledger.besu.datatypes.Hash;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+
+class BonsaiTrieStorageKeysTest {
+
+  @Test
+  void classifiesAccountAndStorageTrieKeys() {
+    assertThat(BonsaiTrieStorageKeys.isAccountTrieLocationKey(Bytes.EMPTY.toArrayUnsafe()))
+        .isTrue();
+    assertThat(BonsaiTrieStorageKeys.isAccountTrieLocationKey(Bytes.fromHexString("0x0102").toArrayUnsafe()))
+        .isTrue();
+    assertThat(BonsaiTrieStorageKeys.isMetadataKey(WORLD_ROOT_HASH_KEY)).isTrue();
+
+    final Hash accountHash = Hash.wrap(Bytes32.repeat((byte) 0xab));
+    final byte[] storageKey =
+        BonsaiTrieStorageKeys.storageTrieKey(accountHash, Bytes.fromHexString("0x01"));
+    assertThat(BonsaiTrieStorageKeys.isStorageTrieKey(storageKey)).isTrue();
+    assertThat(BonsaiTrieStorageKeys.isAccountTrieLocationKey(storageKey)).isFalse();
+  }
+}


### PR DESCRIPTION
## Summary

- Add a dedicated `STORAGE_TRIE_BRANCH_STORAGE` RocksDB column family for Bonsai storage trie nodes (`accountHash || location`)
- Keep account trie nodes and world-state metadata in `TRIE_BRANCH_STORAGE`
- Improve RocksDB locality by preventing account trie and storage trie keys from being interleaved in the same column family
- Migrate existing storage trie entries from `TRIE_BRANCH_STORAGE` on startup, with legacy read fallback for unmigrated data

## Test plan

- [x] `BonsaiTrieStorageKeysTest` — key classification (account vs storage trie vs metadata)
- [x] `BonsaiStorageTrieSegmentMigratorTest` — legacy migration and new write path
- [x] `BonsaiWorldStateKeyValueStorageTest` — existing Bonsai storage behavior
- [x] `BonsaiArchiveReadFlatDbStrategyProviderTest` — archive flat DB strategy with updated segment list
- [ ] Manual: start Besu on an existing Bonsai node and verify migration log + snap sync/healing still work


Made with [Cursor](https://cursor.com)