### PR TITLE
fix(qbft): make RoundState message maps thread-safe

### DIFF
--- a/consensus/qbft-core/src/main/java/org/hyperledger/besu/consensus/qbft/core/statemachine/RoundState.java
+++ b/consensus/qbft-core/src/main/java/org/hyperledger/besu/consensus/qbft/core/statemachine/RoundState.java
@@ -15,9 +15,11 @@
 package org.hyperledger.besu.consensus.qbft.core.statemachine;
 
 import org.hyperledger.besu.consensus.common.bft.ConsensusRoundIdentifier;
+import org.hyperledger.besu.consensus.common.bft.payload.SignedData;
 import org.hyperledger.besu.consensus.qbft.core.messagewrappers.Commit;
 import org.hyperledger.besu.consensus.qbft.core.messagewrappers.Prepare;
 import org.hyperledger.besu.consensus.qbft.core.messagewrappers.Proposal;
+import org.hyperledger.besu.consensus.qbft.core.payload.PreparePayload;
 import org.hyperledger.besu.consensus.qbft.core.types.QbftBlock;
 import org.hyperledger.besu.consensus.qbft.core.validation.MessageValidator;
 import org.hyperledger.besu.crypto.SECPSignature;
@@ -25,7 +27,9 @@ import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.ethereum.mainnet.block.access.list.BlockAccessList;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -48,8 +52,15 @@ public class RoundState {
 
   // Must track the actual Prepare message, not just the sender, as these may need to be reused
   // to send out in a PrepareCertificate.
-  private final Map<Address, Prepare> prepareMessages = new LinkedHashMap<>();
-  private final Map<Address, Commit> commitMessages = new LinkedHashMap<>();
+  //
+  // Synchronized maps: writes (e.g. addCommitMessage) happen on the BFT processor thread while
+  // reads that iterate (e.g. getCommitSeals from block import) can run on another thread. A plain
+  // LinkedHashMap's fail-fast iterator throws ConcurrentModificationException in that case
+  // (see #10806). Insertion order is preserved; every iteration below holds the map's monitor.
+  private final Map<Address, Prepare> prepareMessages =
+      Collections.synchronizedMap(new LinkedHashMap<>());
+  private final Map<Address, Commit> commitMessages =
+      Collections.synchronizedMap(new LinkedHashMap<>());
 
   private boolean prepared = false;
   private boolean committed = false;
@@ -99,8 +110,12 @@ public class RoundState {
     if (proposalMessage.isEmpty()) {
       if (validator.validateProposal(msg)) {
         proposalMessage = Optional.of(msg);
-        prepareMessages.entrySet().removeIf(e -> !validator.validatePrepare(e.getValue()));
-        commitMessages.entrySet().removeIf(e -> !validator.validateCommit(e.getValue()));
+        synchronized (prepareMessages) {
+          prepareMessages.entrySet().removeIf(e -> !validator.validatePrepare(e.getValue()));
+        }
+        synchronized (commitMessages) {
+          commitMessages.entrySet().removeIf(e -> !validator.validateCommit(e.getValue()));
+        }
         updateState();
         return true;
       }
@@ -191,9 +206,11 @@ public class RoundState {
    * @return the commit seals
    */
   public Collection<SECPSignature> getCommitSeals() {
-    return commitMessages.values().stream()
-        .map(cp -> cp.getSignedPayload().getPayload().getCommitSeal())
-        .collect(Collectors.toList());
+    synchronized (commitMessages) {
+      return commitMessages.values().stream()
+          .map(cp -> cp.getSignedPayload().getPayload().getCommitSeal())
+          .collect(Collectors.toList());
+    }
   }
 
   /**
@@ -203,12 +220,17 @@ public class RoundState {
    */
   public Optional<PreparedCertificate> constructPreparedCertificate() {
     if (isPrepared()) {
+      final List<SignedData<PreparePayload>> preparePayloads;
+      synchronized (prepareMessages) {
+        preparePayloads =
+            prepareMessages.values().stream()
+                .map(Prepare::getSignedPayload)
+                .collect(Collectors.toList());
+      }
       return Optional.of(
           new PreparedCertificate(
               proposalMessage.get().getSignedPayload().getPayload().getProposedBlock(),
-              prepareMessages.values().stream()
-                  .map(Prepare::getSignedPayload)
-                  .collect(Collectors.toList()),
+              preparePayloads,
               roundIdentifier.getRoundNumber(),
               proposalMessage.get().getBlockAccessList()));
     }

--- a/consensus/qbft-core/src/test/java/org/hyperledger/besu/consensus/qbft/core/statemachine/RoundStateTest.java
+++ b/consensus/qbft-core/src/test/java/org/hyperledger/besu/consensus/qbft/core/statemachine/RoundStateTest.java
@@ -38,9 +38,13 @@ import org.hyperledger.besu.cryptoservices.NodeKeyUtils;
 import org.hyperledger.besu.datatypes.Hash;
 
 import java.math.BigInteger;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -376,5 +380,70 @@ public class RoundStateTest {
             .map(BftMessage::getSignedPayload)
             .collect(Collectors.toList());
     assertThat(preparedCertificate.get().getPrepares()).isEqualTo(expectedPrepares);
+  }
+
+  @Test
+  public void getCommitSealsIsThreadSafeWhileCommitsAreBeingAdded() throws InterruptedException {
+    when(messageValidator.validateProposal(any())).thenReturn(true);
+    when(messageValidator.validateCommit(any())).thenReturn(true);
+
+    final RoundState roundState = new RoundState(roundIdentifier, 1, messageValidator);
+    roundState.setProposedBlock(
+        validatorMessageFactories
+            .getFirst()
+            .createProposal(
+                roundIdentifier, block, Collections.emptyList(), Collections.emptyList()));
+
+    // Each commit needs a distinct author so it structurally mutates the backing map
+    // (putIfAbsent), which is what makes a fail-fast iterator in getCommitSeals throw.
+    final int commitCount = 500;
+    final List<Commit> commits = new ArrayList<>(commitCount);
+    for (int i = 0; i < commitCount; i++) {
+      final MessageFactory factory = new MessageFactory(NodeKeyUtils.generate(), blockEncoder);
+      commits.add(
+          factory.createCommit(
+              roundIdentifier,
+              blockHash,
+              SIGNATURE_ALGORITHM.createSignature(
+                  BigInteger.valueOf(i + 1), BigInteger.ONE, (byte) 0)));
+    }
+
+    final AtomicReference<Throwable> failure = new AtomicReference<>();
+    final CountDownLatch start = new CountDownLatch(1);
+
+    final Thread writer =
+        new Thread(
+            () -> {
+              try {
+                start.await();
+                for (final Commit commit : commits) {
+                  roundState.addCommitMessage(commit);
+                }
+              } catch (final Throwable t) {
+                failure.compareAndSet(null, t);
+              }
+            });
+
+    final Thread reader =
+        new Thread(
+            () -> {
+              try {
+                start.await();
+                for (int i = 0; i < 5_000 && failure.get() == null; i++) {
+                  roundState.getCommitSeals();
+                }
+              } catch (final Throwable t) {
+                failure.compareAndSet(null, t);
+              }
+            });
+
+    writer.start();
+    reader.start();
+    start.countDown();
+    writer.join(TimeUnit.SECONDS.toMillis(30));
+    reader.join(TimeUnit.SECONDS.toMillis(30));
+
+    assertThat(failure.get()).isNull();
+    assertThat(roundState.getCommitSeals()).hasSize(commitCount);
   }
 }


### PR DESCRIPTION
## PR description

Fixes #10806.

`RoundState` held `prepareMessages` and `commitMessages` in plain `LinkedHashMap`s. Writes (`addCommitMessage` / `addPrepareMessage`, on the BFT processor thread) can run concurrently with reads that iterate the maps:

- `getCommitSeals()` — called from `QbftRound.importBlockToChain()` once quorum is reached
- `constructPreparedCertificate()`

When a commit/prepare is added while one of these iterates, the fail-fast `LinkedHashMap` iterator throws `ConcurrentModificationException`, occasionally failing a block import. The reporter observed this on a permissioned QBFT validator under sustained load, with increasing frequency as GC pressure rose.

This is the same class of bug fixed in #7916/#7920 for `NodeLocalConfigPermissioningController`'s allowlist.

## Changes

- Wrap both maps in `Collections.synchronizedMap(new LinkedHashMap<>())`.
- Hold the map monitor (`synchronized (map) { ... }`) around every iteration: `getCommitSeals()`, the prepare-stream in `constructPreparedCertificate()`, and the two `entrySet().removeIf(...)` calls in `setProposedBlock()`.

Insertion order is preserved (still a `LinkedHashMap` under the wrapper), so commit-seal / prepare ordering is unchanged. `putIfAbsent` and `size()` are individually atomic through the synchronized wrapper.

## Testing

Added `getCommitSealsIsThreadSafeWhileCommitsAreBeingAdded`: one thread adds 500 distinct-author commits while another repeatedly calls `getCommitSeals()`, asserting no exception escapes.

Verified it reproduces the bug — against unpatched `RoundState` the test fails with `ConcurrentModificationException`; with the fix the full `RoundStateTest` suite passes. spotless clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)