### PR TITLE
fix(test): use createPluginsNode for plugin lifecycle ATs

### DIFF
--- a/acceptance-tests/tests/src/acceptanceTest/java/org/hyperledger/besu/tests/acceptance/plugins/CataloglessPluginTest.java
+++ b/acceptance-tests/tests/src/acceptanceTest/java/org/hyperledger/besu/tests/acceptance/plugins/CataloglessPluginTest.java
@@ -27,7 +27,6 @@ import org.hyperledger.besu.tests.acceptance.dsl.AcceptanceTestBase;
 import org.hyperledger.besu.tests.acceptance.dsl.node.BesuNode;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -38,12 +37,15 @@ public class CataloglessPluginTest extends AcceptanceTestBase {
   @Test
   public void warnOnCataloglessPluginByDefault() throws IOException {
     pluginNode =
-        besu.createQbftPluginsNode(
+        besu.createPluginsNode(
             "pluginNode",
             List.of("cataloglessTestPlugins"),
-            PluginConfiguration.DEFAULT,
-            Collections.emptyList(),
-            "DEBUG");
+            builder ->
+                builder
+                    .jsonRpcEnabled()
+                    .jsonRpcAdmin()
+                    .jsonRpcDebug()
+                    .pluginConfiguration(PluginConfiguration.DEFAULT));
 
     cluster.startConsoleCapture();
     cluster.runNodeStart(pluginNode);
@@ -62,14 +64,18 @@ public class CataloglessPluginTest extends AcceptanceTestBase {
   @Test
   public void failsToStartOnCataloglessPluginIfToldSo() throws IOException {
     pluginNode =
-        besu.createQbftPluginsNode(
+        besu.createPluginsNode(
             "pluginNode",
             List.of("cataloglessTestPlugins"),
-            ImmutablePluginConfiguration.builder()
-                .pluginsVerificationMode(PluginsVerificationMode.FULL)
-                .build(),
-            Collections.emptyList(),
-            "DEBUG");
+            builder ->
+                builder
+                    .jsonRpcEnabled()
+                    .jsonRpcAdmin()
+                    .jsonRpcDebug()
+                    .pluginConfiguration(
+                        ImmutablePluginConfiguration.builder()
+                            .pluginsVerificationMode(PluginsVerificationMode.FULL)
+                            .build()));
 
     cluster.startConsoleCapture();
 

--- a/acceptance-tests/tests/src/acceptanceTest/java/org/hyperledger/besu/tests/acceptance/plugins/DependencyConflictPluginTest.java
+++ b/acceptance-tests/tests/src/acceptanceTest/java/org/hyperledger/besu/tests/acceptance/plugins/DependencyConflictPluginTest.java
@@ -27,7 +27,6 @@ import org.hyperledger.besu.tests.acceptance.dsl.AcceptanceTestBase;
 import org.hyperledger.besu.tests.acceptance.dsl.node.BesuNode;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -38,12 +37,15 @@ public class DependencyConflictPluginTest extends AcceptanceTestBase {
   @Test
   public void warnOnOutdatedPluginByDefault() throws IOException {
     pluginNode =
-        besu.createQbftPluginsNode(
+        besu.createPluginsNode(
             "pluginNode",
             List.of("dependencyConflictPlugin1", "dependencyConflictPlugin2"),
-            PluginConfiguration.DEFAULT,
-            Collections.emptyList(),
-            "DEBUG");
+            builder ->
+                builder
+                    .jsonRpcEnabled()
+                    .jsonRpcAdmin()
+                    .jsonRpcDebug()
+                    .pluginConfiguration(PluginConfiguration.DEFAULT));
 
     cluster.startConsoleCapture();
     cluster.runNodeStart(pluginNode);
@@ -66,14 +68,18 @@ public class DependencyConflictPluginTest extends AcceptanceTestBase {
   @Test
   public void failsToStartOnOutdatedPluginIfToldSo() throws IOException {
     pluginNode =
-        besu.createQbftPluginsNode(
+        besu.createPluginsNode(
             "pluginNode",
             List.of("dependencyConflictPlugin1", "dependencyConflictPlugin2"),
-            ImmutablePluginConfiguration.builder()
-                .pluginsVerificationMode(PluginsVerificationMode.FULL)
-                .build(),
-            Collections.emptyList(),
-            "DEBUG");
+            builder ->
+                builder
+                    .jsonRpcEnabled()
+                    .jsonRpcAdmin()
+                    .jsonRpcDebug()
+                    .pluginConfiguration(
+                        ImmutablePluginConfiguration.builder()
+                            .pluginsVerificationMode(PluginsVerificationMode.FULL)
+                            .build()));
 
     cluster.startConsoleCapture();
 

--- a/acceptance-tests/tests/src/acceptanceTest/java/org/hyperledger/besu/tests/acceptance/plugins/OutdatedPluginTest.java
+++ b/acceptance-tests/tests/src/acceptanceTest/java/org/hyperledger/besu/tests/acceptance/plugins/OutdatedPluginTest.java
@@ -28,7 +28,6 @@ import org.hyperledger.besu.tests.acceptance.dsl.node.BesuNode;
 import org.hyperledger.besu.util.BesuVersionUtils;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -39,12 +38,15 @@ public class OutdatedPluginTest extends AcceptanceTestBase {
   @Test
   public void warnOnOutdatedPluginByDefault() throws IOException {
     pluginNode =
-        besu.createQbftPluginsNode(
+        besu.createPluginsNode(
             "pluginNode",
             List.of("outdatedTestPlugins"),
-            PluginConfiguration.DEFAULT,
-            Collections.emptyList(),
-            "DEBUG");
+            builder ->
+                builder
+                    .jsonRpcEnabled()
+                    .jsonRpcAdmin()
+                    .jsonRpcDebug()
+                    .pluginConfiguration(PluginConfiguration.DEFAULT));
 
     cluster.startConsoleCapture();
     cluster.runNodeStart(pluginNode);
@@ -67,14 +69,18 @@ public class OutdatedPluginTest extends AcceptanceTestBase {
   @Test
   public void failsToStartOnOutdatedPluginIfToldSo() throws IOException {
     pluginNode =
-        besu.createQbftPluginsNode(
+        besu.createPluginsNode(
             "pluginNode",
             List.of("outdatedTestPlugins"),
-            ImmutablePluginConfiguration.builder()
-                .pluginsVerificationMode(PluginsVerificationMode.FULL)
-                .build(),
-            Collections.emptyList(),
-            "DEBUG");
+            builder ->
+                builder
+                    .jsonRpcEnabled()
+                    .jsonRpcAdmin()
+                    .jsonRpcDebug()
+                    .pluginConfiguration(
+                        ImmutablePluginConfiguration.builder()
+                            .pluginsVerificationMode(PluginsVerificationMode.FULL)
+                            .build()));
 
     cluster.startConsoleCapture();
 


### PR DESCRIPTION

## PR description

`OutdatedPluginTest`, `CataloglessPluginTest`, and `DependencyConflictPluginTest` call
`cluster.runNodeStart()` directly instead of `cluster.start()`, which bypasses the private
`Cluster.startNode()` logic that wires up bootnodes and populates genesis config from the
node's genesis provider. Combined with `createQbftPluginsNode()` setting `devMode(false)` and
never setting `.network(...)`, the spawned Besu subprocess ended up with **neither** `--network`
**nor** `--genesis-file` on its command line.

With no network/genesis flag, Besu's CLI silently defaulted to **MAINNET**. Confirmed by running
locally and inspecting the actual subprocess args/logs: no `--network` flag present, real mainnet
fork blocks (`Homestead:1150000`, `DAO:1920000`, ... `Osaka:...`) and 21 real mainnet bootnodes in
the logs, and `TTD difficulty is present, creating initial sync for PoS`. Mainnet's baked-in
terminal total difficulty makes `isMergeEnabled()` true, which auto-starts the Engine JSON-RPC
service on its hardcoded default port (8551) — a service the AT harness's own node model has no
idea is even active, so it never requests an ephemeral port for it. When two such processes (or a
leftover process from a prior run) race for that fixed port on the same CI runner, you get an
intermittent `Address already in use` failure — this is the flake seen on CI
(`OutdatedPluginTest > warnOnOutdatedPluginByDefault() FAILED ... Failed to bind Ethereum JSON-RPC
listener to 127.0.0.1:8551: bind(..) failed with error(-98): Address already in use`).

None of these three tests actually exercise QBFT consensus — they only check `net_services` is
active and grep console output for a plugin WARN/ERROR line — so `createQbftPluginsNode` was never
a real requirement, just a convenient existing factory to reuse. This PR switches all three to the
existing `createPluginsNode(name, plugins, configBuilder)` factory (already used by
`RunVersionTest` with the same `cluster.runNodeStart()` bypass pattern), which defaults to
`devMode(true)` and therefore always passes `--network DEV`. DEV's genesis has no
`terminalTotalDifficulty`, so the whole mainnet-fallback → engine-API-auto-enable → fixed-port
chain is broken at the first link.

Verified locally: CLI args now show `--network DEV` on every process, zero occurrences of `8551`
or mainnet fork data in the logs, and all 6 affected test methods (2 per class × 3 classes) pass.

## Fixed Issue(s)
<!-- No dedicated issue was filed for this flake; found while investigating an unrelated CI failure. -->

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR if updates are required in the [Besu documentation](https://github.com/besu-eth/besu-docs).
- [ ] Considered the changelog and [included an update if required](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md#changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew build`
- [x] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://github.com/besu-eth/besu/wiki/Working-through-Hive-tests)