### PR TITLE
Update verification metadata regeneration command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,10 @@ Instructions for how to get started with developing on the Besu codebase. Please
 This project uses [Gradle dependency verification](https://docs.gradle.org/current/userguide/dependency_verification.html). When adding or updating dependencies, regenerate `gradle/verification-metadata.xml` with:
 
 ```shell
-./gradlew --write-verification-metadata sha256 resolveSourceArtifacts
+./gradlew --write-verification-metadata sha256 --refresh-dependencies resolveSourceArtifacts :plugin-api:checkAPICompatibility --rerun-tasks
 ```
 
-The `resolveSourceArtifacts` task ensures source JARs are included in the metadata, which is required for IDE sync (e.g. IntelliJ automatically downloads sources).
+The `resolveSourceArtifacts` task ensures source JARs are included in the metadata, which is required for IDE sync (e.g. IntelliJ automatically downloads sources). The `:plugin-api:checkAPICompatibility` task resolves the released Plugin API baseline so its artifacts are recorded as well. The `--rerun-tasks` and `--refresh-dependencies` flags make the regeneration behave like a clean checkout: without them, cached task results and cached dependency metadata can produce a silently incomplete file that passes locally but fails on a fresh clone.
 
 ### Profiling Besu
 


### PR DESCRIPTION
### Fixed Issue(s)

Follow-up to #10823, addresses the verification metadata failures reported after merge.

The README regeneration command never resolves the Plugin API baseline (it lives in detached configurations that only resolve when `:plugin-api:checkAPICompatibility` executes), so metadata regenerated with it is missing the baseline checksums and fails on clean checkouts. This updates the command to include the check task plus `--rerun-tasks` and `--refresh-dependencies`, so regeneration produces a complete file regardless of local cache state. 

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR if updates are required in the [Besu documentation](https://github.com/besu-eth/besu-docs).
- [ ] Considered the changelog and [included an update if required](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md#changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://github.com/besu-eth/besu/wiki/Working-through-Hive-tests)
