### PR TITLE
fix: fix SnapSyncForkRecoveryAcceptanceTest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 - Dual-stack discovery and RLPx now support binding the same port number for both `--p2p-port` and `--p2p-port-ipv6`, using a single dual-stack socket instead of two independent per-family sockets - simplifying firewall rules for operators. Previously this configuration could fail to start with a port-conflict error. [#10800](https://github.com/besu-eth/besu/pull/10800)
 - Add discovery/RLPx observability metrics for the shared DiscV4/DiscV5 transport and outbound RLPx connections - see the PR description for the full list of new metrics. [#10837](https://github.com/besu-eth/besu/pull/10837)
 - Add `--p2p-tx-feecap` CLI option, the P2P equivalent of `--rpc-tx-feecap`, capping the maximum transaction fees (in Wei) accepted for transactions received from peers. The default is no cap, leaving existing behaviour unchanged. [#10819](https://github.com/besu-eth/besu/pull/10819)
+- Fix a restart race in the acceptance test DSL where a killed process' late `onExit` callback set an exit code on the restarted node, making it skip reloading `besu.ports` and dial the dead process' port. [#10910](https://github.com/besu-eth/besu/issues/10910)
 
 ## 26.7.1
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,6 @@
 - Dual-stack discovery and RLPx now support binding the same port number for both `--p2p-port` and `--p2p-port-ipv6`, using a single dual-stack socket instead of two independent per-family sockets - simplifying firewall rules for operators. Previously this configuration could fail to start with a port-conflict error. [#10800](https://github.com/besu-eth/besu/pull/10800)
 - Add discovery/RLPx observability metrics for the shared DiscV4/DiscV5 transport and outbound RLPx connections - see the PR description for the full list of new metrics. [#10837](https://github.com/besu-eth/besu/pull/10837)
 - Add `--p2p-tx-feecap` CLI option, the P2P equivalent of `--rpc-tx-feecap`, capping the maximum transaction fees (in Wei) accepted for transactions received from peers. The default is no cap, leaving existing behaviour unchanged. [#10819](https://github.com/besu-eth/besu/pull/10819)
-- Fix a restart race in the acceptance test DSL where a killed process' late `onExit` callback set an exit code on the restarted node, making it skip reloading `besu.ports` and dial the dead process' port. [#10910](https://github.com/besu-eth/besu/issues/10910)
 
 ## 26.7.1
 ### Breaking Changes

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/BesuNode.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/BesuNode.java
@@ -139,7 +139,7 @@ public class BesuNode implements NodeConfiguration, RunnableNode, AutoCloseable 
   private final List<String> extraCLIOptions;
   private final List<String> staticNodes;
   private boolean isDnsEnabled = false;
-  private Optional<Integer> exitCode = Optional.empty();
+  private volatile Optional<Integer> exitCode = Optional.empty();
   private final boolean isStrictTxReplayProtectionEnabled;
   private final Map<String, String> environment;
   private SynchronizerConfiguration synchronizerConfiguration;

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ProcessBesuNodeRunner.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ProcessBesuNodeRunner.java
@@ -41,7 +41,6 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -65,7 +64,7 @@ public class ProcessBesuNodeRunner implements BesuNodeRunner {
   private static final Logger PROCESS_LOG =
       LoggerFactory.getLogger("org.hyperledger.besu.SubProcessLog");
 
-  private final Map<String, Process> besuProcesses = new HashMap<>();
+  private final Map<String, Process> besuProcesses = new ConcurrentHashMap<>();
   private final ExecutorService outputProcessorExecutor = Executors.newCachedThreadPool();
   private volatile boolean capturingConsole;
   private final ByteArrayOutputStream consoleContents = new ByteArrayOutputStream();
@@ -130,7 +129,14 @@ public class ProcessBesuNodeRunner implements BesuNodeRunner {
 
       nodeOutputs.put(node.getName(), EvictingQueue.create(MAX_STARTUP_OUTPUT_LINES));
       final Process process = processBuilder.start();
-      process.onExit().thenRun(() -> node.setExitCode(process.exitValue()));
+      process
+          .onExit()
+          .thenRun(
+              () -> {
+                if (besuProcesses.get(node.getName()) == process) {
+                  node.setExitCode(process.exitValue());
+                }
+              });
       outputProcessorExecutor.execute(() -> printOutput(node, process));
       besuProcesses.put(node.getName(), process);
     } catch (final IOException e) {


### PR DESCRIPTION
## PR description

This PR fixes the flaky test `resumesSnapSyncFromPersistedStateAfterRestart` in class `SnapSyncForkRecoveryAcceptanceTest`. 

The `Process.onExit()` triggers a bg thread which can be delivered after `killBesuProcess`'s `waitFor` has already returned. The restart sequence is:

1. Kill the old process
2. `BesuNode.start` clears `exitCode` and spawns the new process
3. The old process' `onExit` callback lands and sets `exitCode` on the node

`BesuNode.start` then sees a non-empty `exitCode` and considers the node as dead and hence skip `loadPortsFile()`, so `portsProperties` are same as the old dead process and hence the test dials a closed port. 

After the fix, the `exitCode` is only recorded while the process is still the node's current one. `killBesuProcess` removes the entry from the `besuProcesses` before killing to prevent a superseded process' late callback becomes no-op. 
## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fixes #10910 

### Thanks for sending a pull request! Have you done the following?

- [X] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [X] Considered documentation and added the `doc-change-required` label to this PR if updates are required in the [Besu documentation](https://github.com/besu-eth/besu-docs).
- [X] Considered the changelog and [included an update if required](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md#changelog).
- [X] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [X] spotless: `./gradlew spotlessApply`
- [X] unit tests: `./gradlew build`
- [X] acceptance tests: `./gradlew acceptanceTest`
- [X] integration tests: `./gradlew integrationTest`
- [X] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://github.com/besu-eth/besu/wiki/Working-through-Hive-tests)


