### PR TITLE
EIP-8037/7928: restore state-gas accounting and block gas dimensions

### DIFF
--- a/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreatorTest.java
+++ b/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreatorTest.java
@@ -352,23 +352,19 @@ class AbstractBlockCreatorTest extends TrustedSetupClassLoaderExtension {
     final Optional<BlockAccessList> maybeBlockAccessList = blockCreationResult.getBlockAccessList();
     assertThat(maybeBlockAccessList).isNotEmpty();
     final BlockAccessList blockAccessList = maybeBlockAccessList.get();
-    final List<AccountChanges> accountChanges = blockAccessList.accountChanges();
+    // The EIP-2935 history contract is not deployed in this genesis, but the pre-execution system
+    // call still reads it, so it appears in the access list with no changes of its own.
+    final List<AccountChanges> accountChanges =
+        blockAccessList.accountChanges().stream()
+            .filter(change -> !change.balanceChanges().isEmpty())
+            .toList();
     assertThat(accountChanges.size()).isEqualTo(3);
-    final AccountChanges accountChange1 = accountChanges.get(0);
-    assertThat(accountChange1.address()).isIn(sender.address(), recipient.address(), coinbase);
-    assertThat(accountChange1.balanceChanges().size()).isEqualTo(1);
-    assertThat(accountChange1.balanceChanges().get(0).postBalance()).isNotEqualTo(Bytes.of(0));
-    assertThat(accountChange1.balanceChanges().get(0).txIndex()).isGreaterThanOrEqualTo(0);
-    final AccountChanges accountChange2 = accountChanges.get(1);
-    assertThat(accountChange2.address()).isIn(sender.address(), recipient.address(), coinbase);
-    assertThat(accountChange2.balanceChanges().size()).isEqualTo(1);
-    assertThat(accountChange2.balanceChanges().get(0).postBalance()).isNotEqualTo(Bytes.of(0));
-    assertThat(accountChange2.balanceChanges().get(0).txIndex()).isGreaterThanOrEqualTo(0);
-    final AccountChanges accountChange3 = accountChanges.get(2);
-    assertThat(accountChange3.address()).isIn(sender.address(), recipient.address(), coinbase);
-    assertThat(accountChange3.balanceChanges().size()).isEqualTo(1);
-    assertThat(accountChange3.balanceChanges().get(0).postBalance()).isNotEqualTo(Bytes.of(0));
-    assertThat(accountChange3.balanceChanges().get(0).txIndex()).isGreaterThanOrEqualTo(0);
+    for (final AccountChanges accountChange : accountChanges) {
+      assertThat(accountChange.address()).isIn(sender.address(), recipient.address(), coinbase);
+      assertThat(accountChange.balanceChanges().size()).isEqualTo(1);
+      assertThat(accountChange.balanceChanges().get(0).postBalance()).isNotEqualTo(Bytes.of(0));
+      assertThat(accountChange.balanceChanges().get(0).txIndex()).isGreaterThanOrEqualTo(0);
+    }
   }
 
   @Test

--- a/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/BlockSizeTransactionSelectorTest.java
+++ b/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/BlockSizeTransactionSelectorTest.java
@@ -246,14 +246,13 @@ class BlockSizeTransactionSelectorTest {
     final long txGasLimit = 50_000L;
     final var tx = createPendingTransaction(txGasLimit);
 
-    // Simulate SSTORE refund scenario:
-    // - Pre-refund gas used: 40,000 (estimateGasUsedByTransaction)
-    // EIP-7778 uses only estimateGasUsedByTransaction, not gasRemaining
+    // An SSTORE refund makes gasRemaining larger than the gas actually consumed; EIP-7778 must
+    // account for the block on the unfloored regular gas instead.
     final long preRefundGasUsed = 40_000L;
 
     final var txProcessingResult = mock(TransactionProcessingResult.class);
-    when(txProcessingResult.getEstimateGasUsedByTransaction()).thenReturn(preRefundGasUsed);
     when(txProcessingResult.getStateGasUsed()).thenReturn(0L);
+    when(txProcessingResult.getRegularGasUsedForBlock()).thenReturn(preRefundGasUsed);
     final var txEvaluationContext =
         new TransactionEvaluationContext(
             blockSelectionContext.pendingBlockHeader(), tx, null, null, null, NEVER_CANCELLED);
@@ -315,9 +314,8 @@ class BlockSizeTransactionSelectorTest {
     // First tx: uses 25M regular, 5M state
     final var tx1 = createPendingTransaction(30_000_000L);
     final var result1 = mock(TransactionProcessingResult.class);
-    when(result1.getEstimateGasUsedByTransaction()).thenReturn(30_000_000L);
     when(result1.getStateGasUsed()).thenReturn(5_000_000L);
-    // calculateTransactionRegularGas returns 30M - 5M = 25M regular
+    when(result1.getRegularGasUsedForBlock()).thenReturn(25_000_000L);
 
     final var ctx1 =
         new TransactionEvaluationContext(
@@ -360,8 +358,8 @@ class BlockSizeTransactionSelectorTest {
     // First tx: gasLimit=30M, uses 20M regular + 10M state = 30M total
     final var tx1 = createPendingTransaction(30_000_000L);
     final var result1 = mock(TransactionProcessingResult.class);
-    when(result1.getEstimateGasUsedByTransaction()).thenReturn(30_000_000L);
     when(result1.getStateGasUsed()).thenReturn(10_000_000L);
+    when(result1.getRegularGasUsedForBlock()).thenReturn(20_000_000L);
 
     final var ctx1 =
         new TransactionEvaluationContext(
@@ -406,9 +404,8 @@ class BlockSizeTransactionSelectorTest {
     // Fill block with regular dimension nearly full: gasLimit=1M, uses 990K regular + 10K state
     final var tx1 = createPendingTransaction(1_000_000L);
     final var result1 = mock(TransactionProcessingResult.class);
-    when(result1.getEstimateGasUsedByTransaction()).thenReturn(1_000_000L);
     when(result1.getStateGasUsed()).thenReturn(10_000L);
-    // regular gas = 1_000_000 - 10_000 = 990_000
+    when(result1.getRegularGasUsedForBlock()).thenReturn(990_000L);
 
     final var ctx1 =
         new TransactionEvaluationContext(

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/BlockGasAccountingStrategy.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/BlockGasAccountingStrategy.java
@@ -101,8 +101,8 @@ public interface BlockGasAccountingStrategy {
         @Override
         public long calculateTransactionRegularGas(
             final Transaction transaction, final TransactionProcessingResult result) {
-          // EIP-7976/EIP-8037: the calldata floor raises what the sender pays but does not
-          // count toward the block's regular gas dimension, so use the unfloored value.
+          // EIP-7976: the calldata floor raises what the sender pays but does not count toward
+          // the block's regular gas dimension.
           return result.getRegularGasUsedForBlock();
         }
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/BlockGasAccountingStrategy.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/BlockGasAccountingStrategy.java
@@ -101,7 +101,9 @@ public interface BlockGasAccountingStrategy {
         @Override
         public long calculateTransactionRegularGas(
             final Transaction transaction, final TransactionProcessingResult result) {
-          return result.getEstimateGasUsedByTransaction() - result.getStateGasUsed();
+          // EIP-7976/EIP-8037: the calldata floor raises what the sender pays but does not
+          // count toward the block's regular gas dimension, so use the unfloored value.
+          return result.getRegularGasUsedForBlock();
         }
 
         @Override
@@ -113,15 +115,12 @@ public interface BlockGasAccountingStrategy {
             final long cumulativeRegularGas,
             final long cumulativeStateGas,
             final long blockGasLimit) {
-          // EIP-8037: per-dimension block gas limit enforcement.
-          // Worst-case regular consumption is capped at TX_MAX_GAS_LIMIT and at
-          // tx.gas - intrinsic_state_gas; worst-case state consumption is tx.gas -
-          // intrinsic_regular_gas. Both must fit in their respective remaining budgets.
+          // The full tx gas limit bounds both dimensions — the intrinsic split is deliberately
+          // not subtracted, since either dimension could consume the whole limit.
           final long regularAvailable = Math.max(0L, blockGasLimit - cumulativeRegularGas);
           final long stateAvailable = Math.max(0L, blockGasLimit - cumulativeStateGas);
-          final long worstCaseRegular =
-              Math.min(txMaxGasLimit, Math.max(0L, txGasLimit - intrinsicStateGas));
-          final long worstCaseState = Math.max(0L, txGasLimit - intrinsicRegularGas);
+          final long worstCaseRegular = Math.min(txMaxGasLimit, txGasLimit);
+          final long worstCaseState = txGasLimit;
           return worstCaseRegular <= regularAvailable && worstCaseState <= stateAvailable;
         }
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessor.java
@@ -387,13 +387,15 @@ public class MainnetTransactionProcessor {
 
       final MessageFrame initialFrame;
       // A creation onto an already-alive (e.g. pre-funded) target adds no leaf, so its intrinsic
-      // NEW_ACCOUNT state gas is refunded.
+      // NEW_ACCOUNT state gas is refunded. Nothing reads this when state gas is inactive.
       boolean createTargetAlreadyAlive = false;
       if (transaction.isContractCreation()) {
         final Address contractAddress =
             Address.contractAddress(senderAddress, sender.getNonce() - 1L);
-        final Account existingTarget = worldState.get(contractAddress);
-        createTargetAlreadyAlive = existingTarget != null && !existingTarget.isEmpty();
+        if (stateGasCalc.isActive()) {
+          final Account existingTarget = worldState.get(contractAddress);
+          createTargetAlreadyAlive = existingTarget != null && !existingTarget.isEmpty();
+        }
         accessLocationTracker.ifPresent(t -> t.addTouchedAccount(contractAddress));
 
         final Bytes initCodeBytes = transaction.getPayload();
@@ -454,8 +456,8 @@ public class MainnetTransactionProcessor {
       // Transaction-level state-gas charges persist regardless of the execution outcome, so put
       // them out of reach of a rollback.
       initialFrame.advanceUndoMark();
-      // Those charges may have drawn from gasRemaining, which would look like frame spill. Clear
-      // it so the failure handler cannot refund them a second time.
+      // They may have drawn from gasRemaining, so clear the spill to stop the failure handler
+      // refunding them a second time.
       initialFrame.resetStateGasSpilled();
 
       Deque<MessageFrame> messageFrameStack = initialFrame.getMessageFrameStack();
@@ -492,20 +494,19 @@ public class MainnetTransactionProcessor {
           refundTxCreateIntrinsicStateGas(initialFrame, stateGasCalc);
         }
       } else {
+        // A real halt reason is more specific, so it wins when both apply.
         if (initialFrame.getExceptionalHaltReason().isPresent()) {
           validationResult =
               ValidationResult.invalid(
                   TransactionInvalidReason.EXECUTION_HALTED,
                   initialFrame.getExceptionalHaltReason().get().getDescription());
-        }
-        if (regularGasLimitExceeded) {
+        } else if (regularGasLimitExceeded) {
           validationResult =
               ValidationResult.invalid(
                   TransactionInvalidReason.EXECUTION_HALTED,
                   "Regular gas consumption exceeds TX_MAX_GAS_LIMIT");
         }
-        // No account persists on a failed creation tx, so the intrinsic NEW_ACCOUNT charge must
-        // be returned to the sender via the reservoir leftover.
+        // No account persists on a failed creation tx, so the intrinsic charge is returned.
         if (stateGasCalc.isActive() && transaction.isContractCreation()) {
           refundTxCreateIntrinsicStateGas(initialFrame, stateGasCalc);
         }
@@ -744,9 +745,8 @@ public class MainnetTransactionProcessor {
   }
 
   /**
-   * Returns a contract-creation transaction's intrinsic NEW_ACCOUNT state gas when no leaf ends up
-   * being added. It goes straight to the reservoir rather than to gasRemaining, because the
-   * intrinsic spill was cleared before execution began.
+   * Refunds a creation transaction's intrinsic NEW_ACCOUNT state gas when no leaf is added. It goes
+   * straight to the reservoir, since the intrinsic spill was cleared before execution began.
    */
   private static void refundTxCreateIntrinsicStateGas(
       final MessageFrame initialFrame, final StateGasCostCalculator stateGasCalc) {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessor.java
@@ -386,9 +386,14 @@ public class MainnetTransactionProcessor {
       }
 
       final MessageFrame initialFrame;
+      // A creation onto an already-alive (e.g. pre-funded) target adds no leaf, so its intrinsic
+      // NEW_ACCOUNT state gas is refunded.
+      boolean createTargetAlreadyAlive = false;
       if (transaction.isContractCreation()) {
         final Address contractAddress =
             Address.contractAddress(senderAddress, sender.getNonce() - 1L);
+        final Account existingTarget = worldState.get(contractAddress);
+        createTargetAlreadyAlive = existingTarget != null && !existingTarget.isEmpty();
         accessLocationTracker.ifPresent(t -> t.addTouchedAccount(contractAddress));
 
         final Bytes initCodeBytes = transaction.getPayload();
@@ -445,18 +450,47 @@ public class MainnetTransactionProcessor {
           }
         }
       }
+
+      // Transaction-level state-gas charges persist regardless of the execution outcome, so put
+      // them out of reach of a rollback.
+      initialFrame.advanceUndoMark();
+      // Those charges may have drawn from gasRemaining, which would look like frame spill. Clear
+      // it so the failure handler cannot refund them a second time.
+      initialFrame.resetStateGasSpilled();
+
       Deque<MessageFrame> messageFrameStack = initialFrame.getMessageFrameStack();
       while (!messageFrameStack.isEmpty()) {
         process(messageFrameStack.peekFirst(), operationTracer);
       }
 
-      // EIP-8037: regular gas consumption is bounded before execution — the initial frame is built
-      // with at most transactionRegularGasLimit() - intrinsicRegularGas of regular gas (see
-      // IntrinsicStateGasCharge.compute), so no runtime revert on regular gas is needed here.
-      final boolean txSucceeded = initialFrame.getState() == MessageFrame.State.COMPLETED_SUCCESS;
+      // Under two-dimensional gas, tx.gasLimit may exceed TX_MAX_GAS_LIMIT to accommodate state
+      // gas, so the cap on regular gas has to be enforced separately here.
+      final long totalRemaining =
+          initialFrame.getRemainingGas() + initialFrame.getStateGasReservoir();
+      final long totalConsumed = transaction.getGasLimit() - totalRemaining;
+      final long regularConsumed = totalConsumed - initialFrame.getStateGasUsed();
+      final boolean regularGasLimitExceeded =
+          regularConsumed > stateGasCalc.transactionRegularGasLimit();
+      if (regularGasLimitExceeded) {
+        LOG.debug(
+            "Transaction {} regular gas {} exceeds TX_MAX_GAS_LIMIT {}, reverting",
+            transaction.getHash(),
+            regularConsumed,
+            stateGasCalc.transactionRegularGasLimit());
+      }
+
+      final boolean txSucceeded =
+          initialFrame.getState() == MessageFrame.State.COMPLETED_SUCCESS
+              && !regularGasLimitExceeded;
 
       if (txSucceeded) {
         worldUpdater.commit();
+        // No leaf was added, so the intrinsic charge is refunded (failure case handled below).
+        if (stateGasCalc.isActive()
+            && transaction.isContractCreation()
+            && createTargetAlreadyAlive) {
+          refundTxCreateIntrinsicStateGas(initialFrame, stateGasCalc);
+        }
       } else {
         if (initialFrame.getExceptionalHaltReason().isPresent()) {
           validationResult =
@@ -464,12 +498,16 @@ public class MainnetTransactionProcessor {
                   TransactionInvalidReason.EXECUTION_HALTED,
                   initialFrame.getExceptionalHaltReason().get().getDescription());
         }
+        if (regularGasLimitExceeded) {
+          validationResult =
+              ValidationResult.invalid(
+                  TransactionInvalidReason.EXECUTION_HALTED,
+                  "Regular gas consumption exceeds TX_MAX_GAS_LIMIT");
+        }
         // No account persists on a failed creation tx, so the intrinsic NEW_ACCOUNT charge must
         // be returned to the sender via the reservoir leftover.
         if (stateGasCalc.isActive() && transaction.isContractCreation()) {
-          final long createStateGas = stateGasCalc.newContractStateGas();
-          initialFrame.incrementStateGasReservoir(createStateGas);
-          initialFrame.decrementStateGasUsed(createStateGas);
+          refundTxCreateIntrinsicStateGas(initialFrame, stateGasCalc);
         }
       }
 
@@ -484,7 +522,9 @@ public class MainnetTransactionProcessor {
       // Refund the sender by what we should and pay the miner fee (note that we're doing them one
       // after the other so that if it is the same account somehow, we end up with the right result)
       final long refundedGas =
-          gasCalculator.calculateGasRefund(transaction, initialFrame, codeDelegationRefund);
+          regularGasLimitExceeded
+              ? 0L
+              : gasCalculator.calculateGasRefund(transaction, initialFrame, codeDelegationRefund);
       final Wei refundedWei = transactionGasPrice.multiply(refundedGas);
       final Wei balancePriorToRefund = sender.getBalance();
       sender.incrementBalance(refundedWei);
@@ -508,9 +548,10 @@ public class MainnetTransactionProcessor {
               .stateGasUsed(initialFrame.getStateGasUsed())
               .refundedGas(refundedGas)
               .floorCost(floorCost)
+              .regularGasLimitExceeded(regularGasLimitExceeded)
               .build()
               .calculate();
-      final long stateGasUsed = initialFrame.getStateGasUsed();
+      final long stateGasUsed = gasResult.effectiveStateGas();
       final long gasUsedByTransaction = gasResult.gasUsedByTransaction();
       final long usedGas = gasResult.usedGas();
       LOG.trace(
@@ -596,15 +637,18 @@ public class MainnetTransactionProcessor {
           accessLocationTracker.map(tracker -> tracker.createPartialBlockAccessView(worldState));
 
       if (txSucceeded) {
-        return TransactionProcessingResult.successful(
-            initialFrame.getLogs(),
-            gasUsedByTransaction,
-            refundedGas,
-            usedGas,
-            stateGasUsed,
-            initialFrame.getOutputData(),
-            partialBlockAccessView,
-            validationResult);
+        final TransactionProcessingResult successResult =
+            TransactionProcessingResult.successful(
+                initialFrame.getLogs(),
+                gasUsedByTransaction,
+                refundedGas,
+                usedGas,
+                stateGasUsed,
+                initialFrame.getOutputData(),
+                partialBlockAccessView,
+                validationResult);
+        successResult.setRegularGasUsedForBlock(gasResult.regularGas());
+        return successResult;
       } else {
         if (initialFrame.getExceptionalHaltReason().isPresent()) {
           LOG.debug(
@@ -618,15 +662,18 @@ public class MainnetTransactionProcessor {
               transaction.getHash(),
               initialFrame.getRevertReason().get());
         }
-        return TransactionProcessingResult.failed(
-            gasUsedByTransaction,
-            refundedGas,
-            usedGas,
-            stateGasUsed,
-            validationResult,
-            initialFrame.getRevertReason(),
-            initialFrame.getExceptionalHaltReason(),
-            partialBlockAccessView);
+        final TransactionProcessingResult failedResult =
+            TransactionProcessingResult.failed(
+                gasUsedByTransaction,
+                refundedGas,
+                usedGas,
+                stateGasUsed,
+                validationResult,
+                initialFrame.getRevertReason(),
+                initialFrame.getExceptionalHaltReason(),
+                partialBlockAccessView);
+        failedResult.setRegularGasUsedForBlock(gasResult.regularGas());
+        return failedResult;
       }
     } catch (final MerkleTrieException re) {
       operationTracer.traceEndTransaction(
@@ -694,6 +741,18 @@ public class MainnetTransactionProcessor {
 
   public GasCalculator getGasCalculator() {
     return gasCalculator;
+  }
+
+  /**
+   * Returns a contract-creation transaction's intrinsic NEW_ACCOUNT state gas when no leaf ends up
+   * being added. It goes straight to the reservoir rather than to gasRemaining, because the
+   * intrinsic spill was cleared before execution began.
+   */
+  private static void refundTxCreateIntrinsicStateGas(
+      final MessageFrame initialFrame, final StateGasCostCalculator stateGasCalc) {
+    final long createStateGas = stateGasCalc.newContractStateGas();
+    initialFrame.incrementStateGasReservoir(createStateGas);
+    initialFrame.decrementStateGasUsed(createStateGas);
   }
 
   /** Halts the initial frame for a pre-execution charge it can't cover. */

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/TransactionGasAccounting.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/TransactionGasAccounting.java
@@ -34,8 +34,17 @@ public abstract class TransactionGasAccounting {
 
   private static final Logger LOG = LoggerFactory.getLogger(TransactionGasAccounting.class);
 
-  /** Result of the gas accounting calculation. */
-  public record GasResult(long gasUsedByTransaction, long usedGas) {}
+  /**
+   * Result of the gas accounting calculation.
+   *
+   * @param effectiveStateGas the state gas dimension
+   * @param gasUsedByTransaction floored 2D gas (max(regular, floor) + state) for
+   *     estimation/receipts
+   * @param usedGas post-refund gas the sender pays
+   * @param regularGas the unfloored regular gas dimension (execution - state) for block accounting
+   */
+  public record GasResult(
+      long effectiveStateGas, long gasUsedByTransaction, long usedGas, long regularGas) {}
 
   /** The transaction gas limit. */
   public abstract long txGasLimit();
@@ -55,6 +64,9 @@ public abstract class TransactionGasAccounting {
   /** Transaction floor cost (EIP-7623), 0 for pre-Prague. */
   public abstract long floorCost();
 
+  /** Whether the regular gas limit was exceeded (EIP-8037). */
+  public abstract boolean regularGasLimitExceeded();
+
   /** Creates a new builder. */
   public static ImmutableTransactionGasAccounting.Builder builder() {
     return ImmutableTransactionGasAccounting.builder();
@@ -63,20 +75,27 @@ public abstract class TransactionGasAccounting {
   /**
    * Calculate gas accounting for a completed transaction.
    *
-   * @return the gas result containing gasUsedByTransaction and usedGas
+   * @return the gas result containing effectiveStateGas, gasUsedByTransaction, usedGas and
+   *     regularGas
    */
   public GasResult calculate() {
+    if (regularGasLimitExceeded()) {
+      return new GasResult(
+          stateGasUsed(), txGasLimit(), txGasLimit(), Math.max(0L, txGasLimit() - stateGasUsed()));
+    }
+
     final long executionGas = txGasLimit() - remainingGas() - stateGasReservoir();
-    final long regularGas = executionGas - stateGasUsed();
+    final long stateGas = stateGasUsed();
+    final long regularGas = executionGas - stateGas;
     if (regularGas < 0) {
       LOG.error(
           "Negative regularGas={} (executionGas={}, stateGas={})",
           regularGas,
           executionGas,
-          stateGasUsed());
+          stateGas);
     }
-    final long gasUsedByTransaction = Math.max(regularGas, floorCost()) + stateGasUsed();
+    final long gasUsedByTransaction = Math.max(regularGas, floorCost()) + stateGas;
     final long usedGas = txGasLimit() - refundedGas();
-    return new GasResult(gasUsedByTransaction, usedGas);
+    return new GasResult(stateGas, gasUsedByTransaction, usedGas, Math.max(0L, regularGas));
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/systemcall/SystemCallProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/systemcall/SystemCallProcessor.java
@@ -82,11 +82,11 @@ public class SystemCallProcessor {
     WorldUpdater blockUpdater = context.getWorldState().updater();
     WorldUpdater systemCallUpdater = blockUpdater.updater();
     // EIP-7928: the account is read before we can know whether there is code to run, so an absent
-    // system contract still belongs in the access list. Flush here too, since the flush at the end
-    // of a successful call is skipped when we throw below.
+    // system contract still belongs in the access list.
     accessLocationTracker.ifPresent(tracker -> tracker.addTouchedAccount(callAddress));
     final Account maybeContract = systemCallUpdater.get(callAddress);
     if (maybeContract == null || maybeContract.getCode().isEmpty()) {
+      // Throwing skips the flush at the end of a successful call, so flush here instead.
       applyAccessLocationTracker(accessLocationTracker, context, systemCallUpdater);
       throw new SystemCallNoCodeAtAddressException(
           maybeContract == null

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/systemcall/SystemCallProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/systemcall/SystemCallProcessor.java
@@ -81,13 +81,17 @@ public class SystemCallProcessor {
       final Optional<AccessLocationTracker> accessLocationTracker) {
     WorldUpdater blockUpdater = context.getWorldState().updater();
     WorldUpdater systemCallUpdater = blockUpdater.updater();
+    // EIP-7928: the account is read before we can know whether there is code to run, so an absent
+    // system contract still belongs in the access list. Flush here too, since the flush at the end
+    // of a successful call is skipped when we throw below.
+    accessLocationTracker.ifPresent(tracker -> tracker.addTouchedAccount(callAddress));
     final Account maybeContract = systemCallUpdater.get(callAddress);
-    if (maybeContract == null) {
-      throw new SystemCallNoCodeAtAddressException("Invalid system call address: " + callAddress);
-    }
-    if (maybeContract.getCode().isEmpty()) {
+    if (maybeContract == null || maybeContract.getCode().isEmpty()) {
+      applyAccessLocationTracker(accessLocationTracker, context, systemCallUpdater);
       throw new SystemCallNoCodeAtAddressException(
-          "Invalid system call, no code at address " + callAddress);
+          maybeContract == null
+              ? "Invalid system call address: " + callAddress
+              : "Invalid system call, no code at address " + callAddress);
     }
 
     final AbstractMessageProcessor processor =
@@ -114,11 +118,7 @@ public class SystemCallProcessor {
       processor.process(stack.peekFirst(), tracer);
     }
 
-    accessLocationTracker.ifPresent(
-        tracker ->
-            context
-                .getBlockAccessListBuilder()
-                .ifPresent(builder -> builder.apply(tracker, systemCallUpdater)));
+    applyAccessLocationTracker(accessLocationTracker, context, systemCallUpdater);
 
     if (frame.getState() == MessageFrame.State.COMPLETED_SUCCESS) {
       systemCallUpdater.commit();
@@ -138,6 +138,17 @@ public class SystemCallProcessor {
             .map(haltReason -> "System call halted: " + haltReason.getDescription())
             .orElse("System call did not execute to completion");
     throw new RuntimeException(errorMessage);
+  }
+
+  private static void applyAccessLocationTracker(
+      final Optional<AccessLocationTracker> accessLocationTracker,
+      final BlockProcessingContext context,
+      final WorldUpdater systemCallUpdater) {
+    accessLocationTracker.ifPresent(
+        tracker ->
+            context
+                .getBlockAccessListBuilder()
+                .ifPresent(builder -> builder.apply(tracker, systemCallUpdater)));
   }
 
   private MessageFrame createMessageFrame(

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/processing/TransactionProcessingResult.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/processing/TransactionProcessingResult.java
@@ -362,9 +362,9 @@ public class TransactionProcessingResult
   }
 
   /**
-   * Returns the unfloored regular gas dimension for EIP-8037 block accounting. The EIP-7976
-   * calldata floor raises what the sender pays but does not count toward the block, so it is
-   * excluded here. The fallback is equivalent whenever the floor is not binding.
+   * Returns the unfloored regular gas dimension for EIP-8037 block accounting: the EIP-7976
+   * calldata floor raises what the sender pays but does not count toward the block. The fallback is
+   * equivalent while the floor is not binding.
    *
    * @return the unfloored regular gas used for block accounting
    */

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/processing/TransactionProcessingResult.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/processing/TransactionProcessingResult.java
@@ -52,6 +52,9 @@ public class TransactionProcessingResult
 
   private final long stateGasUsed;
 
+  /** EIP-8037 block-accounting regular gas; {@link Long#MIN_VALUE} means "not set". */
+  private long regularGasUsedForBlock = Long.MIN_VALUE;
+
   private final List<Log> logs;
 
   private final Bytes output;
@@ -356,6 +359,29 @@ public class TransactionProcessingResult
    */
   public long getStateGasUsed() {
     return stateGasUsed;
+  }
+
+  /**
+   * Returns the unfloored regular gas dimension for EIP-8037 block accounting. The EIP-7976
+   * calldata floor raises what the sender pays but does not count toward the block, so it is
+   * excluded here. The fallback is equivalent whenever the floor is not binding.
+   *
+   * @return the unfloored regular gas used for block accounting
+   */
+  public long getRegularGasUsedForBlock() {
+    return regularGasUsedForBlock == Long.MIN_VALUE
+        ? estimateGasUsedByTransaction - stateGasUsed
+        : regularGasUsedForBlock;
+  }
+
+  /**
+   * Sets the unfloored regular gas dimension for EIP-8037 block accounting.
+   *
+   * @param regularGasUsedForBlock the unfloored regular gas
+   */
+  @SuppressWarnings("checkstyle:HiddenField")
+  public void setRegularGasUsedForBlock(final long regularGasUsedForBlock) {
+    this.regularGasUsedForBlock = regularGasUsedForBlock;
   }
 
   /**

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/AbstractBlockProcessorIntegrationTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/AbstractBlockProcessorIntegrationTest.java
@@ -90,6 +90,10 @@ class AbstractBlockProcessorIntegrationTest {
       Address.fromHexString("0x0000884d2aa32eaa155f59a2f24efa73d9008282");
   private static final Address BUILDER_EXIT_CONTRACT =
       Address.fromHexString("0x000014574a74c805590aff9499fc7a690f008282");
+  // EIP-2935 history contract. It is not deployed in this test genesis, but the pre-execution
+  // system call still reads the account, so EIP-7928 lists it in every block's access list.
+  private static final Address HISTORY_STORAGE_CONTRACT =
+      Address.fromHexString("0x0000f90827f1c53a10cb7a02335b175320002935");
 
   private static final KeyPair ACCOUNT_GENESIS_1_KEYPAIR =
       generateKeyPair("c87509a1c067bbde78beb793e6fa76530b6382a4c0241e5e4a9ec0a0f44dc0d3");
@@ -377,7 +381,8 @@ class AbstractBlockProcessorIntegrationTest {
         WITHDRAWAL_CONTRACT,
         CONSOLIDATION_CONTRACT,
         BUILDER_DEPOSIT_CONTRACT,
-        BUILDER_EXIT_CONTRACT);
+        BUILDER_EXIT_CONTRACT,
+        HISTORY_STORAGE_CONTRACT);
 
     assertBalanceMatchesWorldState(sequentialResult, Address.fromHexStringStrict(ACCOUNT_2));
     assertBalanceMatchesWorldState(sequentialResult, Address.fromHexStringStrict(ACCOUNT_3));
@@ -400,7 +405,8 @@ class AbstractBlockProcessorIntegrationTest {
         WITHDRAWAL_CONTRACT,
         CONSOLIDATION_CONTRACT,
         BUILDER_DEPOSIT_CONTRACT,
-        BUILDER_EXIT_CONTRACT);
+        BUILDER_EXIT_CONTRACT,
+        HISTORY_STORAGE_CONTRACT);
 
     assertBalanceMatchesWorldState(parallelResult, Address.fromHexStringStrict(ACCOUNT_2));
     assertBalanceMatchesWorldState(parallelResult, Address.fromHexStringStrict(ACCOUNT_3));
@@ -461,6 +467,7 @@ class AbstractBlockProcessorIntegrationTest {
         CONSOLIDATION_CONTRACT,
         BUILDER_DEPOSIT_CONTRACT,
         BUILDER_EXIT_CONTRACT,
+        HISTORY_STORAGE_CONTRACT,
         coinbase);
 
     assertBalanceMatchesWorldState(blockProcessingResult, Address.fromHexStringStrict(ACCOUNT_2));
@@ -525,6 +532,7 @@ class AbstractBlockProcessorIntegrationTest {
         CONSOLIDATION_CONTRACT,
         BUILDER_DEPOSIT_CONTRACT,
         BUILDER_EXIT_CONTRACT,
+        HISTORY_STORAGE_CONTRACT,
         Address.fromHexStringStrict(ACCOUNT_GENESIS_1),
         coinbase);
 
@@ -606,6 +614,7 @@ class AbstractBlockProcessorIntegrationTest {
         CONSOLIDATION_CONTRACT,
         BUILDER_DEPOSIT_CONTRACT,
         BUILDER_EXIT_CONTRACT,
+        HISTORY_STORAGE_CONTRACT,
         coinbase);
 
     assertBalanceMatchesWorldState(blockProcessingResult, Address.fromHexStringStrict(ACCOUNT_2));
@@ -681,6 +690,7 @@ class AbstractBlockProcessorIntegrationTest {
         CONSOLIDATION_CONTRACT,
         BUILDER_DEPOSIT_CONTRACT,
         BUILDER_EXIT_CONTRACT,
+        HISTORY_STORAGE_CONTRACT,
         coinbase);
 
     assertBalanceMatchesWorldState(blockProcessingResult, Address.fromHexStringStrict(ACCOUNT_2));
@@ -740,6 +750,7 @@ class AbstractBlockProcessorIntegrationTest {
         CONSOLIDATION_CONTRACT,
         BUILDER_DEPOSIT_CONTRACT,
         BUILDER_EXIT_CONTRACT,
+        HISTORY_STORAGE_CONTRACT,
         coinbase);
 
     // contract balance is unchanged so no balance changes recorded
@@ -802,6 +813,7 @@ class AbstractBlockProcessorIntegrationTest {
         CONSOLIDATION_CONTRACT,
         BUILDER_DEPOSIT_CONTRACT,
         BUILDER_EXIT_CONTRACT,
+        HISTORY_STORAGE_CONTRACT,
         coinbase);
 
     // contract balance is unchanged so no balance changes recorded
@@ -874,6 +886,7 @@ class AbstractBlockProcessorIntegrationTest {
         CONSOLIDATION_CONTRACT,
         BUILDER_DEPOSIT_CONTRACT,
         BUILDER_EXIT_CONTRACT,
+        HISTORY_STORAGE_CONTRACT,
         coinbase);
 
     assertBalanceMatchesWorldState(blockProcessingResult, contractAddress);
@@ -944,6 +957,7 @@ class AbstractBlockProcessorIntegrationTest {
         CONSOLIDATION_CONTRACT,
         BUILDER_DEPOSIT_CONTRACT,
         BUILDER_EXIT_CONTRACT,
+        HISTORY_STORAGE_CONTRACT,
         coinbase);
 
     assertBalanceMatchesWorldState(blockProcessingResult, contractAddress);
@@ -1014,6 +1028,7 @@ class AbstractBlockProcessorIntegrationTest {
         CONSOLIDATION_CONTRACT,
         BUILDER_DEPOSIT_CONTRACT,
         BUILDER_EXIT_CONTRACT,
+        HISTORY_STORAGE_CONTRACT,
         coinbase);
 
     assertBalanceMatchesWorldState(blockProcessingResult, contractAddress);
@@ -1085,6 +1100,7 @@ class AbstractBlockProcessorIntegrationTest {
         CONSOLIDATION_CONTRACT,
         BUILDER_DEPOSIT_CONTRACT,
         BUILDER_EXIT_CONTRACT,
+        HISTORY_STORAGE_CONTRACT,
         coinbase);
 
     assertBalanceMatchesWorldState(blockProcessingResult, contractAddress);

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/BlockGasAccountingStrategyTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/BlockGasAccountingStrategyTest.java
@@ -69,7 +69,6 @@ public class BlockGasAccountingStrategyTest {
     when(result.getStateGasUsed()).thenReturn(0L);
     when(result.getRegularGasUsedForBlock()).thenReturn(PRE_REFUND_GAS);
 
-    // Amsterdam strategy: estimateGasUsedByTransaction - stateGasUsed = 70,000 - 0 = 70,000
     final long blockGas =
         BlockGasAccountingStrategy.AMSTERDAM.calculateTransactionRegularGas(tx, result);
 
@@ -139,12 +138,10 @@ public class BlockGasAccountingStrategyTest {
 
     final TransactionProcessingResult result = mock(TransactionProcessingResult.class);
     when(result.getGasRemaining()).thenReturn(GAS_REMAINING);
-    // estimateGasUsedByTransaction = 70,000 (pre-refund), stateGas = 10,000
     when(result.getEstimateGasUsedByTransaction()).thenReturn(PRE_REFUND_GAS);
     when(result.getStateGasUsed()).thenReturn(10_000L);
     when(result.getRegularGasUsedForBlock()).thenReturn(60_000L);
 
-    // Amsterdam block gas = estimateGas - stateGas = 70,000 - 10,000 = 60,000
     final long blockGas =
         BlockGasAccountingStrategy.AMSTERDAM.calculateTransactionRegularGas(tx, result);
     assertThat(blockGas).isEqualTo(60_000L);

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/BlockGasAccountingStrategyTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/BlockGasAccountingStrategyTest.java
@@ -67,6 +67,7 @@ public class BlockGasAccountingStrategyTest {
     when(result.getGasRemaining()).thenReturn(GAS_REMAINING);
     when(result.getEstimateGasUsedByTransaction()).thenReturn(PRE_REFUND_GAS);
     when(result.getStateGasUsed()).thenReturn(0L);
+    when(result.getRegularGasUsedForBlock()).thenReturn(PRE_REFUND_GAS);
 
     // Amsterdam strategy: estimateGasUsedByTransaction - stateGasUsed = 70,000 - 0 = 70,000
     final long blockGas =
@@ -92,6 +93,7 @@ public class BlockGasAccountingStrategyTest {
     when(result.getGasRemaining()).thenReturn(gasRemainingAfterRefund);
     when(result.getEstimateGasUsedByTransaction()).thenReturn(preRefundGasUsed);
     when(result.getStateGasUsed()).thenReturn(0L);
+    when(result.getRegularGasUsedForBlock()).thenReturn(preRefundGasUsed);
 
     // Frontier: 100,000 - 40,000 = 60,000 (benefits from refund)
     final long frontierGas =
@@ -119,6 +121,7 @@ public class BlockGasAccountingStrategyTest {
     when(result.getGasRemaining()).thenReturn(gasRemaining);
     when(result.getEstimateGasUsedByTransaction()).thenReturn(gasUsed);
     when(result.getStateGasUsed()).thenReturn(0L);
+    when(result.getRegularGasUsedForBlock()).thenReturn(gasUsed);
 
     final long frontierGas =
         BlockGasAccountingStrategy.FRONTIER.calculateTransactionRegularGas(tx, result);
@@ -139,6 +142,7 @@ public class BlockGasAccountingStrategyTest {
     // estimateGasUsedByTransaction = 70,000 (pre-refund), stateGas = 10,000
     when(result.getEstimateGasUsedByTransaction()).thenReturn(PRE_REFUND_GAS);
     when(result.getStateGasUsed()).thenReturn(10_000L);
+    when(result.getRegularGasUsedForBlock()).thenReturn(60_000L);
 
     // Amsterdam block gas = estimateGas - stateGas = 70,000 - 10,000 = 60,000
     final long blockGas =

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/Eip8037GasLimitTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/Eip8037GasLimitTest.java
@@ -191,21 +191,10 @@ class Eip8037GasLimitTest {
 
   @Test
   void exceptionalHaltShouldNotDeleteAccountsViaSelfDestructs() {
-    // Defense-in-depth regression test: when the initial frame ends in EXCEPTIONAL_HALT
-    // (txSucceeded
-    // = false), any selfdestruct markers left on the frame must NOT cause deleteAccount calls on
-    // the
-    // world state. Before the MTP fix, the unconditional
-    // getSelfDestructs().forEach(worldState::deleteAccount) loop fired even for failed
-    // transactions,
-    // permanently deleting pre-existing accounts from world state.
-    //
-    // Note: this originally targeted the regularGasLimitExceeded path (regular gas portion exceeds
-    // TX_MAX_GAS_LIMIT), but that admission check has since moved out of
-    // MainnetTransactionProcessor
-    // into block-level BlockGasAccountingStrategy#hasBlockCapacity, which runs before a transaction
-    // is even selected for execution. EXCEPTIONAL_HALT is exercised instead, as the still-reachable
-    // failure path that leaves txSucceeded false at this layer.
+    // Regression test: a failed transaction once deleted the accounts its selfdestruct markers
+    // named, wiping pre-existing accounts from world state. EXCEPTIONAL_HALT is the cheapest way
+    // to reach that failure branch — driving regular gas past TX_MAX_GAS_LIMIT reaches the same
+    // one.
     setupCommonMocks(20_000_000L);
 
     final Address childAddress =

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/TransactionGasAccountingTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/TransactionGasAccountingTest.java
@@ -30,7 +30,8 @@ public class TransactionGasAccountingTest {
         .stateGasReservoir(0L)
         .stateGasUsed(0L)
         .refundedGas(0L)
-        .floorCost(0L);
+        .floorCost(0L)
+        .regularGasLimitExceeded(false);
   }
 
   @Test

--- a/evm/src/main/java/org/hyperledger/besu/evm/frame/MessageFrame.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/frame/MessageFrame.java
@@ -223,8 +223,8 @@ public class MessageFrame {
   // is refunded on success.
   private boolean createTargetWasAlive = false;
 
-  // EIP-8037: state gas this frame drew from its own gasRemaining once the reservoir ran dry.
-  // Frame-local like gasRemaining, so refunds and failures can unwind it separately.
+  // EIP-8037: state gas drawn from gasRemaining once the reservoir ran dry. Frame-local, so
+  // refunds and failures can unwind it separately.
   private long stateGasSpilled = 0L;
 
   // Transaction state fields.
@@ -949,7 +949,7 @@ public class MessageFrame {
   // ---- stateGasSpilled ----
 
   /**
-   * Returns the net state gas this frame has spilled into its own gasRemaining.
+   * Returns the net state gas this frame has spilled into gasRemaining.
    *
    * @return the spilled state gas
    */
@@ -958,7 +958,7 @@ public class MessageFrame {
   }
 
   /**
-   * Adds to this frame's spilled state gas, when absorbing a successful child's spill.
+   * Adds to this frame's spilled state gas, so a parent can absorb a successful child's spill.
    *
    * @param amount the amount to add
    */
@@ -966,7 +966,7 @@ public class MessageFrame {
     this.stateGasSpilled += amount;
   }
 
-  /** Resets this frame's spilled state gas to zero, once its charges are fully unwound. */
+  /** Clears the spill once its charges are unwound, so they cannot be refunded twice. */
   public void resetStateGasSpilled() {
     this.stateGasSpilled = 0L;
   }
@@ -1027,9 +1027,8 @@ public class MessageFrame {
   }
 
   /**
-   * Credits state gas back in LIFO order: gasRemaining up to the frame's spill, then the reservoir.
-   * The routing is observable — gas returned to gasRemaining is invisible to a sub-call, which can
-   * only draw state gas from the reservoir.
+   * Credits state gas back in LIFO order: the frame's spill first, then the reservoir. The order is
+   * observable, since a sub-call can only draw state gas from the reservoir.
    *
    * @param amount the refill amount
    */
@@ -1268,8 +1267,8 @@ public class MessageFrame {
   }
 
   /**
-   * Records whether the CREATE/CREATE2 being spawned from this frame targets an address that was
-   * already alive (existed and non-empty).
+   * Records whether the CREATE/CREATE2 spawned from this frame targets an already-alive (existing,
+   * non-empty) address.
    *
    * @param wasAlive true if the create target was already alive
    */
@@ -1278,8 +1277,8 @@ public class MessageFrame {
   }
 
   /**
-   * Whether the most recent CREATE/CREATE2 from this frame targeted an already-alive address, in
-   * which case no leaf is added and its NEW_ACCOUNT state gas is refunded.
+   * Whether the most recent CREATE/CREATE2 targeted an already-alive address, in which case no leaf
+   * is added and its NEW_ACCOUNT state gas is refunded.
    *
    * @return true if the create target was already alive
    */
@@ -1511,8 +1510,8 @@ public class MessageFrame {
   }
 
   /**
-   * Advances the undo mark so later rollbacks do not undo changes made before this point. Used to
-   * protect the transaction's intrinsic state-gas charges from the initial frame reverting.
+   * Advances the undo mark, so that a rollback of the initial frame cannot undo the transaction's
+   * intrinsic state-gas charges.
    */
   public void advanceUndoMark() {
     this.undoMark = txValues.transientStorage().mark();

--- a/evm/src/main/java/org/hyperledger/besu/evm/frame/MessageFrame.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/frame/MessageFrame.java
@@ -219,6 +219,14 @@ public class MessageFrame {
   private Code createdCode = null;
   private final boolean isStatic;
 
+  // EIP-8037: an already-alive CREATE/CREATE2 target adds no leaf, so its NEW_ACCOUNT state gas
+  // is refunded on success.
+  private boolean createTargetWasAlive = false;
+
+  // EIP-8037: state gas this frame drew from its own gasRemaining once the reservoir ran dry.
+  // Frame-local like gasRemaining, so refunds and failures can unwind it separately.
+  private long stateGasSpilled = 0L;
+
   // Transaction state fields.
   private final List<Log> logs = new ArrayList<>();
   private final Map<Address, Wei> refunds = new HashMap<>();
@@ -247,7 +255,7 @@ public class MessageFrame {
   private Optional<Eip7928AccessList> eip7928AccessList = Optional.empty();
 
   /** The mark of the undoable collections at the creation of this message frame */
-  private final long undoMark;
+  private long undoMark;
 
   /**
    * Builder builder.
@@ -938,6 +946,31 @@ public class MessageFrame {
     }
   }
 
+  // ---- stateGasSpilled ----
+
+  /**
+   * Returns the net state gas this frame has spilled into its own gasRemaining.
+   *
+   * @return the spilled state gas
+   */
+  public long getStateGasSpilled() {
+    return stateGasSpilled;
+  }
+
+  /**
+   * Adds to this frame's spilled state gas, when absorbing a successful child's spill.
+   *
+   * @param amount the amount to add
+   */
+  public void incrementStateGasSpilled(final long amount) {
+    this.stateGasSpilled += amount;
+  }
+
+  /** Resets this frame's spilled state gas to zero, once its charges are fully unwound. */
+  public void resetStateGasSpilled() {
+    this.stateGasSpilled = 0L;
+  }
+
   // ---- consume ----
 
   /**
@@ -950,52 +983,66 @@ public class MessageFrame {
   public boolean consumeStateGas(final long amount) {
     final long reservoirBefore = txValues.stateGasReservoir().get();
     final long gasLeftBefore = gasRemaining;
-    // Draw from the reservoir first, then from gasRemaining for whatever the reservoir can't cover.
     final long fromReservoir = Math.min(reservoirBefore, amount);
     final long fromGas = amount - fromReservoir;
     if (gasRemaining < fromGas) {
-      // OOG: do the accounting last so we leave the counters untouched on failure.
-      if (LOG.isTraceEnabled()) {
-        LOG.trace(
-            "EIP-8037 CONSUME_STATE depth={} requested={} reservoirBefore={} gasLeftBefore={} ok=false reservoirAfter={} gasLeftAfter={} stateGasUsedAfter={}",
-            getDepth(),
-            amount,
-            reservoirBefore,
-            gasLeftBefore,
-            reservoirBefore,
-            gasLeftBefore,
-            txValues.stateGasUsed().get());
-      }
+      traceConsumeState(
+          amount, reservoirBefore, gasLeftBefore, false, reservoirBefore, gasLeftBefore);
       return false;
     }
     txValues.stateGasReservoir().set(reservoirBefore - fromReservoir);
     gasRemaining -= fromGas;
+    // Track the spill so refunds can unwind it back to gasRemaining first (LIFO).
+    stateGasSpilled += fromGas;
     txValues.stateGasUsed().set(txValues.stateGasUsed().get() + amount);
+    traceConsumeState(
+        amount,
+        reservoirBefore,
+        gasLeftBefore,
+        true,
+        txValues.stateGasReservoir().get(),
+        gasRemaining);
+    return true;
+  }
+
+  private void traceConsumeState(
+      final long amount,
+      final long reservoirBefore,
+      final long gasLeftBefore,
+      final boolean ok,
+      final long reservoirAfter,
+      final long gasLeftAfter) {
     if (LOG.isTraceEnabled()) {
       LOG.trace(
-          "EIP-8037 CONSUME_STATE depth={} requested={} reservoirBefore={} gasLeftBefore={} ok=true reservoirAfter={} gasLeftAfter={} stateGasUsedAfter={}",
+          "EIP-8037 CONSUME_STATE depth={} requested={} reservoirBefore={} gasLeftBefore={} ok={} reservoirAfter={} gasLeftAfter={} stateGasUsedAfter={}",
           getDepth(),
           amount,
           reservoirBefore,
           gasLeftBefore,
-          txValues.stateGasReservoir().get(),
-          gasRemaining,
+          ok,
+          reservoirAfter,
+          gasLeftAfter,
           txValues.stateGasUsed().get());
     }
-    return true;
   }
 
   /**
-   * Refills the state-gas reservoir (EIP-8037): credits {@code amount} back to the reservoir and
-   * decrements {@code stateGasUsed}. Applied when a state-growing operation does not actually grow
-   * state (SSTORE 0→X→0, CREATE silent or child failure). Both mutations are {@code
-   * UndoScalar}-scoped and therefore rolled back on revert/halt — the refill contributes to the
-   * reservoir only when the full frame chain succeeds.
+   * Credits state gas back in LIFO order: gasRemaining up to the frame's spill, then the reservoir.
+   * The routing is observable — gas returned to gasRemaining is invisible to a sub-call, which can
+   * only draw state gas from the reservoir.
    *
    * @param amount the refill amount
    */
   public void refillStateGasReservoir(final long amount) {
-    incrementStateGasReservoir(amount);
+    final long fromGasLeft = Math.min(amount, stateGasSpilled);
+    if (fromGasLeft > 0L) {
+      incrementRemainingGas(fromGasLeft);
+      stateGasSpilled -= fromGasLeft;
+    }
+    final long toReservoir = amount - fromGasLeft;
+    if (toReservoir > 0L) {
+      incrementStateGasReservoir(toReservoir);
+    }
     decrementStateGasUsed(amount);
   }
 
@@ -1221,6 +1268,26 @@ public class MessageFrame {
   }
 
   /**
+   * Records whether the CREATE/CREATE2 being spawned from this frame targets an address that was
+   * already alive (existed and non-empty).
+   *
+   * @param wasAlive true if the create target was already alive
+   */
+  public void setCreateTargetWasAlive(final boolean wasAlive) {
+    this.createTargetWasAlive = wasAlive;
+  }
+
+  /**
+   * Whether the most recent CREATE/CREATE2 from this frame targeted an already-alive address, in
+   * which case no leaf is added and its NEW_ACCOUNT state gas is refunded.
+   *
+   * @return true if the create target was already alive
+   */
+  public boolean wasCreateTargetAlive() {
+    return createTargetWasAlive;
+  }
+
+  /**
    * Returns the current gas price.
    *
    * @return the current gas price
@@ -1441,6 +1508,14 @@ public class MessageFrame {
   /** Undo all the changes done by this message frame, such as when a revert is called for. */
   public void rollback() {
     txValues.undoChanges(undoMark);
+  }
+
+  /**
+   * Advances the undo mark so later rollbacks do not undo changes made before this point. Used to
+   * protect the transaction's intrinsic state-gas charges from the initial frame reverting.
+   */
+  public void advanceUndoMark() {
+    this.undoMark = txValues.transientStorage().mark();
   }
 
   /**

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/AbstractCallOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/AbstractCallOperation.java
@@ -240,13 +240,9 @@ public abstract class AbstractCallOperation extends AbstractOperation {
 
     // EIP-8037: Charge state gas for new account creation in CALL. Charge all the gas upfront,
     // before any further work (and before touching the BAL below).
-    if (!transferValue.isZero()) {
-      final Account recipient = frame.getWorldUpdater().get(recipientAddress);
-      if (recipient == null || recipient.isEmpty()) {
-        if (!frame.consumeStateGas(gasCalculator().stateGasCostCalculator().newAccountStateGas())) {
-          return new OperationResult(cost, ExceptionalHaltReason.INSUFFICIENT_GAS);
-        }
-      }
+    if (callCreatesNewAccount(frame, recipientAddress, transferValue)
+        && !frame.consumeStateGas(gasCalculator().stateGasCostCalculator().newAccountStateGas())) {
+      return new OperationResult(cost, ExceptionalHaltReason.INSUFFICIENT_GAS);
     }
 
     // Record the 7702 delegation target in the BAL once the gas checks have passed. getCode() does
@@ -273,6 +269,8 @@ public abstract class AbstractCallOperation extends AbstractOperation {
     final boolean insufficientBalance = transferValue.compareTo(balance) > 0;
     final boolean isFrameDepthTooDeep = frame.getDepth() >= 1024;
     if (insufficientBalance || isFrameDepthTooDeep) {
+      // EIP-8037: no child frame runs, so no account is created — undo the charge above.
+      refundCallNewAccountStateGas(frame, recipientAddress, transferValue);
       frame.expandMemory(inputDataOffset(frame), inputDataLength(frame));
       frame.expandMemory(outputDataOffset(frame), outputDataLength(frame));
       // For the following, we either increment the gas or return zero, so we don't get double
@@ -351,6 +349,14 @@ public abstract class AbstractCallOperation extends AbstractOperation {
     final long gasRemaining = childFrame.getRemainingGas();
     frame.incrementRemainingGas(gasRemaining);
 
+    // On success the parent takes over the child's spill so later refunds can unwind it. On
+    // failure the child already returned it, and no account was created, so undo that charge.
+    if (childFrame.getState() == State.COMPLETED_SUCCESS) {
+      frame.incrementStateGasSpilled(childFrame.getStateGasSpilled());
+    } else {
+      refundCallNewAccountStateGas(frame, childFrame.getContractAddress(), childFrame.getValue());
+    }
+
     frame.popStackItems(getStackItemsConsumed());
     Bytes resultItem;
 
@@ -359,6 +365,24 @@ public abstract class AbstractCallOperation extends AbstractOperation {
 
     final int currentPC = frame.getPC();
     frame.setPC(currentPC + 1);
+  }
+
+  /** Whether the CALL transfers value to a non-existent or empty recipient, creating a leaf. */
+  private static boolean callCreatesNewAccount(
+      final MessageFrame frame, final Address recipientAddress, final Wei transferValue) {
+    if (transferValue.isZero()) {
+      return false;
+    }
+    final Account recipient = frame.getWorldUpdater().get(recipientAddress);
+    return recipient == null || recipient.isEmpty();
+  }
+
+  /** Re-tests the charge condition, so this is a no-op when nothing was charged. */
+  private void refundCallNewAccountStateGas(
+      final MessageFrame frame, final Address recipientAddress, final Wei transferValue) {
+    if (callCreatesNewAccount(frame, recipientAddress, transferValue)) {
+      frame.refillStateGasReservoir(gasCalculator().stateGasCostCalculator().newAccountStateGas());
+    }
   }
 
   Bytes getCallResultStackItem(final MessageFrame childFrame) {

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/AbstractCallOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/AbstractCallOperation.java
@@ -368,9 +368,10 @@ public abstract class AbstractCallOperation extends AbstractOperation {
   }
 
   /** Whether the CALL transfers value to a non-existent or empty recipient, creating a leaf. */
-  private static boolean callCreatesNewAccount(
+  private boolean callCreatesNewAccount(
       final MessageFrame frame, final Address recipientAddress, final Wei transferValue) {
-    if (transferValue.isZero()) {
+    // Only state-gas metering charges for this, so nothing needs the lookup otherwise.
+    if (transferValue.isZero() || !gasCalculator().stateGasCostCalculator().isActive()) {
       return false;
     }
     final Account recipient = frame.getWorldUpdater().get(recipientAddress);

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/AbstractCreateOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/AbstractCreateOperation.java
@@ -206,6 +206,10 @@ public abstract class AbstractCreateOperation extends AbstractOperation {
     final Address contractAddress = generateTargetContractAddress(parent, code);
     final Bytes inputData = getInputData(parent);
 
+    // EIP-8037: an already-alive target adds no leaf, so complete() refunds its NEW_ACCOUNT gas.
+    final var existingTarget = parent.getWorldUpdater().get(contractAddress);
+    parent.setCreateTargetWasAlive(existingTarget != null && !existingTarget.isEmpty());
+
     final long childGasStipend =
         gasCalculator().gasAvailableForChildCreate(parent.getRemainingGas());
     parent.decrementRemainingGas(childGasStipend);
@@ -256,6 +260,13 @@ public abstract class AbstractCreateOperation extends AbstractOperation {
 
     if (childFrame.getState() == MessageFrame.State.COMPLETED_SUCCESS) {
       Address createdAddress = childFrame.getContractAddress();
+      // Absorb the child's spill before the refund below, so the refund unwinds the combined
+      // spill rather than only this frame's share.
+      frame.incrementStateGasSpilled(childFrame.getStateGasSpilled());
+      if (frame.wasCreateTargetAlive()) {
+        frame.refillStateGasReservoir(
+            gasCalculator().stateGasCostCalculator().newContractStateGas());
+      }
       frame.pushStackItem(Words.fromAddress(createdAddress));
       frame.setReturnData(Bytes.EMPTY);
       onSuccess(frame, createdAddress);

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/AbstractCreateOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/AbstractCreateOperation.java
@@ -207,8 +207,11 @@ public abstract class AbstractCreateOperation extends AbstractOperation {
     final Bytes inputData = getInputData(parent);
 
     // EIP-8037: an already-alive target adds no leaf, so complete() refunds its NEW_ACCOUNT gas.
-    final var existingTarget = parent.getWorldUpdater().get(contractAddress);
-    parent.setCreateTargetWasAlive(existingTarget != null && !existingTarget.isEmpty());
+    // Nothing reads the flag when state gas is inactive.
+    if (gasCalculator().stateGasCostCalculator().isActive()) {
+      final var existingTarget = parent.getWorldUpdater().get(contractAddress);
+      parent.setCreateTargetWasAlive(existingTarget != null && !existingTarget.isEmpty());
+    }
 
     final long childGasStipend =
         gasCalculator().gasAvailableForChildCreate(parent.getRemainingGas());
@@ -271,11 +274,8 @@ public abstract class AbstractCreateOperation extends AbstractOperation {
       frame.setReturnData(Bytes.EMPTY);
       onSuccess(frame, createdAddress);
     } else {
-      // EIP-8037: on child frame revert or exceptional
-      // halt, the account-creation state gas (112 × cpsb) charged at this CREATE/CREATE2 opcode
-      // is refunded to the reservoir — no account was created so no state gas should be paid.
-      // The child's own state gas charges (e.g. inner SSTOREs, code deposits) are already
-      // refunded into the reservoir by handleStateGasRevertSpill / handleStateGasHalt in
+      // EIP-8037: the child reverted or halted, so no account was created and this opcode's
+      // account-creation state gas is refunded. The child's own charges were already unwound by
       // AbstractMessageProcessor.
       frame.refillStateGasReservoir(gasCalculator().stateGasCostCalculator().newContractStateGas());
       frame.setReturnData(childFrame.getOutputData());

--- a/evm/src/main/java/org/hyperledger/besu/evm/processor/AbstractMessageProcessor.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/processor/AbstractMessageProcessor.java
@@ -139,9 +139,8 @@ public abstract class AbstractMessageProcessor {
   }
 
   /**
-   * EIP-8037 state-gas accounting on frame failure. The rollback restores the reservoir to its
-   * frame-entry value; the spilled portion goes back to gasRemaining, which a revert propagates to
-   * the parent and a halt subsequently burns.
+   * EIP-8037 state-gas accounting on frame failure. The spill goes back to gasRemaining rather than
+   * the reservoir, because a revert propagates it to the parent and a halt burns it.
    */
   private void handleStateGasOnFrameFailure(final MessageFrame frame) {
     clearAccumulatedStateBesidesGasAndOutput(frame);

--- a/evm/src/main/java/org/hyperledger/besu/evm/processor/AbstractMessageProcessor.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/processor/AbstractMessageProcessor.java
@@ -139,21 +139,17 @@ public abstract class AbstractMessageProcessor {
   }
 
   /**
-   * EIP-8037 state-gas accounting on frame failure (REVERT or exceptional HALT). Rolls back the
-   * frame's UndoScalar state-gas mutations, then credits any gas-left spill back to the reservoir
-   * so the parent (or sender, on top-level failure) recovers it. Halt and revert share this path
-   * because both propagate the full state_gas_used back via incorporate_child_on_error.
+   * EIP-8037 state-gas accounting on frame failure. The rollback restores the reservoir to its
+   * frame-entry value; the spilled portion goes back to gasRemaining, which a revert propagates to
+   * the parent and a halt subsequently burns.
    */
   private void handleStateGasOnFrameFailure(final MessageFrame frame) {
-    final long stateGasUsedBefore = frame.getStateGasUsed();
-    final long reservoirBefore = frame.getStateGasReservoir();
     clearAccumulatedStateBesidesGasAndOutput(frame);
-    final long stateGasRestored = stateGasUsedBefore - frame.getStateGasUsed();
-    final long reservoirRestored = frame.getStateGasReservoir() - reservoirBefore;
-    final long spill = stateGasRestored - reservoirRestored;
-    if (spill > 0) {
-      frame.incrementStateGasReservoir(spill);
+    final long spilled = frame.getStateGasSpilled();
+    if (spilled > 0) {
+      frame.incrementRemainingGas(spilled);
     }
+    frame.resetStateGasSpilled();
   }
 
   private void exceptionalHalt(final MessageFrame frame) {


### PR DESCRIPTION
## PR description

One of two remaining PRs restoring Amsterdam to the `tests-glamsterdam-devnet@v6.1.1`
spec, after #10766 (EIP-8246) landed. Rebased onto current `main`, so "Files changed"
is this PR's own content: 14 files, +356/−122. #10908 follows this one.

Restores the EIP-8037 state-gas machinery that was dropped when the Amsterdam work was
upstreamed to main, and fixes the EIP-7928 block access list for absent system
contracts. Main currently fails 808 of the 5420 `_amsterdam_` reference tests; this PR
plus #10908 brings that to 0.

### State-gas spill model

State-gas charges draw from the reservoir first and from `gasRemaining` last. Refunds
have to unwind that in LIFO order, and frame failure has to return the spill to
`gasRemaining`. Main routed both to the reservoir instead, which is observable: gas
parked in the reservoir is visible to a sub-call, gas returned to `gasRemaining` is
not.

Touches `MessageFrame` (spill tracking, LIFO `refillStateGasReservoir`,
`advanceUndoMark`) and `AbstractMessageProcessor` (failure handler).

### Refunds that depend on it

- `CALL` refunds its `NEW_ACCOUNT` charge when no child frame runs (insufficient
  balance, max depth) or the child fails.
- `CREATE`/`CREATE2` and contract-creation transactions refund theirs when the target
  address was already alive, since no leaf is added.
- A parent absorbs a successful child's spill so later refunds unwind the combined
  amount.

### Block gas accounting (EIP-7976/7778)

The block's regular-gas dimension now uses unfloored regular gas via
`getRegularGasUsedForBlock()`. The calldata floor raises what the sender pays but does
not count toward the block. Also restores the runtime `TX_MAX_GAS_LIMIT` check on
regular gas and the per-dimension block capacity check.

### EIP-7928

A system call reads the contract account before it can know whether there is code to
run, so an absent system contract now appears in the block access list instead of being
omitted. This also fixes two reference tests that fail on `glamsterdam-devnet-6`.

## Fixed Issue(s)

n/a

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew :evm:test :ethereum:core:test :ethereum:blockcreation:test`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests — this branch still points at `tests-bal@v7.3.1`; the bump to
      `v6.1.1` and a green run land in #10908
