### PR TITLE
Key precompile result caches by content, not a 32-bit hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - `--rpc-tx-feecap` will treat a value of 0 as limiting fees to 0. Today it treats 0 as "do not cap fees". To achieve similar behaviour set it to a suitably large value to effectively prevent any fee capping.
 
 ### Bug fixes
+- Key precompiled-contract result caches (BLAKE2F and others sharing `AbstractPrecompiledContract`) by the actual input content instead of a 32-bit `Arrays.hashCode` digest of it. Two distinct inputs could share the same 32-bit digest, so an attacker able to construct such a collision could evict/replace the same cache entry on every call, causing deterministic cache thrashing.
 - Return `BLOCK_NOT_FOUND` for unknown block hashes and `GENESIS_BLOCK_NOT_TRACEABLE` for genesis blocks from `debug_traceBlockByHash`. [#10701](https://github.com/besu-eth/besu/pull/10701)
 - Bonsai world state rolling failures are now logged at `WARN` instead of `INFO`, and a missing block header or trie log during a roll reports which block hash or trie log was missing. [#10859](https://github.com/besu-eth/besu/issues/10859)
 - Fix a deadlock where `FullSyncTargetManager`'s (and checkpoint sync's) retry loop could hang forever waiting for a new peer to connect, even though the already-connected peer just needed its outstanding-request budget to free back up. The same fix was applied to snap/fast sync's pivot block selection. [#10864](https://github.com/besu-eth/besu/issues/10864)

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/AbstractBLS12PrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/AbstractBLS12PrecompiledContract.java
@@ -116,7 +116,7 @@ public abstract class AbstractBLS12PrecompiledContract implements PrecompiledCon
 
     PrecompileInputResultTuple res = null;
 
-    Integer cacheKey = null;
+    Bytes cacheKey = null;
     final Bytes cachedInput = input.size() > inputLimit ? input.slice(0, inputLimit) : input;
 
     if (enableResultCaching) {
@@ -241,5 +241,5 @@ public abstract class AbstractBLS12PrecompiledContract implements PrecompiledCon
    *
    * @return precompile cache.
    */
-  protected abstract Cache<Integer, PrecompileInputResultTuple> getCache();
+  protected abstract Cache<Bytes, PrecompileInputResultTuple> getCache();
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/AbstractPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/AbstractPrecompiledContract.java
@@ -16,7 +16,6 @@ package org.hyperledger.besu.evm.precompile;
 
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
-import java.util.Arrays;
 import java.util.function.Consumer;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
@@ -102,15 +101,16 @@ public abstract class AbstractPrecompiledContract implements PrecompiledContract
 
   /**
    * Calculate a cache key over the leading {@code prefixLen} bytes of {@code input}. Bytes beyond
-   * the semantic prefix are ignored.
+   * the semantic prefix are ignored. The key is the semantic prefix itself (compared by content),
+   * not a 32-bit digest of it, so distinct inputs can never collide into the same cache bucket.
    *
    * @param input bytes
    * @param prefixLen number of leading bytes to include in the key
-   * @return integer cache key
+   * @return cache key
    */
-  public static Integer getCacheKey(final Bytes input, final int prefixLen) {
+  public static Bytes getCacheKey(final Bytes input, final int prefixLen) {
     final int len = Math.min(prefixLen, input.size());
-    return Arrays.hashCode(input.slice(0, len).toArray());
+    return input.slice(0, len).copy();
   }
 
   /** Per-cache byte-weight cap. */
@@ -118,17 +118,17 @@ public abstract class AbstractPrecompiledContract implements PrecompiledContract
 
   /**
    * Shared Caffeine builder for precompile result caches. Caps total weight at {@value
-   * #CACHE_MAX_WEIGHT_BYTES} bytes and weighs each entry by {@code Integer.BYTES + cachedInput
-   * size}, so even zero-byte inputs carry weight and entry count is bounded.
+   * #CACHE_MAX_WEIGHT_BYTES} bytes and weighs each entry by {@code key size + cachedInput size}, so
+   * even zero-byte inputs carry weight and entry count is bounded.
    *
    * @return a configured Caffeine builder; callers chain {@code .build()} (and may add {@code
    *     .expireAfterWrite(...)}).
    */
-  public static Caffeine<Integer, PrecompileInputResultTuple> resultCacheBuilder() {
+  public static Caffeine<Bytes, PrecompileInputResultTuple> resultCacheBuilder() {
     return Caffeine.newBuilder()
         .maximumWeight(CACHE_MAX_WEIGHT_BYTES)
         .weigher(
-            (final Integer k, final PrecompileInputResultTuple v) ->
-                Integer.BYTES + v.cachedInput().size());
+            (final Bytes k, final PrecompileInputResultTuple v) ->
+                k.size() + v.cachedInput().size());
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/AltBN128AddPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/AltBN128AddPrecompiledContract.java
@@ -39,7 +39,7 @@ public class AltBN128AddPrecompiledContract extends AbstractAltBnPrecompiledCont
   private static final String PRECOMPILE_NAME = "BN254_ADD";
 
   private final long gasCost;
-  private static final Cache<Integer, PrecompileInputResultTuple> bnAddCache =
+  private static final Cache<Bytes, PrecompileInputResultTuple> bnAddCache =
       AbstractPrecompiledContract.resultCacheBuilder().build();
 
   AltBN128AddPrecompiledContract(final GasCalculator gasCalculator, final long gasCost) {
@@ -63,7 +63,7 @@ public class AltBN128AddPrecompiledContract extends AbstractAltBnPrecompiledCont
       final Bytes input, @NotNull final MessageFrame messageFrame) {
 
     PrecompileInputResultTuple res;
-    Integer cacheKey = null;
+    Bytes cacheKey = null;
     final Bytes cachedInput =
         input.size() > PARAMETER_LENGTH ? input.slice(0, PARAMETER_LENGTH) : input;
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/AltBN128MulPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/AltBN128MulPrecompiledContract.java
@@ -45,7 +45,7 @@ public class AltBN128MulPrecompiledContract extends AbstractAltBnPrecompiledCont
 
   private static final Bytes POINT_AT_INFINITY = Bytes.repeat((byte) 0, 64);
   private final long gasCost;
-  private static final Cache<Integer, PrecompileInputResultTuple> bnMulCache =
+  private static final Cache<Bytes, PrecompileInputResultTuple> bnMulCache =
       AbstractPrecompiledContract.resultCacheBuilder().build();
 
   AltBN128MulPrecompiledContract(final GasCalculator gasCalculator, final long gasCost) {
@@ -74,7 +74,7 @@ public class AltBN128MulPrecompiledContract extends AbstractAltBnPrecompiledCont
     }
 
     PrecompileInputResultTuple res;
-    Integer cacheKey = null;
+    Bytes cacheKey = null;
     final Bytes cachedInput =
         input.size() > PARAMETER_LENGTH ? input.slice(0, PARAMETER_LENGTH) : input;
     if (enableResultCaching) {

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/AltBN128PairingPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/AltBN128PairingPrecompiledContract.java
@@ -46,7 +46,7 @@ public class AltBN128PairingPrecompiledContract extends AbstractAltBnPrecompiled
   private static final int PARAMETER_LENGTH = 192;
   private static final String PRECOMPILE_NAME = "BN254_PAIRING";
 
-  private static final Cache<Integer, PrecompileInputResultTuple> bnPairingCache =
+  private static final Cache<Bytes, PrecompileInputResultTuple> bnPairingCache =
       AbstractPrecompiledContract.resultCacheBuilder()
           .expireAfterWrite(15, TimeUnit.MINUTES) // Evict 15 minutes after each entry is written
           .build();
@@ -103,7 +103,7 @@ public class AltBN128PairingPrecompiledContract extends AbstractAltBnPrecompiled
           null, Optional.of(ExceptionalHaltReason.PRECOMPILE_ERROR));
     }
     PrecompileInputResultTuple res;
-    Integer cacheKey = null;
+    Bytes cacheKey = null;
     if (enableResultCaching) {
       cacheKey = getCacheKey(input, input.size());
       res = bnPairingCache.getIfPresent(cacheKey);

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLAKE2BFPrecompileContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLAKE2BFPrecompileContract.java
@@ -38,7 +38,7 @@ public class BLAKE2BFPrecompileContract extends AbstractPrecompiledContract {
   private static final Logger LOG = LoggerFactory.getLogger(BLAKE2BFPrecompileContract.class);
   private static final String PRECOMPILE_NAME = "BLAKE2F";
 
-  private static final Cache<Integer, PrecompileInputResultTuple> blakeCache =
+  private static final Cache<Bytes, PrecompileInputResultTuple> blakeCache =
       AbstractPrecompiledContract.resultCacheBuilder().build();
 
   /**
@@ -83,7 +83,7 @@ public class BLAKE2BFPrecompileContract extends AbstractPrecompiledContract {
           null, Optional.of(ExceptionalHaltReason.PRECOMPILE_ERROR));
     }
     PrecompileInputResultTuple res = null;
-    Integer cacheKey = null;
+    Bytes cacheKey = null;
     if (enableResultCaching) {
       cacheKey = getCacheKey(input, MESSAGE_LENGTH_BYTES);
       res = blakeCache.getIfPresent(cacheKey);
@@ -92,7 +92,7 @@ public class BLAKE2BFPrecompileContract extends AbstractPrecompiledContract {
           cacheEventConsumer.accept(new CacheEvent(PRECOMPILE_NAME, CacheMetric.HIT));
           return res.cachedResult();
         } else {
-          LOG.info(
+          LOG.debug(
               "false positive blake2bf {}, cache key {}, cached input: {}, input: {}",
               input.getClass().getSimpleName(),
               cacheKey,

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLS12G1AddPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLS12G1AddPrecompiledContract.java
@@ -23,7 +23,7 @@ import org.apache.tuweni.bytes.Bytes;
 public class BLS12G1AddPrecompiledContract extends AbstractBLS12PrecompiledContract {
 
   private static final int PARAMETER_LENGTH = 256;
-  private static final Cache<Integer, PrecompileInputResultTuple> g1AddCache =
+  private static final Cache<Bytes, PrecompileInputResultTuple> g1AddCache =
       AbstractPrecompiledContract.resultCacheBuilder().build();
 
   /** Instantiates a new BLS12G1 Add precompiled contract. */
@@ -37,7 +37,7 @@ public class BLS12G1AddPrecompiledContract extends AbstractBLS12PrecompiledContr
   }
 
   @Override
-  protected Cache<Integer, PrecompileInputResultTuple> getCache() {
+  protected Cache<Bytes, PrecompileInputResultTuple> getCache() {
     return g1AddCache;
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLS12G1MultiExpPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLS12G1MultiExpPrecompiledContract.java
@@ -25,7 +25,7 @@ import org.apache.tuweni.bytes.Bytes;
 public class BLS12G1MultiExpPrecompiledContract extends AbstractBLS12PrecompiledContract {
 
   private static final int PARAMETER_LENGTH = 160;
-  private static final Cache<Integer, PrecompileInputResultTuple> g1MSMCache =
+  private static final Cache<Bytes, PrecompileInputResultTuple> g1MSMCache =
       AbstractPrecompiledContract.resultCacheBuilder()
           .expireAfterWrite(15, TimeUnit.MINUTES) // Evict 15 minutes after each entry is written
           .build();
@@ -45,7 +45,7 @@ public class BLS12G1MultiExpPrecompiledContract extends AbstractBLS12Precompiled
   }
 
   @Override
-  protected Cache<Integer, PrecompileInputResultTuple> getCache() {
+  protected Cache<Bytes, PrecompileInputResultTuple> getCache() {
     return g1MSMCache;
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLS12G2AddPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLS12G2AddPrecompiledContract.java
@@ -23,7 +23,7 @@ import org.apache.tuweni.bytes.Bytes;
 public class BLS12G2AddPrecompiledContract extends AbstractBLS12PrecompiledContract {
 
   private static final int PARAMETER_LENGTH = 512;
-  private static final Cache<Integer, PrecompileInputResultTuple> g2AddCache =
+  private static final Cache<Bytes, PrecompileInputResultTuple> g2AddCache =
       AbstractPrecompiledContract.resultCacheBuilder().build();
 
   /** Instantiates a new BLS12_G2 Add precompiled contract. */
@@ -37,7 +37,7 @@ public class BLS12G2AddPrecompiledContract extends AbstractBLS12PrecompiledContr
   }
 
   @Override
-  protected Cache<Integer, PrecompileInputResultTuple> getCache() {
+  protected Cache<Bytes, PrecompileInputResultTuple> getCache() {
     return g2AddCache;
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLS12G2MultiExpPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLS12G2MultiExpPrecompiledContract.java
@@ -25,7 +25,7 @@ import org.apache.tuweni.bytes.Bytes;
 public class BLS12G2MultiExpPrecompiledContract extends AbstractBLS12PrecompiledContract {
 
   private static final int PARAMETER_LENGTH = 288;
-  private static final Cache<Integer, PrecompileInputResultTuple> g2MSMCache =
+  private static final Cache<Bytes, PrecompileInputResultTuple> g2MSMCache =
       AbstractPrecompiledContract.resultCacheBuilder()
           .expireAfterWrite(15, TimeUnit.MINUTES) // Evict 15 minutes after each entry is written
           .build();
@@ -45,7 +45,7 @@ public class BLS12G2MultiExpPrecompiledContract extends AbstractBLS12Precompiled
   }
 
   @Override
-  protected Cache<Integer, PrecompileInputResultTuple> getCache() {
+  protected Cache<Bytes, PrecompileInputResultTuple> getCache() {
     return g2MSMCache;
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLS12MapFp2ToG2PrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLS12MapFp2ToG2PrecompiledContract.java
@@ -23,7 +23,7 @@ import org.apache.tuweni.bytes.Bytes;
 public class BLS12MapFp2ToG2PrecompiledContract extends AbstractBLS12PrecompiledContract {
 
   private static final int PARAMETER_LENGTH = 128;
-  private static final Cache<Integer, PrecompileInputResultTuple> mapfp2g2Cache =
+  private static final Cache<Bytes, PrecompileInputResultTuple> mapfp2g2Cache =
       AbstractPrecompiledContract.resultCacheBuilder().build();
 
   /** Instantiates a new BLS12MapFp2ToG2 precompiled contract. */
@@ -40,7 +40,7 @@ public class BLS12MapFp2ToG2PrecompiledContract extends AbstractBLS12Precompiled
   }
 
   @Override
-  protected Cache<Integer, PrecompileInputResultTuple> getCache() {
+  protected Cache<Bytes, PrecompileInputResultTuple> getCache() {
     return mapfp2g2Cache;
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLS12MapFpToG1PrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLS12MapFpToG1PrecompiledContract.java
@@ -23,7 +23,7 @@ import org.apache.tuweni.bytes.Bytes;
 public class BLS12MapFpToG1PrecompiledContract extends AbstractBLS12PrecompiledContract {
 
   private static final int PARAMETER_LENGTH = 64;
-  private static final Cache<Integer, PrecompileInputResultTuple> mapFpToG1Cache =
+  private static final Cache<Bytes, PrecompileInputResultTuple> mapFpToG1Cache =
       AbstractPrecompiledContract.resultCacheBuilder().build();
 
   /** Instantiates a new BLS12MapFpToG1 precompiled contract. */
@@ -40,7 +40,7 @@ public class BLS12MapFpToG1PrecompiledContract extends AbstractBLS12PrecompiledC
   }
 
   @Override
-  protected Cache<Integer, PrecompileInputResultTuple> getCache() {
+  protected Cache<Bytes, PrecompileInputResultTuple> getCache() {
     return mapFpToG1Cache;
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLS12PairingPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLS12PairingPrecompiledContract.java
@@ -25,7 +25,7 @@ import org.apache.tuweni.bytes.Bytes;
 public class BLS12PairingPrecompiledContract extends AbstractBLS12PrecompiledContract {
 
   private static final int PARAMETER_LENGTH = 384;
-  private static final Cache<Integer, PrecompileInputResultTuple> pairingCache =
+  private static final Cache<Bytes, PrecompileInputResultTuple> pairingCache =
       AbstractPrecompiledContract.resultCacheBuilder()
           .expireAfterWrite(15, TimeUnit.MINUTES) // Evict 15 minutes after each entry is written
           .build();
@@ -45,7 +45,7 @@ public class BLS12PairingPrecompiledContract extends AbstractBLS12PrecompiledCon
   }
 
   @Override
-  protected Cache<Integer, PrecompileInputResultTuple> getCache() {
+  protected Cache<Bytes, PrecompileInputResultTuple> getCache() {
     return pairingCache;
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/ECRECPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/ECRECPrecompiledContract.java
@@ -45,7 +45,7 @@ public class ECRECPrecompiledContract extends AbstractPrecompiledContract {
   private static final int SEMANTIC_INPUT_LENGTH = 128;
   final SignatureAlgorithm signatureAlgorithm;
   private static final String PRECOMPILE_NAME = "ECREC";
-  private static final Cache<Integer, PrecompileInputResultTuple> ecrecCache =
+  private static final Cache<Bytes, PrecompileInputResultTuple> ecrecCache =
       AbstractPrecompiledContract.resultCacheBuilder().build();
 
   /**
@@ -90,7 +90,7 @@ public class ECRECPrecompiledContract extends AbstractPrecompiledContract {
     }
 
     PrecompileInputResultTuple res;
-    Integer cacheKey = null;
+    Bytes cacheKey = null;
     final Bytes cachedInput =
         input.size() > SEMANTIC_INPUT_LENGTH ? input.slice(0, SEMANTIC_INPUT_LENGTH) : input;
     if (enableResultCaching) {

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/KZGPointEvalPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/KZGPointEvalPrecompiledContract.java
@@ -39,8 +39,9 @@ public class KZGPointEvalPrecompiledContract implements PrecompiledContract {
   private static final AtomicBoolean loaded = new AtomicBoolean(false);
 
   private static final String PRECOMPILE_NAME = "KZGPointEval";
-  private static final Cache<Integer, PrecompileInputResultTuple> kzgCache =
+  private static final Cache<Bytes, PrecompileInputResultTuple> kzgCache =
       AbstractPrecompiledContract.resultCacheBuilder().build();
+  private static final int PREFIX_LENGTH = 192;
 
   /** Default result caching to false unless otherwise set. */
   protected static Boolean enableResultCaching = Boolean.FALSE;
@@ -127,16 +128,16 @@ public class KZGPointEvalPrecompiledContract implements PrecompiledContract {
   public PrecompileContractResult computePrecompile(
       final Bytes input, @NotNull final MessageFrame messageFrame) {
 
-    if (input.size() != 192) {
+    if (input.size() != PREFIX_LENGTH) {
       return PrecompileContractResult.halt(
           null, Optional.of(ExceptionalHaltReason.PRECOMPILE_ERROR));
     }
 
     PrecompileInputResultTuple res;
-    Integer cacheKey = null;
+    Bytes cacheKey = null;
 
     if (enableResultCaching) {
-      cacheKey = AbstractPrecompiledContract.getCacheKey(input, 192);
+      cacheKey = AbstractPrecompiledContract.getCacheKey(input, PREFIX_LENGTH);
       res = kzgCache.getIfPresent(cacheKey);
       if (res != null) {
         if (res.cachedInput().equals(input)) {

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/P256VerifyPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/P256VerifyPrecompiledContract.java
@@ -90,7 +90,7 @@ public class P256VerifyPrecompiledContract extends AbstractPrecompiledContract {
   private final GasCalculator gasCalculator;
   private final SignatureAlgorithm signatureAlgorithm;
 
-  private static final Cache<Integer, PrecompileInputResultTuple> p256VerifyCache =
+  private static final Cache<Bytes, PrecompileInputResultTuple> p256VerifyCache =
       AbstractPrecompiledContract.resultCacheBuilder().build();
 
   /**
@@ -131,7 +131,7 @@ public class P256VerifyPrecompiledContract extends AbstractPrecompiledContract {
       return PrecompileContractResult.success(INVALID);
     }
     PrecompileInputResultTuple res = null;
-    Integer cacheKey = null;
+    Bytes cacheKey = null;
     if (enableResultCaching) {
       cacheKey = getCacheKey(input, SECP256R1_INPUT_LENGTH);
       res = p256VerifyCache.getIfPresent(cacheKey);

--- a/evm/src/test/java/org/hyperledger/besu/evm/precompile/BLAKE2BFPrecompileContractCacheCollisionTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/precompile/BLAKE2BFPrecompileContractCacheCollisionTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.evm.precompile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.evm.EvmSpecVersion;
+import org.hyperledger.besu.evm.fluent.EvmSpec;
+import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.precompile.AbstractPrecompiledContract.CacheEvent;
+import org.hyperledger.besu.evm.precompile.AbstractPrecompiledContract.CacheMetric;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.MutableBytes;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression test asserting that two distinct, valid, zero-round BLAKE2F inputs whose leading 213
+ * bytes previously shared a single 32-bit {@code Arrays.hashCode} value: {@code 31*0 + 0 == 31*1 +
+ * (byte) 0xe1}. Alternating them evicted/replaced the single-entry hash bucket on every call,
+ * causing deterministic cache thrashing and log amplification.
+ */
+class BLAKE2BFPrecompileContractCacheCollisionTest {
+
+  private final PrecompiledContract contract =
+      EvmSpec.evmSpec(EvmSpecVersion.ISTANBUL)
+          .getPrecompileContractRegistry()
+          .get(Address.BLAKE2B_F_COMPRESSION);
+
+  private final MessageFrame messageFrame = mock(MessageFrame.class);
+
+  // 213 zero bytes: 0 rounds, all-zero h/m/t, finalization flag 0. A valid zero-round call.
+  private static final Bytes INPUT_A = Bytes.wrap(new byte[213]);
+
+  // Differs from INPUT_A only at bytes 20 and 21 (0x01, 0xe1). Rounds (bytes 0-3) and the
+  // finalization flag (byte 212) stay zero, so this is also a valid zero-round call.
+  private static final Bytes INPUT_B;
+
+  static {
+    final MutableBytes mutable = MutableBytes.create(213);
+    mutable.set(20, (byte) 0x01);
+    mutable.set(21, (byte) 0xe1);
+    INPUT_B = mutable.copy();
+  }
+
+  @BeforeEach
+  void enableCaching() {
+    AbstractPrecompiledContract.setPrecompileCaching(true);
+  }
+
+  @AfterEach
+  void resetCaching() {
+    AbstractPrecompiledContract.setPrecompileCaching(false);
+    AbstractPrecompiledContract.setCacheEventConsumer(__ -> {});
+  }
+
+  @Test
+  void collidingHashPrefixesNoLongerShareACacheBucket() {
+    assertThat(AbstractPrecompiledContract.getCacheKey(INPUT_A, 213))
+        .isNotEqualTo(AbstractPrecompiledContract.getCacheKey(INPUT_B, 213));
+  }
+
+  @Test
+  void alternatingTheCollidingPairProducesHitsNotFalsePositives() {
+    // Warm both entries first.
+    contract.computePrecompile(INPUT_A, messageFrame);
+    contract.computePrecompile(INPUT_B, messageFrame);
+
+    final List<CacheEvent> events = new ArrayList<>();
+    AbstractPrecompiledContract.setCacheEventConsumer(events::add);
+
+    for (int i = 0; i < 10; i++) {
+      contract.computePrecompile(INPUT_A, messageFrame);
+      contract.computePrecompile(INPUT_B, messageFrame);
+    }
+
+    assertThat(events).extracting(CacheEvent::cacheMetric).containsOnly(CacheMetric.HIT);
+  }
+}

--- a/evm/src/test/java/org/hyperledger/besu/evm/precompile/PrecompileCachePrefixBoundTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/precompile/PrecompileCachePrefixBoundTest.java
@@ -75,9 +75,9 @@ class PrecompileCachePrefixBoundTest {
     final Bytes paddedShort = Bytes.concatenate(prefix, Bytes.repeat((byte) 0xab, 16));
     final Bytes paddedLong = Bytes.concatenate(prefix, MutableBytes.create(1_600_000));
 
-    final int prefixKey = AbstractPrecompiledContract.getCacheKey(prefix, 128);
-    final int paddedShortKey = AbstractPrecompiledContract.getCacheKey(paddedShort, 128);
-    final int paddedLongKey = AbstractPrecompiledContract.getCacheKey(paddedLong, 128);
+    final Bytes prefixKey = AbstractPrecompiledContract.getCacheKey(prefix, 128);
+    final Bytes paddedShortKey = AbstractPrecompiledContract.getCacheKey(paddedShort, 128);
+    final Bytes paddedLongKey = AbstractPrecompiledContract.getCacheKey(paddedLong, 128);
 
     assertThat(paddedShortKey).isEqualTo(prefixKey);
     assertThat(paddedLongKey).isEqualTo(prefixKey);


### PR DESCRIPTION
## Summary
`AbstractPrecompiledContract`'s shared result cache keyed entries by `Arrays.hashCode()` of the semantic input prefix — a 32-bit digest. Two distinct, valid inputs can share the same 32-bit digest (a BLAKE2F example: `31*0 + 0 == 31*1 + (byte) 0xe1` for the first two bytes), so an attacker able to construct such a collision could evict/replace the same cache entry on every call, causing deterministic cache thrashing instead of the intended memoization.

## Change
- Key the cache by the input prefix itself (compared by content) so distinct inputs can never collide into the same bucket.
- Update the cache-weigher to use the key's own size now that the key is a `Bytes` value instead of an `Integer`.

## Test plan
- [x] `BLAKE2BFPrecompileContractCacheCollisionTest` — regression test for the specific collision
- [x] `PrecompileCachePrefixBoundTest` — updated/passing