### PR TITLE
Clear error for enr: bootnodes without discv5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Layered txpool: fix the sender balance check rejecting zero upfront cost transactions from zero balance senders, which caused free gas networks to produce only empty blocks [#10751](https://github.com/besu-eth/besu/pull/10751)
 - Fix `eth_sendRawTransaction` returning `-32603 Internal Error` instead of `-32602 Invalid params` for malformed RLP inputs such as `0x80`. [#10735](https://github.com/besu-eth/besu/issues/10735)
 - Skip DNS discovery records that fail enode conversion (e.g. out-of-range port) instead of dropping the rest of the batch [#10752](https://github.com/besu-eth/besu/pull/10752)
+- Fix misleading "Invalid enode URL syntax" error when an `enr:` bootnode is passed to `--bootnodes` without `--Xv5-discovery-enabled`; Besu now reports a clear error directing the user to enable discv5
 
 ### Additions and Improvements
 - Upgrade jackson dependencies to 2.21.5 and opentelemetry to 1.62.0 [#10775](https://github.com/besu-eth/besu/pull/10775)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 - Layered txpool: fix the sender balance check rejecting zero upfront cost transactions from zero balance senders, which caused free gas networks to produce only empty blocks [#10751](https://github.com/besu-eth/besu/pull/10751)
 - Fix `eth_sendRawTransaction` returning `-32603 Internal Error` instead of `-32602 Invalid params` for malformed RLP inputs such as `0x80`. [#10735](https://github.com/besu-eth/besu/issues/10735)
 - Skip DNS discovery records that fail enode conversion (e.g. out-of-range port) instead of dropping the rest of the batch [#10752](https://github.com/besu-eth/besu/pull/10752)
-- Fix misleading "Invalid enode URL syntax" error when an `enr:` bootnode is passed to `--bootnodes` without `--Xv5-discovery-enabled`; Besu now reports a clear error directing the user to enable discv5
+- Fix misleading "Invalid enode URL syntax" error when an `enr:` bootnode is passed to `--bootnodes` without `--Xv5-discovery-enabled`; Besu now reports a clear error directing the user to enable discv5 [#10845](https://github.com/besu-eth/besu/pull/10845)
 
 ### Additions and Improvements
 - Upgrade jackson dependencies to 2.21.5 and opentelemetry to 1.62.0 [#10775](https://github.com/besu-eth/besu/pull/10775)

--- a/app/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/app/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -2577,6 +2577,17 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
                       })
                   .toList());
         } else {
+          rawBootnodes.stream()
+              .filter(node -> node.regionMatches(true, 0, "enr:", 0, 4))
+              .findFirst()
+              .ifPresent(
+                  enr -> {
+                    throw new ParameterException(
+                        commandLine,
+                        "ENR bootnodes require discv5 discovery. Enable it with --Xv5-discovery-enabled. Invalid bootnode: '"
+                            + enr
+                            + "'.");
+                  });
           final List<EnodeURLImpl> enodes = buildEnodes(rawBootnodes, getEnodeDnsConfiguration());
           DiscoveryConfiguration.assertValidBootnodes(enodes);
           builder.setEnodeBootNodes(enodes);

--- a/app/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/app/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -1057,6 +1057,16 @@ public class BesuCommandTest extends CommandTestAbstract {
   }
 
   @Test
+  public void callingWithEnrBootnodeButV5DisabledMustDisplayError() {
+    parseCommand("--bootnodes", VALID_ENR_1);
+    assertThat(commandOutput.toString(UTF_8)).isEmpty();
+    assertThat(commandErrorOutput.toString(UTF_8))
+        .contains("ENR bootnodes require discv5 discovery")
+        .contains("--Xv5-discovery-enabled")
+        .contains(VALID_ENR_1);
+  }
+
+  @Test
   public void bootnodesOptionMustBeUsed() {
     parseCommand("--bootnodes", String.join(",", VALID_ENODE_STRINGS));
 


### PR DESCRIPTION
## PR description

Passing an `enr:` record to `--bootnodes` without `--Xv5-discovery-enabled` fell through to the v4 enode parser and failed with a misleading `Invalid enode URL syntax` error.

This detects `enr:` entries (case-insensitive) on the v4 bootnode path and reports an actionable error directing the operator to enable discv5, instead of the confusing enode syntax message.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR if updates are required in the [Besu documentation](https://github.com/besu-eth/besu-docs).
- [x] Considered the changelog and [included an update if required](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md#changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://github.com/besu-eth/besu/wiki/Working-through-Hive-tests)
