### PR TITLE
improve max open files derive mechanism

### DIFF
--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBCLIOptions.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBCLIOptions.java
@@ -29,19 +29,19 @@ public class RocksDBCLIOptions {
   /** The constant DEFAULT_MAX_OPEN_FILES. */
   public static final int DEFAULT_MAX_OPEN_FILES = 1024;
 
-  /** Max open files for machines with at least 4 GiB available memory. */
-  public static final int MAX_OPEN_FILES_4GB = 2048;
-
-  /** Max open files for machines with at least 8 GiB available memory. */
-  public static final int MAX_OPEN_FILES_8GB = 4096;
-
-  /** Max open files for machines with at least 16 GiB available memory. */
-  public static final int MAX_OPEN_FILES_16GB = 8192;
-
-  /** Max open files for machines with at least 32 GiB available memory. */
-  public static final int MAX_OPEN_FILES_32GB = 16384;
-
+  /** Number of bytes in one gibibyte (GiB), {@code 1024^3}. */
   private static final long GIB = 1024L * 1024L * 1024L;
+
+  /** Minimum max-open-files value used when deriving from available memory. */
+  private static final int MIN_MAX_OPEN_FILES = 1024;
+
+  /** Maximum max-open-files value used when deriving from available memory. */
+  private static final int MAX_MAX_OPEN_FILES = 16384;
+
+  /**
+   * Scale factor used to derive max open files from available memory ({@code 512} files per GiB).
+   */
+  private static final int OPEN_FILES_PER_GIB = 512;
 
   /** The constant DEFAULT_CACHE_CAPACITY. */
   public static final long DEFAULT_CACHE_CAPACITY = 134217728;
@@ -261,25 +261,15 @@ public class RocksDBCLIOptions {
   }
 
   /**
-   * Calculates max open files for the given available memory.
+   * Calculates max open files for the given available memory using a continuous scale of 512 files
+   * per GiB, clamped between 1024 and 16384.
    *
    * @param availableMemoryBytes the available memory in bytes
-   * @return the max open files value for the matching memory tier
+   * @return the derived max open files value
    */
   public static int calculateMaxOpenFiles(final long availableMemoryBytes) {
-    if (availableMemoryBytes >= 32L * GIB) {
-      return MAX_OPEN_FILES_32GB;
-    }
-    if (availableMemoryBytes >= 16L * GIB) {
-      return MAX_OPEN_FILES_16GB;
-    }
-    if (availableMemoryBytes >= 8L * GIB) {
-      return MAX_OPEN_FILES_8GB;
-    }
-    if (availableMemoryBytes >= 4L * GIB) {
-      return MAX_OPEN_FILES_4GB;
-    }
-    return DEFAULT_MAX_OPEN_FILES;
+    final long computed = (availableMemoryBytes * OPEN_FILES_PER_GIB) / GIB;
+    return (int) Math.min(MAX_MAX_OPEN_FILES, Math.max(MIN_MAX_OPEN_FILES, computed));
   }
 
   /**

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBCLIOptions.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBCLIOptions.java
@@ -30,7 +30,7 @@ public class RocksDBCLIOptions {
   public static final int DEFAULT_MAX_OPEN_FILES = 1024;
 
   /** Number of bytes in one gibibyte (GiB), {@code 1024^3}. */
-  private static final long GIB = 1024L * 1024L * 1024L;
+  public static final long GIB = 1024L * 1024L * 1024L;
 
   /** Minimum max-open-files value used when deriving from available memory. */
   private static final int MIN_MAX_OPEN_FILES = 1024;

--- a/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBCLIOptionsTest.java
+++ b/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBCLIOptionsTest.java
@@ -20,11 +20,8 @@ import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration
 import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.DEFAULT_CACHE_CAPACITY;
 import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.DEFAULT_IS_HIGH_SPEC;
 import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.DEFAULT_MAX_OPEN_FILES;
+import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.GIB;
 import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.IS_HIGH_SPEC;
-import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.MAX_OPEN_FILES_16GB;
-import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.MAX_OPEN_FILES_32GB;
-import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.MAX_OPEN_FILES_4GB;
-import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.MAX_OPEN_FILES_8GB;
 import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.MAX_OPEN_FILES_FLAG;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -42,7 +39,10 @@ import picocli.CommandLine;
 
 public class RocksDBCLIOptionsTest {
 
-  private static final long GIB = 1024L * 1024L * 1024L;
+  private static final int MAX_OPEN_FILES_4GB = 2048;
+  private static final int MAX_OPEN_FILES_8GB = 4096;
+  private static final int MAX_OPEN_FILES_16GB = 8192;
+  private static final int MAX_OPEN_FILES_32GB = 16384;
 
   @Test
   public void defaultValues() {
@@ -142,6 +142,16 @@ public class RocksDBCLIOptionsTest {
     assertMaxOpenFilesDerivedFromAvailableMemory(8L * GIB, MAX_OPEN_FILES_8GB);
     assertMaxOpenFilesDerivedFromAvailableMemory(16L * GIB, MAX_OPEN_FILES_16GB);
     assertMaxOpenFilesDerivedFromAvailableMemory(32L * GIB, MAX_OPEN_FILES_32GB);
+  }
+
+  @Test
+  public void autoMaxOpenFilesAroundSixteenGibBoundary() {
+    // Continuous scale: 512 files per GiB, so values near 16 GiB are not snapped to 8192.
+    final long fifteenPointNineGib = (159L * GIB) / 10;
+    final long sixteenPointOneGib = (161L * GIB) / 10;
+
+    assertMaxOpenFilesDerivedFromAvailableMemory(fifteenPointNineGib, 8140);
+    assertMaxOpenFilesDerivedFromAvailableMemory(sixteenPointOneGib, 8243);
   }
 
   private static RocksDBFactoryConfiguration toDomainObjectWithAvailableMemory(


### PR DESCRIPTION
## PR description
- Replace the discrete memory tiers for RocksDB `max_open_files` with a continuous formula based on available memory: `512 × available GiB`, with a floor of `1024` and a cap of `16384`.
- This avoids big jumps when available memory is just below or just above a tier threshold.

### Motivation
Today we use fixed thresholds (4 / 8 / 16 / 32 GiB). This is too strict around the boundaries.
For example:
- with **15.9 GiB** available memory → we get **4096** max open files
- with **16.1 GiB** available memory → we get **8192** max open files
So a very small difference in free memory can change a lot the value, and this can impact RocksDB performance a lot.
The continuous formula gives values much closer in this case (~8140 vs ~8243), so the behaviour is more proportional to the real available memory.

### Compatibility / existing behaviour
We keep the same behaviour on the previous tier points:
- 4 GiB → 2048
- 8 GiB → 4096
- 16 GiB → 8192
- 32 GiB → 16384

Also for low memory hosts (< ~2 GiB), we still keep the minimum at `1024`, same as before.
So for machines that were exactly on the old thresholds, nothing changes. The change mainly helps hosts that are between the old tiers (especially just below 8 / 16 / 32 GiB).
Explicit CLI override (`--Xplugin-rocksdb-max-open-files`) is still supported.

### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR if updates are required in the [Besu documentation](https://github.com/besu-eth/besu-docs).
- [ ] Considered the changelog and [included an update if required](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md#changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://github.com/besu-eth/besu/wiki/Working-through-Hive-tests)


