### PR TITLE
EIP-2780: fold transfer log cost into TX_VALUE_COST

### DIFF
--- a/ethereum/referencetests/build.gradle
+++ b/ethereum/referencetests/build.gradle
@@ -346,7 +346,7 @@ dependencies {
     )
   devnetTarConfig(
     group: 'ethereum', name: 'execution-specs',
-    version: 'tests-glamsterdam-devnet@v7.2.0', classifier: 'fixtures_glamsterdam-devnet', ext: 'tar.gz'
+    version: 'tests-glamsterdam-devnet@v8.0.0', classifier: 'fixtures_glamsterdam-devnet', ext: 'tar.gz'
     )
   referenceTestImplementation 'com.fasterxml.jackson.core:jackson-databind'
   referenceTestImplementation 'com.google.guava:guava'

--- a/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/AmsterdamGasCalculator.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/AmsterdamGasCalculator.java
@@ -74,6 +74,17 @@ public class AmsterdamGasCalculator extends OsakaGasCalculator {
   protected static final long ACCOUNT_WRITE = 8_000L;
 
   /**
+   * Per-address cost of a transaction access list entry: the cold access it prepays, less the warm
+   * access the entry still pays on its first touch, so prepaying is gas-neutral.
+   * COLD_ACCOUNT_ACCESS - WARM_STORAGE_READ_COST
+   */
+  private static final long ACCESS_LIST_ADDRESS_COST = 2_900L;
+
+  /** Per-storage-key access list cost. See {@link #ACCESS_LIST_ADDRESS_COST}. */
+  private static final long ACCESS_LIST_STORAGE_KEY_COST =
+      COLD_STORAGE_ACCESS - WARM_STORAGE_READ_COST;
+
+  /**
    * Flat write cost charged once per slot, on its first change in the transaction. Replaces the
    * Berlin SSTORE set/reset distinction; the set-from-zero surcharge now lives entirely in state
    * gas (see {@link Eip8037StateGasCostCalculator#storageSetStateGas}).
@@ -189,13 +200,17 @@ public class AmsterdamGasCalculator extends OsakaGasCalculator {
 
   @Override
   public long accessListGasCost(final int addresses, final int storageSlots) {
-    // EIP-8038: per-entry access cost is the cold access cost for both addresses and storage keys.
+    // EIP-8038: per-entry access cost is the cold access cost minus the warm access the prepaid
+    // entry still pays when it is first touched, so prepaying is gas-neutral with a cold access
+    // rather than costing WARM_ACCESS more.
     // EIP-7981: plus the access-list data floor, so the data is always charged at the floor rate
     // regardless of which branch of the gasUsed max() wins.
     return clampedAdd(
-        clampedMultiply(addresses, clampedAdd(COLD_ACCOUNT_ACCESS, ACCESS_LIST_ADDRESS_FLOOR_COST)),
         clampedMultiply(
-            storageSlots, clampedAdd(COLD_STORAGE_ACCESS, ACCESS_LIST_STORAGE_KEY_FLOOR_COST)));
+            addresses, clampedAdd(ACCESS_LIST_ADDRESS_COST, ACCESS_LIST_ADDRESS_FLOOR_COST)),
+        clampedMultiply(
+            storageSlots,
+            clampedAdd(ACCESS_LIST_STORAGE_KEY_COST, ACCESS_LIST_STORAGE_KEY_FLOOR_COST)));
   }
 
   @Override

--- a/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/AmsterdamGasCalculator.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/AmsterdamGasCalculator.java
@@ -106,18 +106,13 @@ public class AmsterdamGasCalculator extends OsakaGasCalculator {
   private static final long TX_DATA_TOKEN_STANDARD = 4L;
 
   /**
-   * EIP-2780: cost of a value-bearing transaction's recipient charges, covering the recipient
-   * balance write (4,244) and the EIP-7708 transfer log (1,756). Charged in intrinsic gas for a
-   * value-bearing call; a self-transfer writes only the sender, so it charges neither.
+   * EIP-2780: single charge covering everything a value-bearing call does to its recipient — the
+   * balance write and the EIP-7708 transfer log. The log is no longer priced as a separate
+   * primitive, so this is the only value-dependent term in the intrinsic. A self-transfer writes
+   * only the sender and emits no log, so it charges nothing; a contract creation covers both
+   * through {@link #CREATE_ACCESS} and likewise charges nothing.
    */
   private static final long TX_VALUE_COST = 6_000L;
-
-  /**
-   * EIP-7708: the transfer-log half of {@link #TX_VALUE_COST}, needed on its own because a
-   * value-bearing contract creation covers the balance write through {@link #CREATE_ACCESS} but
-   * still emits the log.
-   */
-  private static final long TRANSFER_LOG_COST = 1_756L;
 
   /**
    * EIP-2780: state-independent regular gas per EIP-7702 authorization, charged in intrinsic gas:
@@ -239,19 +234,21 @@ public class AmsterdamGasCalculator extends OsakaGasCalculator {
    * calldata floor so the floor never undercuts the transaction's own intrinsic base.
    */
   private static long baseRecipientRegularGas(final Transaction transaction) {
-    final boolean valueTransfer = !transaction.getValue().isZero();
     if (transaction.isContractCreation()) {
-      // CREATE_ACCESS already covers the recipient balance write; a value-bearing creation still
-      // emits the EIP-7708 transfer log.
-      return valueTransfer ? CREATE_ACCESS + TRANSFER_LOG_COST : CREATE_ACCESS;
+      // CREATE_ACCESS covers the recipient balance write, and the EIP-7708 transfer log is now
+      // folded into TX_VALUE_COST rather than charged on its own, so a creation costs the same
+      // whether or not it carries value.
+      return CREATE_ACCESS;
     }
     if (isSelfTransfer(transaction)) {
       // A self-transfer touches and writes only the sender, both covered by TX_BASE. Value makes no
       // difference either, since EIP-7708 emits no transfer log when sender and recipient match.
       return 0L;
     }
-    // TX_VALUE_COST already bundles the recipient balance write and the EIP-7708 transfer log.
-    return valueTransfer ? COLD_ACCOUNT_ACCESS + TX_VALUE_COST : COLD_ACCOUNT_ACCESS;
+    // TX_VALUE_COST bundles the recipient balance write and the EIP-7708 transfer log.
+    return transaction.getValue().isZero()
+        ? COLD_ACCOUNT_ACCESS
+        : COLD_ACCOUNT_ACCESS + TX_VALUE_COST;
   }
 
   /** EIP-2780: a self-transfer (sender == recipient) skips the recipient and value charges. */

--- a/evm/src/test/java/org/hyperledger/besu/evm/gascalculator/AmsterdamGasCalculatorTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/gascalculator/AmsterdamGasCalculatorTest.java
@@ -80,14 +80,15 @@ class AmsterdamGasCalculatorTest {
 
   @Test
   void accessListGasCostIncludesDataFloor() {
-    // EIP-8038: per-entry access cost raised to COLD_ACCESS (3,000) for both addresses and keys.
+    // EIP-8038: per-entry access cost is COLD_ACCESS (3,000) - WARM_ACCESS (100) = 2,900 for both
+    // addresses and keys, so a prepaid entry is gas-neutral with a cold access.
     // EIP-7981 data floor: +1280/address + 2048/key.
-    // One address + zero keys  = 3000 + 1280 = 4280
-    assertThat(amsterdamGasCalculator.accessListGasCost(1, 0)).isEqualTo(4280L);
-    // One address + one key    = 4280 + 3000 + 2048 = 9328
-    assertThat(amsterdamGasCalculator.accessListGasCost(1, 1)).isEqualTo(9328L);
-    // Three addresses + five keys = 3*4280 + 5*(3000+2048) = 12840 + 25240 = 38080
-    assertThat(amsterdamGasCalculator.accessListGasCost(3, 5)).isEqualTo(38080L);
+    // One address + zero keys  = 2900 + 1280 = 4180
+    assertThat(amsterdamGasCalculator.accessListGasCost(1, 0)).isEqualTo(4180L);
+    // One address + one key    = 4180 + 2900 + 2048 = 9128
+    assertThat(amsterdamGasCalculator.accessListGasCost(1, 1)).isEqualTo(9128L);
+    // Three addresses + five keys = 3*4180 + 5*(2900+2048) = 12540 + 24740 = 37280
+    assertThat(amsterdamGasCalculator.accessListGasCost(3, 5)).isEqualTo(37280L);
   }
 
   @Test

--- a/evm/src/test/java/org/hyperledger/besu/evm/gascalculator/AmsterdamGasCalculatorTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/gascalculator/AmsterdamGasCalculatorTest.java
@@ -140,10 +140,10 @@ class AmsterdamGasCalculatorTest {
         Arguments.of("ETH to delegated account", RECIPIENT, Wei.ONE, 21_000L),
         Arguments.of("self-transfer, sender delegated", SENDER, Wei.ONE, 12_000L),
         Arguments.of("ETH creating a new account", RECIPIENT, Wei.ONE, 21_000L),
-        // to == null: contract creation. The recipient balance write is already covered by
-        // CREATE_ACCESS, but a value-bearing creation still pays the EIP-7708 transfer log (1,756).
+        // to == null: contract creation. CREATE_ACCESS covers the recipient balance write and the
+        // EIP-7708 transfer log is folded into TX_VALUE_COST, so value makes no difference.
         Arguments.of("create, value = 0", null, Wei.ZERO, 23_000L),
-        Arguments.of("create, value > 0", null, Wei.ONE, 24_756L),
+        Arguments.of("create, value > 0", null, Wei.ONE, 23_000L),
         Arguments.of("create, target pre-exists", null, Wei.ZERO, 23_000L));
   }
 

--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -2415,14 +2415,9 @@
             <sha256 value="3e2b02d49fe903eda4fd8caca5cbf0d139c470e97e1de9a85299b1b034f97099" origin="Manual"/>
          </artifact>
       </component>
-      <component group="ethereum" name="execution-specs" version="tests-glamsterdam-devnet@v6.1.1">
-         <artifact name="execution-specs-tests-glamsterdam-devnet@v6.1.1-fixtures_glamsterdam-devnet.tar.gz">
-            <sha256 value="45c1e1489c31aac055f8ccd38bd0f1466aab87d9d61178e9979e79164e4ee02b" origin="Manual"/>
-         </artifact>
-      </component>
-      <component group="ethereum" name="execution-specs" version="tests-glamsterdam-devnet@v7.2.0">
-         <artifact name="execution-specs-tests-glamsterdam-devnet@v7.2.0-fixtures_glamsterdam-devnet.tar.gz">
-            <sha256 value="29ba214eaf37c880c845179994cb62e82a0fb63e58f83e6c640d85f3e7d7a796" origin="Manual, verified against GitHub release digest"/>
+      <component group="ethereum" name="execution-specs" version="tests-glamsterdam-devnet@v8.0.0">
+         <artifact name="execution-specs-tests-glamsterdam-devnet@v8.0.0-fixtures_glamsterdam-devnet.tar.gz">
+            <sha256 value="4974647c6cc005f7e481f593c24b14771b67a1f468e9f65658398152536b3cf6" origin="Manual, verified against GitHub release digest"/>
          </artifact>
       </component>
       <component group="info.picocli" name="picocli" version="4.7.6">


### PR DESCRIPTION
## Description

Implements the EIP-2780 spec change [`04dd54c`](https://github.com/ethereum/EIPs/commit/04dd54c2e7ec1f408cf4a150d5c1aa43573bd025), which folds the transfer log cost into `TX_VALUE_COST`.

`TRANSFER_LOG_COST` (1,756) is gone from the schedule as a standalone primitive. `TX_VALUE_COST` (6,000) now covers both the recipient balance write and the EIP-7708 transfer log, and is the only value-dependent term in the intrinsic.

## What changes

The one observable difference is a **contract-creation transaction carrying value**:

| Case | Before | After |
| :---- | :----: | :----: |
| Create transaction, `tx.value` = 0 | 23,000 | 23,000 |
| Create transaction, `tx.value` > 0 | 24,756 | **23,000** |
| ETH transfer to existing EOA / contract | 21,000 | 21,000 |
| ETH transfer to self | 12,000 | 12,000 |
| No-transfer to EOA / contract | 15,000 | 15,000 |

A creation covers the recipient balance write through `CREATE_ACCESS` and does not charge `TX_VALUE_COST`, so with the log folded in there is nothing left for it to pay — a value-bearing creation now costs exactly what a zero-value one does.

Value-bearing calls to another account are unchanged: `COLD_ACCOUNT_ACCESS + TX_VALUE_COST` already summed to 21,000, since `TX_VALUE_COST` was raised to 6,000 when the transfer log was first bundled in.

The EIP-3120 calldata floor anchor follows automatically — it shares `baseRecipientRegularGas` with the intrinsic, so the floor for a value-bearing creation drops by the same 1,756.

## Testing

- `AmsterdamGasCalculatorTest` tracks the "Transaction reference cases" table of the EIP row by row; the `create, value > 0` row is updated to 23,000.
- `:evm:test` and the `ethereum:core` transaction-processor and block-processor integration tests pass.

Devnet reference tests are **not** yet updated for these spec changes, so a portion of `referenceTestsDevnet --tests "*_amsterdam_*"` still fails against the current fixtures. This will be re-validated once fixtures covering the change are released.
