### PR TITLE
Enforce presence of requestsHash header field from Prague on

### DIFF
--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV4Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV4Test.java
@@ -26,6 +26,7 @@ import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErr
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -47,6 +48,7 @@ import org.hyperledger.besu.ethereum.mainnet.BodyValidation;
 import org.hyperledger.besu.ethereum.mainnet.requests.MainnetRequestsValidator;
 import org.hyperledger.besu.evm.gascalculator.PragueGasCalculator;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
+import org.hyperledger.besu.plugin.services.rpc.RpcResponseType;
 
 import java.util.List;
 import java.util.Map;
@@ -147,6 +149,49 @@ public class EngineNewPayloadV4Test extends EngineNewPayloadV3Test {
     assertThat(res.getCode()).isEqualTo(INVALID_PARAMS.getCode());
     assertThat(res.getMessage()).isEqualTo("Invalid execution requests params");
     verify(engineCallListener, times(1)).executionEngineCalled();
+  }
+
+  @Test
+  public void shouldRejectMissingRequestsParamAtRpcLayerBeforeBlockProcessing() {
+    // EIP-7685: the RequestsHashPresentValidationRule must not change Engine API error reporting.
+    // An absent executionRequests param (rather than an explicit null) is caught by the sealed
+    // hierarchy's own param-count check before any version-specific parameter parsing runs, so it
+    // surfaces as the generic INVALID_ENGINE_NEW_PAYLOAD_PARAMS error. Either way it must
+    // short-circuit before block processing (where the header rule runs), rather than becoming an
+    // INVALID payload-status success response.
+    final BlockHeader blockHeader = createBlockHeader(getMinSupportedTimestamp());
+
+    var resp =
+        resp(
+            mockEnginePayloadParam(blockHeader, emptyList()),
+            emptyVersionedHashesParam(),
+            zeroParentBeaconBlockRootParam());
+
+    assertThat(resp.getType()).isEqualTo(RpcResponseType.ERROR);
+    assertThat(fromErrorResp(resp).getCode()).isEqualTo(INVALID_PARAMS.getCode());
+    assertThat(fromErrorResp(resp).getMessage())
+        .isEqualTo(INVALID_ENGINE_NEW_PAYLOAD_PARAMS.getMessage());
+    verify(mergeCoordinator, never()).rememberBlock(any(), any());
+  }
+
+  @Test
+  public void shouldReturnValidWhenPraguePayloadHasEmptyExecutionRequests() {
+    // EIP-7685: a Prague block with an empty execution requests list carries the empty requests
+    // hash (not an absent field) and must be accepted. Guards the presence rule against confusing
+    // EMPTY_REQUESTS_HASH with a missing field.
+    final List<Request> emptyRequests = List.of();
+    BlockHeader blockHeader =
+        setupPayloadV4(
+            getMinSupportedTimestamp(),
+            new BlockProcessingResult(
+                Optional.of(
+                    new BlockProcessingOutputs(null, List.of(), Optional.of(emptyRequests)))),
+            emptyRequests);
+
+    var resp =
+        respV4(mockEnginePayloadParam(blockHeader, emptyList()), requestsAsParam(emptyRequests));
+
+    assertValidResponse(blockHeader, resp);
   }
 
   @Test

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/AbstractBlockProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/AbstractBlockProcessor.java
@@ -462,7 +462,16 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
           worldState.updater().updater());
 
       final var optionalRequestsHash = blockHeader.getRequestsHash();
-      if (maybeRequests.isPresent() && optionalRequestsHash.isPresent()) {
+      if (maybeRequests.isPresent()) {
+        if (optionalRequestsHash.isEmpty()) {
+          final String errorMessage =
+              "Block has execution requests but header is missing the requestsHash field";
+          LOG.error(errorMessage);
+          if (worldState instanceof BonsaiWorldState) {
+            ((BonsaiWorldStateUpdateAccumulator) worldState.updater()).reset();
+          }
+          return new BlockProcessingResult(Optional.empty(), errorMessage);
+        }
         final List<Request> requests = maybeRequests.get();
         final Hash headerRequestsHash = optionalRequestsHash.get();
         Hash calculatedRequestHash = BodyValidation.requestsHash(requests);

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetBlockHeaderValidator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetBlockHeaderValidator.java
@@ -30,6 +30,7 @@ import org.hyperledger.besu.ethereum.mainnet.headervalidationrules.IncrementalTi
 import org.hyperledger.besu.ethereum.mainnet.headervalidationrules.NoBlobRule;
 import org.hyperledger.besu.ethereum.mainnet.headervalidationrules.NoDifficultyRule;
 import org.hyperledger.besu.ethereum.mainnet.headervalidationrules.NoNonceRule;
+import org.hyperledger.besu.ethereum.mainnet.headervalidationrules.RequestsHashPresentValidationRule;
 import org.hyperledger.besu.ethereum.mainnet.headervalidationrules.TimestampBoundedByFutureParameter;
 import org.hyperledger.besu.ethereum.mainnet.headervalidationrules.TimestampMoreRecentThanParent;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
@@ -138,5 +139,13 @@ public final class MainnetBlockHeaderValidator {
       final GasLimitCalculator gasLimitCalculator) {
     return mergeBlockHeaderValidator(feeMarket, gasCalculator, gasLimitCalculator)
         .addRule(new BlobGasValidationRule(gasCalculator, gasLimitCalculator));
+  }
+
+  public static BlockHeaderValidator.Builder requestsAwareBlockHeaderValidator(
+      final FeeMarket feeMarket,
+      final GasCalculator gasCalculator,
+      final GasLimitCalculator gasLimitCalculator) {
+    return blobAwareBlockHeaderValidator(feeMarket, gasCalculator, gasLimitCalculator)
+        .addRule(new RequestsHashPresentValidationRule());
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetProtocolSpecs.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetProtocolSpecs.java
@@ -968,6 +968,9 @@ public abstract class MainnetProtocolSpecs {
                         .build())
             // EIP-2935 Blockhash processor
             .preExecutionProcessor(getPraguePreExecutionProcessor(genesisConfigOptions))
+            // EIP-7685: requestsHash header field is mandatory from Prague onwards
+            .blockHeaderValidatorBuilder(
+                MainnetBlockHeaderValidator::requestsAwareBlockHeaderValidator)
             .hardforkId(PRAGUE);
     if (isPoAConsensus(genesisConfigOptions) && !hasSystemContractAddresses(genesisConfigOptions)) {
       LOG.warn(

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/RequestsHashPresentValidationRule.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/RequestsHashPresentValidationRule.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.mainnet.headervalidationrules;
+
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.mainnet.DetachedBlockHeaderValidationRule;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Ensures that a block header carries the {@code requestsHash} field once EIP-7685 is active. From
+ * Prague onwards every block header must include {@code requestsHash}, including blocks whose
+ * execution requests list is empty (in which case the field holds the empty requests hash). A
+ * header that omits the field entirely is invalid regardless of its block body, so this presence
+ * check is intentionally independent of the parent header.
+ */
+public class RequestsHashPresentValidationRule implements DetachedBlockHeaderValidationRule {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(RequestsHashPresentValidationRule.class);
+
+  @Override
+  public boolean validate(final BlockHeader header, final BlockHeader parent) {
+    if (header.getRequestsHash().isEmpty()) {
+      LOG.info(
+          "Invalid block header: requestsHash field is required from Prague onwards but is missing");
+      return false;
+    }
+    return true;
+  }
+
+  @Override
+  public String toString() {
+    return "RequestsHashPresent";
+  }
+}

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/AbstractBlockProcessorIntegrationTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/AbstractBlockProcessorIntegrationTest.java
@@ -101,6 +101,11 @@ class AbstractBlockProcessorIntegrationTest {
   private static final String GENESIS_RESOURCE =
       "/org/hyperledger/besu/ethereum/mainnet/genesis-bp-it.json";
 
+  // Deterministic requests hash produced by the Prague system-contract predeploys for the blocks
+  // built in this test (no test transaction enqueues execution requests).
+  private static final Hash BLOCK_REQUESTS_HASH =
+      Hash.fromHexString("0x5f7606bf4b9eb2a8414aaa53f4c84062ec8789d24c604453563dc26e4ae65837");
+
   @BeforeEach
   public void setUp() {
     final ExecutionContextTestFixture contextTestFixture =
@@ -1165,6 +1170,10 @@ class AbstractBlockProcessorIntegrationTest {
             .stateRoot(Hash.fromHexString(stateRoot))
             .gasLimit(30_000_000L)
             .baseFeePerGas(baseFeePerGas)
+            // Prague is active at genesis here, so the mandatory requestsHash field must be
+            // present. The system-contract predeploys deterministically yield this requests hash
+            // for these blocks (none of the test transactions enqueue new requests).
+            .requestsHash(BLOCK_REQUESTS_HASH)
             .buildHeader();
     BlockBody blockBody =
         new BlockBody(Arrays.asList(transactions), Collections.emptyList(), Optional.empty());

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/MainnetBlockProcessorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/MainnetBlockProcessorTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.Wei;
+import org.hyperledger.besu.ethereum.BlockProcessingResult;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.Block;
@@ -29,10 +30,13 @@ import org.hyperledger.besu.ethereum.core.BlockBody;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.mainnet.blockhash.FrontierPreExecutionProcessor;
+import org.hyperledger.besu.ethereum.mainnet.requests.RequestProcessorCoordinator;
 import org.hyperledger.besu.ethereum.mainnet.staterootcommitter.DefaultStateRootCommitterFactory;
 import org.hyperledger.besu.ethereum.referencetests.ReferenceTestBlockchain;
 import org.hyperledger.besu.ethereum.referencetests.ReferenceTestWorldState;
 import org.hyperledger.besu.plugin.services.worldstate.MutableWorldState;
+
+import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -117,5 +121,75 @@ public class MainnetBlockProcessorTest extends AbstractBlockProcessorTest {
 
     // An empty block with 0 reward should change the world state prior to EIP158
     assertThat(worldState.rootHash()).isNotEqualTo(initialHash);
+  }
+
+  @Test
+  public void rejectsBlockWhenRequestsHashMissingButRequestsProcessed() {
+    // EIP-7685: when a requests processor is configured (Prague+) the header must carry
+    // requestsHash. An absent field must fail rather than silently skip the hash comparison.
+    final Blockchain blockchain = new ReferenceTestBlockchain();
+    when(protocolSpec.getRequestProcessorCoordinator())
+        .thenReturn(Optional.of(RequestProcessorCoordinator.noOp()));
+    final MainnetBlockProcessor blockProcessor =
+        new MainnetBlockProcessor(
+            transactionProcessor,
+            transactionReceiptFactory,
+            Wei.ZERO,
+            BlockHeader::getCoinbase,
+            true,
+            protocolSchedule,
+            BalConfiguration.DEFAULT);
+    final MutableWorldState worldState = ReferenceTestWorldState.create(emptyMap());
+
+    final Block block =
+        new Block(
+            new BlockHeaderTestFixture()
+                .transactionsRoot(Hash.EMPTY_LIST_HASH)
+                .ommersHash(Hash.EMPTY_LIST_HASH)
+                .requestsHash(null)
+                .buildHeader(),
+            BlockBody.empty());
+
+    final BlockProcessingResult result =
+        blockProcessor.processBlock(protocolContext, blockchain, worldState, block);
+
+    assertThat(result.isSuccessful()).isFalse();
+    assertThat(result.errorMessage)
+        .hasValueSatisfying(msg -> assertThat(msg).contains("missing the requestsHash field"));
+  }
+
+  @Test
+  public void rejectsBlockWhenRequestsHashPresentButDoesNotMatch() {
+    // The hash-mismatch path (field present but wrong) must keep its existing error message,
+    // distinct from the missing-field message above.
+    final Blockchain blockchain = new ReferenceTestBlockchain();
+    when(protocolSpec.getRequestProcessorCoordinator())
+        .thenReturn(Optional.of(RequestProcessorCoordinator.noOp()));
+    final MainnetBlockProcessor blockProcessor =
+        new MainnetBlockProcessor(
+            transactionProcessor,
+            transactionReceiptFactory,
+            Wei.ZERO,
+            BlockHeader::getCoinbase,
+            true,
+            protocolSchedule,
+            BalConfiguration.DEFAULT);
+    final MutableWorldState worldState = ReferenceTestWorldState.create(emptyMap());
+
+    final Block block =
+        new Block(
+            new BlockHeaderTestFixture()
+                .transactionsRoot(Hash.EMPTY_LIST_HASH)
+                .ommersHash(Hash.EMPTY_LIST_HASH)
+                .requestsHash(Hash.fromHexStringLenient("0xdeadbeef"))
+                .buildHeader(),
+            BlockBody.empty());
+
+    final BlockProcessingResult result =
+        blockProcessor.processBlock(protocolContext, blockchain, worldState, block);
+
+    assertThat(result.isSuccessful()).isFalse();
+    assertThat(result.errorMessage)
+        .hasValueSatisfying(msg -> assertThat(msg).startsWith("Requests hash mismatch"));
   }
 }

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/RequestsHashMissingBlockImportTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/RequestsHashMissingBlockImportTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.mainnet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.hyperledger.besu.config.GenesisConfig;
+import org.hyperledger.besu.ethereum.core.Block;
+import org.hyperledger.besu.ethereum.core.ExecutionContextTestFixture;
+import org.hyperledger.besu.ethereum.rlp.RLP;
+import org.hyperledger.besu.plugin.services.storage.DataStorageFormat;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.junit.jupiter.api.Test;
+
+/**
+ * EIP-7685: a Prague block whose RLP header omits the mandatory {@code requestsHash} field must be
+ * rejected by full block import rather than accepted as chain head.
+ */
+class RequestsHashMissingBlockImportTest {
+
+  private static final String GENESIS_RESOURCE =
+      "/org/hyperledger/besu/ethereum/mainnet/genesis-prague-missing-requests-hash.json";
+
+  // 575-byte raw block RLP for a Prague block with an empty body and no requestsHash header field.
+  private static final String RAW_BLOCK_RLP_HEX =
+      "0xf9023cf90236a03d1cd8c35772cc88dfe5c96faf999b9497d19e482134fd1ef52f80c0b44ec4bca01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347940000000000000000000000000000000000000000a00f9cfbdcb99570c0d0d3a4ca1f5b827c5f9e2f8a057d54b0602299f27c7e5195a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421b901000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000080018401c9c380800180a0c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a47088000000000000000007a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b4218080a00000000000000000000000000000000000000000000000000000000000004788c0c0c0";
+
+  private static final String EXPECTED_BLOCK_HASH =
+      "0x9e7900131c0cf6634b5645324f324bb43e06325635ed33ce42599083ce100a72";
+
+  @Test
+  void rejectsPragueBlockMissingRequestsHash() {
+    final ExecutionContextTestFixture fixture =
+        ExecutionContextTestFixture.builder(GenesisConfig.fromResource(GENESIS_RESOURCE))
+            .dataStorageFormat(DataStorageFormat.BONSAI)
+            .build();
+
+    final Block block =
+        Block.readFrom(
+            RLP.input(Bytes.fromHexString(RAW_BLOCK_RLP_HEX)), new MainnetBlockHeaderFunctions());
+
+    // Sanity: the requestsHash field really is absent from this block.
+    assertThat(block.getHeader().getRequestsHash()).isEmpty();
+    assertThat(block.getHash().toHexString()).isEqualTo(EXPECTED_BLOCK_HASH);
+
+    final BlockImportResult importResult =
+        fixture
+            .getProtocolSchedule()
+            .getByBlockHeader(block.getHeader())
+            .getBlockImporter()
+            .importBlock(
+                fixture.getProtocolContext(),
+                block,
+                HeaderValidationMode.FULL,
+                HeaderValidationMode.FULL);
+
+    assertThat(importResult.isImported()).isFalse();
+    assertThat(fixture.getBlockchain().contains(block.getHash())).isFalse();
+  }
+
+  @Test
+  void rejectsPragueBlockMissingRequestsHashUnderLightValidation() {
+    // The SNAP/RLPx sync pivot uses light header validation. The presence rule opts into light
+    // validation so this path is covered too.
+    final ExecutionContextTestFixture fixture =
+        ExecutionContextTestFixture.builder(GenesisConfig.fromResource(GENESIS_RESOURCE))
+            .dataStorageFormat(DataStorageFormat.BONSAI)
+            .build();
+
+    final Block block =
+        Block.readFrom(
+            RLP.input(Bytes.fromHexString(RAW_BLOCK_RLP_HEX)), new MainnetBlockHeaderFunctions());
+
+    final BlockImportResult importResult =
+        fixture
+            .getProtocolSchedule()
+            .getByBlockHeader(block.getHeader())
+            .getBlockImporter()
+            .importBlock(
+                fixture.getProtocolContext(),
+                block,
+                HeaderValidationMode.LIGHT,
+                HeaderValidationMode.LIGHT);
+
+    assertThat(importResult.isImported()).isFalse();
+    assertThat(fixture.getBlockchain().contains(block.getHash())).isFalse();
+  }
+}

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/RequestsHashPresentValidationRuleTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/RequestsHashPresentValidationRuleTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.mainnet.headervalidationrules;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
+
+import org.junit.jupiter.api.Test;
+
+class RequestsHashPresentValidationRuleTest {
+
+  private final RequestsHashPresentValidationRule rule = new RequestsHashPresentValidationRule();
+
+  @Test
+  void rejectsHeaderWithMissingRequestsHash() {
+    final BlockHeader parent = new BlockHeaderTestFixture().buildHeader();
+    final BlockHeader header = new BlockHeaderTestFixture().requestsHash(null).buildHeader();
+
+    assertThat(header.getRequestsHash()).isEmpty();
+    assertThat(rule.validate(header, parent)).isFalse();
+  }
+
+  @Test
+  void acceptsHeaderWithEmptyRequestsHash() {
+    final BlockHeader parent = new BlockHeaderTestFixture().buildHeader();
+    final BlockHeader header =
+        new BlockHeaderTestFixture().requestsHash(Hash.EMPTY_REQUESTS_HASH).buildHeader();
+
+    assertThat(rule.validate(header, parent)).isTrue();
+  }
+
+  @Test
+  void acceptsHeaderWithPopulatedRequestsHash() {
+    final BlockHeader parent = new BlockHeaderTestFixture().buildHeader();
+    final BlockHeader header =
+        new BlockHeaderTestFixture()
+            .requestsHash(Hash.fromHexStringLenient("0x1234"))
+            .buildHeader();
+
+    assertThat(rule.validate(header, parent)).isTrue();
+  }
+
+  @Test
+  void includedInLightValidation() {
+    // requestsHash presence is a detached header property and must be enforced even on the
+    // light-validation sync path.
+    assertThat(rule.includeInLightValidation()).isTrue();
+  }
+}

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/parallelization/AbstractParallelBlockProcessorIntegrationTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/parallelization/AbstractParallelBlockProcessorIntegrationTest.java
@@ -204,6 +204,12 @@ public abstract class AbstractParallelBlockProcessorIntegrationTest {
             .stateRoot(stateRoot)
             .gasLimit(30_000_000L)
             .baseFeePerGas(baseFee)
+            // Prague is active at genesis here, so the mandatory requestsHash field must be
+            // present. The system-contract predeploys deterministically yield this requests hash
+            // for these blocks (none of the test transactions enqueue new requests).
+            .requestsHash(
+                Hash.fromHexString(
+                    "0x5f7606bf4b9eb2a8414aaa53f4c84062ec8789d24c604453563dc26e4ae65837"))
             .buildHeader();
     final BlockBody blockBody =
         new BlockBody(Arrays.asList(txs), Collections.emptyList(), Optional.empty());

--- a/ethereum/core/src/test/resources/org/hyperledger/besu/ethereum/mainnet/genesis-prague-missing-requests-hash.json
+++ b/ethereum/core/src/test/resources/org/hyperledger/besu/ethereum/mainnet/genesis-prague-missing-requests-hash.json
@@ -1,0 +1,75 @@
+{
+  "config": {
+    "chainId": 42,
+    "homesteadBlock": 0,
+    "eip150Block": 0,
+    "eip155Block": 0,
+    "eip158Block": 0,
+    "byzantiumBlock": 0,
+    "constantinopleBlock": 0,
+    "petersburgBlock": 0,
+    "istanbulBlock": 0,
+    "muirGlacierBlock": 0,
+    "berlinBlock": 0,
+    "londonBlock": 0,
+    "terminalTotalDifficulty": 0,
+    "shanghaiTime": 0,
+    "cancunTime": 0,
+    "pragueTime": 0,
+    "blobSchedule": {
+      "cancun": {
+        "target": 3,
+        "max": 6,
+        "baseFeeUpdateFraction": 3338477
+      },
+      "prague": {
+        "target": 6,
+        "max": 9,
+        "baseFeeUpdateFraction": 5007716
+      }
+    },
+    "ethash": {},
+    "depositContractAddress": "0x4242424242424242424242424242424242424242",
+    "withdrawalRequestContractAddress": "0x00A3ca265EBcb825B45F985A16CEFB49958cE017",
+    "consolidationRequestContractAddress": "0x00b42dbF2194e931E80326D950320f7d9Dbeac02"
+  },
+  "nonce": "0x0",
+  "timestamp": "0x0",
+  "extraData": "0x",
+  "gasLimit": "0x1C9C380",
+  "difficulty": "0x0",
+  "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "coinbase": "0x0000000000000000000000000000000000000000",
+  "alloc": {
+    "0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02": {
+      "balance": "0x0",
+      "nonce": "0x1",
+      "code": "0x3373fffffffffffffffffffffffffffffffffffffffe14604d57602036146024575f5ffd5b5f35801560495762001fff810690815414603c575f5ffd5b62001fff01545f5260205ff35b5f5ffd5b62001fff42064281555f359062001fff015500",
+      "storage": {}
+    },
+    "0x4242424242424242424242424242424242424242": {
+      "balance": "0x0",
+      "nonce": "0x1",
+      "code": "0x00",
+      "storage": {}
+    },
+    "0x00A3ca265EBcb825B45F985A16CEFB49958cE017": {
+      "balance": "0x0",
+      "nonce": "0x1",
+      "code": "0x00",
+      "storage": {}
+    },
+    "0x00b42dbF2194e931E80326D950320f7d9Dbeac02": {
+      "balance": "0x0",
+      "nonce": "0x1",
+      "code": "0x00",
+      "storage": {}
+    }
+  },
+  "number": "0x0",
+  "gasUsed": "0x0",
+  "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "baseFeePerGas": "0x7",
+  "excessBlobGas": "0x0",
+  "blobGasUsed": "0x0"
+}


### PR DESCRIPTION
## Summary
EIP-7685 requires every post-Prague block header to carry a `requestsHash` field, including blocks with an empty execution requests list (using the empty-list hash). Block import previously accepted headers that omitted the field entirely, since no validation rule checked for its presence independent of the parent header.

## Change
- Adds `RequestsHashPresentValidationRule`, wired into the Prague block header validator, to reject any post-Prague header missing `requestsHash`.

## Test plan
- [x] `RequestsHashPresentValidationRuleTest` — unit coverage for the new rule
- [x] `RequestsHashMissingBlockImportTest` — end-to-end import of a Prague block whose header omits `requestsHash` is rejected