### PR TITLE
Enable NullAway for metrics RocksDB

### DIFF
--- a/metrics/rocksdb/build.gradle
+++ b/metrics/rocksdb/build.gradle
@@ -15,6 +15,19 @@
 
 apply plugin: 'java-library'
 
+compileJava {
+  options.errorprone {
+    check('NullAway', net.ltgt.gradle.errorprone.CheckSeverity.ERROR)
+    option('NullAway:AnnotatedPackages', 'org.hyperledger.besu.metrics.rocksdb')
+  }
+}
+
+tasks.named('compileTestJava', JavaCompile).configure {
+  options.errorprone {
+    check('NullAway', net.ltgt.gradle.errorprone.CheckSeverity.OFF)
+  }
+}
+
 jar {
   archiveBaseName = calculateArtifactId(project)
   manifest {
@@ -31,8 +44,12 @@ jar {
 dependencies {
   api 'org.slf4j:slf4j-api'
 
+  errorprone 'com.uber.nullaway:nullaway'
+
   implementation project(':metrics:core')
   implementation project(':plugin-api')
 
   implementation 'org.rocksdb:rocksdbjni'
+
+  compileOnly 'org.jspecify:jspecify'
 }


### PR DESCRIPTION
## PR description

Enable NullAway for the `metrics/rocksdb` module.

This change:
- enforces NullAway at `ERROR` severity for production sources under `org.hyperledger.besu.metrics.rocksdb`
- keeps NullAway disabled for test compilation, following the migration recipe
- adds the NullAway Error Prone dependency and JSpecify as a compile-only dependency

No production or test source changes were required, and neither dependency is added to the runtime classpath. A temporary nullable-dereference probe was rejected by NullAway as expected and then fully reverted.

## Fixed Issue(s)

Part of #10442 (`metrics/rocksdb`)

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR if updates are required in the [Besu documentation](https://github.com/besu-eth/besu-docs). No documentation changes are required.
- [x] Considered the changelog and [included an update if required](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md#changelog). No changelog entry is required.
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests — not applicable; this does not change database formats or runtime behavior.

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew --no-daemon :metrics:rocksdb:build :metrics:rocksdb:spotlessCheck --rerun-tasks`
- [x] unit tests: `GRADLE_MAX_TEST_FORKS=1 ./gradlew --no-daemon build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://github.com/besu-eth/besu/wiki/Working-through-Hive-tests)

Additional validation: `./gradlew --no-daemon --no-parallel checkLicense`.
