### PR TITLE
Cleanup start scripts from pre-Java25 configuration

### DIFF
--- a/app/src/main/scripts/unixStartScript.txt
+++ b/app/src/main/scripts/unixStartScript.txt
@@ -112,11 +112,9 @@ fi
 
 # Add default JVM options here. You can also use JAVA_OPTS and ${optsEnvironmentVar} to pass JVM options to this script.
 if [ "\$JAVA_VERSION" -ge 25 ]; then
-    DEFAULT_JVM_OPTS=@DEFAULT_JVM_OPTS_25@
-elif [ "\$JAVA_VERSION" -ge 21 ]; then
     DEFAULT_JVM_OPTS=${defaultJvmOpts}
 else
-    die "Java version must be at least 21 (detected: \$JAVA_VERSION)"
+    die "Java version must be at least 25 (detected: \$JAVA_VERSION)"
 fi
 
 # Increase the maximum file descriptors if we can.

--- a/app/src/main/scripts/windowsStartScript.txt
+++ b/app/src/main/scripts/windowsStartScript.txt
@@ -90,15 +90,10 @@ if not defined JAVA_VERSION (
 
 @rem Add default JVM options here. You can also use JAVA_OPTS and ${optsEnvironmentVar} to pass JVM options to this script.
 if %JAVA_VERSION% GEQ 25 goto setJvmOpts25
-if %JAVA_VERSION% GEQ 21 goto setJvmOpts21
-echo Java version must be at least 21 (detected: %JAVA_VERSION%)
+echo Java version must be at least 25 (detected: %JAVA_VERSION%)
 goto fail
 
 :setJvmOpts25
-set DEFAULT_JVM_OPTS=@DEFAULT_JVM_OPTS_25@
-goto execute
-
-:setJvmOpts21
 set DEFAULT_JVM_OPTS=${defaultJvmOpts}
 goto execute
 

--- a/build.gradle
+++ b/build.gradle
@@ -952,20 +952,16 @@ run {
   }
 }
 
-def defaultJvmOpts21 = application.applicationDefaultJvmArgs + [
+def defaultJvmOpts25 = application.applicationDefaultJvmArgs + [
   "-XX:MaxHeapFreeRatio=30",
   "-XX:MinHeapFreeRatio=10",
   "-XX:MaxGCPauseMillis=100",
-  "-XX:StartFlightRecording,settings=default.jfc",
-  "-Xlog:jfr*=off"
-]
-
-def defaultJvmOpts25 = defaultJvmOpts21 + [
   "-XX:+UseCompactObjectHeaders",
+  "-XX:StartFlightRecording,settings=default.jfc",
+  "-Xlog:jfr*=off",
   // log4j-layout-template-json opportunistically uses a jctools queue (already on the classpath
   // via netty-all) to recycle buffers for structured logging formats, which triggers the JEP 471
-  // terminally-deprecated sun.misc.Unsafe warning on first use. This flag was only added in
-  // JDK 23, so it must stay in the Java 25+ bucket, not the shared/21+ default JVM args.
+  // terminally-deprecated sun.misc.Unsafe warning on first use.
   "--sun-misc-unsafe-memory-access=allow"
 ]
 
@@ -975,23 +971,10 @@ def evmToolJvmOpts = [
   "-Dsecp256k1.randomize=false"
 ]
 
-def serializeDefaultJvmOpts(opts) {
-  return "'" + opts.collect{ '"' + it.replaceAll(/"/, '\\"').replaceAll(/\$/, '\\$') + '"' }.join(' ') + "'"
-}
-
-def tweakStartScript(createScriptTask, jvmOptsForJava25) {
+def tweakStartScript(createScriptTask) {
   def shortenWindowsClasspath = { line ->
     line.replaceAll(/^set CLASSPATH=.*$/, "set CLASSPATH=%APP_HOME%/lib/*")
   }
-
-  // Replace Java 25 opts placeholder - must be before BESU_HOME replacement
-  createScriptTask.unixScript.text = createScriptTask.unixScript.text
-    .replace('@DEFAULT_JVM_OPTS_25@', jvmOptsForJava25)
-
-  // For Windows, remove the outer single quotes
-  def windowsJvmOpts = jvmOptsForJava25.replaceAll(/^'|'$/, '')
-  createScriptTask.windowsScript.text = createScriptTask.windowsScript.text
-    .replace('@DEFAULT_JVM_OPTS_25@', windowsJvmOpts)
 
   createScriptTask.unixScript.text = createScriptTask.unixScript.text.replace('BESU_HOME', '\$APP_HOME')
   createScriptTask.windowsScript.text = createScriptTask.windowsScript.text.replace('BESU_HOME', '%~dp0..')
@@ -1005,10 +988,10 @@ def tweakStartScript(createScriptTask, jvmOptsForJava25) {
 }
 
 startScripts {
-  defaultJvmOpts = defaultJvmOpts21
+  defaultJvmOpts = defaultJvmOpts25
   unixStartScriptGenerator.template = resources.text.fromFile("${projectDir}/app/src/main/scripts/unixStartScript.txt")
   windowsStartScriptGenerator.template = resources.text.fromFile("${projectDir}/app/src/main/scripts/windowsStartScript.txt")
-  doLast { tweakStartScript(startScripts, serializeDefaultJvmOpts(defaultJvmOpts25)) }
+  doLast { tweakStartScript(startScripts) }
 }
 
 task untunedStartScripts(type: CreateStartScripts) {
@@ -1019,7 +1002,7 @@ task untunedStartScripts(type: CreateStartScripts) {
   defaultJvmOpts = untunedJvmOpts
   unixStartScriptGenerator.template = resources.text.fromFile("${projectDir}/app/src/main/scripts/unixStartScript.txt")
   windowsStartScriptGenerator.template = resources.text.fromFile("${projectDir}/app/src/main/scripts/windowsStartScript.txt")
-  doLast { tweakStartScript(untunedStartScripts, serializeDefaultJvmOpts(untunedJvmOpts)) }
+  doLast { tweakStartScript(untunedStartScripts) }
 }
 
 task evmToolStartScripts(type: CreateStartScripts) {
@@ -1030,7 +1013,7 @@ task evmToolStartScripts(type: CreateStartScripts) {
   defaultJvmOpts = evmToolJvmOpts
   unixStartScriptGenerator.template = resources.text.fromFile("${projectDir}/app/src/main/scripts/unixStartScript.txt")
   windowsStartScriptGenerator.template = resources.text.fromFile("${projectDir}/app/src/main/scripts/windowsStartScript.txt")
-  doLast { tweakStartScript(evmToolStartScripts, serializeDefaultJvmOpts(evmToolJvmOpts)) }
+  doLast { tweakStartScript(evmToolStartScripts) }
 }
 
 task autocomplete(type: JavaExec) {


### PR DESCRIPTION
## PR description

We are already requiring Java25 to run, so removed support for Java21 in startup script as cleanup

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR if updates are required in the [Besu documentation](https://github.com/besu-eth/besu-docs).
- [ ] Considered the changelog and [included an update if required](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md#changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://github.com/besu-eth/besu/wiki/Working-through-Hive-tests)


