### PR TITLE
Remove the Plugin API source-hash check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 ### Additions and Improvements
 - Add `--logging-format` CLI option to select structured JSON console logging (`ECS`, `GCP`, `LOGSTASH`, `GELF`) in addition to the default `PLAIN` pattern output, without requiring a custom `LOG4J_CONFIGURATION_FILE`. Each format is a bundled Log4j2 configuration file selected at startup. [#9626](https://github.com/besu-eth/besu/issues/9626)
 - Add a japicmp compatibility check (`:plugin-api:checkAPICompatibility`) that fails the build if the Plugin API changes in any way that is not a pure addition against the last released version [#10823](https://github.com/besu-eth/besu/pull/10823)
+- Remove the Plugin API source-hash check (`:plugin-api:checkAPIChanges`), which fired on any source edit without saying anything about actual compatibility. The japicmp check is now the compatibility gate for the Plugin API [#10879](https://github.com/besu-eth/besu/pull/10879)
 - Update besu-native to 2.0.0
 - Remove the unused `ethereum:verkletrie` module and the `ipa-multipoint` native dependency it pulled in. Verkle trie support had already been fully removed from the storage/worldstate layers in earlier work; this removes the last remaining vestige (standalone Bandersnatch curve arithmetic with no callers).
 - Upgrade jackson dependencies to 2.21.5 and opentelemetry to 1.62.0 [#10775](https://github.com/besu-eth/besu/pull/10775)

--- a/build.gradle
+++ b/build.gradle
@@ -695,9 +695,7 @@ task checkMavenCoordinateCollisions {
   }
 }
 
-tasks.register('checkPluginAPIChanges', DefaultTask) {}
-checkPluginAPIChanges.dependsOn(':plugin-api:checkAPIChanges')
-check.dependsOn('checkPluginAPIChanges', 'checkMavenCoordinateCollisions')
+check.dependsOn('checkMavenCoordinateCollisions')
 
 subprojects {
 

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -11,8 +11,6 @@
  * specific language governing permissions and limitations under the License.
  */
 
-import java.security.MessageDigest
-
 apply plugin: 'java-library'
 apply plugin: 'me.champeau.gradle.japicmp'
 jar {
@@ -40,41 +38,6 @@ dependencies {
 }
 
 configurations { testArtifacts }
-
-class FileStateChecker extends DefaultTask {
-
-  @Input
-  Set<File> files
-
-  @Input
-  String knownHash
-
-  @TaskAction
-  def CheckState() {
-    def digestor = MessageDigest.getInstance("SHA-256")
-
-    this.files.toSorted(Comparator.comparing({it.canonicalPath})).each {
-      digestor.update(it.readBytes())
-    }
-    def currentHash = digestor.digest().encodeBase64().toString()
-    if (this.knownHash != currentHash) {
-      throw new GradleException("""For the Plugin APIs the checksum of the project did not match what was expected.
-
-If this is a deliberate change where you have thought through backwards compatibility,
-then update "Expected" for "Calculated" in the appropriate build.gradle as the knownHash for this task.
-Expected   : ${this.knownHash}
-Calculated : ${currentHash}
-""")
-    }
-  }
-}
-
-tasks.register('checkAPIChanges', FileStateChecker) {
-  description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
-  files = sourceSets.main.allJava.files
-  knownHash = 'wU4MSsEw/Y35zYOTHciA+COCAQw63bjdsFkQt5DJT/k='
-}
-check.dependsOn('checkAPIChanges')
 
 // The released jar to compare against; the transitive configuration lets the baseline
 // type hierarchy resolve, so missing supertypes do not show up as API changes.


### PR DESCRIPTION
### Description

Remove the Plugin API source-hash check (`:plugin-api:checkAPIChanges`).

The `checkAPIChanges` task hashed the module's sources and failed on any edit, requiring a manual restamp each time while saying nothing about actual compatibility. The japicmp check (#10823, `:plugin-api:checkAPICompatibility`) now gates the Plugin API, so the hash task and its `FileStateChecker` class are retired, along with the root-level `checkPluginAPIChanges` umbrella task whose only purpose was delegating to it.

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR if updates are required in the [Besu documentation](https://github.com/besu-eth/besu-docs).
- [x] Considered the changelog and [included an update if required](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md#changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://github.com/besu-eth/besu/wiki/Working-through-Hive-tests)
