### PR TITLE
Bound devp2p block-gossip fetch work by deduplicating announcements per block number

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/messages/NewBlockHashesMessage.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/messages/NewBlockHashesMessage.java
@@ -21,7 +21,6 @@ import org.hyperledger.besu.ethereum.rlp.BytesValueRLPInput;
 import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
 
 import java.util.Iterator;
-import java.util.Objects;
 
 import com.google.common.collect.Iterators;
 import org.apache.tuweni.bytes.Bytes;
@@ -40,11 +39,10 @@ public final class NewBlockHashesMessage extends AbstractMessageData {
     return new NewBlockHashesMessage(message.getData());
   }
 
-  public static NewBlockHashesMessage create(
-      final Iterable<NewBlockHashesMessage.NewBlockHash> hashes) {
+  public static NewBlockHashesMessage create(final Iterable<BlockAnnouncement> hashes) {
     final BytesValueRLPOutput tmp = new BytesValueRLPOutput();
     tmp.startList();
-    for (final NewBlockHashesMessage.NewBlockHash hash : hashes) {
+    for (final BlockAnnouncement hash : hashes) {
       tmp.startList();
       tmp.writeBytes(hash.hash().getBytes());
       tmp.writeLongScalar(hash.number());
@@ -63,13 +61,13 @@ public final class NewBlockHashesMessage extends AbstractMessageData {
     return EthProtocolMessages.NEW_BLOCK_HASHES;
   }
 
-  public Iterator<NewBlockHashesMessage.NewBlockHash> getNewHashes() {
+  public Iterator<BlockAnnouncement> getNewHashes() {
     return new BytesValueRLPInput(data, false)
         .readList(
             rlpInput -> {
               rlpInput.enterList();
-              final NewBlockHashesMessage.NewBlockHash res =
-                  new NewBlockHashesMessage.NewBlockHash(
+              final BlockAnnouncement res =
+                  new BlockAnnouncement(
                       Hash.wrap(rlpInput.readBytes32()), rlpInput.readLongScalar());
               rlpInput.leaveList();
               return res;
@@ -82,44 +80,11 @@ public final class NewBlockHashesMessage extends AbstractMessageData {
     return Iterators.toString(getNewHashes());
   }
 
-  public static final class NewBlockHash {
-
-    private final Hash hash;
-
-    private final long number;
-
-    public NewBlockHash(final Hash hash, final long number) {
-      this.hash = hash;
-      this.number = number;
-    }
-
-    public long number() {
-      return number;
-    }
-
-    public Hash hash() {
-      return hash;
-    }
+  public record BlockAnnouncement(Hash hash, long number) {
 
     @Override
     public String toString() {
       return number() + " (" + hash() + ")";
-    }
-
-    @Override
-    public boolean equals(final Object that) {
-      if (this == that) {
-        return true;
-      }
-      if (!(that instanceof NewBlockHashesMessage.NewBlockHash other)) {
-        return false;
-      }
-      return other.hash.equals(hash) && other.number == number;
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(hash, number);
     }
   }
 }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/BlockPropagationManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/BlockPropagationManager.java
@@ -32,6 +32,7 @@ import org.hyperledger.besu.ethereum.core.ProcessableBlockHeader;
 import org.hyperledger.besu.ethereum.eth.manager.EthContext;
 import org.hyperledger.besu.ethereum.eth.manager.EthMessage;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeer;
+import org.hyperledger.besu.ethereum.eth.manager.PeerReputation;
 import org.hyperledger.besu.ethereum.eth.manager.peertask.InvalidPeerTaskResponseException;
 import org.hyperledger.besu.ethereum.eth.manager.peertask.PeerTaskExecutorResponseCode;
 import org.hyperledger.besu.ethereum.eth.manager.peertask.PeerTaskExecutorResult;
@@ -40,7 +41,7 @@ import org.hyperledger.besu.ethereum.eth.manager.peertask.task.GetHeadersFromPee
 import org.hyperledger.besu.ethereum.eth.manager.peertask.task.GetHeadersFromPeerTask.Direction;
 import org.hyperledger.besu.ethereum.eth.messages.EthProtocolMessages;
 import org.hyperledger.besu.ethereum.eth.messages.NewBlockHashesMessage;
-import org.hyperledger.besu.ethereum.eth.messages.NewBlockHashesMessage.NewBlockHash;
+import org.hyperledger.besu.ethereum.eth.messages.NewBlockHashesMessage.BlockAnnouncement;
 import org.hyperledger.besu.ethereum.eth.messages.NewBlockMessage;
 import org.hyperledger.besu.ethereum.eth.sync.state.PendingBlocksManager;
 import org.hyperledger.besu.ethereum.eth.sync.state.SyncState;
@@ -57,13 +58,14 @@ import org.hyperledger.besu.plugin.services.MetricsSystem;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
@@ -73,7 +75,6 @@ import java.util.stream.Collectors;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
-import org.apache.tuweni.bytes.Bytes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -346,7 +347,7 @@ public class BlockPropagationManager implements UnverifiedForkchoiceListener {
         return;
       }
 
-      importOrSavePendingBlock(block, message.getPeer().nodeId());
+      importOrSavePendingBlock(block, message.getPeer());
     } catch (final RLPException e) {
       LOG.debug(
           "Malformed NEW_BLOCK message received from peer (BREACH_OF_PROTOCOL), disconnecting: {}",
@@ -360,33 +361,54 @@ public class BlockPropagationManager implements UnverifiedForkchoiceListener {
     final Blockchain blockchain = protocolContext.getBlockchain();
     final NewBlockHashesMessage newBlockHashesMessage =
         NewBlockHashesMessage.readFrom(message.getData());
+    final EthPeer peer = message.getPeer();
+
     try {
       // Register announced blocks
-      final List<NewBlockHash> announcedBlocks =
+      final List<BlockAnnouncement> announcedBlocks =
           Lists.newArrayList(newBlockHashesMessage.getNewHashes());
       LOG.atTrace()
-          .setMessage("New block hashes from network {} from peer {}. Current status {}")
+          .setMessage("New block announcements from network {} from peer {}. Current status {}")
           .addArgument(() -> toLogString(announcedBlocks))
-          .addArgument(message::getPeer)
+          .addArgument(peer)
           .addArgument(this)
           .log();
 
-      for (final NewBlockHash announcedBlock : announcedBlocks) {
-        message.getPeer().registerKnownBlock(announcedBlock.hash());
-        message.getPeer().registerHeight(announcedBlock.hash(), announcedBlock.number());
+      // keep only the first hash seen for each block number
+      final SortedMap<Long, Hash> hashesByBlockNumber = new TreeMap<>();
+      boolean duplicateAnnouncementFound = false;
+      for (final BlockAnnouncement announcedBlock : announcedBlocks) {
+        if (hashesByBlockNumber.containsKey(announcedBlock.number())) {
+          duplicateAnnouncementFound = true;
+          LOG.trace("Duplicate block announcement received from peer {}: {}", peer, announcedBlock);
+        } else {
+          hashesByBlockNumber.put(announcedBlock.number(), announcedBlock.hash());
+        }
       }
+
+      // penalize peer that sends duplicate block announcements
+      if (duplicateAnnouncementFound) {
+        peer.recordUselessResponse("newBlockHashes");
+      }
+
+      // update peer chain state
+      hashesByBlockNumber.forEach(
+          (number, hash) -> {
+            peer.registerKnownBlock(hash);
+            peer.registerHeight(hash, number);
+          });
 
       // Filter announced blocks for blocks we care to import
       final long localChainHeight = protocolContext.getBlockchain().getChainHeadBlockNumber();
       final long bestChainHeight = syncState.bestChainHeight(localChainHeight);
-      final List<NewBlockHash> relevantAnnouncements =
+      final List<BlockAnnouncement> relevantAnnouncements =
           announcedBlocks.stream()
               .filter(a -> shouldImportBlockAtHeight(a.number(), localChainHeight, bestChainHeight))
-              .collect(Collectors.toList());
+              .toList();
 
       // Filter for blocks we don't yet know about
-      final List<NewBlockHash> newBlocks = new ArrayList<>();
-      for (final NewBlockHash announcedBlock : relevantAnnouncements) {
+      final List<BlockAnnouncement> newBlocks = new ArrayList<>();
+      for (final BlockAnnouncement announcedBlock : relevantAnnouncements) {
         if (pendingBlocksManager.contains(announcedBlock.hash())) {
           LOG.trace("New block hash from network {} is already pending", announcedBlock);
           continue;
@@ -403,7 +425,7 @@ public class BlockPropagationManager implements UnverifiedForkchoiceListener {
           LOG.debug("New block hash from network {} is a known bad block", announcedBlock);
           continue;
         }
-        if (processingBlocksManager.addRequestedBlock(announcedBlock.hash())) {
+        if (processingBlocksManager.addRequestedBlock(announcedBlock, peer)) {
           newBlocks.add(announcedBlock);
         } else {
           LOG.trace("New block hash from network {} was already requested", announcedBlock);
@@ -411,15 +433,15 @@ public class BlockPropagationManager implements UnverifiedForkchoiceListener {
       }
 
       // Process known blocks we care about
-      for (final NewBlockHash newBlock : newBlocks) {
-        processAnnouncedBlock(message.getPeer(), newBlock);
+      for (final BlockAnnouncement newBlock : newBlocks) {
+        processAnnouncedBlock(peer, newBlock);
       }
     } catch (final RLPException e) {
       LOG.debug(
           "Malformed NEW_BLOCK_HASHES message received from peer (BREACH_OF_PROTOCOL), disconnecting: {}",
-          message.getPeer(),
+          peer,
           e);
-      message.getPeer().disconnect(DisconnectReason.BREACH_OF_PROTOCOL_MALFORMED_MESSAGE_RECEIVED);
+      peer.disconnect(DisconnectReason.BREACH_OF_PROTOCOL_MALFORMED_MESSAGE_RECEIVED);
     }
   }
 
@@ -429,14 +451,24 @@ public class BlockPropagationManager implements UnverifiedForkchoiceListener {
   }
 
   private CompletableFuture<Block> processAnnouncedBlock(
-      final EthPeer peer, final NewBlockHash blockHash) {
+      final EthPeer peer, final BlockAnnouncement blockHash) {
     LOG.trace("Retrieve announced block by header {} from peers", blockHash);
     return getBlockFromPeers(Optional.of(peer), blockHash.number(), Optional.of(blockHash.hash()));
   }
 
-  private void requestParentBlock(final Block block) {
+  private void requestParentBlock(final Block block, final EthPeer peer) {
     final BlockHeader blockHeader = block.getHeader();
-    if (processingBlocksManager.addRequestedBlock(blockHeader.getParentHash())) {
+    if (blockHeader.getNumber() == 0) {
+      LOG.atDebug()
+          .setMessage("Ignoring parent request for block {} with no parent")
+          .addArgument(blockHeader::toLogString)
+          .log();
+      return;
+    }
+    // Register the block we are about to fetch — the parent — so the entry keys match the
+    // registerReceivedBlock/registerFailedGetBlock removal (which key off the retrieved block).
+    if (processingBlocksManager.addRequestedBlock(
+        new BlockAnnouncement(blockHeader.getParentHash(), blockHeader.getNumber() - 1L), peer)) {
       retrieveParentBlock(blockHeader);
     } else {
       LOG.debug("Parent block with hash {} is already requested", blockHeader.getParentHash());
@@ -558,7 +590,7 @@ public class BlockPropagationManager implements UnverifiedForkchoiceListener {
             blockExecutorResult ->
                 importOrSavePendingBlock(
                     blockExecutorResult.result().get().getFirst(),
-                    blockExecutorResult.ethPeers().getLast().nodeId()))
+                    blockExecutorResult.ethPeers().getLast()))
         .orTimeout(TIMEOUT, TimeUnit.MILLISECONDS);
   }
 
@@ -628,10 +660,7 @@ public class BlockPropagationManager implements UnverifiedForkchoiceListener {
   }
 
   @VisibleForTesting
-  CompletableFuture<Block> importOrSavePendingBlock(final Block block, final Bytes nodeId) {
-    // Synchronize to avoid race condition where block import event fires after the
-    // blockchain.contains() check and before the block is registered, causing onBlockAdded() to be
-    // invoked for the parent of this block before we are able to register it.
+  CompletableFuture<Block> importOrSavePendingBlock(final Block block, final EthPeer peer) {
     LOG.atTrace()
         .setMessage("Import or save pending block {}")
         .addArgument(block::toLogString)
@@ -647,9 +676,9 @@ public class BlockPropagationManager implements UnverifiedForkchoiceListener {
 
     if (!protocolContext.getBlockchain().contains(block.getHeader().getParentHash())) {
       // Block isn't connected to local chain, save it to pending blocks collection
-      if (savePendingBlock(block, nodeId)) {
+      if (savePendingBlock(block, peer)) {
         // if block is saved as pending, try to resolve it
-        maybeProcessPendingBlocks(block);
+        maybeProcessPendingBlocks(block, peer);
       }
       return CompletableFuture.completedFuture(block);
     }
@@ -695,12 +724,12 @@ public class BlockPropagationManager implements UnverifiedForkchoiceListener {
    * Save the given block.
    *
    * @param block the block to track
-   * @param nodeId node that sent the block
+   * @param peer node that sent the block
    * @return true if the block was added (was not previously present)
    */
-  private boolean savePendingBlock(final Block block, final Bytes nodeId) {
+  private boolean savePendingBlock(final Block block, final EthPeer peer) {
     synchronized (pendingBlocksManager) {
-      if (pendingBlocksManager.registerPendingBlock(block, nodeId)) {
+      if (pendingBlocksManager.registerPendingBlock(block, peer)) {
         LOG.info(
             "Saved announced block for future import {} - {} saved block(s)",
             block.toLogString(),
@@ -715,7 +744,7 @@ public class BlockPropagationManager implements UnverifiedForkchoiceListener {
    * Try to request the lowest ancestor for the given pending block or process the descendants if
    * the ancestor is already in the chain
    */
-  private void maybeProcessPendingBlocks(final Block block) {
+  private void maybeProcessPendingBlocks(final Block block, final EthPeer peer) {
     // Try to get the lowest ancestor pending for this block, so we can import it
     final Optional<Block> lowestPending = pendingBlocksManager.pendingAncestorBlockOf(block);
     if (lowestPending.isPresent()) {
@@ -724,7 +753,7 @@ public class BlockPropagationManager implements UnverifiedForkchoiceListener {
       if (!protocolContext
           .getBlockchain()
           .contains(lowestPendingBlock.getHeader().getParentHash())) {
-        requestParentBlock(lowestPendingBlock);
+        requestParentBlock(lowestPendingBlock, peer);
       } else {
         LOG.trace("Parent block is already in the chain");
         // if the parent is already imported, process its children
@@ -784,9 +813,9 @@ public class BlockPropagationManager implements UnverifiedForkchoiceListener {
         && importRange.contains(distanceFromBestPeer);
   }
 
-  private String toLogString(final Collection<NewBlockHash> newBlockHashs) {
-    return newBlockHashs.stream()
-        .map(NewBlockHash::toString)
+  private String toLogString(final Collection<BlockAnnouncement> blockAnnouncements) {
+    return blockAnnouncements.stream()
+        .map(BlockAnnouncement::toString)
         .collect(Collectors.joining(", ", "[", "]"));
   }
 
@@ -820,39 +849,87 @@ public class BlockPropagationManager implements UnverifiedForkchoiceListener {
   }
 
   static class ProcessingBlocksManager {
-    private final Set<Hash> importingBlocks = Collections.newSetFromMap(new ConcurrentHashMap<>());
-    private final Set<Hash> requestedBlocks = Collections.newSetFromMap(new ConcurrentHashMap<>());
-    private final Set<Long> requestedNonAnnouncedBlocks =
-        Collections.newSetFromMap(new ConcurrentHashMap<>());
+    record HashAndPeer(Hash hash, EthPeer peer) {}
 
-    boolean addRequestedBlock(final Hash hash) {
-      return requestedBlocks.add(hash);
+    private final Set<Hash> importingBlocks = new HashSet<>();
+    private final SortedMap<Long, HashAndPeer> requestedBlocksByNumber = new TreeMap<>();
+    private final Set<Long> requestedNonAnnouncedBlocks = new HashSet<>();
+
+    synchronized boolean addRequestedBlock(
+        final BlockAnnouncement announcement, final EthPeer peer) {
+      if (requestedBlocksByNumber.containsKey(announcement.number())) {
+        final HashAndPeer existing = requestedBlocksByNumber.get(announcement.number());
+        if (existing.hash.equals(announcement.hash())) {
+          LOG.debug(
+              "New block announcement {} from peer {} is already being requested from peer {}",
+              announcement,
+              peer,
+              existing.peer);
+          return false;
+        }
+
+        // duplicate block announcement from same peer, ignore
+        if (existing.peer.equals(peer)) {
+          return false;
+        }
+
+        // the block number is the same, but the hash differs, accept the announcement only if the
+        // incoming peer has a better reputation
+        final PeerReputation incomingPeerReputation = peer.getReputation();
+        final PeerReputation existingPeerReputation = existing.peer.getReputation();
+        LOG.debug(
+            "New block announcement {} from peer {} has same number as existing announcement {} but different hash from peer {}",
+            announcement,
+            peer,
+            existing.hash,
+            existing.peer);
+        if (incomingPeerReputation.compareTo(existingPeerReputation) > 0) {
+          LOG.debug(
+              "Incoming peer reputation {} is better than existing peer reputation {} accepting the new announcement",
+              incomingPeerReputation,
+              existingPeerReputation);
+          requestedBlocksByNumber.put(
+              announcement.number(), new HashAndPeer(announcement.hash(), peer));
+          return true;
+        }
+        return false;
+      }
+      requestedBlocksByNumber.put(
+          announcement.number(), new HashAndPeer(announcement.hash(), peer));
+      return true;
     }
 
-    public boolean addNonAnnouncedBlocks(final long blockNumber) {
+    synchronized boolean addNonAnnouncedBlocks(final long blockNumber) {
       return requestedNonAnnouncedBlocks.add(blockNumber);
     }
 
-    public boolean alreadyImporting(final Hash hash) {
+    synchronized boolean alreadyImporting(final Hash hash) {
       return importingBlocks.contains(hash);
     }
 
-    public synchronized void registerReceivedBlock(final Block block) {
-      requestedBlocks.remove(block.getHash());
+    synchronized void registerReceivedBlock(final Block block) {
+      requestedBlocksByNumber.computeIfPresent(
+          block.getHeader().getNumber(),
+          (_, baap) -> block.getHash().equals(baap.hash()) ? null : baap);
       requestedNonAnnouncedBlocks.remove(block.getHeader().getNumber());
     }
 
-    public synchronized void registerFailedGetBlock(
+    synchronized void registerFailedGetBlock(
         final long blockNumber, final Optional<Hash> maybeBlockHash) {
       requestedNonAnnouncedBlocks.remove(blockNumber);
-      maybeBlockHash.ifPresent(requestedBlocks::remove);
+      if (maybeBlockHash.isPresent()) {
+        requestedBlocksByNumber.computeIfPresent(
+            blockNumber, (_, hap) -> maybeBlockHash.get().equals(hap.hash()) ? null : hap);
+      } else {
+        requestedBlocksByNumber.remove(blockNumber);
+      }
     }
 
-    public boolean addImportingBlock(final Hash hash) {
+    synchronized boolean addImportingBlock(final Hash hash) {
       return importingBlocks.add(hash);
     }
 
-    public void registerBlockImportDone(final Hash hash) {
+    synchronized void registerBlockImportDone(final Hash hash) {
       importingBlocks.remove(hash);
     }
 
@@ -861,8 +938,8 @@ public class BlockPropagationManager implements UnverifiedForkchoiceListener {
       return "ProcessingBlocksManager{"
           + "importingBlocks="
           + importingBlocks
-          + ", requestedBlocks="
-          + requestedBlocks
+          + ", requestedBlocksByNumber="
+          + requestedBlocksByNumber
           + ", requestedNonAnnouncedBlocks="
           + requestedNonAnnouncedBlocks
           + '}';

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/state/PendingBlocksManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/state/PendingBlocksManager.java
@@ -19,6 +19,7 @@ import static java.util.Collections.newSetFromMap;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.eth.manager.EthPeer;
 import org.hyperledger.besu.ethereum.eth.sync.SynchronizerConfiguration;
 import org.hyperledger.besu.ethereum.eth.sync.state.cache.ImmutablePendingBlock;
 import org.hyperledger.besu.ethereum.eth.sync.state.cache.PendingBlockCache;
@@ -32,8 +33,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
-
-import org.apache.tuweni.bytes.Bytes;
 
 public class PendingBlocksManager {
 
@@ -53,14 +52,15 @@ public class PendingBlocksManager {
    * Track the given block.
    *
    * @param block the block to track
-   * @param nodeId node that sent the block
+   * @param peer node that sent the block
    * @return true if the block was added (was not previously present)
    */
-  public boolean registerPendingBlock(final Block block, final Bytes nodeId) {
+  public boolean registerPendingBlock(final Block block, final EthPeer peer) {
 
     final ImmutablePendingBlock previousValue =
         this.pendingBlocks.putIfAbsent(
-            block.getHash(), ImmutablePendingBlock.builder().block(block).nodeId(nodeId).build());
+            block.getHash(),
+            ImmutablePendingBlock.builder().block(block).nodeId(peer.nodeId()).build());
     if (previousValue != null) {
       return false;
     }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/messages/NewBlockHashesMessageTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/messages/NewBlockHashesMessageTest.java
@@ -38,7 +38,7 @@ public final class NewBlockHashesMessageTest {
 
   @Test
   public void blockHeadersRoundTrip() throws IOException {
-    final List<NewBlockHashesMessage.NewBlockHash> hashes = new ArrayList<>();
+    final List<NewBlockHashesMessage.BlockAnnouncement> hashes = new ArrayList<>();
     final ByteBuffer buffer =
         ByteBuffer.wrap(Resources.toByteArray(this.getClass().getResource("/50.blocks")));
     for (int i = 0; i < 50; ++i) {
@@ -49,7 +49,7 @@ public final class NewBlockHashesMessageTest {
       final RLPInput oneBlock = new BytesValueRLPInput(Bytes.wrap(block), false);
       oneBlock.enterList();
       final BlockHeader header = BlockHeader.readFrom(oneBlock, new MainnetBlockHeaderFunctions());
-      hashes.add(new NewBlockHashesMessage.NewBlockHash(header.getHash(), header.getNumber()));
+      hashes.add(new NewBlockHashesMessage.BlockAnnouncement(header.getHash(), header.getNumber()));
       // We don't care about the bodies, just the header hashes
       oneBlock.skipNext();
       oneBlock.skipNext();
@@ -58,7 +58,7 @@ public final class NewBlockHashesMessageTest {
     final MessageData raw =
         new RawMessage(EthProtocolMessages.NEW_BLOCK_HASHES, initialMessage.getData());
     final NewBlockHashesMessage message = NewBlockHashesMessage.readFrom(raw);
-    final Iterator<NewBlockHashesMessage.NewBlockHash> readHeaders = message.getNewHashes();
+    final Iterator<NewBlockHashesMessage.BlockAnnouncement> readHeaders = message.getNewHashes();
     for (int i = 0; i < 50; ++i) {
       Assertions.assertThat(readHeaders.next()).isEqualTo(hashes.get(i));
     }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/AbstractBlockPropagationManagerTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/AbstractBlockPropagationManagerTest.java
@@ -51,6 +51,7 @@ import org.hyperledger.besu.ethereum.eth.manager.EthProtocolManager;
 import org.hyperledger.besu.ethereum.eth.manager.EthProtocolManagerTestBuilder;
 import org.hyperledger.besu.ethereum.eth.manager.EthProtocolManagerTestUtil;
 import org.hyperledger.besu.ethereum.eth.manager.EthScheduler;
+import org.hyperledger.besu.ethereum.eth.manager.PeerReputation;
 import org.hyperledger.besu.ethereum.eth.manager.RespondingEthPeer;
 import org.hyperledger.besu.ethereum.eth.manager.RespondingEthPeer.Responder;
 import org.hyperledger.besu.ethereum.eth.manager.peertask.PeerTaskExecutor;
@@ -90,7 +91,13 @@ import org.mockito.stubbing.Answer;
 
 public abstract class AbstractBlockPropagationManagerTest {
 
-  private static final Bytes NODE_ID_1 = Bytes.fromHexString("0x00");
+  private static final EthPeer PEER_1 = peerWithNodeId(Bytes.fromHexString("0x00"));
+
+  private static EthPeer peerWithNodeId(final Bytes nodeId) {
+    final EthPeer peer = mock(EthPeer.class);
+    when(peer.nodeId()).thenReturn(nodeId);
+    return peer;
+  }
 
   protected BlockchainSetupUtil blockchainUtil;
   protected ProtocolSchedule protocolSchedule;
@@ -189,12 +196,12 @@ public abstract class AbstractBlockPropagationManagerTest {
     final NewBlockHashesMessage nextAnnouncement =
         NewBlockHashesMessage.create(
             Collections.singletonList(
-                new NewBlockHashesMessage.NewBlockHash(
+                new NewBlockHashesMessage.BlockAnnouncement(
                     nextBlock.getHash(), nextBlock.getHeader().getNumber())));
     final NewBlockHashesMessage nextNextAnnouncement =
         NewBlockHashesMessage.create(
             Collections.singletonList(
-                new NewBlockHashesMessage.NewBlockHash(
+                new NewBlockHashesMessage.BlockAnnouncement(
                     nextNextBlock.getHash(), nextNextBlock.getHeader().getNumber())));
     final Responder responder = RespondingEthPeer.blockchainResponder(getFullBlockchain());
 
@@ -226,12 +233,12 @@ public abstract class AbstractBlockPropagationManagerTest {
     final NewBlockHashesMessage nextAnnouncement =
         NewBlockHashesMessage.create(
             Collections.singletonList(
-                new NewBlockHashesMessage.NewBlockHash(
+                new NewBlockHashesMessage.BlockAnnouncement(
                     nextBlock.getHash(), nextBlock.getHeader().getNumber())));
     final NewBlockHashesMessage nextNextAnnouncement =
         NewBlockHashesMessage.create(
             Collections.singletonList(
-                new NewBlockHashesMessage.NewBlockHash(
+                new NewBlockHashesMessage.BlockAnnouncement(
                     nextNextBlock.getHash(), nextNextBlock.getHeader().getNumber())));
     final Responder responder = RespondingEthPeer.blockchainResponder(getFullBlockchain());
 
@@ -341,7 +348,7 @@ public abstract class AbstractBlockPropagationManagerTest {
     final NewBlockHashesMessage block1Msg =
         NewBlockHashesMessage.create(
             Collections.singletonList(
-                new NewBlockHashesMessage.NewBlockHash(
+                new NewBlockHashesMessage.BlockAnnouncement(
                     block1.getHash(), block1.getHeader().getNumber())));
     final NewBlockMessage block2Msg =
         NewBlockMessage.create(
@@ -351,7 +358,7 @@ public abstract class AbstractBlockPropagationManagerTest {
     final NewBlockHashesMessage block3Msg =
         NewBlockHashesMessage.create(
             Collections.singletonList(
-                new NewBlockHashesMessage.NewBlockHash(
+                new NewBlockHashesMessage.BlockAnnouncement(
                     block3.getHash(), block3.getHeader().getNumber())));
     final NewBlockMessage block4Msg =
         NewBlockMessage.create(
@@ -408,7 +415,7 @@ public abstract class AbstractBlockPropagationManagerTest {
     final NewBlockHashesMessage newBlockHash =
         NewBlockHashesMessage.create(
             Collections.singletonList(
-                new NewBlockHashesMessage.NewBlockHash(
+                new NewBlockHashesMessage.BlockAnnouncement(
                     nextBlock.getHash(), nextBlock.getHeader().getNumber())));
     final NewBlockMessage newBlock =
         NewBlockMessage.create(
@@ -429,6 +436,122 @@ public abstract class AbstractBlockPropagationManagerTest {
 
     assertThat(blockchain.contains(nextBlock.getHash())).isTrue();
     verify(stubBlockImporter, times(1)).importBlock(eq(protocolContext), eq(nextBlock), any());
+  }
+
+  @Test
+  public void dedupesDifferentHashesForTheSameNumberInSingleMessage() {
+    final ProtocolSchedule stubProtocolSchedule = spy(protocolSchedule);
+    final ProtocolSpec stubProtocolSpec = spy(protocolSchedule.getByBlockHeader(blockHeader(2)));
+    final BlockImporter stubBlockImporter = spy(stubProtocolSpec.getBlockImporter());
+    doReturn(stubProtocolSpec).when(stubProtocolSchedule).getByBlockHeader(any());
+    doReturn(stubBlockImporter).when(stubProtocolSpec).getBlockImporter();
+    final BlockPropagationManager blockPropagationManager =
+        new BlockPropagationManager(
+            syncConfig,
+            stubProtocolSchedule,
+            protocolContext,
+            ethProtocolManager.ethContext(),
+            syncState,
+            pendingBlocksManager,
+            metricsSystem,
+            blockBroadcaster);
+
+    blockchainUtil.importFirstBlocks(2);
+    final Block nextBlock = blockchainUtil.getBlock(2);
+    assertThat(blockchain.contains(nextBlock.getHash())).isFalse();
+
+    blockPropagationManager.start();
+
+    final RespondingEthPeer peer = EthProtocolManagerTestUtil.createPeer(ethProtocolManager, 0);
+    // One message announcing the real block plus a bogus, different hash at the SAME number. The
+    // real announcement is first, so only it is requested; the second is deduped by block number.
+    final NewBlockHashesMessage message =
+        NewBlockHashesMessage.create(
+            List.of(
+                new NewBlockHashesMessage.BlockAnnouncement(
+                    nextBlock.getHash(), nextBlock.getHeader().getNumber()),
+                new NewBlockHashesMessage.BlockAnnouncement(
+                    Hash.fromHexString("0x" + "de".repeat(32)),
+                    nextBlock.getHeader().getNumber())));
+    final Responder responder = RespondingEthPeer.blockchainResponder(getFullBlockchain());
+
+    EthProtocolManagerTestUtil.broadcastMessage(ethProtocolManager, peer, message);
+    peer.respondWhile(responder, peer::hasOutstandingRequests);
+
+    assertThat(blockchain.contains(nextBlock.getHash())).isTrue();
+    // imported exactly once — the second (different-hash, same-number) announcement was deduped
+    verify(stubBlockImporter, times(1)).importBlock(eq(protocolContext), eq(nextBlock), any());
+  }
+
+  @Test
+  public void penalizesPeerThatAnnouncesDuplicateBlockNumbersInSingleMessage() {
+    final BlockPropagationManager blockPropagationManager =
+        new BlockPropagationManager(
+            syncConfig,
+            protocolSchedule,
+            protocolContext,
+            ethProtocolManager.ethContext(),
+            syncState,
+            pendingBlocksManager,
+            metricsSystem,
+            blockBroadcaster);
+
+    blockchainUtil.importFirstBlocks(2);
+    final Block nextBlock = blockchainUtil.getBlock(2);
+
+    blockPropagationManager.start();
+
+    final RespondingEthPeer peer = EthProtocolManagerTestUtil.createPeer(ethProtocolManager, 0);
+    // Two announcements for the SAME block number (different hashes) in one message: abusive, since
+    // a well-behaved peer announces one hash per number.
+    final NewBlockHashesMessage message =
+        NewBlockHashesMessage.create(
+            List.of(
+                new NewBlockHashesMessage.BlockAnnouncement(
+                    nextBlock.getHash(), nextBlock.getHeader().getNumber()),
+                new NewBlockHashesMessage.BlockAnnouncement(
+                    Hash.fromHexString("0x" + "de".repeat(32)),
+                    nextBlock.getHeader().getNumber())));
+
+    EthProtocolManagerTestUtil.broadcastMessage(ethProtocolManager, peer, message);
+
+    // The peer is penalized: its reputation drops below a freshly-connected peer's.
+    assertThat(peer.getEthPeer().getReputation().compareTo(new PeerReputation())).isLessThan(0);
+  }
+
+  @Test
+  public void doesNotPenalizePeerForDistinctBlockNumberAnnouncements() {
+    final BlockPropagationManager blockPropagationManager =
+        new BlockPropagationManager(
+            syncConfig,
+            protocolSchedule,
+            protocolContext,
+            ethProtocolManager.ethContext(),
+            syncState,
+            pendingBlocksManager,
+            metricsSystem,
+            blockBroadcaster);
+
+    blockchainUtil.importFirstBlocks(2);
+    final Block block2 = blockchainUtil.getBlock(2);
+    final Block block3 = blockchainUtil.getBlock(3);
+
+    blockPropagationManager.start();
+
+    final RespondingEthPeer peer = EthProtocolManagerTestUtil.createPeer(ethProtocolManager, 0);
+    // One hash per distinct block number: legitimate, must not be penalized.
+    final NewBlockHashesMessage message =
+        NewBlockHashesMessage.create(
+            List.of(
+                new NewBlockHashesMessage.BlockAnnouncement(
+                    block2.getHash(), block2.getHeader().getNumber()),
+                new NewBlockHashesMessage.BlockAnnouncement(
+                    block3.getHash(), block3.getHeader().getNumber())));
+
+    EthProtocolManagerTestUtil.broadcastMessage(ethProtocolManager, peer, message);
+
+    // No duplicate numbers → reputation unchanged from a freshly-connected peer's.
+    assertThat(peer.getEthPeer().getReputation().compareTo(new PeerReputation())).isEqualTo(0);
   }
 
   @Test
@@ -461,7 +584,7 @@ public abstract class AbstractBlockPropagationManagerTest {
     final NewBlockHashesMessage newBlockHash =
         NewBlockHashesMessage.create(
             Collections.singletonList(
-                new NewBlockHashesMessage.NewBlockHash(
+                new NewBlockHashesMessage.BlockAnnouncement(
                     nextBlock.getHash(), nextBlock.getHeader().getNumber())));
     final NewBlockMessage newBlock =
         NewBlockMessage.create(
@@ -496,7 +619,7 @@ public abstract class AbstractBlockPropagationManagerTest {
     final NewBlockHashesMessage futureAnnouncement =
         NewBlockHashesMessage.create(
             Collections.singletonList(
-                new NewBlockHashesMessage.NewBlockHash(
+                new NewBlockHashesMessage.BlockAnnouncement(
                     futureBlock.getHash(), futureBlock.getHeader().getNumber())));
 
     // Broadcast
@@ -551,7 +674,7 @@ public abstract class AbstractBlockPropagationManagerTest {
     final NewBlockHashesMessage oldAnnouncement =
         NewBlockHashesMessage.create(
             Collections.singletonList(
-                new NewBlockHashesMessage.NewBlockHash(
+                new NewBlockHashesMessage.BlockAnnouncement(
                     oldBlock.getHash(), oldBlock.getHeader().getNumber())));
 
     // Broadcast
@@ -559,7 +682,7 @@ public abstract class AbstractBlockPropagationManagerTest {
     final Responder responder = RespondingEthPeer.blockchainResponder(getFullBlockchain());
     peer.respondWhile(responder, peer::hasOutstandingRequests);
 
-    verify(propManager, times(0)).importOrSavePendingBlock(any(), any(Bytes.class));
+    verify(propManager, times(0)).importOrSavePendingBlock(any(), any(EthPeer.class));
     assertThat(blockchain.contains(oldBlock.getHash())).isFalse();
   }
 
@@ -586,7 +709,7 @@ public abstract class AbstractBlockPropagationManagerTest {
     final Responder responder = RespondingEthPeer.blockchainResponder(getFullBlockchain());
     peer.respondWhile(responder, peer::hasOutstandingRequests);
 
-    verify(propManager, times(0)).importOrSavePendingBlock(any(), any(Bytes.class));
+    verify(propManager, times(0)).importOrSavePendingBlock(any(), any(EthPeer.class));
     assertThat(blockchain.contains(oldBlock.getHash())).isFalse();
   }
 
@@ -707,10 +830,62 @@ public abstract class AbstractBlockPropagationManagerTest {
     blockchainUtil.importFirstBlocks(2);
     final Block nextBlock = blockchainUtil.getBlock(2);
 
-    blockPropagationManager.importOrSavePendingBlock(nextBlock, NODE_ID_1);
-    blockPropagationManager.importOrSavePendingBlock(nextBlock, NODE_ID_1);
+    blockPropagationManager.importOrSavePendingBlock(nextBlock, PEER_1);
+    blockPropagationManager.importOrSavePendingBlock(nextBlock, PEER_1);
 
     verify(ethScheduler, times(1)).scheduleSyncWorkerTask(any(Supplier.class));
+  }
+
+  @Test
+  public void shouldNotRequestParentForPendingBlockAtNumberZero() {
+    // A peer can announce a bogus block at number 0 with an unknown parent. Retrieving its
+    // "parent" would request block number -1 and register a bogus requestedBlocksByNumber entry;
+    // the genesis guard in requestParentBlock must skip it, scheduling no fetch at all.
+    final EthScheduler ethScheduler = mock(EthScheduler.class);
+    final EthContext ethContext =
+        new EthContext(
+            new EthPeers(
+                () -> protocolSchedule.getByBlockHeader(blockchain.getChainHeadHeader()),
+                TestClock.fixed(),
+                metricsSystem,
+                EthProtocolConfiguration.DEFAULT_MAX_MESSAGE_SIZE,
+                Collections.emptyList(),
+                Bytes.random(64),
+                25,
+                25,
+                false,
+                SyncMode.SNAP,
+                new ForkIdManager(blockchain, Collections.emptyList(), Collections.emptyList())),
+            new EthMessages(),
+            ethScheduler,
+            null);
+    final BlockPropagationManager blockPropagationManager =
+        new BlockPropagationManager(
+            syncConfig,
+            protocolSchedule,
+            protocolContext,
+            ethContext,
+            syncState,
+            pendingBlocksManager,
+            metricsSystem,
+            blockBroadcaster);
+
+    blockchainUtil.importFirstBlocks(2);
+
+    // Number 0 with a random (unknown) parent hash — not connected to the local chain.
+    final Block blockZeroWithUnknownParent =
+        new BlockDataGenerator()
+            .block(
+                BlockOptions.create()
+                    .setBlockNumber(0)
+                    .setBlockHeaderFunctions(new MainnetBlockHeaderFunctions()));
+
+    blockPropagationManager.importOrSavePendingBlock(blockZeroWithUnknownParent, PEER_1);
+
+    // It is saved as pending (its parent is not in the chain) ...
+    assertThat(pendingBlocksManager.contains(blockZeroWithUnknownParent.getHash())).isTrue();
+    // ... but no parent fetch is scheduled: the genesis block has no parent to retrieve.
+    verifyNoInteractions(ethScheduler);
   }
 
   @Test
@@ -777,7 +952,7 @@ public abstract class AbstractBlockPropagationManagerTest {
   private NewBlockHashesMessage createNewBlockHashMessage(final Block block) {
     return NewBlockHashesMessage.create(
         Collections.singletonList(
-            new NewBlockHashesMessage.NewBlockHash(
+            new NewBlockHashesMessage.BlockAnnouncement(
                 block.getHash(), block.getHeader().getNumber())));
   }
 
@@ -857,7 +1032,7 @@ public abstract class AbstractBlockPropagationManagerTest {
                     .setBlockHeaderFunctions(new MainnetBlockHeaderFunctions()));
 
     assertThat(badBlocksManager.getBadBlocks()).isEmpty();
-    blockPropagationManager.importOrSavePendingBlock(badBlock, NODE_ID_1);
+    blockPropagationManager.importOrSavePendingBlock(badBlock, PEER_1);
     assertThat(badBlocksManager.getBadBlocks().size()).isEqualTo(1);
 
     verify(ethScheduler, times(1)).scheduleSyncWorkerTask(any(Supplier.class));
@@ -892,7 +1067,7 @@ public abstract class AbstractBlockPropagationManagerTest {
     // handleNewBlockFromNetwork must short-circuit before dispatching to importOrSavePendingBlock.
     // Checking addImportingBlock alone would also pass via the defensive second check inside
     // importOrSavePendingBlock, so verify the dispatch itself never happened.
-    verify(propManager, never()).importOrSavePendingBlock(any(), any(Bytes.class));
+    verify(propManager, never()).importOrSavePendingBlock(any(), any(EthPeer.class));
     // BadBlockManager should still contain exactly one entry — we didn't re-add it.
     assertThat(badBlocksManager.getBadBlocks().size()).isEqualTo(1);
   }
@@ -919,13 +1094,18 @@ public abstract class AbstractBlockPropagationManagerTest {
     final NewBlockHashesMessage newBlockHashesMessage =
         NewBlockHashesMessage.create(
             Collections.singletonList(
-                new NewBlockHashesMessage.NewBlockHash(
+                new NewBlockHashesMessage.BlockAnnouncement(
                     badBlock.getHash(), badBlock.getHeader().getNumber())));
 
     EthProtocolManagerTestUtil.broadcastMessage(ethProtocolManager, peer, newBlockHashesMessage);
 
     // The hash announcement should have been filtered out before requesting the body.
-    verify(processingBlocksManager, never()).addRequestedBlock(badBlock.getHash());
+    verify(processingBlocksManager, never())
+        .addRequestedBlock(
+            eq(
+                new NewBlockHashesMessage.BlockAnnouncement(
+                    badBlock.getHash(), badBlock.getHeader().getNumber())),
+            any());
     // No body request should have been issued to the peer.
     assertThat(peer.hasOutstandingRequests()).isFalse();
   }
@@ -988,7 +1168,7 @@ public abstract class AbstractBlockPropagationManagerTest {
     badBlocksManager.addBadBlock(badBlock, BadBlockCause.fromValidationFailure("test"));
     assertThat(badBlocksManager.getBadBlocks().size()).isEqualTo(1);
 
-    blockPropagationManager.importOrSavePendingBlock(badBlock, NODE_ID_1);
+    blockPropagationManager.importOrSavePendingBlock(badBlock, PEER_1);
 
     // The defensive check should have short-circuited before scheduling validation.
     verify(ethScheduler, never()).scheduleSyncWorkerTask(any(Supplier.class));
@@ -1016,7 +1196,7 @@ public abstract class AbstractBlockPropagationManagerTest {
     final NewBlockHashesMessage nextAnnouncement =
         NewBlockHashesMessage.create(
             Collections.singletonList(
-                new NewBlockHashesMessage.NewBlockHash(
+                new NewBlockHashesMessage.BlockAnnouncement(
                     nextBlock.getHash(), nextBlock.getHeader().getNumber())));
 
     // Broadcast first message
@@ -1060,7 +1240,7 @@ public abstract class AbstractBlockPropagationManagerTest {
     final NewBlockHashesMessage nextAnnouncement =
         NewBlockHashesMessage.create(
             Collections.singletonList(
-                new NewBlockHashesMessage.NewBlockHash(
+                new NewBlockHashesMessage.BlockAnnouncement(
                     nextBlock.getHash(), nextBlock.getHeader().getNumber())));
 
     // Broadcast first message
@@ -1107,7 +1287,7 @@ public abstract class AbstractBlockPropagationManagerTest {
     final NewBlockHashesMessage nextAnnouncement =
         NewBlockHashesMessage.create(
             Collections.singletonList(
-                new NewBlockHashesMessage.NewBlockHash(
+                new NewBlockHashesMessage.BlockAnnouncement(
                     nextBlock.getHash(), nextBlock.getHeader().getNumber())));
     final Responder responder = RespondingEthPeer.blockchainResponder(getFullBlockchain());
 
@@ -1182,7 +1362,7 @@ public abstract class AbstractBlockPropagationManagerTest {
     final NewBlockHashesMessage nextAnnouncement =
         NewBlockHashesMessage.create(
             Collections.singletonList(
-                new NewBlockHashesMessage.NewBlockHash(
+                new NewBlockHashesMessage.BlockAnnouncement(
                     nextBlock.getHash(), nextBlock.getHeader().getNumber())));
 
     Mockito.reset(peerTaskExecutor);
@@ -1219,7 +1399,12 @@ public abstract class AbstractBlockPropagationManagerTest {
     Mockito.verify(peerTaskExecutor).execute(Mockito.any(GetBodiesFromPeerTask.class));
     Mockito.verifyNoMoreInteractions(peerTaskExecutor);
 
-    verify(processingBlocksManager).addRequestedBlock(nextBlock.getHash());
+    verify(processingBlocksManager)
+        .addRequestedBlock(
+            eq(
+                new NewBlockHashesMessage.BlockAnnouncement(
+                    nextBlock.getHash(), nextBlock.getHeader().getNumber())),
+            any());
     verify(processingBlocksManager).addImportingBlock(nextBlock.getHash());
     verify(processingBlocksManager).registerReceivedBlock(nextBlock);
     verify(processingBlocksManager).registerBlockImportDone(nextBlock.getHash());

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/ProcessingBlocksManagerTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/ProcessingBlocksManagerTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.eth.sync;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.core.Block;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.eth.manager.EthPeer;
+import org.hyperledger.besu.ethereum.eth.manager.PeerReputation;
+import org.hyperledger.besu.ethereum.eth.messages.NewBlockHashesMessage.BlockAnnouncement;
+import org.hyperledger.besu.ethereum.eth.sync.BlockPropagationManager.ProcessingBlocksManager;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+class ProcessingBlocksManagerTest {
+
+  private final ProcessingBlocksManager manager = new ProcessingBlocksManager();
+
+  private static Hash hash(final int i) {
+    return Hash.fromHexString(String.format("0x%064x", i));
+  }
+
+  private static BlockAnnouncement announcement(final int hash, final long number) {
+    return new BlockAnnouncement(hash(hash), number);
+  }
+
+  private static EthPeer peerWithScore(final int score) {
+    final EthPeer peer = mock(EthPeer.class);
+    when(peer.getReputation()).thenReturn(new PeerReputation(score, 150));
+    return peer;
+  }
+
+  private static Block block(final int hash, final long number) {
+    final BlockHeader header = mock(BlockHeader.class);
+    when(header.getNumber()).thenReturn(number);
+    final Block block = mock(Block.class);
+    when(block.getHash()).thenReturn(hash(hash));
+    when(block.getHeader()).thenReturn(header);
+    return block;
+  }
+
+  @Test
+  void deduplicatesDifferentHashesForTheSameNumberFromTheSamePeer() {
+    final EthPeer peer = peerWithScore(100);
+
+    assertThat(manager.addRequestedBlock(announcement(1, 5), peer)).isTrue();
+    // same block number, different hash, same (not strictly better) peer → rejected
+    assertThat(manager.addRequestedBlock(announcement(2, 5), peer)).isFalse();
+  }
+
+  @Test
+  void exactDuplicateAnnouncementIsRejected() {
+    final EthPeer peer = peerWithScore(100);
+
+    assertThat(manager.addRequestedBlock(announcement(1, 5), peer)).isTrue();
+    assertThat(manager.addRequestedBlock(announcement(1, 5), peer)).isFalse();
+  }
+
+  @Test
+  void differentBlockNumbersAreIndependent() {
+    final EthPeer peer = peerWithScore(100);
+
+    assertThat(manager.addRequestedBlock(announcement(1, 5), peer)).isTrue();
+    assertThat(manager.addRequestedBlock(announcement(2, 6), peer)).isTrue();
+  }
+
+  @Test
+  void strictlyBetterReputationSupersedesSameNumber() {
+    assertThat(manager.addRequestedBlock(announcement(1, 5), peerWithScore(50))).isTrue();
+    // strictly better reputation for the same number replaces the announcement
+    assertThat(manager.addRequestedBlock(announcement(2, 5), peerWithScore(100))).isTrue();
+    // not strictly better than the current holder (100) → rejected
+    assertThat(manager.addRequestedBlock(announcement(3, 5), peerWithScore(75))).isFalse();
+    assertThat(manager.addRequestedBlock(announcement(4, 5), peerWithScore(100))).isFalse();
+  }
+
+  @Test
+  void registerReceivedBlockFreesTheNumberWhenHashMatches() {
+    final EthPeer peer = peerWithScore(100);
+    assertThat(manager.addRequestedBlock(announcement(1, 5), peer)).isTrue();
+
+    manager.registerReceivedBlock(block(1, 5));
+
+    // number 5 is free again
+    assertThat(manager.addRequestedBlock(announcement(2, 5), peer)).isTrue();
+  }
+
+  @Test
+  void registerReceivedBlockKeepsEntryWhenHashDiffers() {
+    final EthPeer peer = peerWithScore(100);
+    assertThat(manager.addRequestedBlock(announcement(1, 5), peer)).isTrue();
+
+    // a received block at the same number but a different hash must not evict the tracked one
+    manager.registerReceivedBlock(block(2, 5));
+
+    assertThat(manager.addRequestedBlock(announcement(3, 5), peer)).isFalse();
+  }
+
+  @Test
+  void registerFailedGetBlockFreesTheNumberWhenHashMatches() {
+    final EthPeer peer = peerWithScore(100);
+    assertThat(manager.addRequestedBlock(announcement(1, 5), peer)).isTrue();
+
+    manager.registerFailedGetBlock(5, Optional.of(hash(1)));
+
+    assertThat(manager.addRequestedBlock(announcement(2, 5), peer)).isTrue();
+  }
+
+  @Test
+  void registerFailedGetBlockKeepsEntryWhenHashDiffers() {
+    final EthPeer peer = peerWithScore(100);
+    assertThat(manager.addRequestedBlock(announcement(1, 5), peer)).isTrue();
+
+    // a failed fetch reported for a different hash at the same number must not evict the tracked
+    // one
+    manager.registerFailedGetBlock(5, Optional.of(hash(2)));
+
+    assertThat(manager.addRequestedBlock(announcement(3, 5), peer)).isFalse();
+  }
+
+  @Test
+  void registerFailedGetBlockWithoutHashClearsTheNumber() {
+    final EthPeer peer = peerWithScore(100);
+    assertThat(manager.addRequestedBlock(announcement(1, 5), peer)).isTrue();
+
+    // non-announced retrieval failures clear the number unconditionally
+    manager.registerFailedGetBlock(5, Optional.empty());
+
+    assertThat(manager.addRequestedBlock(announcement(2, 5), peer)).isTrue();
+  }
+
+  @Test
+  void aSinglePeerCannotScheduleMultipleFetchesForOneNumber() {
+    final EthPeer peer = peerWithScore(100);
+    assertThat(manager.addRequestedBlock(announcement(1, 5), peer)).isTrue();
+    // every subsequent distinct hash for the same number from the same peer is rejected,
+    // so one peer cannot drive more than one outstanding fetch per block number
+    for (int h = 2; h <= 20; h++) {
+      assertThat(manager.addRequestedBlock(announcement(h, 5), peer)).isFalse();
+    }
+  }
+
+  @Test
+  void importingBlocksAreTrackedAndCleared() {
+    assertThat(manager.alreadyImporting(hash(1))).isFalse();
+    assertThat(manager.addImportingBlock(hash(1))).isTrue();
+    assertThat(manager.alreadyImporting(hash(1))).isTrue();
+    // a second attempt to import the same block is rejected while in flight
+    assertThat(manager.addImportingBlock(hash(1))).isFalse();
+
+    manager.registerBlockImportDone(hash(1));
+    assertThat(manager.alreadyImporting(hash(1))).isFalse();
+  }
+}

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/state/PendingBlocksManagerTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/state/PendingBlocksManagerTest.java
@@ -15,9 +15,12 @@
 package org.hyperledger.besu.ethereum.eth.sync.state;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockDataGenerator;
+import org.hyperledger.besu.ethereum.eth.manager.EthPeer;
 import org.hyperledger.besu.ethereum.eth.sync.SynchronizerConfiguration;
 
 import java.util.ArrayDeque;
@@ -33,8 +36,14 @@ import org.junit.jupiter.api.Test;
 
 public class PendingBlocksManagerTest {
 
-  private static final Bytes NODE_ID_1 = Bytes.fromHexString("0x00");
-  private static final Bytes NODE_ID_2 = Bytes.fromHexString("0x01");
+  private static final EthPeer PEER_1 = peerWithNodeId(Bytes.fromHexString("0x00"));
+  private static final EthPeer PEER_2 = peerWithNodeId(Bytes.fromHexString("0x01"));
+
+  private static EthPeer peerWithNodeId(final Bytes nodeId) {
+    final EthPeer peer = mock(EthPeer.class);
+    when(peer.nodeId()).thenReturn(nodeId);
+    return peer;
+  }
 
   private PendingBlocksManager pendingBlocksManager;
   private BlockDataGenerator gen;
@@ -54,7 +63,7 @@ public class PendingBlocksManagerTest {
     // Sanity check
     assertThat(pendingBlocksManager.contains(block.getHash())).isFalse();
 
-    pendingBlocksManager.registerPendingBlock(block, NODE_ID_1);
+    pendingBlocksManager.registerPendingBlock(block, PEER_1);
 
     assertThat(pendingBlocksManager.contains(block.getHash())).isTrue();
     final List<Block> pendingBlocksForParent =
@@ -65,7 +74,7 @@ public class PendingBlocksManagerTest {
   @Test
   public void deregisterPendingBlock() {
     final Block block = gen.block();
-    pendingBlocksManager.registerPendingBlock(block, NODE_ID_1);
+    pendingBlocksManager.registerPendingBlock(block, PEER_1);
     pendingBlocksManager.deregisterPendingBlock(block.getHeader());
 
     assertThat(pendingBlocksManager.contains(block.getHash())).isFalse();
@@ -82,8 +91,8 @@ public class PendingBlocksManagerTest {
     final Block childBlock2 = gen.nextBlock(parentBlock);
     final List<Block> children = Arrays.asList(childBlock, childBlock2);
 
-    pendingBlocksManager.registerPendingBlock(childBlock, NODE_ID_1);
-    pendingBlocksManager.registerPendingBlock(childBlock2, NODE_ID_1);
+    pendingBlocksManager.registerPendingBlock(childBlock, PEER_1);
+    pendingBlocksManager.registerPendingBlock(childBlock2, PEER_1);
 
     assertThat(pendingBlocksManager.contains(childBlock.getHash())).isTrue();
     assertThat(pendingBlocksManager.contains(childBlock2.getHash())).isTrue();
@@ -101,8 +110,8 @@ public class PendingBlocksManagerTest {
     final Block childBlock = gen.nextBlock(parentBlock);
     final Block childBlock2 = gen.nextBlock(parentBlock);
 
-    pendingBlocksManager.registerPendingBlock(childBlock, NODE_ID_1);
-    pendingBlocksManager.registerPendingBlock(childBlock2, NODE_ID_1);
+    pendingBlocksManager.registerPendingBlock(childBlock, PEER_1);
+    pendingBlocksManager.registerPendingBlock(childBlock2, PEER_1);
     pendingBlocksManager.deregisterPendingBlock(childBlock.getHeader());
 
     assertThat(pendingBlocksManager.contains(childBlock.getHash())).isFalse();
@@ -121,7 +130,7 @@ public class PendingBlocksManagerTest {
     final List<Block> blocks = gen.blockSequence(10);
 
     for (final Block block : blocks) {
-      pendingBlocksManager.registerPendingBlock(block, NODE_ID_1);
+      pendingBlocksManager.registerPendingBlock(block, PEER_1);
       assertThat(pendingBlocksManager.contains(block.getHash())).isTrue();
     }
 
@@ -156,12 +165,12 @@ public class PendingBlocksManagerTest {
       final Block generatedBlock =
           gen.block(gen.nextBlockOptions(parentBlock).setTimestamp((long) i));
       childBlockFromNodeOne.add(generatedBlock);
-      pendingBlocksManager.registerPendingBlock(generatedBlock, NODE_ID_1);
+      pendingBlocksManager.registerPendingBlock(generatedBlock, PEER_1);
     }
 
     // add new block from node 2
     final Block childBlockFromNodeTwo = gen.nextBlock(parentBlock);
-    pendingBlocksManager.registerPendingBlock(childBlockFromNodeTwo, NODE_ID_2);
+    pendingBlocksManager.registerPendingBlock(childBlockFromNodeTwo, PEER_2);
 
     // check blocks from node 1 in the cache (node 1 should replace the lowest priority block)
     final List<Block> pendingBlocksForParent =
@@ -194,7 +203,7 @@ public class PendingBlocksManagerTest {
     // block 0
     childBlockFromNodeOne.add(
         gen.block(new BlockDataGenerator.BlockOptions().setBlockNumber(0).setTimestamp(0L)));
-    pendingBlocksManager.registerPendingBlock(childBlockFromNodeOne.getLast(), NODE_ID_1);
+    pendingBlocksManager.registerPendingBlock(childBlockFromNodeOne.getLast(), PEER_1);
 
     // block 1
     childBlockFromNodeOne.add(
@@ -202,7 +211,7 @@ public class PendingBlocksManagerTest {
             gen.nextBlockOptions(childBlockFromNodeOne.element())
                 .setBlockNumber(1)
                 .setTimestamp(1L)));
-    pendingBlocksManager.registerPendingBlock(childBlockFromNodeOne.getLast(), NODE_ID_1);
+    pendingBlocksManager.registerPendingBlock(childBlockFromNodeOne.getLast(), PEER_1);
 
     // block 1 reorg
     final Block reorgBlock =
@@ -211,7 +220,7 @@ public class PendingBlocksManagerTest {
                 .setBlockNumber(1)
                 .setTimestamp(3L));
     childBlockFromNodeOne.add(reorgBlock);
-    pendingBlocksManager.registerPendingBlock(reorgBlock, NODE_ID_1);
+    pendingBlocksManager.registerPendingBlock(reorgBlock, PEER_1);
 
     // block 2
     childBlockFromNodeOne.add(
@@ -219,21 +228,21 @@ public class PendingBlocksManagerTest {
             gen.nextBlockOptions(childBlockFromNodeOne.element())
                 .setBlockNumber(2)
                 .setTimestamp(2L)));
-    pendingBlocksManager.registerPendingBlock(childBlockFromNodeOne.getLast(), NODE_ID_1);
+    pendingBlocksManager.registerPendingBlock(childBlockFromNodeOne.getLast(), PEER_1);
 
     assertThat(pendingBlocksManager.contains(reorgBlock.getHash())).isTrue();
 
     // try to add a new block (not added because low priority : block number too high)
     final Block lowPriorityBlock =
         gen.block(BlockDataGenerator.BlockOptions.create().setBlockNumber(10));
-    pendingBlocksManager.registerPendingBlock(lowPriorityBlock, NODE_ID_1);
+    pendingBlocksManager.registerPendingBlock(lowPriorityBlock, PEER_1);
     assertThat(pendingBlocksManager.contains(lowPriorityBlock.getHash())).isFalse();
 
     // try to add a new block (added because high priority : low block number and high timestamp)
     final Block highPriorityBlock =
         gen.block(
             gen.nextBlockOptions(childBlockFromNodeOne.getFirst()).setTimestamp(Long.MAX_VALUE));
-    pendingBlocksManager.registerPendingBlock(highPriorityBlock, NODE_ID_1);
+    pendingBlocksManager.registerPendingBlock(highPriorityBlock, PEER_1);
     assertThat(pendingBlocksManager.contains(highPriorityBlock.getHash())).isTrue();
 
     // check blocks in the cache
@@ -255,9 +264,9 @@ public class PendingBlocksManagerTest {
     final Block childBlock = gen.nextBlock(parentBlock);
     final Block childBlock2 = gen.nextBlock(parentBlock);
 
-    pendingBlocksManager.registerPendingBlock(parentBlock, NODE_ID_1);
-    pendingBlocksManager.registerPendingBlock(childBlock, NODE_ID_1);
-    pendingBlocksManager.registerPendingBlock(childBlock2, NODE_ID_1);
+    pendingBlocksManager.registerPendingBlock(parentBlock, PEER_1);
+    pendingBlocksManager.registerPendingBlock(childBlock, PEER_1);
+    pendingBlocksManager.registerPendingBlock(childBlock2, PEER_1);
 
     assertThat(pendingBlocksManager.lowestAnnouncedBlock()).contains(parentBlock.getHeader());
   }
@@ -274,12 +283,12 @@ public class PendingBlocksManagerTest {
     final Block forkChild = gen.nextBlock(forkBlock);
 
     // register chain with one missing block
-    pendingBlocksManager.registerPendingBlock(block, NODE_ID_1);
-    pendingBlocksManager.registerPendingBlock(child, NODE_ID_1);
+    pendingBlocksManager.registerPendingBlock(block, PEER_1);
+    pendingBlocksManager.registerPendingBlock(child, PEER_1);
 
     // Register fork with one missing parent
-    pendingBlocksManager.registerPendingBlock(forkBlock, NODE_ID_1);
-    pendingBlocksManager.registerPendingBlock(forkChild, NODE_ID_1);
+    pendingBlocksManager.registerPendingBlock(forkBlock, PEER_1);
+    pendingBlocksManager.registerPendingBlock(forkChild, PEER_1);
 
     // assert it is able to follow the chain
     final Optional<Block> blockAncestor = pendingBlocksManager.pendingAncestorBlockOf(child);
@@ -298,7 +307,7 @@ public class PendingBlocksManagerTest {
   public void shouldReturnLowestAncestorPendingBlock_sameBlock() {
     final BlockDataGenerator gen = new BlockDataGenerator();
     final Block block = gen.block();
-    pendingBlocksManager.registerPendingBlock(block, NODE_ID_1);
+    pendingBlocksManager.registerPendingBlock(block, PEER_1);
     final Optional<Block> b = pendingBlocksManager.pendingAncestorBlockOf(block);
     assertThat(b).contains(block);
   }


### PR DESCRIPTION
## Summary
The block-propagation range already bounds the block numbers a peer can announce, but a single peer could still request unbounded fetch work by sending many different hashes for the same number.

## Change
- Track requested blocks in a `SortedMap` keyed by block number: a second announcement for a number already requested is accepted only if it comes from a peer with strictly better reputation (and supersedes the previous one). A single peer can no longer schedule more than one fetch per number, bounding outstanding work to roughly (connected peers x propagation range).
- Fixes two related issues found during review: `requestParentBlock` now registers the parent it actually fetches so entry keys match on removal (previously the child was registered, leaking the entry); `ProcessingBlocksManager.alreadyImporting` is synchronized like the other accessors now that `importingBlocks` is a plain `HashSet`.

## Test plan
- [x] `ProcessingBlocksManagerTest` — new coverage for the dedup/reputation logic
- [x] `AbstractBlockPropagationManagerTest`, `NewBlockHashesMessageTest`, `PendingBlocksManagerTest` — updated/passing