### PR TITLE
EIP-2780/7702/8038: intrinsic gas, delegation accounting, fixtures v6.1.1

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/CodeDelegationProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/CodeDelegationProcessor.java
@@ -27,9 +27,9 @@ import org.hyperledger.besu.evm.worldstate.CodeDelegationService;
 import org.hyperledger.besu.evm.worldstate.WorldUpdater;
 
 import java.math.BigInteger;
-import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -77,15 +77,10 @@ public class CodeDelegationProcessor {
       final Optional<AccessLocationTracker> eip7928AccessList) {
     final CodeDelegationResult result = new CodeDelegationResult();
 
-    // EIP-2780: the runtime ACCOUNT_WRITE is charged on the first write to an authority within the
-    // transaction. Seed the set with the accounts the transaction has already paid to write: the
-    // sender (covered by TX_BASE_COST) and, on a value-bearing transaction, the recipient (covered
-    // by TX_VALUE_COST).
-    final Set<Address> writtenAccounts = new HashSet<>();
-    writtenAccounts.add(transaction.getSender());
-    if (!transaction.getValue().isZero()) {
-      transaction.getTo().ifPresent(writtenAccounts::add);
-    }
+    // Per authority, whether it held a delegation in the pre-transaction state. Captured on the
+    // first authorization for that authority, before a prior one in this transaction could have
+    // changed its code.
+    final Map<Address, Boolean> delegatedBeforeTx = new HashMap<>();
 
     transaction
         .getCodeDelegationList()
@@ -93,7 +88,7 @@ public class CodeDelegationProcessor {
         .forEach(
             codeDelegation ->
                 processCodeDelegation(
-                    worldUpdater, codeDelegation, result, writtenAccounts, eip7928AccessList));
+                    worldUpdater, codeDelegation, result, delegatedBeforeTx, eip7928AccessList));
 
     return result;
   }
@@ -102,17 +97,19 @@ public class CodeDelegationProcessor {
       final WorldUpdater worldUpdater,
       final CodeDelegation codeDelegation,
       final CodeDelegationResult result,
-      final Set<Address> writtenAccounts,
+      final Map<Address, Boolean> delegatedBeforeTx,
       final Optional<AccessLocationTracker> eip7928AccessList) {
     LOG.trace("Processing code delegation: {}", codeDelegation);
 
     if (!isCodeDelegationValid(codeDelegation)) {
+      result.incrementInvalidAuthorization();
       return;
     }
 
     final Optional<Address> maybeAuthorizer = codeDelegation.authorizer();
     if (maybeAuthorizer.isEmpty()) {
       LOG.trace("Invalid signature for code delegation");
+      result.incrementInvalidAuthorization();
       return;
     }
 
@@ -128,41 +125,41 @@ public class CodeDelegationProcessor {
     result.addAccessedDelegatorAddress(authorizer);
 
     if (!canSetCodeDelegation(codeDelegation, maybeExistingAccount)) {
+      result.incrementInvalidAuthorization();
       return;
     }
 
-    // the worst-case STATE_BYTES_PER_NEW_ACCOUNT and ACCOUNT_WRITE charged at intrinsic time
-    // are only refilled/refunded if the authority already exists AND is non-empty
-    // (non-zero nonce, non-zero balance, or non-empty code). A present-but-empty account is
-    // treated like a brand-new leaf for gas purposes.
-    final boolean authorityAlreadyExists =
-        maybeExistingAccount.isPresent() && !maybeExistingAccount.get().isEmpty();
+    final boolean authorityAlreadyExists = maybeExistingAccount.isPresent();
+    final boolean delegatedNow =
+        authorityAlreadyExists && hasCodeDelegation(maybeExistingAccount.get().getCode());
 
     final MutableAccount authority =
-        maybeExistingAccount.isEmpty()
-            ? worldUpdater.createAccount(authorizer)
-            : worldUpdater.getAccount(authorizer);
+        authorityAlreadyExists
+            ? worldUpdater.getAccount(authorizer)
+            : worldUpdater.createAccount(authorizer);
+    eip7928AccessList.ifPresent(t -> t.addTouchedAccount(authority.getAddress()));
 
     if (authorityAlreadyExists) {
       result.incrementAlreadyExistingDelegators();
     }
 
-    // EIP-2780: charge ACCOUNT_WRITE at most once per authority, and only when this authorization
-    // is the first thing in the transaction to write it.
-    if (writtenAccounts.add(authorizer)) {
-      result.incrementAuthorityWrites();
-    }
-
-    // AUTH_BASE state gas is refunded when no new delegation-indicator bytes are written: either
-    // the authority already carries a delegation designator (overwritten in place) or the
-    // authorization clears the delegation (auth.address == 0).
-    final boolean hasExistingDelegation =
-        maybeExistingAccount.isPresent() && hasCodeDelegation(maybeExistingAccount.get().getCode());
-    if (hasExistingDelegation || codeDelegation.address().equals(Address.ZERO)) {
+    // AUTH_BASE is refilled only when no new indicator bytes are written. The two flags differ
+    // because delegatedNow may reflect an indicator written earlier in this same transaction,
+    // which still had to be paid for; delegatedBefore never does.
+    final boolean delegatedBefore =
+        delegatedBeforeTx.computeIfAbsent(authorizer, a -> delegatedNow);
+    if (codeDelegation.address().equals(Address.ZERO)) {
+      // Clearing writes no indicator bytes, so AUTH_BASE refills once — twice if the delegation
+      // being cleared was itself created earlier in this transaction.
+      result.incrementAuthBaseRefundCount();
+      if (delegatedNow && !delegatedBefore) {
+        result.incrementAuthBaseRefundCount();
+      }
+    } else if (delegatedNow || delegatedBefore) {
+      // Overwriting an existing designator in place writes no new indicator bytes.
       result.incrementAuthBaseRefundCount();
     }
 
-    eip7928AccessList.ifPresent(t -> t.addTouchedAccount(authority.getAddress()));
     codeDelegationService.processCodeDelegation(authority, codeDelegation.address());
     authority.incrementNonce();
   }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/CodeDelegationResult.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/CodeDelegationResult.java
@@ -23,14 +23,10 @@ public class CodeDelegationResult {
   private final Set<Address> accessedDelegatorAddresses = new HashSet<>(Address.SIZE);
   private long alreadyExistingDelegators = 0L;
   private long authBaseRefundCount = 0L;
-  private long authorityWrites = 0L;
+  private long invalidAuthorizations = 0L;
 
   public void addAccessedDelegatorAddress(final Address address) {
     accessedDelegatorAddresses.add(address);
-  }
-
-  public void incrementAuthorityWrites() {
-    authorityWrites += 1;
   }
 
   public void incrementAlreadyExistingDelegators() {
@@ -58,13 +54,15 @@ public class CodeDelegationResult {
     return authBaseRefundCount;
   }
 
+  public void incrementInvalidAuthorization() {
+    invalidAuthorizations += 1;
+  }
+
   /**
-   * EIP-2780: the number of authorizations that performed the first write to their authority within
-   * the transaction, and therefore owe the runtime ACCOUNT_WRITE charge. Authorizations whose
-   * authority was already written — the sender, the recipient of a value-bearing transaction, or an
-   * authority written by a preceding valid authorization — are not counted.
+   * Invalid authorizations grow no state, so each refunds its full worst-case intrinsic charge:
+   * NEW_ACCOUNT + AUTH_BASE state gas plus the regular ACCOUNT_WRITE.
    */
-  public long authorityWrites() {
-    return authorityWrites;
+  public long invalidAuthorizations() {
+    return invalidAuthorizations;
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessor.java
@@ -311,9 +311,8 @@ public class MainnetTransactionProcessor {
       }
 
       long codeDelegationRefund = 0L;
-      long alreadyExistingDelegators = 0L;
+      long refundableDelegators = 0L;
       long authBaseRefundCount = 0L;
-      long codeDelegationAuthorityWrites = 0L;
       if (transaction.getType().equals(TransactionType.DELEGATE_CODE)) {
         if (maybeCodeDelegationProcessor.isEmpty()) {
           throw new RuntimeException("Code delegation processor is required for 7702 transactions");
@@ -325,11 +324,14 @@ public class MainnetTransactionProcessor {
                 .get()
                 .process(delegationUpdater, transaction, accessLocationTracker);
         eip2930WarmAddressList.addAll(codeDelegationResult.accessedDelegatorAddresses());
-        alreadyExistingDelegators = codeDelegationResult.alreadyExistingDelegators();
-        authBaseRefundCount = codeDelegationResult.authBaseRefundCount();
-        codeDelegationAuthorityWrites = codeDelegationResult.authorityWrites();
-        codeDelegationRefund =
-            gasCalculator.calculateDelegateCodeGasRefund(alreadyExistingDelegators);
+        // EIP-7702: an invalid authorization grows no state, so it refunds its full worst-case
+        // intrinsic charge, like an authority that already existed. Not pre-Amsterdam.
+        final long invalidAuthorizations =
+            stateGasCalc.isActive() ? codeDelegationResult.invalidAuthorizations() : 0L;
+        refundableDelegators =
+            codeDelegationResult.alreadyExistingDelegators() + invalidAuthorizations;
+        authBaseRefundCount = codeDelegationResult.authBaseRefundCount() + invalidAuthorizations;
+        codeDelegationRefund = gasCalculator.calculateDelegateCodeGasRefund(refundableDelegators);
         delegationUpdater.commit();
       }
 
@@ -347,7 +349,7 @@ public class MainnetTransactionProcessor {
       final IntrinsicStateGasCharge intrinsicCharge =
           IntrinsicStateGasCharge.compute(
               transaction,
-              alreadyExistingDelegators,
+              refundableDelegators,
               authBaseRefundCount,
               gasAvailable,
               intrinsicRegularGas,
@@ -427,30 +429,7 @@ public class MainnetTransactionProcessor {
                 .eip2930AccessListWarmAddresses(eip2930WarmAddressList)
                 .build();
 
-        // EIP-2780: the runtime charges below run after the transaction is already valid but before
-        // the first frame executes, in spec order: authorization writes, then recipient creation.
-        // Running out of gas here doesn't invalidate the transaction, it halts it exceptionally.
-        final long authorityWriteGas =
-            gasCalculator.delegateCodeAccountWriteGasCost(codeDelegationAuthorityWrites);
-        if (authorityWriteGas > 0L) {
-          if (initialFrame.getRemainingGas() < authorityWriteGas) {
-            haltForInsufficientGas(initialFrame);
-          } else {
-            initialFrame.decrementRemainingGas(authorityWriteGas);
-          }
-        }
-
-        // EIP-2780: charge NEW_ACCOUNT state gas on the depth-0 frame for a positive value transfer
-        if (initialFrame.getState() != MessageFrame.State.EXCEPTIONAL_HALT
-            && stateGasCalc.isActive()
-            && !transaction.getValue().isZero()) {
-          final Account recipient = worldState.get(to);
-          if (recipient == null || recipient.isEmpty()) {
-            if (!initialFrame.consumeStateGas(stateGasCalc.newAccountStateGas())) {
-              haltForInsufficientGas(initialFrame);
-            }
-          }
-        }
+        chargeTransactionEntry(initialFrame, worldState, to, stateGasCalc);
       }
 
       // Transaction-level state-gas charges persist regardless of the execution outcome, so put
@@ -762,6 +741,41 @@ public class MainnetTransactionProcessor {
   }
 
   /**
+   * Charges the EIP-2780 transaction-entry costs on the depth-0 frame of a non-create transaction,
+   * before any opcode runs, halting the frame if it cannot pay. {@code worldState} is the
+   * transaction-level updater, which already has the recipient cached from code resolution, so
+   * reading its pre-value-transfer state costs no extra lookup.
+   */
+  private void chargeTransactionEntry(
+      final MessageFrame initialFrame,
+      final WorldUpdater worldState,
+      final Address to,
+      final StateGasCostCalculator stateGasCalc) {
+    if (!stateGasCalc.isActive()) {
+      return;
+    }
+    final Account recipient = worldState.get(to);
+    boolean outOfGas = false;
+    // Positive value to a non-alive recipient. Precompiles are deliberately not excluded, since
+    // a zero-balance precompile is not "alive" under EIP-161 either.
+    if (!initialFrame.getValue().isZero() && (recipient == null || recipient.isEmpty())) {
+      outOfGas = !initialFrame.consumeStateGas(stateGasCalc.newAccountStateGas());
+    }
+    // EIP-7702: top-level access to a delegated recipient's target costs cold account access.
+    if (!outOfGas && recipient != null && hasCodeDelegation(recipient.getCode())) {
+      final long delegationAccessCost = gasCalculator.getColdAccountAccessCost();
+      if (initialFrame.getRemainingGas() >= delegationAccessCost) {
+        initialFrame.decrementRemainingGas(delegationAccessCost);
+      } else {
+        outOfGas = true;
+      }
+    }
+    if (outOfGas) {
+      haltForInsufficientGas(initialFrame);
+    }
+  }
+
+  /**
    * Settles accounts marked for self-destruction at transaction finalization. Under EIP-8246 each
    * account is cleared (nonce reset, code and storage removed) but keeps its balance — EIP-161
    * state clearing (via {@code clearAccountsThatAreEmpty}) then removes any account left with a
@@ -800,7 +814,7 @@ public class MainnetTransactionProcessor {
 
     static IntrinsicStateGasCharge compute(
         final Transaction transaction,
-        final long alreadyExistingDelegators,
+        final long refundableDelegators,
         final long authBaseRefundCount,
         final long gasAvailable,
         final long intrinsicRegularGas,
@@ -825,7 +839,7 @@ public class MainnetTransactionProcessor {
         final long perAuthIntrinsic =
             stateGasCalc.authBaseStateGas() + stateGasCalc.emptyAccountDelegationStateGas();
         acc.drain(perAuthIntrinsic * totalDelegations);
-        long refund = stateGasCalc.emptyAccountDelegationStateGas() * alreadyExistingDelegators;
+        long refund = stateGasCalc.emptyAccountDelegationStateGas() * refundableDelegators;
         refund += stateGasCalc.authBaseStateGas() * authBaseRefundCount;
         if (refund > 0L) {
           acc.refund(refund);

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/CodeDelegationProcessorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/CodeDelegationProcessorTest.java
@@ -65,6 +65,10 @@ class CodeDelegationProcessorTest {
       Address.fromHexString("0x1111111111111111111111111111111111111111");
   private static final Address TX_TO =
       Address.fromHexString("0x2222222222222222222222222222222222222222");
+  private static final Address AUTHORITY =
+      Address.fromHexString("0x3333333333333333333333333333333333333333");
+  private static final Address OTHER_DELEGATE_ADDRESS =
+      Address.fromHexString("0x4444444444444444444444444444444444444444");
 
   @BeforeEach
   void setUp() {
@@ -371,15 +375,101 @@ class CodeDelegationProcessorTest {
   }
 
   @Test
-  void shouldTreatPresentButEmptyAccountAsNewLeaf() {
+  void shouldRefundAuthBaseOnceWhenSameAuthorityIsDelegatedTwiceInOneTransaction() {
+    // Arrange: two authorizations for one authority. The first writes fresh indicator bytes, the
+    // second overwrites them in place.
+    CodeDelegation first = delegationForAuthority(DELEGATE_ADDRESS);
+    CodeDelegation second = delegationForAuthority(OTHER_DELEGATE_ADDRESS);
+    when(transaction.getCodeDelegationList()).thenReturn(Optional.of(List.of(first, second)));
+    // Absent for the first authorization, then present carrying the designator it wrote.
+    when(worldUpdater.get(any())).thenReturn(null).thenReturn(authority);
+    when(worldUpdater.createAccount(any())).thenReturn(authority);
+    when(worldUpdater.getAccount(any())).thenReturn(authority);
+    when(authority.getNonce()).thenReturn(0L);
+    when(authority.getCode()).thenReturn(delegationCode());
+    when(codeDelegationService.canSetCodeDelegation(any())).thenReturn(true);
+
+    // Act
+    CodeDelegationResult result = processor.process(worldUpdater, transaction, Optional.empty());
+
+    // Assert: only the second authorization overwrote an existing designator.
+    assertThat(result.authBaseRefundCount()).isEqualTo(1);
+    assertThat(result.alreadyExistingDelegators()).isEqualTo(1);
+    assertThat(result.invalidAuthorizations()).isZero();
+    verify(authority, times(2)).incrementNonce();
+  }
+
+  @Test
+  void shouldRefundAuthBaseTwiceWhenDelegationWrittenInTransactionIsThenCleared() {
+    // Arrange: one authority delegated and then cleared within the same transaction.
+    CodeDelegation set = delegationForAuthority(DELEGATE_ADDRESS);
+    CodeDelegation clear = delegationForAuthority(Address.ZERO);
+    when(transaction.getCodeDelegationList()).thenReturn(Optional.of(List.of(set, clear)));
+    when(worldUpdater.get(any())).thenReturn(null).thenReturn(authority);
+    when(worldUpdater.createAccount(any())).thenReturn(authority);
+    when(worldUpdater.getAccount(any())).thenReturn(authority);
+    when(authority.getNonce()).thenReturn(0L);
+    when(authority.getCode()).thenReturn(delegationCode());
+    when(codeDelegationService.canSetCodeDelegation(any())).thenReturn(true);
+
+    // Act
+    CodeDelegationResult result = processor.process(worldUpdater, transaction, Optional.empty());
+
+    // Assert: clearing writes no indicator bytes, and the designator it cleared was itself paid
+    // for earlier in this transaction, so both authorizations refund AUTH_BASE.
+    assertThat(result.authBaseRefundCount()).isEqualTo(2);
+    verify(authority, times(2)).incrementNonce();
+  }
+
+  @Test
+  void shouldRefundAuthBaseOnceWhenClearingDelegationThatPredatesTheTransaction() {
+    // Arrange: the designator being cleared was not written by this transaction, so unlike the
+    // case above there is no second AUTH_BASE to give back.
+    CodeDelegation clear = delegationForAuthority(Address.ZERO);
+    when(transaction.getCodeDelegationList()).thenReturn(Optional.of(List.of(clear)));
+    when(worldUpdater.get(any())).thenReturn(authority);
+    when(worldUpdater.getAccount(any())).thenReturn(authority);
+    when(authority.getNonce()).thenReturn(0L);
+    when(authority.getCode()).thenReturn(delegationCode());
+    when(codeDelegationService.canSetCodeDelegation(any())).thenReturn(true);
+
+    // Act
+    CodeDelegationResult result = processor.process(worldUpdater, transaction, Optional.empty());
+
+    // Assert
+    assertThat(result.authBaseRefundCount()).isEqualTo(1);
+    assertThat(result.alreadyExistingDelegators()).isEqualTo(1);
+    verify(authority).incrementNonce();
+  }
+
+  private static Bytes delegationCode() {
+    return Bytes.concatenate(CodeDelegationHelper.CODE_DELEGATION_PREFIX, Bytes.random(20));
+  }
+
+  /**
+   * A nonce-0 authorization for {@link #AUTHORITY}. Mocked rather than signed, so that the delegate
+   * address can vary while the recovered authority stays the same.
+   */
+  private CodeDelegation delegationForAuthority(final Address delegateAddress) {
+    final CodeDelegation delegation = mock(CodeDelegation.class);
+    when(delegation.chainId()).thenReturn(CHAIN_ID);
+    when(delegation.nonce()).thenReturn(0L);
+    when(delegation.address()).thenReturn(delegateAddress);
+    when(delegation.signature())
+        .thenReturn(new SECPSignature(BigInteger.ONE, BigInteger.ONE, (byte) 0));
+    when(delegation.authorizer()).thenReturn(Optional.of(AUTHORITY));
+    return delegation;
+  }
+
+  @Test
+  void shouldTreatPresentButEmptyAccountAsExistingDelegator() {
     // Arrange: an account that exists in the updater but is empty (nonce 0, balance 0, no code).
-    // Per the spec (account_exists_and_is_non_empty) this must be treated like a brand-new leaf:
-    // no already-existing-delegator refund.
+    // No new leaf is added for it, so it counts as an already-existing delegator and the
+    // worst-case NEW_ACCOUNT / ACCOUNT_WRITE reserved at the intrinsic phase is refunded.
     CodeDelegation codeDelegation = createCodeDelegation(CHAIN_ID, 0L);
     when(transaction.getCodeDelegationList()).thenReturn(Optional.of(List.of(codeDelegation)));
     when(worldUpdater.get(any())).thenReturn(authority);
     when(worldUpdater.getAccount(any())).thenReturn(authority);
-    when(authority.isEmpty()).thenReturn(true);
     when(authority.getNonce()).thenReturn(0L);
     when(authority.getCode()).thenReturn(Bytes.EMPTY);
     when(codeDelegationService.canSetCodeDelegation(any())).thenReturn(true);
@@ -388,14 +478,31 @@ class CodeDelegationProcessorTest {
     CodeDelegationResult result = processor.process(worldUpdater, transaction, Optional.empty());
 
     // Assert
-    assertThat(result.alreadyExistingDelegators()).isZero();
+    assertThat(result.alreadyExistingDelegators()).isEqualTo(1);
+    // A fresh (non-zero) delegation designator is written, so AUTH_BASE is not refunded.
     assertThat(result.authBaseRefundCount()).isZero();
     verify(worldUpdater, never()).createAccount(any());
     verify(authority).incrementNonce();
   }
 
   @Test
-  void shouldCountAuthorityWriteForAuthorityWrittenFirstByTheAuthorization() {
+  void shouldCountInvalidAuthorizationForRejectedAuthorization() {
+    // Arrange: nonce mismatch against a non-existent authority — the authorization is rejected.
+    CodeDelegation codeDelegation = createCodeDelegation(CHAIN_ID, 1L);
+    when(transaction.getCodeDelegationList()).thenReturn(Optional.of(List.of(codeDelegation)));
+    when(worldUpdater.get(any())).thenReturn(null);
+
+    // Act
+    CodeDelegationResult result = processor.process(worldUpdater, transaction, Optional.empty());
+
+    // Assert: an invalid authorization grows no state, so its full worst-case intrinsic charge
+    // is refunded.
+    assertThat(result.invalidAuthorizations()).isEqualTo(1);
+    verify(worldUpdater, never()).createAccount(any());
+  }
+
+  @Test
+  void shouldNotCountInvalidAuthorizationForAcceptedAuthorization() {
     // Arrange
     CodeDelegation codeDelegation = createCodeDelegation(CHAIN_ID, 0L);
     when(transaction.getCodeDelegationList()).thenReturn(Optional.of(List.of(codeDelegation)));
@@ -405,79 +512,22 @@ class CodeDelegationProcessorTest {
     // Act
     CodeDelegationResult result = processor.process(worldUpdater, transaction, Optional.empty());
 
-    // Assert: EIP-2780 charges the runtime ACCOUNT_WRITE for this authority.
-    assertThat(result.authorityWrites()).isEqualTo(1);
-  }
-
-  @Test
-  void shouldNotCountAuthorityWriteWhenAuthorityIsTheSender() {
-    // Arrange: the sender's write is already covered by TX_BASE_COST.
-    CodeDelegation codeDelegation = createCodeDelegation(CHAIN_ID, 0L);
-    when(transaction.getSender()).thenReturn(codeDelegation.authorizer().orElseThrow());
-    when(transaction.getCodeDelegationList()).thenReturn(Optional.of(List.of(codeDelegation)));
-    when(worldUpdater.get(any())).thenReturn(null);
-    when(worldUpdater.createAccount(any())).thenReturn(authority);
-
-    // Act
-    CodeDelegationResult result = processor.process(worldUpdater, transaction, Optional.empty());
-
     // Assert
-    assertThat(result.authorityWrites()).isZero();
+    assertThat(result.invalidAuthorizations()).isZero();
     verify(authority).incrementNonce();
   }
 
   @Test
-  void shouldNotCountAuthorityWriteWhenAuthorityIsRecipientOfValueBearingTransaction() {
-    // Arrange: the recipient's write is already covered by TX_VALUE_COST.
-    CodeDelegation codeDelegation = createCodeDelegation(CHAIN_ID, 0L);
-    when(transaction.getValue()).thenReturn(Wei.ONE);
-    when(transaction.getTo()).thenReturn(Optional.of(codeDelegation.authorizer().orElseThrow()));
+  void shouldCountInvalidAuthorizationForWrongChainId() {
+    // Arrange
+    CodeDelegation codeDelegation = createCodeDelegation(BigInteger.valueOf(999), 0L);
     when(transaction.getCodeDelegationList()).thenReturn(Optional.of(List.of(codeDelegation)));
-    when(worldUpdater.get(any())).thenReturn(null);
-    when(worldUpdater.createAccount(any())).thenReturn(authority);
 
     // Act
     CodeDelegationResult result = processor.process(worldUpdater, transaction, Optional.empty());
 
     // Assert
-    assertThat(result.authorityWrites()).isZero();
-  }
-
-  @Test
-  void shouldCountAuthorityWriteAtMostOncePerAuthority() {
-    // Arrange: two valid authorizations for the same authority — only the first one writes it.
-    // Same chain id, delegate address, nonce and signature, so both recover the same authority.
-    CodeDelegation first = createCodeDelegation(CHAIN_ID, 0L);
-    CodeDelegation second = createCodeDelegation(CHAIN_ID, 0L);
-    assertThat(second.authorizer()).isEqualTo(first.authorizer());
-    when(transaction.getCodeDelegationList()).thenReturn(Optional.of(List.of(first, second)));
-    when(worldUpdater.get(any())).thenReturn(null).thenReturn(authority);
-    when(worldUpdater.createAccount(any())).thenReturn(authority);
-    when(worldUpdater.getAccount(any())).thenReturn(authority);
-    when(authority.getNonce()).thenReturn(0L);
-    when(authority.getCode()).thenReturn(Bytes.EMPTY);
-    when(codeDelegationService.canSetCodeDelegation(any())).thenReturn(true);
-
-    // Act
-    CodeDelegationResult result = processor.process(worldUpdater, transaction, Optional.empty());
-
-    // Assert
-    verify(authority, times(2)).incrementNonce();
-    assertThat(result.authorityWrites()).isEqualTo(1);
-  }
-
-  @Test
-  void shouldNotCountAuthorityWriteForRejectedAuthorization() {
-    // Arrange: an authorization that never writes its authority owes no ACCOUNT_WRITE.
-    CodeDelegation codeDelegation = createCodeDelegation(CHAIN_ID, 1L);
-    when(transaction.getCodeDelegationList()).thenReturn(Optional.of(List.of(codeDelegation)));
-    when(worldUpdater.get(any())).thenReturn(null);
-
-    // Act
-    CodeDelegationResult result = processor.process(worldUpdater, transaction, Optional.empty());
-
-    // Assert
-    assertThat(result.authorityWrites()).isZero();
+    assertThat(result.invalidAuthorizations()).isEqualTo(1);
     verify(worldUpdater, never()).createAccount(any());
   }
 

--- a/ethereum/referencetests/build.gradle
+++ b/ethereum/referencetests/build.gradle
@@ -346,7 +346,7 @@ dependencies {
     )
   devnetTarConfig(
     group: 'ethereum', name: 'execution-specs',
-    version: 'tests-bal@v7.3.1', classifier: 'fixtures_bal', ext: 'tar.gz'
+    version: 'tests-glamsterdam-devnet@v6.1.1', classifier: 'fixtures_glamsterdam-devnet', ext: 'tar.gz'
     )
   referenceTestImplementation 'com.fasterxml.jackson.core:jackson-databind'
   referenceTestImplementation 'com.google.guava:guava'

--- a/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/AmsterdamGasCalculator.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/AmsterdamGasCalculator.java
@@ -62,9 +62,6 @@ public class AmsterdamGasCalculator extends OsakaGasCalculator {
   private static final long ACCESS_LIST_STORAGE_KEY_FLOOR_COST =
       ACCESS_LIST_STORAGE_KEY_BYTES * TOTAL_COST_FLOOR_PER_BYTE;
 
-  // EIP-8037: New regular gas constants for Amsterdam
-  private static final long TX_CREATE_COST = 9_000L;
-
   // --- EIP-8038: state-access gas repricing (see the EIP for the authoritative values) ---
 
   /** Cold account access cost. */
@@ -94,6 +91,9 @@ public class AmsterdamGasCalculator extends OsakaGasCalculator {
    */
   private static final long CREATE_ACCESS = ACCOUNT_WRITE + COLD_ACCOUNT_ACCESS;
 
+  /** EIP-2780: top-level contract-creation cost, equal to the CREATE recipient access. */
+  private static final long TX_CREATE_COST = CREATE_ACCESS;
+
   /** Per-word copy cost used for EXTCODECOPY memory-copy accounting. */
   private static final long COPY_WORD_GAS_COST = 3L;
 
@@ -108,16 +108,21 @@ public class AmsterdamGasCalculator extends OsakaGasCalculator {
   /**
    * EIP-2780: cost of a value-bearing transaction's recipient charges, covering the recipient
    * balance write (4,244) and the EIP-7708 transfer log (1,756). Charged in intrinsic gas for a
-   * value-bearing call; a contract creation covers the balance write through {@link #CREATE_ACCESS}
-   * and a self-transfer writes only the sender, so neither charges it.
+   * value-bearing call; a self-transfer writes only the sender, so it charges neither.
    */
   private static final long TX_VALUE_COST = 6_000L;
 
   /**
-   * EIP-2780: the intrinsic (state-independent) regular gas per EIP-7702 authorization:
+   * EIP-7708: the transfer-log half of {@link #TX_VALUE_COST}, needed on its own because a
+   * value-bearing contract creation covers the balance write through {@link #CREATE_ACCESS} but
+   * still emits the log.
+   */
+  private static final long TRANSFER_LOG_COST = 1_756L;
+
+  /**
+   * EIP-2780: regular gas per EIP-7702 authorization, in addition to {@link #ACCOUNT_WRITE}:
    * AUTH_TUPLE_BYTES(101) * TX_DATA_TOKEN_FLOOR(16) + ECRECOVER(3000) + COLD_ACCOUNT_ACCESS(3000) +
-   * 2 * WARM_ACCESS(100) = 7,816. The {@link #ACCOUNT_WRITE} an authorization may additionally
-   * perform is state-dependent and charged at runtime, not reserved here.
+   * 2 * WARM_ACCESS(100) = 7,816.
    */
   private static final long REGULAR_PER_AUTH_BASE_COST =
       101L * 16L + 3_000L + COLD_ACCOUNT_ACCESS + 2L * 100L;
@@ -212,18 +217,25 @@ public class AmsterdamGasCalculator extends OsakaGasCalculator {
     final long dataCost = tokens * TX_DATA_TOKEN_STANDARD;
 
     final long recipientRegular;
+    final boolean valueTransfer = !transaction.getValue().isZero();
     if (transaction.isContractCreation()) {
-      // A value-bearing creation adds nothing: the recipient balance write is already covered by
-      // CREATE_ACCESS, so create intrinsic is the same with and without value.
-      recipientRegular = CREATE_ACCESS + initCodeCost(payloadSize);
+      // CREATE_ACCESS already covers the recipient balance write; a value-bearing creation still
+      // emits the EIP-7708 transfer log.
+      long create = CREATE_ACCESS + initCodeCost(payloadSize);
+      if (valueTransfer) {
+        create += TRANSFER_LOG_COST;
+      }
+      recipientRegular = create;
     } else if (isSelfTransfer(transaction)) {
-      // A self-transfer touches and writes only the sender, both covered by TX_BASE.
+      // A self-transfer touches and writes only the sender, both covered by TX_BASE. Value makes no
+      // difference either, since EIP-7708 emits no transfer log when sender and recipient match.
       recipientRegular = 0L;
     } else {
-      recipientRegular =
-          transaction.getValue().isZero()
-              ? COLD_ACCOUNT_ACCESS
-              : COLD_ACCOUNT_ACCESS + TX_VALUE_COST;
+      long call = COLD_ACCOUNT_ACCESS;
+      if (valueTransfer) {
+        call += TX_VALUE_COST;
+      }
+      recipientRegular = call;
     }
 
     return clampedAdd(clampedAdd(TX_BASE, dataCost), clampedAdd(recipientRegular, baselineGas));
@@ -296,10 +308,8 @@ public class AmsterdamGasCalculator extends OsakaGasCalculator {
 
   @Override
   public long txCreateCost() {
-    // EIP-8038: CREATE/CREATE2 opcodes are charged CREATE_ACCESS in regular gas (plus the
-    // new-account state-creation cost as state gas). The transaction-intrinsic create cost is
-    // repriced separately by EIP-2780; txCreateExtraGasCost() below keeps the EIP-8037 value.
-    return CREATE_ACCESS;
+    // EIP-8038: regular gas only; the new-account creation cost is charged as state gas.
+    return TX_CREATE_COST;
   }
 
   @Override
@@ -367,23 +377,16 @@ public class AmsterdamGasCalculator extends OsakaGasCalculator {
 
   @Override
   public long delegateCodeGasCost(final int delegateCodeListLength) {
-    // EIP-2780: only the state-independent REGULAR_PER_AUTH_BASE_COST (7,816) is intrinsic and
-    // therefore part of the validity check. The per-authority ACCOUNT_WRITE is state-dependent
-    // and charged at runtime by delegateCodeAccountWriteGasCost.
-    return REGULAR_PER_AUTH_BASE_COST * delegateCodeListLength;
-  }
-
-  @Override
-  public long delegateCodeAccountWriteGasCost(final long authorityWrites) {
-    // EIP-2780: ACCOUNT_WRITE per authorization performing the first write to its authority.
-    return ACCOUNT_WRITE * authorityWrites;
+    // EIP-2780: the per-authority ACCOUNT_WRITE is reserved worst-case here instead of charged at
+    // runtime, so it is part of the validity check and refunded afterwards where nothing grew.
+    return (ACCOUNT_WRITE + REGULAR_PER_AUTH_BASE_COST) * delegateCodeListLength;
   }
 
   @Override
   public long calculateDelegateCodeGasRefund(final long alreadyExistingAccounts) {
-    // EIP-2780: nothing to refund — no regular gas is over-reserved at the intrinsic phase, and
-    // state gas uses its own refund path.
-    return 0L;
+    // EIP-7702: refund the worst-case ACCOUNT_WRITE for authorizations that grew no account —
+    // authority already existed, or the authorization was invalid.
+    return ACCOUNT_WRITE * alreadyExistingAccounts;
   }
 
   @Override

--- a/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/GasCalculator.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/GasCalculator.java
@@ -703,19 +703,6 @@ public interface GasCalculator {
   }
 
   /**
-   * EIP-2780: the runtime regular gas charged for the account writes performed while processing the
-   * EIP-7702 authorization list. Zero before Amsterdam, where the whole per-authorization cost is
-   * reserved at the intrinsic phase instead.
-   *
-   * @param authorityWrites the number of authorizations that performed the first write to their
-   *     authority within the transaction
-   * @return the gas cost
-   */
-  default long delegateCodeAccountWriteGasCost(final long authorityWrites) {
-    return 0L;
-  }
-
-  /**
    * Calculates the refund for processing the 7702 code delegation list if a delegator account
    * already exists in the trie.
    *

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/SStoreOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/SStoreOperation.java
@@ -69,6 +69,16 @@ public class SStoreOperation extends AbstractOperation {
 
   @Override
   public OperationResult execute(final MessageFrame frame, final EVM evm) {
+    final UInt256 key = UInt256.fromBytes(frame.popStackItem());
+    final UInt256 newValue = UInt256.fromBytes(frame.popStackItem());
+
+    // EIP-8038: resolve the account ahead of the gas checks below, so that an SSTORE which halts
+    // for insufficient gas has still recorded the account in the block access list.
+    final MutableAccount account = getMutableAccount(frame.getRecipientAddress(), frame);
+    if (account == null) {
+      return ILLEGAL_STATE_CHANGE;
+    }
+
     final long remainingGas = frame.getRemainingGas();
 
     if (frame.isStatic()) {
@@ -79,22 +89,8 @@ public class SStoreOperation extends AbstractOperation {
       return new OperationResult(minimumGasRemaining, ExceptionalHaltReason.INSUFFICIENT_GAS);
     }
 
-    final UInt256 key = UInt256.fromBytes(frame.popStackItem());
-    final UInt256 newValue = UInt256.fromBytes(frame.popStackItem());
-
-    final Address address = frame.getRecipientAddress();
-
-    final long sloadCost =
-        frame.warmUpStorage(address, key) ? 0L : gasCalculator().getSStoreColdAccessGasCost();
-    if (remainingGas < sloadCost) {
-      return new OperationResult(sloadCost, ExceptionalHaltReason.INSUFFICIENT_GAS);
-    }
-
-    final MutableAccount account = getMutableAccount(address, frame);
-    if (account == null) {
-      return ILLEGAL_STATE_CHANGE;
-    }
-
+    final Address address = account.getAddress();
+    final boolean slotIsWarm = frame.warmUpStorage(address, key);
     final Supplier<UInt256> currentValueSupplier =
         Suppliers.memoize(() -> getStorageValue(account, key, frame));
     final Supplier<UInt256> originalValueSupplier =
@@ -102,7 +98,7 @@ public class SStoreOperation extends AbstractOperation {
 
     final long cost =
         gasCalculator().slotAccessCost(newValue, currentValueSupplier, originalValueSupplier)
-            + sloadCost;
+            + (slotIsWarm ? 0L : gasCalculator().getSStoreColdAccessGasCost());
     if (remainingGas < cost) {
       return new OperationResult(cost, ExceptionalHaltReason.INSUFFICIENT_GAS);
     }

--- a/evm/src/test/java/org/hyperledger/besu/evm/gascalculator/AmsterdamGasCalculatorTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/gascalculator/AmsterdamGasCalculatorTest.java
@@ -138,10 +138,10 @@ class AmsterdamGasCalculatorTest {
         Arguments.of("ETH to delegated account", RECIPIENT, Wei.ONE, 21_000L),
         Arguments.of("self-transfer, sender delegated", SENDER, Wei.ONE, 12_000L),
         Arguments.of("ETH creating a new account", RECIPIENT, Wei.ONE, 21_000L),
-        // to == null: contract creation. Value-bearing and target-pre-exists rows are identical —
-        // the recipient balance write is already covered by CREATE_ACCESS.
+        // to == null: contract creation. The recipient balance write is already covered by
+        // CREATE_ACCESS, but a value-bearing creation still pays the EIP-7708 transfer log (1,756).
         Arguments.of("create, value = 0", null, Wei.ZERO, 23_000L),
-        Arguments.of("create, value > 0", null, Wei.ONE, 23_000L),
+        Arguments.of("create, value > 0", null, Wei.ONE, 24_756L),
         Arguments.of("create, target pre-exists", null, Wei.ZERO, 23_000L));
   }
 
@@ -171,23 +171,23 @@ class AmsterdamGasCalculatorTest {
   }
 
   @Test
-  void eip2780AuthorizationIntrinsicExcludesAccountWrite() {
-    // EIP-2780: only REGULAR_PER_AUTH_BASE_COST (7,816) is intrinsic — the ACCOUNT_WRITE an
-    // authorization may perform is state-dependent and charged at runtime instead.
-    assertThat(amsterdamGasCalculator.delegateCodeGasCost(1)).isEqualTo(7_816L);
-    assertThat(amsterdamGasCalculator.delegateCodeGasCost(3)).isEqualTo(23_448L);
+  void eip2780AuthorizationIntrinsicReservesAccountWrite() {
+    // EIP-2780: ACCOUNT_WRITE (8,000) + REGULAR_PER_AUTH_BASE_COST (7,816) = 15,816 is reserved
+    // per authorization at the intrinsic phase.
+    assertThat(amsterdamGasCalculator.delegateCodeGasCost(1)).isEqualTo(15_816L);
+    assertThat(amsterdamGasCalculator.delegateCodeGasCost(3)).isEqualTo(47_448L);
 
-    // A zero-value 7702 transaction with one authorization: 15,000 + 7,816 = 22,816.
+    // A zero-value 7702 transaction with one authorization: 15,000 + 15,816 = 30,816.
     final Transaction tx = transactionWith(RECIPIENT, Wei.ZERO, Bytes.EMPTY, 1);
-    assertThat(amsterdamGasCalculator.transactionIntrinsicRegularGas(tx)).isEqualTo(22_816L);
+    assertThat(amsterdamGasCalculator.transactionIntrinsicRegularGas(tx)).isEqualTo(30_816L);
   }
 
   @Test
-  void eip2780AuthorityWriteIsChargedAtRuntime() {
-    assertThat(amsterdamGasCalculator.delegateCodeAccountWriteGasCost(0)).isZero();
-    assertThat(amsterdamGasCalculator.delegateCodeAccountWriteGasCost(2)).isEqualTo(16_000L);
-    // Nothing is over-reserved up front, so there is no per-authorization refund.
-    assertThat(amsterdamGasCalculator.calculateDelegateCodeGasRefund(2)).isZero();
+  void eip2780AuthorityWriteIsRefundedWhenNoAccountGrows() {
+    // The worst-case ACCOUNT_WRITE reserved per authorization is refunded for authorities that
+    // already existed (and for invalid authorizations, which the processor folds into that count).
+    assertThat(amsterdamGasCalculator.calculateDelegateCodeGasRefund(0)).isZero();
+    assertThat(amsterdamGasCalculator.calculateDelegateCodeGasRefund(2)).isEqualTo(16_000L);
   }
 
   private Transaction transactionWith(

--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -2415,9 +2415,9 @@
             <sha256 value="3e2b02d49fe903eda4fd8caca5cbf0d139c470e97e1de9a85299b1b034f97099" origin="Manual"/>
          </artifact>
       </component>
-      <component group="ethereum" name="execution-specs" version="tests-bal@v7.3.1">
-         <artifact name="execution-specs-tests-bal@v7.3.1-fixtures_bal.tar.gz">
-            <sha256 value="3c9bd8799a506a96f74162863efdf5eaa00226e645db6523346fdb7c5ba0bf62" origin="Manual"/>
+      <component group="ethereum" name="execution-specs" version="tests-glamsterdam-devnet@v6.1.1">
+         <artifact name="execution-specs-tests-glamsterdam-devnet@v6.1.1-fixtures_glamsterdam-devnet.tar.gz">
+            <sha256 value="45c1e1489c31aac055f8ccd38bd0f1466aab87d9d61178e9979e79164e4ee02b" origin="Manual"/>
          </artifact>
       </component>
       <component group="info.picocli" name="picocli" version="4.7.6">


### PR DESCRIPTION
## PR description

Last of the PRs restoring Amsterdam to the `tests-glamsterdam-devnet@v6.1.1` spec,
after #10766 (EIP-8246). **Stacked on #10907** — "Files changed" is cumulative until
that merges; this PR's own content is the single commit
`EIP-2780/7702/8038: intrinsic gas, delegation accounting, fixtures v6.1.1`
(10 files, +165/−221).

Aligns Amsterdam transaction-level gas pricing with `v6.1.1` and bumps the
reference-test fixtures to that release. **With #10907 in place this takes the
`_amsterdam_` reference tests from 808 failures to 0** — two better than
`glamsterdam-devnet-6` itself, which fails `bal_2935_absent_contract` and
`bal_4788_absent_contract`; both are fixed by #10907.

### EIP-2780 intrinsic gas

- A value-bearing contract creation pays the EIP-7708 transfer log (1,756) on top of
  `CREATE_ACCESS`.
- `txCreateExtraGasCost` is `CREATE_ACCESS` (11,000), not 9,000.

### EIP-7702 authorizations

The intrinsic cost per authorization is `ACCOUNT_WRITE + REGULAR_PER_AUTH_BASE_COST`
(15,816), reserved worst-case and refunded for authorities that grew no account — those
that already existed, and those whose authorization was invalid. This replaces the
runtime per-authority `ACCOUNT_WRITE` charge currently on main.

`CodeDelegationProcessor` now tracks whether an authority was delegated *before* the
transaction, so `AUTH_BASE` refills distinguish a designator that predates the
transaction from one written earlier within it.

### Transaction entry

A top-level call to a recipient carrying an EIP-7702 delegation pays cold account
access — this was not charged at all. Moved alongside the `NEW_ACCOUNT` state-gas charge
into `chargeTransactionEntry`, so both land before the undo mark advances and therefore
survive a revert.

### EIP-8038

`SSTORE` resolves the account before the cold-access check, so an out-of-gas `SSTORE`
still records the account in the block access list.

## Fixed Issue(s)

n/a

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew :evm:test :ethereum:core:test :ethereum:blockcreation:test`
- [x] reference tests: `./gradlew referenceTestsDevnet --tests "*_amsterdam_*"` — 5420 tests, 0 failures
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
